### PR TITLE
Fix for legend.remove() bug with matplotlib < 1.4

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -644,10 +644,13 @@ class CliProduct(object):
 
         # image plots don't have legends
         if not self.is_image():
-            self.ax.legend(prop={'size': 10})
+            leg = self.ax.legend(prop={'size': 10})
             # if only one series is plotted hide legend
-            if self.n_datasets == 1 and self.ax.legend_:
-                self.ax.legend_.remove()
+            if self.n_datasets == 1 and leg:
+                try:
+                    leg.remove()
+                except NotImplementedError:
+                    leg.set_visible(False)
 
         # add titles
         title = ''


### PR DESCRIPTION
The linked commit hacks around bug #37 by catching the `NotImplementedError` raised by mpl < 1.4 and simply hiding the legend instead. I've tested generating the examples for the documentation, and things look fine.

@areeda, without thorough testing, can you tell me whether this is good enough. I'd rather not place a hard requirement on matplotlib >= 1.4 just yet.

This PR fixes #37.