### PR TITLE
Improvements to time-domain filtering

### DIFF
--- a/docs/ex2rst.py
+++ b/docs/ex2rst.py
@@ -64,6 +64,10 @@ for i,line in enumerate(lines):
     if line.startswith(('if __name__ == ', '# Show')):
         break
 
+    # hide lines
+    if line.endswith('# hide'):
+        continue
+
     # find block docs
     if line.startswith('"""'):
         indoc = not indoc

--- a/docs/timeseries/filtering.rst
+++ b/docs/timeseries/filtering.rst
@@ -24,9 +24,20 @@ The following methods of the `TimeSeries` provide functionality for band-passing
 General filtering
 =================
 
-While the above methods provide an easy way to remove unwanted frequency information, the :meth:`~TimeSeries.filter` method provides a way to apply a generic filter to any `TimeSeries` data:
+While the above methods provide an easy way to remove unwanted frequency information, the :meth:`~TimeSeries.zpk` and, more generally, :meth:`~TimeSeries.filter` methods provide a way to apply a general filters to any `TimeSeries` data:
 
 .. autosummary::
 
+   TimeSeries.zpk
    TimeSeries.filter
 
+========
+Examples
+========
+
+See the following examples for usage of the above functions:
+
+.. toctree::
+   :maxdepth: 1
+
+   ../examples/timeseries/filter

--- a/examples/timeseries/filter.py
+++ b/examples/timeseries/filter.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Filtering a `TimeSeries` with a ZPK filter
+
+Several data streams read from the LIGO detectors are whitened before being
+recorded to prevent numerical errors when using single-precision data
+storage.
+In this example we read such `channel <gwpy.detector.Channel>` and undo the
+whitening to show the physical content of these data.
+
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+__currentmodule__ = 'gwpy.timeseries'
+
+# First, we import the `TimeSeries` and `~TimeSeries.fetch` the data:
+from gwpy.timeseries import TimeSeries
+white = TimeSeries.fetch(
+    'L1:OAF-CAL_DARM_DQ', 'March 2 2015 12:00', 'March 2 2015 12:30')
+
+# Now, we can re-calibrate these data into displacement units by first applying
+# a `highpass <TimeSeries.highpass>` filter to remove the low-frequency noise,
+# and then applying our de-whitening filter in `ZPK <TimeSeries.zpk>` format 
+# with five zeros at 100 Hz and five poles at 1 Hz (giving an overall DC
+# gain of 10 :sup:`-10`:
+hp = white.highpass(4)
+displacement = hp.zpk([100]*5, [1]*5, 1e-10)
+
+# We can visualise the impact of the whitening by calculating the ASD
+# `~gwpy.spectrum.Spectrum` before and after the filter,
+
+whiteasd = white.asd(8, 4)
+dispasd = displacement.asd(8, 4)
+
+# and plotting:
+
+from gwpy.plotter import SpectrumPlot
+plot = SpectrumPlot(whiteasd, dispasd, sep=True, sharex=True, label=None)
+
+# Here we have passed the two `spectra <gwpy.spectrum.Spectrum>` in order,
+# then `sep=True` to display them on separate Axes, `sharex=True` to tie 
+# the `~matplotlib.axis.XAxis` of each of the `~gwpy.plotter.SpectrumAxes` 
+# together, and `label=None` to remove any unwanted legends.
+#
+# Finally, we prettify our plot with some limits, and some labels:
+plot.text(0.95, 0.05, 'Preliminary', fontsize=40, color='gray', ha='right', rotation=45, va='bottom', alpha=0.5)  # hide
+plot.axes[0].set_ylabel('ASD [whitened]')
+plot.axes[1].set_ylabel(r'ASD [m/\rtHz]')
+plot.axes[1].set_xlabel('Frequency [Hz]')
+plot.axes[1].set_ylim(1e-20, 1e-15)
+plot.axes[1].set_xlim(5, 4000)
+plot.show()

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -255,12 +255,50 @@ class Spectrogram(Array2D):
                         frequencies=(hasattr(self, '_frequencies') and
                                      self.frequencies or None))
 
+    def zpk(self, zeros, poles, gain):
+        """Filter this `Spectrogram` by applying a zero-pole-gain filter
+
+        Parameters
+        ----------
+        zeros : `array-like`
+            list of zero frequencies (in Hertz)
+        poles : `array-like`
+            list of pole frequencies (in Hertz)
+        gain : `float`
+            DC gain of filter
+
+        Returns
+        -------
+        specgram : `Spectrogram`
+            the frequency-domain filtered version of the input data
+
+        See Also
+        --------
+        Spectrogram.filter
+            for details on how a digital ZPK-format filter is applied
+
+        Examples
+        --------
+        To apply a zpk filter with file poles at 100 Hz, and five zeros at
+        1 Hz (giving an overall DC gain of 1e-10)::
+
+            >>> data2 = data.zpk([100]*5, [1]*5, 1e-10)
+        """
+        return self.filter(zeros, poles, gain)
+
     def filter(self, *filt, **kwargs):
         """Apply the given filter to this `Spectrogram`.
 
         Recognised filter arguments are converted into the standard
         ``(numerator, denominator)`` representation before being applied
         to this `Spectrogram`.
+
+        .. note::
+
+           Unlike the related
+           :meth:`TimeSeries.filter <gwpy.timeseries.TimeSeries.filter>`
+           method, here all frequency information (e.g. frequencies of
+           poles or zeros in a ZPK) is assumed to be in Hertz.
 
         Parameters
         ----------
@@ -279,6 +317,8 @@ class Spectrogram(Array2D):
 
         See also
         --------
+        Spectrum.zpk
+            for information on filtering in zero-pole-gain format
         scipy.signal.zpk2tf
             for details on converting ``(zeros, poles, gain)`` into
             transfer function format
@@ -287,13 +327,6 @@ class Spectrogram(Array2D):
             format
         scipy.signal.freqs
             for details on the filtering calculation
-
-        Examples
-        --------
-        To apply a zpk filter with a pole at 0 Hz, a zero at 100 Hz and
-        a gain of 25::
-
-            >>> data2 = data.filter([100], [0], 25)
 
         Raises
         ------

--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -122,12 +122,50 @@ class Spectrum(Series):
         from ..plotter import SpectrumPlot
         return SpectrumPlot(self, **kwargs)
 
+    def zpk(self, zeros, poles, gain):
+        """Filter this `Spectrum` by applying a zero-pole-gain filter
+
+        Parameters
+        ----------
+        zeros : `array-like`
+            list of zero frequencies (in Hertz)
+        poles : `array-like`
+            list of pole frequencies (in Hertz)
+        gain : `float`
+            DC gain of filter
+
+        Returns
+        -------
+        spectrum : `Spectrum`
+            the frequency-domain filtered version of the input data
+
+        See Also
+        --------
+        Spectrum.filter
+            for details on how a digital ZPK-format filter is applied
+
+        Examples
+        --------
+        To apply a zpk filter with file poles at 100 Hz, and five zeros at
+        1 Hz (giving an overall DC gain of 1e-10)::
+
+            >>> data2 = data.zpk([100]*5, [1]*5, 1e-10)
+        """
+        return self.filter(zeros, poles, gain)
+
     def filter(self, *filt, **kwargs):
         """Apply the given filter to this `Spectrum`.
 
         Recognised filter arguments are converted into the standard
         ``(numerator, denominator)`` representation before being applied
         to this `Spectrum`.
+
+        .. note::
+
+           Unlike the related
+           :meth:`TimeSeries.filter <gwpy.timeseries.TimeSeries.filter>`
+           method, here all frequency information (e.g. frequencies of
+           poles or zeros in a ZPK) is assumed to be in Hertz.
 
         Parameters
         ----------
@@ -146,6 +184,8 @@ class Spectrum(Series):
 
         See also
         --------
+        Spectrum.zpk
+            for information on filtering in zero-pole-gain format
         scipy.signal.zpk2tf
             for details on converting ``(zeros, poles, gain)`` into
             transfer function format
@@ -154,13 +194,6 @@ class Spectrum(Series):
             format
         scipy.signal.freqs
             for details on the filtering calculation
-
-        Examples
-        --------
-        To apply a zpk filter with a pole at 0 Hz, a zero at 100 Hz and
-        a gain of 25::
-
-            >>> data2 = data.filter([100], [0], 25)
 
         Raises
         ------

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -915,7 +915,7 @@ class TimeSeries(Series):
             the maximum loss in the passband (dB).
         gstop : `float`
             the minimum attenuation in the stopband (dB).
-        stop: `float`
+        stop : `float`
             stop-band edge frequency, defaults to `frequency/2`
 
         Returns
@@ -925,8 +925,8 @@ class TimeSeries(Series):
 
         See Also
         --------
-        signal.buttord
-        signal.butter
+        scipy.signal.buttord
+        scipy.signal.butter
             for details on how the filter is designed
         TimeSeries.filter
             for details on how the filter is applied
@@ -973,8 +973,8 @@ class TimeSeries(Series):
 
         See Also
         --------
-        signal.buttord
-        signal.butter
+        scipy.signal.buttord
+        scipy.signal.butter
             for details on how the filter is designed
         TimeSeries.filter
             for details on how the filter is applied
@@ -1021,7 +1021,8 @@ class TimeSeries(Series):
 
         See Also
         --------
-        signal.buttord, signal.butter
+        scipy.signal.buttord
+        scipy.signal.butter
             for details on how the filter is designed
         TimeSeries.filter
             for details on how the filter is applied
@@ -1151,7 +1152,8 @@ class TimeSeries(Series):
     def filter(self, *filt):
         """Apply the given filter to this `TimeSeries`.
 
-        Recognised filter arguments are converted into the standard
+        All recognised filter arguments are converted either into cascading
+        second-order sections (if scipy >= 0.16 is installed), or into the
         ``(numerator, denominator)`` representation before being applied
         to this `TimeSeries`.
 
@@ -1173,8 +1175,8 @@ class TimeSeries(Series):
             one of:
 
             - :class:`scipy.signal.lti`
-            - `M`x`N` `numpy.ndarray` of second-order-sections
-              (`scipy>=0.16.0` only)
+            - `MxN` `numpy.ndarray` of second-order-sections
+              (`scipy` >= 0.16 only)
             - ``(numerator, denominator)`` polynomials
             - ``(zeros, poles, gain)``
             - ``(A, B, C, D)`` 'state-space' representation


### PR DESCRIPTION
The current `TimeSeries.filter` time-domain filtering requires the user to give digital, Z-domain filter components. This PR implements a `TimeSeries.zpk` method which translates real zpk components in Hertz into S-domain then Z-domain and passes to `TimeSeries.filter`.

I have also included the relevant changes to documentation, and a new example for time-domain filtering.