### PR TITLE
cli/spectrogram.py: add option for high time res spectrograms

### DIFF
--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -96,8 +96,8 @@ class Spectrogram(CliProduct):
                                                       overlap=ovlp_sec)
         else:
             specgram = self.timeseries[0].spectrogram2(fftlength=secpfft,
-                                                      overlap=ovlp_sec)
-        specgram = specgram ** (1/2.) # ASD
+                                                       overlap=ovlp_sec)
+        specgram = specgram ** (1/2.)   # ASD
 
         norm = False
         if arg_list.norm:

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -87,8 +87,17 @@ class Spectrogram(CliProduct):
         stride = max(2*secpfft, stride)
         fs = self.timeseries[0].sample_rate.value
 
-        specgram = self.timeseries[0].spectrogram(stride, fftlength=secpfft,
-                                                  overlap=ovlp_sec) ** (1/2.)
+        # based on the number of FFT calculation choose between
+        # high time resolution and high SNR
+        snr_nfft = self.dur / (secpfft * stride)
+        if (snr_nfft > 512):
+            specgram = self.timeseries[0].spectrogram(stride,
+                                                      fftlength=secpfft,
+                                                      overlap=ovlp_sec)
+        else:
+            specgram = self.timeseries[0].spectrogram2(fftlength=secpfft,
+                                                      overlap=ovlp_sec)
+        specgram = specgram ** (1/2.) # ASD
 
         norm = False
         if arg_list.norm:

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -101,7 +101,7 @@ class Spectrogram(CliProduct):
 
         norm = False
         if arg_list.norm:
-            specgram = specgram.ratio('mean')
+            specgram = specgram.ratio('median')
             norm = True
 
         # set default frequency limits
@@ -126,17 +126,15 @@ class Spectrogram(CliProduct):
 
         if arg_list.imax:
             up = float(arg_list.imax)
-        elif norm:
-            up = 4
         else:
             up = 100
-        if norm or arg_list.nopct:
+        if arg_list.nopct:
             imax = up
         else:
             imax = percentile(specgram, up)
 
         if norm:
-            self.plot = specgram.plot(vmin=imin, vmax=imax)
+            self.plot = specgram.plot(norm='log', vmin=imin, vmax=imax)
             self.scaleText = 'Normalized to mean'
         elif arg_list.lincolors:
             self.plot = specgram.plot(vmin=imin, vmax=imax)


### PR DESCRIPTION
This uses median for normalization and chooses between spectrogram and spectrogram2 based on the number of FFTs calculated