### PR TITLE
Allow custom IFO prefix for Channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - sudo apt-get --assume-yes --allow-unauthenticated install lscsoft-archive-keyring
   - sudo apt-get update -qq
   - sudo apt-get --assume-yes install libhdf5-dev lalframe-python ldas-tools-framecpp-python
+  - sudo apt-get --assume-yes install python-nds2-client
   # install build dependencies
   - travis_retry pip install -q tornado jinja2 GitPython
   # install cython

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -108,13 +108,13 @@ class Channel(object):
             name = str(name)
         # make a new channel
         # strip off NDS stuff for 'name'
-        self.name = str(name).split(',')[0]
         # parse name into component parts
         try:
             parts = self.parse_channel_name(name)
         except (TypeError, ValueError):
-            pass
+            self.name = str(name)
         else:
+            self.name = str(name).split(',')[0]
             for key, val in parts.iteritems():
                 try:
                     setattr(self, key, val)

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -286,7 +286,10 @@ class Channel(object):
 
         :type: `str`
         """
-        return self._ifo
+        try:
+            return self._ifo
+        except AttributeError:
+            self._ifo = None
 
     @property
     def system(self):

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -84,8 +84,8 @@ class Channel(object):
     (https://cis.ligo.org) for which a query interface is provided.
     """
     MATCH = re.compile(
-        r'(?P<ifo>[A-Z]\d):'  # match IFO prefix
-         '(?P<system>[a-zA-Z0-9]+)'  # match system
+        r'((?:(?P<ifo>[A-Z]\d))?|[\w-]+):'  # match IFO prefix
+         '(?:(?P<system>[a-zA-Z0-9]+))?'  # match system
          '(?:[-_](?P<subsystem>[a-zA-Z0-9]+))?'  # match subsystem
          '(?:_(?P<signal>[a-zA-Z0-9_]+))?'  # match signal
          '(?:\.(?P<trend>[a-z]+))?'  # match trend type

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -297,7 +297,10 @@ class Channel(object):
 
         :type: `str`
         """
-        return self._system
+        try:
+            return self._system
+        except AttributeError:
+            self._system = None
 
     @property
     def subsystem(self):
@@ -305,7 +308,10 @@ class Channel(object):
 
         :type: `str`
         """
-        return self._subsystem
+        try:
+            return self._subsystem
+        except AttributeError:
+            self._subsystem = None
 
     @property
     def signal(self):
@@ -313,7 +319,10 @@ class Channel(object):
 
         :type: `str`
         """
-        return self._signal
+        try:
+            return self._signal
+        except AttributeError:
+            self._signal = None
 
     @property
     def texname(self):

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -325,6 +325,17 @@ class Channel(object):
             self._signal = None
 
     @property
+    def trend(self):
+        """Trend type for this `Channel`.
+
+        :type: `str`
+        """
+        try:
+            return self._trend
+        except AttributeError:
+            self._trend = None
+
+    @property
     def texname(self):
         """Name of this `Channel` in LaTeX printable format.
         """

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -74,7 +74,7 @@ class Channel(object):
     (https://cis.ligo.org) for which a query interface is provided.
     """
     MATCH = re.compile(
-        r'(?P<ifo>[A-Z]\d):'  # match IFO prefix
+        r'(?P<ifo>[A-Z0-9-]+):'  # match IFO prefix
          '(?P<system>[a-zA-Z0-9]+)'  # match system
          '(?:[-_](?P<subsystem>[a-zA-Z0-9]+))?'  # match subsystem
          '(?:_(?P<signal>[a-zA-Z0-9_]+))?'  # match signal

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -84,7 +84,7 @@ class Channel(object):
     (https://cis.ligo.org) for which a query interface is provided.
     """
     MATCH = re.compile(
-        r'(?P<ifo>[A-Z0-9-]+):'  # match IFO prefix
+        r'(?P<ifo>[A-Z]\d):'  # match IFO prefix
          '(?P<system>[a-zA-Z0-9]+)'  # match system
          '(?:[-_](?P<subsystem>[a-zA-Z0-9]+))?'  # match subsystem
          '(?:_(?P<signal>[a-zA-Z0-9_]+))?'  # match signal

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -33,8 +33,18 @@ from astropy import units
 try:
     from ..io.nds import (NDS2_CHANNEL_TYPE, NDS2_CHANNEL_TYPESTR)
 except ImportError:
-    NDS2_CHANNEL_TYPESTR = {}
-    NDS2_CHANNEL_TYPE = {}
+    NDS2_CHANNEL_TYPESTR = {
+        1: 'online',
+         2: 'raw',
+         4: 'reduced',
+         8: 's-trend',
+         16: 'm-trend',
+         32: 'test-pt',
+         64: 'static',
+         128: 'rds',
+    }
+    NDS2_CHANNEL_TYPE = dict((val, key) for (key, val) in
+                             NDS2_CHANNEL_TYPESTR.iteritems())
 
 from .. import version
 from ..segments import (Segment, SegmentList, SegmentListDict)

--- a/gwpy/tests/detector.py
+++ b/gwpy/tests/detector.py
@@ -106,6 +106,13 @@ class ChannelTests(unittest.TestCase):
                 self.assertTrue(new.ifo == self.channel.split(':', 1)[0])
                 self.assertTrue(new.sample_rate == units.Quantity(32768, 'Hz'))
 
+    def test_fmcs_parse(self):
+        new = Channel('LVE-EX:X3_810BTORR.mean,m-trend')
+        self.assertEqual(new.ifo, 'LVE-EX')
+        self.assertEqual(new.name, 'LVE-EX:X3_810BTORR.mean')
+        self.assertEqual(new.trend, 'mean')
+        self.assertEqual(new.type, 'm-trend')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/gwpy/tests/detector.py
+++ b/gwpy/tests/detector.py
@@ -108,7 +108,7 @@ class ChannelTests(unittest.TestCase):
 
     def test_fmcs_parse(self):
         new = Channel('LVE-EX:X3_810BTORR.mean,m-trend')
-        self.assertEqual(new.ifo, 'LVE-EX')
+        self.assertEqual(new.ifo, None)
         self.assertEqual(new.name, 'LVE-EX:X3_810BTORR.mean')
         self.assertEqual(new.trend, 'mean')
         self.assertEqual(new.type, 'm-trend')


### PR DESCRIPTION
Old LIGO FMCS channels have odd prefixes, but are still valid channels, e.g.

```
'LVE-EX:X3_810BTORR.mean,m-trend'
```

This PR introduces a unittest to make sure these channels can be parsed, and amends the `Channel.MATCH` regular expression to allow custom prefixes.

This should fix #31.