### PR TITLE
First steps in PyCBC integration

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -51,12 +51,13 @@ clean:
 	-rm -rf examples/*/
 	-rm -rf $(BUILDDIR)
 	-rm -rf _generated
-	-rm -rf $(LALSUITE_DOXTAG)
+	-rm -f $(LALSUITE_DOXTAG)
+	-rm -f pycbc.inv
 
 apidoc:
 	sphinx-apidoc -o _generated ../gwpy
 
-html: $(CLIEXAMPLES) examples lalsuite_dox.tag
+html: $(CLIEXAMPLES) examples lalsuite_dox.tag pycbc.inv
 	@cp -r $(BUILDDIR)/cli_examples $(BUILDDIR)/html
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
@@ -265,3 +266,6 @@ $(CLIEXAMPLEDIR)/cli-spg-01.png: $(CLIEXAMPLEDIR)
 
 $(LALSUITE_DOXTAG):
 	wget --no-check-certificate https://www.lsc-group.phys.uwm.edu/daswg/projects/lal/nightly/docs/html/lalsuite_dox.tag -O $@ --quiet
+
+pycbc.inv:
+	gsiscp ldas-pcdev2.ligo.caltech.edu:~cbc/public_html/docs/pycbc/objects.inv pycbc.inv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,6 +266,9 @@ intersphinx_mapping = {
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('http://matplotlib.sourceforge.net/', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
+    'gwpy': ('http://gwpy.github.io/docs/stable/', None),
+    'pycbc': ('https://ldas-jobs.ligo.caltech.edu/~cbc/docs/pycbc/',
+              'pycbc.inv'),
 }
 
 

--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -277,3 +277,40 @@ class Spectrum(Series):
                        self.f0.value, self.df.value, unit, self.size)
         lalfs.data.data = self.data
         return lalfs
+
+    @classmethod
+    def from_pycbc(cls, fs):
+        """Convert a `pycbc.types.frequencyseries.FrequencySeries` into
+        a `Spectrum`
+
+        Parameters
+        ----------
+        fs : `pycbc.types.frequencyseries.FrequencySeries`
+            the input PyCBC `~pycbc.types.frequencyseries.FrequencySeries`
+            array
+
+        Returns
+        -------
+        spectrum : `Spectrum`
+            a GWpy version of the input frequency series
+        """
+        """
+        return cls(fs.data, f0=0, df=fs.delta_f, epoch=fs.epoch)
+
+    @with_import('pycbc.types')
+    def to_pycbc(self, copy=True):
+        """Convert this `Spectrum` into a
+        `pycbc.types.frequencyseries.FrequencySeries`
+
+        Parameters
+        ----------
+        copy : `bool`, optional, default: `True`
+            if `True`, copy these data to a new array
+
+        Returns
+        -------
+        frequencyseries : `pycbc.types.frequencyseries.FrequencySeries`
+            a PyCBC representation of this `Spectrum`
+        """
+        return types.FrequencySeries(self.data, delta_f=self.df.to('Hz').value,
+                                     epoch=self.epoch.gps, copy=copy)

--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -294,7 +294,6 @@ class Spectrum(Series):
         spectrum : `Spectrum`
             a GWpy version of the input frequency series
         """
-        """
         return cls(fs.data, f0=0, df=fs.delta_f, epoch=fs.epoch)
 
     @with_import('pycbc.types')

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1583,6 +1583,41 @@ class TimeSeries(Series):
         lalts.data.data = self.data
         return lalts
 
+    @classmethod
+    def from_pycbc(cls, ts):
+        """Convert a `pycbc.types.timeseries.TimeSeries` into a `TimeSeries`
+
+        Parameters
+        ----------
+        ts : `pycbc.types.timeseries.TimeSeries`
+            the input PyCBC `~pycbc.types.timeseries.TimeSeries` array
+
+        Returns
+        -------
+        timeseries : `TimeSeries`
+            a GWpy version of the input timeseries
+        """
+        return cls(ts.data, epoch=ts.epoch, sample_rate=1/ts.delta_t)
+
+    @with_import('pycbc.types')
+    def to_pycbc(self, copy=True):
+        """Convert this `TimeSeries` into a PyCBC
+        `~pycbc.types.timeseries.TimeSeries`
+
+        Parameters
+        ----------
+        copy : `bool`, optional, default: `True`
+            if `True`, copy these data to a new array
+
+        Returns
+        -------
+        timeseries : `~pycbc.types.timeseries.TimeSeries`
+            a PyCBC representation of this `TimeSeries`
+        """
+        return types.TimeSeries(self.data,
+                                delta_t=self.dx.to('s').value,
+                                epoch=self.epoch.gps, copy=copy)
+
     # -------------------------------------------
     # TimeSeries operations
 


### PR DESCRIPTION
This PR introduces two new methods for each of the `TimeSeries` and `Spectrum` objects:

- `to_pycbc` convert to the relevant PyCBC objects
- `from_pycbc` convert from the relevant PyCBC objects

This includes the relevant links to the PyCBC sphinx documentation.