### PR TITLE
New generic ASCII reader for LIGO_LW tables

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -26,6 +26,7 @@ from six import string_types
 import warnings
 
 from glue.lal import (Cache, CacheEntry)
+from glue.ligolw.table import Table
 
 from astropy.io.registry import _get_valid_format
 
@@ -204,7 +205,10 @@ def read_cache(cache, target, nproc, post, *args, **kwargs):
     # combine and return
     data = zip(*sorted(pout, key=lambda out: out[0]))[1]
     try:
-        out = data[0].copy()
+        if issubclass(target, Table):
+            out = data[0]
+        else:
+            out = data[0].copy()
     except AttributeError:
         out = data[0]
     for datum in data[1:]:

--- a/gwpy/table/io/ascii.py
+++ b/gwpy/table/io/ascii.py
@@ -35,8 +35,8 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
 
 
-def ascii_table_factory(table, format, trig_func, cols=None, comments='#',
-                        delimiter=None):
+def table_from_ascii_factory(table, format, trig_func, cols=None, comments='#',
+                             delimiter=None):
     """Build a table reader for the given format
 
     Parameters
@@ -50,7 +50,8 @@ def ascii_table_factory(table, format, trig_func, cols=None, comments='#',
     cols : `list` of `str`
         list of columns that can be read by default for this format
     """
-    def table_from_ascii(f, format=None, columns=cols, filt=None, nproc=1):
+    def table_from_ascii_rows(
+            f, format=None, columns=cols, filt=None, nproc=1):
         """Build a `~{0}` from events in an ASCII file.
 
         Parameters
@@ -103,4 +104,4 @@ def ascii_table_factory(table, format, trig_func, cols=None, comments='#',
                 if filt is None or filt(row):
                     append(row)
         return out
-    return table_from_ascii
+    return table_from_ascii_rows

--- a/gwpy/table/io/omega.py
+++ b/gwpy/table/io/omega.py
@@ -26,7 +26,7 @@ from numpy import loadtxt
 
 from astropy.io import registry
 
-from .ascii import ascii_table_factory
+from .ascii import table_from_ascii_factory
 from ..lsctables import (SnglBurstTable, SnglBurst)
 from ... import version
 from ...io.cache import file_list
@@ -71,7 +71,8 @@ def sngl_burst_from_omega(line, columns=OMEGA_COLUMNS):
     t.search = u'omega'
 
     if isinstance(line, str):
-        line = map(float, line.rstrip('\n').split())
+        line = line.rstrip('\n').split()
+    line = map(float, line)
     try:
         peak, freq, duration, band, nerg, clst_size, clst_nerg, clst_N = line
     except IndexError:
@@ -213,12 +214,12 @@ def sngl_burst_from_omegadq(line, columns=OMEGADQ_COLUMNS):
 # register OmegaDQ
 registry.register_reader(
     'omegadq', SnglBurstTable,
-    ascii_table_factory(SnglBurstTable, 'omegadq',
-                        sngl_burst_from_omegadq, OMEGADQ_COLUMNS))
+    table_from_ascii_factory(SnglBurstTable, 'omegadq',
+                             sngl_burst_from_omegadq, OMEGADQ_COLUMNS))
 
 # register Omega
 registry.register_reader(
     'omega', SnglBurstTable,
-    ascii_table_factory(SnglBurstTable, 'omega',
-                        sngl_burst_from_omega, OMEGA_COLUMNS,
-                        comments='%'))
+    table_from_ascii_factory(SnglBurstTable, 'omega',
+                             sngl_burst_from_omega, OMEGA_COLUMNS,
+                             comments='%'))

--- a/gwpy/table/utils.py
+++ b/gwpy/table/utils.py
@@ -35,6 +35,22 @@ EVENT_TABLES = (lsctables.SnglBurstTable,
                 lsctables.MultiInspiralTable,
                 lsctables.SnglRingdownTable)
 
+TIME_COLUMN = {
+    lsctables.CoincInspiralTable.tableName: ('end_time', 'end_time_ns'),
+    lsctables.CoincRingdownTable.tableName: ('start_time', 'start_time_ns'),
+    lsctables.MultiBurstTable.tableName: ('peak_time', 'peak_time_ns'),
+    lsctables.MultiInspiralTable.tableName: ('end_time', 'end_time_ns'),
+    lsctables.SimBurstTable.tableName: ('time_geocent_gps',
+                                        'time_geocent_gps_ns'),
+    lsctables.SimInspiralTable.tableName: ('geocent_end_time',
+                                           'geocent_end_time_ns'),
+    lsctables.SimRingdownTable.tableName: ('geocent_start_time',
+                                           'geocent_start_time_ns'),
+    lsctables.SnglBurstTable.tableName: ('peak_time', 'peak_time_ns'),
+    lsctables.SnglInspiralTable.tableName: ('end_time', 'end_time_ns'),
+    lsctables.SnglRingdownTable.tableName: ('start_time', 'start_time_ns'),
+}
+
 
 def get_table_column(table, column, dtype=numpy.dtype(float)):
     """Extract a column from the given table.


### PR DESCRIPTION
This PR introduces a new generic ASCII row reader method, which is registered to read white-space delimiter ASCII and comma-separated csv files for all `LIGO_LW` tables.

This PR fixes #42.