### PR TITLE
cli: fixes for matplotlib units error on py26

### DIFF
--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -141,8 +141,8 @@ class Coherence(CliProduct):
         # if the specified frequency limits adjust our ymin and ymax values
         # at this point self.ymin and self.ymax represent the full spectra
         import numpy
-        mymin = numpy.min(cohs[0])
-        mymax = numpy.max(cohs[0])
+        mymin = cohs[0].data.min()
+        mymax = cohs[0].data.max()
         myfmin = 1/self.secpfft * cohs[0].frequencies.unit
         myfmax = maxfs/2
         if arg_list.fmin:

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -105,8 +105,8 @@ class TimeSeries(CliProduct):
 
                 if e >= self.timeseries[idx].size:
                     e = self.timeseries[idx].size - 1
-                new_ymin = min(new_ymin, npmin(self.timeseries[idx][b:e]))
-                new_ymax = max(new_ymax, npmax(self.timeseries[idx][b:e]))
+                new_ymin = min(new_ymin, npmin(self.timeseries[idx].data[b:e]))
+                new_ymax = max(new_ymax, npmax(self.timeseries[idx].data[b:e]))
             self.ymin = new_ymin
             self.ymax = new_ymax
         if self.yscale_factor > 1:


### PR DESCRIPTION
This PR fixes a python2.6/matplotlib bug where astropy Quantities are pushed through the matplotlib units interface, resulting in a `SystemError`.

This single commit just makes sure a couple of `set_ylim` calls receive float-like objects, and not Quantities.