### PR TITLE
Fix for tests failing when CIS fails to respond

### DIFF
--- a/gwpy/tests/detector.py
+++ b/gwpy/tests/detector.py
@@ -20,6 +20,7 @@
 """
 
 import sys
+from urllib2 import URLError
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -65,6 +66,12 @@ class ChannelTests(unittest.TestCase):
     def test_query(self):
         try:
             new = Channel.query(self.channel)
+        except URLError as e:
+            msg = str(e)
+            if ('timed out' in msg.lower() or
+                'connection reset' in msg.lower()):
+                self.skipTest(msg)
+            raise
         except Exception as e:
             try:
                 import kerberos


### PR DESCRIPTION
This PR introduces a catch to the `Channel` `test_query` test, which would fail whenever the CIS host (`cis.ligo.org`) is unavailable.