### PR TITLE
Fix unittests on python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
 before_install:
   - mkdir builds

--- a/gwpy/tests/detector.py
+++ b/gwpy/tests/detector.py
@@ -19,7 +19,12 @@
 """Unit test for detector module
 """
 
-import unittest
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 import numpy
 
@@ -64,11 +69,11 @@ class ChannelTests(unittest.TestCase):
             try:
                 import kerberos
             except ImportError:
-                raise unittest.SkipTest('Channel.query() requires kerberos '
+                self.skipTest('Channel.query() requires kerberos '
                                         'to be installed')
             else:
                 if isinstance(e, kerberos.GSSError):
-                    raise unittest.SkipTest(str(e))
+                    self.skipTest(str(e))
                 else:
                     raise
         self.assertTrue(str(new) == self.channel)
@@ -80,7 +85,7 @@ class ChannelTests(unittest.TestCase):
         try:
             import nds2
         except ImportError as e:
-            return unittest.SkipTest(str(e))
+            self.skipTest(str(e))
         new = Channel.query_nds2(self.channel, host=NDSHOST,
                                  type=nds2.channel.CHANNEL_TYPE_RAW)
         self.assertTrue(str(new) == self.channel)
@@ -93,12 +98,12 @@ class ChannelTests(unittest.TestCase):
         try:
             import nds2
         except ImportError as e:
-            return unittest.SkipTest(str(e))
+            self.skipTest(str(e))
         else:
             try:
                 conn = nds2.connection(NDSHOST)
             except Exception as f:
-                return unittest.SkipTest(str(f))
+                self.skipTest(str(f))
             else:
                 nds2channel = conn.find_channels(self.channel)[0]
                 new = Channel.from_nds2(nds2channel)

--- a/gwpy/tests/segments.py
+++ b/gwpy/tests/segments.py
@@ -147,7 +147,7 @@ class DataQualityFlagTests(unittest.TestCase):
         try:
             flag.write(hdfout)
         except ImportError as e:
-            raise unittest.SkipTest(str(e))
+            self.skipTest(str(e))
         else:
             if delete:
                 os.remove(hdfout)
@@ -157,7 +157,7 @@ class DataQualityFlagTests(unittest.TestCase):
         try:
             hdfout = self.test_write_hdf5(delete=False)
         except ImportError as e:
-            raise unittest.SkipTest(str(e))
+            self.skipTest(str(e))
         else:
             flag = DataQualityFlag.read(hdfout)
             os.remove(hdfout)
@@ -173,7 +173,7 @@ class DataQualityFlagTests(unittest.TestCase):
             flag = DataQualityFlag.query_dqsegdb(
                 QUERY_FLAG, QUERY_START, QUERY_END, url=QUERY_URL)
         except (ImportError, URLError) as e:
-            raise unittest.SkipTest(str(e))
+            self.skipTest(str(e))
         else:
             self.assertEqual(flag.known, QUERY_KNOWN)
             self.assertEqual(flag.active, QUERY_ACTIVE)

--- a/gwpy/tests/timeseries.py
+++ b/gwpy/tests/timeseries.py
@@ -21,8 +21,13 @@
 
 import os
 import os.path
-import unittest
+import sys
 import tempfile
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from numpy import random
 
@@ -74,13 +79,13 @@ class TimeSeriesTests(unittest.TestCase):
         try:
             self.frame_read(format='lalframe')
         except ImportError as e:
-            raise unittest.SkipTest(str(e))
+            self.skipTest(str(e))
 
     def test_frame_read_framecpp(self):
         try:
             self.frame_read(format='framecpp')
         except ImportError as e:
-            raise unittest.SkipTest(str(e))
+            self.skipTest(str(e))
 
     def test_ascii_write(self, delete=True):
         self.ts = TimeSeries(self.data, sample_rate=1, name='TEST CASE',
@@ -106,7 +111,7 @@ class TimeSeriesTests(unittest.TestCase):
         try:
             self.ts.write(hdfout)
         except ImportError as e:
-            raise unittest.SkipTest(str(e))
+            self.skipTest(str(e))
         finally:
             if delete and os.path.isfile(hdfout):
                 os.remove(hdfout)
@@ -116,7 +121,7 @@ class TimeSeriesTests(unittest.TestCase):
         try:
             hdfout = self.test_hdf5_write(delete=False)
         except ImportError as e:
-            raise unittest.SkipTest(str(e))
+            self.skipTest(str(e))
         else:
             try:
                 ts = TimeSeries.read(hdfout, 'TEST CASE')

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,11 @@ try:
 except ImportError:
     extra_install_requires.append('ordereddict>=1.1')
 
+# test for unittest2
+extra_tests_require = []
+if sys.version < '2.7':
+    extra_tests_require.append('unittest2')
+
 # import sphinx commands
 try:
     from sphinx.setup_command import BuildDoc
@@ -323,6 +328,8 @@ setup(name=PACKAGENAME,
           'astropy >= 0.4',
           'six >= 1.5',
       ] + extra_install_requires,
+      tests_require=[
+      ] + extra_tests_require,
       extras_require={
           'nds': ['nds2-client'],
           'gwf': ['ldas-tools'],


### PR DESCRIPTION
This PR adds the backport `unittest2` module as a `tests_require` dependency in `setup.py`.

This should fix #34.