### PR TITLE
GPS epoch-based server selection

### DIFF
--- a/gwpy/io/nds.py
+++ b/gwpy/io/nds.py
@@ -98,7 +98,9 @@ def host_resolution_order(ifo, env='NDSSERVER'):
         prefix for IFO of interest
     env : `str`, optional
         environment variable name to use for server order,
-        default ``'NDSSERVER'``
+        default ``'NDSSERVER'``. The contents of this variable should
+        be a comma-separated list of `host:port` strings, e.g.
+        ``'nds1.server.com:80,nds2.server.com:80'``
 
     Returns
     -------

--- a/gwpy/io/nds.py
+++ b/gwpy/io/nds.py
@@ -108,8 +108,8 @@ def host_resolution_order(ifo, env='NDSSERVER'):
     hosts = []
     # if NDSSERVER environment variable exists, it will contain a
     # comma-separated list of host:port strings giving the logical ordering
-    if env and os.getenv('NDSSERVER'):
-        for host in os.getenv('NDSSERVER').split(','):
+    if env and os.getenv(env):
+        for host in os.getenv(env).split(','):
             try:
                 host, port = host.rsplit(':', 1)
             except ValueError:

--- a/gwpy/tests/io.py
+++ b/gwpy/tests/io.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit test for `io` module
+"""
+
+import os
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from .. import version
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+
+class IoTests(unittest.TestCase):
+
+    def test_nds2_host_order_none(self):
+        """Test `host_resolution_order` with `None` IFO
+        """
+        try:
+            from ..io import nds
+        except ImportError as e:
+            self.skipTest(str(e))
+        hro = nds.host_resolution_order(None, env=None)
+        self.assertListEqual(hro, [('nds.ligo.caltech.edu', 31200)])
+
+    def test_nds2_host_order_ifo(self):
+        """Test `host_resolution_order` with `ifo` argument
+        """
+        try:
+            from ..io import nds
+        except ImportError as e:
+            self.skipTest(str(e))
+        hro = nds.host_resolution_order('L1', env=None)
+        self.assertListEqual(
+            hro, [('nds.ligo-la.caltech.edu', 31200),
+                  ('nds.ligo.caltech.edu', 31200)])
+
+    def test_nds2_host_order_ndsserver(self):
+        """Test `host_resolution_order` with default env set
+        """
+        try:
+            from ..io import nds
+        except ImportError as e:
+            self.skipTest(str(e))
+        os.environ['NDSSERVER'] = 'test1.ligo.org:80,test2.ligo.org:43'
+        hro = nds.host_resolution_order(None)
+        self.assertListEqual(
+            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+        hro = nds.host_resolution_order('L1')
+        self.assertListEqual(
+            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+
+    def test_nds2_host_order_env(self):
+        """Test `host_resolution_order` with non-default env set
+        """
+        try:
+            from ..io import nds
+        except ImportError as e:
+            self.skipTest(str(e))
+        os.environ['TESTENV'] = 'test1.ligo.org:80,test2.ligo.org:43'
+        hro = nds.host_resolution_order(None, env='TESTENV')
+        self.assertListEqual(
+            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+
+    def test_nds2_host_order_epoch(self):
+        """Test `host_resolution_order` with old GPS epoch
+        """
+        try:
+            from ..io import nds
+        except ImportError as e:
+            self.skipTest(str(e))
+        # test kwarg doesn't change anything
+        hro = nds.host_resolution_order('L1', epoch='now')
+        self.assertListEqual(
+            hro, [('nds.ligo-la.caltech.edu', 31200),
+                  ('nds.ligo.caltech.edu', 31200)])
+        # test old epoch puts CIT ahead of LLO
+        hro = nds.host_resolution_order('L1', epoch='Jan 1 2015')
+        self.assertListEqual(
+            hro, [('nds.ligo.caltech.edu', 31200),
+                  ('nds.ligo-la.caltech.edu', 31200)])
+        # test epoch doesn't operate with env
+        os.environ['TESTENV'] = 'test1.ligo.org:80,test2.ligo.org:43'
+        hro = nds.host_resolution_order('L1', epoch='now', env='TESTENV')
+        self.assertListEqual(
+            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1744,7 +1744,7 @@ class TimeSeriesDict(OrderedDict):
                 ifo = list(ifos)[0]
             else:
                 ifo = None
-            hostlist = ndsio.host_resolution_order(ifo)
+            hostlist = ndsio.host_resolution_order(ifo, epoch=start)
             for host, port in hostlist:
                 try:
                     return cls.fetch(channels, start, end, host=host,


### PR DESCRIPTION
This PR introduces the `epoch` keyword argument to the NDS2 server selection algorithm (`gwpy.io.nds.host_resolution_order`). Additionally, this introduces a series of related unittests.

This fixes #27. 