### PR TITLE
Set default colours for SegmentAxes.plot_dqflag

### DIFF
--- a/gwpy/plotter/segments.py
+++ b/gwpy/plotter/segments.py
@@ -176,7 +176,7 @@ class SegmentAxes(TimeSeriesAxes):
         return out
 
     @auto_refresh
-    def plot_dqflag(self, flag, y=None, known='x', facecolor='green',
+    def plot_dqflag(self, flag, y=None, known='red', facecolor=(0.2, 0.8, 0.2),
                     **kwargs):
         """Plot a :class:`~gwpy.segments.DataQualityFlag`
         onto these axes

--- a/gwpy/plotter/segments.py
+++ b/gwpy/plotter/segments.py
@@ -168,7 +168,7 @@ class SegmentAxes(TimeSeriesAxes):
         out = []
         for lab, flag in flags.iteritems():
             if label.lower() == 'name':
-                lab = ts.name
+                lab = flag.name
             elif label.lower() != 'key':
                 lab = label
             out.append(self.plot(flag, label=rUNDERSCORE.sub(r'\_', lab),


### PR DESCRIPTION
This PR changes the default colours for the `SegmentAxes.plot_dqflag` method to `active` = 'green', and `known' = 'red'.

This fixes #53.