### PR TITLE
New over-dense spectrogram method (TimeSeries.spectrogram2)

### DIFF
--- a/examples/spectrogram/spectrogram2.py
+++ b/examples/spectrogram/spectrogram2.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Plotting an over-dense, short-duration `Spectrogram`
+
+The normal `~TimeSeries.spectrogram` method uses non-overlapping intervals
+to calculate discrete PSDs for each stride. This is fine for long-duration
+data, but give poor resolution when studying short-duration phenomena.
+
+The `~TimeSeries.spectrogram2` method allows for highly-overlapping FFT
+calculations to over-sample the frequency content of the input `TimeSeries`
+to produce a much more feature-rich output.
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+__currentmodule__ = 'gwpy.timeseries'
+
+# As with the other `~gwpy.spectrogram.Spectrogram` examples, we import the
+# `TimeSeries` class, and :meth:`~TimeSeries.fetch` the data, but in this
+# example we only need 5 seconds of datam,
+from gwpy.timeseries import TimeSeries
+gwdata = TimeSeries.fetch(
+    'L1:OAF-CAL_DARM_DQ', 'Feb 28 2015 06:02:05', 'Feb 28 2015 06:02:10')
+
+# Now we can call the `~TimeSeries.spectrogram2` method of `gwdata` to
+# calculate our over-dense `~gwpy.spectrogram.Spectrogram`
+specgram = gwdata.spectrogram2(fftlength=0.15, overlap=0.14) ** (1/2.)
+
+# To whiten the `specgram` we can use the :meth:`~Spectrogram.ratio` method
+# to divide by the overall median:
+medratio = specgram.ratio('median')
+
+# Finally, we make a plot:
+plot = medratio.plot(norm='log', vmin=0.5, vmax=10)
+plot.set_yscale('log')
+plot.set_ylim(40, 8192)
+plot.add_colorbar(label='Amplitude relative to median')
+plot.set_title('L1 $h(t)$ with noise interference')
+plot.show()

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -676,8 +676,10 @@ class TimeSeries(Series):
         from ..spectrum import scale_timeseries_units
         # get parameters
         sampling = units.Quantity(self.sample_rate, 'Hz').value
-        fftlength = units.Quantity(fftlength, 's').value
-        overlap = units.Quantity(overlap, 's').value
+        if isinstance(fftlength, units.Quantity):
+            fftlength = units.Quantity(fftlength, 's').value
+        if isinstance(overlap, units.Quantity):
+            overlap = units.Quantity(overlap, 's').value
         nfft = int(fftlength * sampling)  # number of points per FFT
         noverlap = int(overlap * sampling)  # number of points of overlap
         nstride = nfft - noverlap  # number of points between FFTs
@@ -704,7 +706,7 @@ class TimeSeries(Series):
                                            **kwargs)[1]
         # normalize for over-dense grid
         density = nfft//nstride
-        weights = signal.triang(density, 6)
+        weights = signal.triang(density)
         for i in xrange(nsteps):
             # get indices of overlapping columns
             x0 = max(0, i+1-density)

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -685,7 +685,7 @@ class TimeSeries(Series):
         nstride = nfft - noverlap  # number of points between FFTs
 
         # create output object
-        nsteps = int(self.size // nstride)  # number of columns
+        nsteps = int(self.size // nstride) - 1  # number of columns
         nfreqs = int(nfft // 2 + 1)  # number of rows
         unit = scale_timeseries_units(self.unit, scaling)
         tmp = numpy.zeros((nsteps, nfreqs), dtype=self.dtype)


### PR DESCRIPTION
This PR introduces a new over-dense spectrogram method for calculating and displaying short-duration spectrograms. Also included is a new example, with the following code:

```python
from gwpy.timeseries import TimeSeries
gwdata = TimeSeries.fetch('L1:OAF-CAL_DARM_DQ', 'Feb 28 2015 06:02:05', 'Feb 28 2015 06:02:10')
specgram = gwdata.spectrogram2(fftlength=0.15, overlap=0.14) ** (1/2.)
medratio = specgram.ratio('median')
plot = medratio.plot(norm='log', vmin=0.5, vmax=10)
plot.set_yscale('log')
plot.set_ylim(40, 8192)
plot.add_colorbar(label='Amplitude relative to median')
plot.set_title('L1 $h(t)$ with noise interference')
plot.show()
```

which produces the following output:

![spectrogram2](https://cloud.githubusercontent.com/assets/1618530/6566495/4fe189ba-c688-11e4-92e2-bec8189b7a7b.png)

There are minor problems with precision errors making their way up to determine the length of the spectrogram, but since this is mainly for visualisation purposes, I'm not too fussed.

This should fix #25.