### PR TITLE
Rebuild of Array and sub-classes

### DIFF
--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -82,7 +82,7 @@ class Coherence(CliProduct):
         for idx in range(1, len(self.timeseries)):
             legend_text = self.timeseries[idx].channel.name
             if legend_text != ref_name and self.timeseries[idx].min() != \
-                    self.timeseries[idx].data.max():
+                    self.timeseries[idx].value.max():
                 next_ts = idx
                 break
         if next_ts == 0:
@@ -141,8 +141,8 @@ class Coherence(CliProduct):
         # if the specified frequency limits adjust our ymin and ymax values
         # at this point self.ymin and self.ymax represent the full spectra
         import numpy
-        mymin = cohs[0].data.min()
-        mymax = cohs[0].data.max()
+        mymin = cohs[0].value.min()
+        mymax = cohs[0].value.max()
         myfmin = 1/self.secpfft * cohs[0].frequencies.unit
         myfmax = maxfs/2
         if arg_list.fmin:
@@ -159,8 +159,8 @@ class Coherence(CliProduct):
                     stop = t[0][t[0].size-1]
                 else:
                     stop = cohs[idx].frequencies.size - 1
-                mymin = min(mymin, numpy.min(cohs[idx].data[strt:stop]))
-                mymax = max(mymax, numpy.max(cohs[idx].data[strt:stop]))
+                mymin = min(mymin, numpy.min(cohs[idx].value[strt:stop]))
+                mymax = max(mymax, numpy.max(cohs[idx].value[strt:stop]))
 
         self.ymin = mymin
         self.ymax = mymax

--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -100,7 +100,7 @@ class Coherence(CliProduct):
                     print 'Channel %s at %d has min=max,it cannot be used ' \
                           'as a reference channel' \
                           % self.timeseries[ref_idx].channel.name, \
-                        self.timeseries[ref_idx].times.epoch.gps
+                        self.timeseries[ref_idx].epoch.gps
                 else:
                     for idxp in range(1, len(time_group)):
                         next_ts = time_group[idxp]
@@ -110,7 +110,7 @@ class Coherence(CliProduct):
                             print 'Channel %s at %d has min=max, coherence ' \
                                   'with this channel will not be calculated' \
                                   % self.timeseries[next_ts].channel.name, \
-                                self.timeseries[next_ts].times.epoch.gps
+                                self.timeseries[next_ts].epoch.gps
                         else:
                             maxfs = max(maxfs,
                                         self.timeseries[next_ts].sample_rate)
@@ -123,7 +123,7 @@ class Coherence(CliProduct):
 
                             legend_text = self.timeseries[next_ts].channel.name
                             if len(self.start_list) > 1:
-                                legend_text += ", %s" % snd_ts.times.epoch.gps
+                                legend_text += ", %s" % snd_ts.epoch.gps
                             coh.name = legend_text
 
                             # coh2 = 1 / (1-coh) : how to implement alt scaler

--- a/gwpy/cli/coherencegram.py
+++ b/gwpy/cli/coherencegram.py
@@ -109,12 +109,12 @@ class Coherencegram(CliProduct):
             norm = True
 
         # set default frequency limits
-        self.fmax = coh.span_y.end.value
+        self.fmax = coh.band[1]
         self.fmin = 1 / secpfft
 
         # default time axis
-        self.xmin = self.timeseries[0].times.data.min()
-        self.xmax = self.timeseries[0].times.data.max()
+        self.xmin = self.timeseries[0].times.value.min()
+        self.xmax = self.timeseries[0].times.value.max()
 
         # set intensity (color) limits
         imin = coh.min().value

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -109,12 +109,12 @@ class Spectrogram(CliProduct):
         self.fmin = 1 / secpfft
 
         # default time axis
-        self.xmin = self.timeseries[0].times.data.min()
-        self.xmax = self.timeseries[0].times.data.max()
+        self.xmin = self.timeseries[0].times.value.min()
+        self.xmax = self.timeseries[0].times.value.max()
 
         # set intensity (color) limits
-        imin = specgram.data.min()
-        imax = specgram.data.max()
+        imin = specgram.value.min()
+        imax = specgram.value.max()
         if arg_list.imin:
             lo = float(arg_list.imin)
         else:

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -89,12 +89,12 @@ class Spectrum(CliProduct):
         fs = self.timeseries[0].sample_rate.value
         self.fmin = 1/self.secpfft
         self.fmax = fs/2
-        self.ymin = spectrum.data.min()
-        self.ymax = spectrum.data.max()
+        self.ymin = spectrum.value.min()
+        self.ymax = spectrum.value.max()
 
         label = self.timeseries[0].channel.name
         if len(self.start_list) > 1:
-            label += ", %s" % self.timeseries[0].times.epoch.gps
+            label += ", %s" % self.timeseries[0].epoch.gps
         spectrum.name = label
         self.plot = spectrum.plot()
 
@@ -105,12 +105,12 @@ class Spectrum(CliProduct):
                 spectra.append(specb)
                 fsb = self.timeseries[idx].sample_rate.value
                 self.fmax = max(self.fmax, fsb/2)
-                self.ymin = min(self.ymin, specb.data.min())
-                self.ymax = max(self.ymax, specb.data.max())
+                self.ymin = min(self.ymin, specb.value.min())
+                self.ymax = max(self.ymax, specb.value.max())
 
                 label = self.timeseries[idx].channel.name
                 if len(self.start_list) > 1:
-                    label += ", %s" % self.timeseries[idx].times.epoch.gps
+                    label += ", %s" % self.timeseries[idx].epoch.gps
                 specb.name = label
                 self.plot.add_spectrum(specb)
         self.log(2, ('Frequency range: [%f, %f]' % (self.fmin, self.fmax)))
@@ -136,8 +136,8 @@ class Spectrum(CliProduct):
                         stop = t[0][0]
                     else:
                         stop = spectra[idx].frequencies.size - 1
-                    mymin = min(mymin, numpy.min(spectra[idx].data[strt:stop]))
-                    mymax = max(mymax, numpy.max(spectra[idx].data[strt:stop]))
+                    mymin = min(mymin, numpy.min(spectra[idx].value[strt:stop]))
+                    mymax = max(mymax, numpy.max(spectra[idx].value[strt:stop]))
 
             self.ymin = mymin
             self.ymax = mymax

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -123,15 +123,15 @@ class Spectrum(CliProduct):
             myfmin = self.fmin
             myfmax = self.fmax
             if arg_list.fmin:
-                myfmin = float(arg_list.fmin) * spectra[0].frequencies.unit
+                myfmin = float(arg_list.fmin)
             if arg_list.fmax:
-                myfmax = float(arg_list.fmax) * spectra[0].frequencies.unit
+                myfmax = float(arg_list.fmax)
 
             for idx in range(0, len(spectra)):
-                t = numpy.where(spectra[idx].frequencies >= myfmin)
+                t = numpy.where(spectra[idx].frequencies.value >= myfmin)
                 if t[0].size:
                     strt = t[0][0]
-                    t = numpy.where(spectra[idx].frequencies >= myfmax)
+                    t = numpy.where(spectra[idx].frequencies.value >= myfmax)
                     if t[0].size:
                         stop = t[0][0]
                     else:

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -55,20 +55,20 @@ class TimeSeries(CliProduct):
         from numpy import min as npmin
         from numpy import max as npmax
 
-        if self.timeseries[0].data.size <= self.max_size:
+        if self.timeseries[0].size <= self.max_size:
             self.plot = self.timeseries[0].plot()
         else:
             self.plot = self.timeseries[0].plot(linestyle='None', marker='.')
         self.ymin = self.timeseries[0].min().value
         self.ymax = self.timeseries[0].max().value
-        self.xmin = self.timeseries[0].times.data.min()
-        self.xmax = self.timeseries[0].times.data.max()
+        self.xmin = self.timeseries[0].times.value.min()
+        self.xmax = self.timeseries[0].times.value.max()
 
         if len(self.timeseries) > 1:
             for idx in range(1, len(self.timeseries)):
                 chname = self.timeseries[idx].channel.name
                 lbl = label_to_latex(chname)
-                if self.timeseries[idx].data.size <= self.max_size:
+                if self.timeseries[idx].size <= self.max_size:
                     self.plot.add_timeseries(self.timeseries[idx], label=lbl)
                 else:
                     self.plot.add_timeseries(self.timeseries[idx], label=lbl,
@@ -76,9 +76,9 @@ class TimeSeries(CliProduct):
                 self.ymin = min(self.ymin, self.timeseries[idx].min().value)
                 self.ymax = max(self.ymax, self.timeseries[idx].max().value)
                 self.xmin = min(self.xmin,
-                                self.timeseries[idx].times.data.min())
+                                self.timeseries[idx].times.value.min())
                 self.xmax = max(self.xmax,
-                                self.timeseries[idx].times.data.max())
+                                self.timeseries[idx].times.value.max())
         # if they chose to set the range of the x-axis find the range of y
         strt = self.xmin
         stop = self.xmax
@@ -105,8 +105,8 @@ class TimeSeries(CliProduct):
 
                 if e >= self.timeseries[idx].size:
                     e = self.timeseries[idx].size - 1
-                new_ymin = min(new_ymin, npmin(self.timeseries[idx].data[b:e]))
-                new_ymax = max(new_ymax, npmax(self.timeseries[idx].data[b:e]))
+                new_ymin = min(new_ymin, npmin(self.timeseries[idx].value[b:e]))
+                new_ymax = max(new_ymax, npmax(self.timeseries[idx].value[b:e]))
             self.ymin = new_ymin
             self.ymax = new_ymax
         if self.yscale_factor > 1:

--- a/gwpy/data/array.py
+++ b/gwpy/data/array.py
@@ -165,6 +165,17 @@ class Array(Quantity):
             prefixstr, arrstr, indent, metadata)
 
     # -------------------------------------------
+    # Pickle helpers
+
+    def dumps(self, order='C'):
+        return super(Quantity, self).dumps()
+    dumps.__doc__ = numpy.ndarray.dumps.__doc__
+
+    def tostring(self, order='C'):
+        return super(Quantity, self).tostring()
+    tostring.__doc__ = numpy.ndarray.tostring.__doc__
+
+    # -------------------------------------------
     # array methods
 
     def median(self, axis=None, out=None, overwrite_input=False):

--- a/gwpy/data/array.py
+++ b/gwpy/data/array.py
@@ -94,6 +94,12 @@ class Array(Quantity):
     # -------------------------------------------
     # array manipulations
 
+    def _wrap_function(self, function, *args, **kwargs):
+        out = super(Array, self)._wrap_function(function, *args, **kwargs)
+        if out.ndim == 0:
+            return Quantity(out.value, out.unit)
+        return out
+
     def __quantity_subclass__(self, unit):
         return type(self), True
     __quantity_subclass__.__doc__ = Quantity.__quantity_subclass__.__doc__
@@ -178,9 +184,11 @@ class Array(Quantity):
     # -------------------------------------------
     # array methods
 
-    def median(self, axis=None, out=None, overwrite_input=False):
-        return numpy.median(self, axis=axis, out=out,
-                            overwrite_input=overwrite_input)
+    def median(self, axis=None, out=None, overwrite_input=False,
+               keepdims=False):
+        return self._wrap_function(numpy.median, axis, out=out,
+                                   overwrite_input=overwrite_input,
+                                   keepdims=keepdims)
     median.__doc__ = numpy.median.__doc__
 
     @property

--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -239,7 +239,7 @@ class Array2D(Series):
     def __array_wrap__(self, obj, context=None):
         """Wrap an array as an `Array2D` with metadata
         """
-        result = super(Array2D, self).__array_wrap__(obj, context=None)
+        result = super(Array2D, self).__array_wrap__(obj, context=context)
         try:
             result._xindex = self._xindex
         except AttributeError:

--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -142,7 +142,7 @@ class Array2D(Series):
             return self._yindex
         except AttributeError:
             self._yindex = self.y0 + (
-                numpy.arange(self.shape[1], dtype=self.dtype) * self.dy)
+                numpy.arange(self.shape[1]) * self.dy)
             return self._yindex
 
     @yindex.setter

--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -20,8 +20,6 @@
 """
 
 import numpy
-import inspect
-from scipy import signal
 
 from astropy.units import (Unit, Quantity)
 
@@ -30,311 +28,164 @@ __version__ = version.version
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 from .array import Array
-from ..segments import Segment
 
 
 class Series(Array):
-    """A one-dimensional array with metadata
-    """
-    _metadata_slots = Array._metadata_slots + ['x0', 'dx', 'xunit', 'logx']
-    xunit = Unit('')
+    _metadata_slots = Array._metadata_slots + ['x0', 'dx']
+    _default_xunit = Unit('')
+    _ndim = 1
 
-    def __new__(cls, data, dtype=None, copy=False, subok=True, **metadata):
-        """Define a new `Series`
-        """
-        if isinstance(data, (list, tuple)):
-            data = numpy.asarray(data)
-        if not data.ndim == 1:
-            raise ValueError("Cannot create a %s with more than one "
-                             "dimension" % cls.__name__)
-        return super(Series, cls).__new__(cls, data, dtype=dtype, copy=copy,
-                                          subok=subok, **metadata)
-
-    # simple slice, need to copy x0 away from self
-    def __getslice__(self, i, j):
-        new = super(Series, self).__getslice__(i, j).copy()
-        new.metadata = self.metadata.copy()
-        if 'x0' in new.metadata and 'dx' in self.metadata:
-            new.x0 = self.x0 + (i * self.dx)
+    def __new__(cls, value, unit=None, xindex=None, x0=0, dx=1, **kwargs):
+        shape = numpy.shape(value)
+        if len(shape) != cls._ndim:
+            raise ValueError("Cannot generate Series with %d-dimensional data"
+                             % len(shape))
+        new = super(Series, cls).__new__(cls, value, unit=unit, **kwargs)
+        if isinstance(x0, Quantity):
+            xunit = x0.unit
+        elif isinstance(dx, Quantity):
+            xunit = dx.unit
+        else:
+            xunit = cls._default_xunit
+        new.x0 = Quantity(x0, xunit)
+        new.dx = Quantity(dx, xunit)
+        new.xindex = xindex
         return new
 
-    # rebuild getitem to handle complex slicing
-    def __getitem__(self, item):
-        if isinstance(item, (float, int)):
-            return Quantity(super(Series, self).__getitem__(item), self.unit)
-        elif isinstance(item, slice):
-            item = slice(item.start is not None and int(item.start) or None,
-                         item.stop is not None and int(item.stop) or None,
-                         item.step is not None and int(item.step) or None)
-            new = super(Series, self).__getitem__(item)
-            if item.start:
-                new.x0 = float(self.x0.value)
-                new.x0 += item.start * new.dx
-            if item.step:
-                new.dx = float(self.dx.value)
-                new.dx *= item.step
-            return new
-        else:
-            new = super(Series, self).__getitem__(item)
-            if isinstance(item, (list, tuple, numpy.ndarray)):
-                new.index = self.index[item]
-            else:
-                new.index = self.index[item.argmax()]
-            return new
-
-    # -------------------------------------------
-    # Series properties
-
     @property
-    def x0(self):
-        """X-axis value of first sample
-        """
-        return self.metadata['x0']
-
-    @x0.setter
-    def x0(self, value):
-        if isinstance(value, Quantity):
-            self.metadata['x0'] = value.to(self.xunit)
-        else:
-            self.metadata['x0'] = Quantity(value, self.xunit)
-
-    @x0.deleter
-    def x0(self):
-        del self.metadata['x0']
-
-    @property
-    def dx(self):
-        """Distance between samples on the x-axis
-        """
-        return self.metadata['dx']
-
-    @dx.setter
-    def dx(self, value):
-        if isinstance(value, Quantity):
-            self.metadata['dx'] = value.to(self.xunit)
-        else:
-            self.metadata['dx'] = Quantity(value, self.xunit)
-
-    @dx.deleter
-    def dx(self):
-        del self.metadata['dx']
-
-    @property
-    def span(self):
-        """Extent of this `Series`
-        """
-        return Segment(self.x0.value,
-                       self.x0.value + self.shape[0] * self.dx.value)
-
-    @property
-    def index(self):
+    def xindex(self):
         """Positions of the data on the x-axis
 
         :type: `Series`
         """
         try:
-            return self._index
+            return self._xindex
         except AttributeError:
-            if not self.size:
-                self.index = numpy.ndarray(0)
-            elif self.logx:
-                logdx = (numpy.log10(self.x0.value + self.dx.value) -
-                         numpy.log10(self.x0.value))
-                logx1 = numpy.log10(self.x0.value) + self.shape[-1] * logdx
-                self.index = numpy.logspace(numpy.log10(self.x0.value), logx1,
-                                            num=self.shape[-1])
-            else:
-                self.index = (numpy.arange(self.shape[-1]) * self.dx.value +
-                              self.x0.value)
-            return self.index
+            self._xindex = self.x0 + (
+                numpy.arange(self.shape[0], dtype=self.dtype) * self.dx)
+            return self._xindex
 
-    @index.setter
-    def index(self, samples):
-        if not isinstance(samples, Array):
-            try:
-                self.epoch
-            except AttributeError:
-                self.x0 = samples[0]
-            fname = inspect.stack()[0][3]
-            if self.name:
-                name = '%s %s' % (self.name, fname)
-            else:
-                name = None
-            samples = Array(samples, unit=self.xunit, name=name,
-                            epoch=self.epoch, channel=self.channel, copy=True)
-        self._index = samples
-        try:
-            self.x0 = self.index[0]
-        except IndexError:
-            pass
-        try:
-            self.dx = self.index[1] - self.index[0]
-        except IndexError:
-            pass
+    @xindex.setter
+    def xindex(self, index):
+        if isinstance(index, Quantity):
+            self._xindex = index
+        elif index is None:
+            del self.xindex
+            return
+        else:
+            index = Quantity(index, unit=self._default_xunit)
+            self._xindex = index
+        self.x0 = index[0]
+        if index.size:
+            self.dx = index[1] - index[0]
+        else:
+            self.dx = None
 
-    @index.deleter
-    def index(self):
-        del self._index
+    @xindex.deleter
+    def xindex(self):
+        try:
+            del self._xindex
+        except AttributeError:
+            pass
 
     @property
-    def logx(self):
-        """Boolean telling whether this `Series` has a logarithmic
-        x-axis scale
-        """
+    def x0(self):
+        return self._x0
+
+    @x0.setter
+    def x0(self, value):
+        if not isinstance(value, Quantity) and value is not None:
+            value = Quantity(value, self._default_xunit)
         try:
-            return self.metadata['logx']
-        except KeyError:
-            self.logx = False
-            return self.logx
-
-    @logx.setter
-    def logx(self, val):
-        if (val and 'logx' in self.metadata and not self.metadata['logx'] and
-                'index' in self.metadata):
-            del self.index
-        self.metadata['logx'] = bool(val)
-
-    # -------------------------------------------
-    # Series methods
-
-    def resample(self, rate, window=None, dtype=None):
-        """Resample this Series to a new rate
-
-        Parameters
-        ----------
-        rate : `float`
-            rate to which to resample this `Series`
-        window : array_like, callable, string, float, or tuple, optional
-            specifies the window applied to the signal in the Fourier
-            domain.
-        dtype : :class:`numpy.dtype`, default: `None`
-            specific data type for output, defaults to input dtype
-
-        Returns
-        -------
-        Series
-            a new Series with the resampling applied, and the same
-            metadata
-        """
-        if isinstance(rate, Quantity):
-            rate = rate.value
-        N = int(self.shape[0] * self.dx.value * rate)
-        data = signal.resample(self.data, N, window=window)
-        new = self.__class__(data, dtype=dtype or self.dtype)
-        new.metadata = self.metadata.copy()
-        new.dx = 1 / float(rate)
-        return new
-
-    def decimate(self, q, n=None, ftype='iir', axis=-1):
-        """Downsample the signal by using a filter.
-
-        By default, an order 8 Chebyshev type I filter is used.
-        A 30 point FIR filter with hamming window is used if
-        `ftype` is 'fir'.
-
-        Parameters
-        ----------
-        q : `int`
-            the downsampling factor.
-        n : `int`, optional
-            the order of the filter (1 less than the length for 'fir').
-        ftype : `str`: {'iir', 'fir'}, optional
-            the type of the lowpass filter.
-        axis : `int`, optional
-            The axis along which to decimate.
-
-        Returns
-        -------
-        y : ndarray
-        The down-sampled signal.
-
-        See also
-        --------
-        :meth:`scipy.resample`
-        """
-        if not isinstance(q, int):
-            raise TypeError("q must be an integer")
-        if n is None:
-            if ftype == 'fir':
-                n = 30
-            else:
-                n = 8
-        if ftype == 'fir':
-            b = signal.firwin(n + 1, 1. / q, window='hamming')
-            a = 1.
-        else:
-            b, a = signal.cheby1(n, 0.05, 0.8 / q)
-        y = signal.lfilter(b, a, self.data, axis=axis)
-        out = self.__class__(y, **self.metadata)
-        sl = [slice(None)] * y.ndim
-        sl[axis] = slice(None, None, q)
-        return out[sl]
-
-    def find_peaks(self, widths, min_snr=5, min_length=1, **kwargs):
-        """Find peaks in this `Series`
-
-        Parameters
-        ----------
-        widths : sequence
-            1-D array of widths of interest (in samples)
-        **kwargs
-            other keyword arguments used by the underlying method
-            :meth:`~scipy.signal.find_peaks_cwt`
-
-        Returns
-        -------
-        peakseries : `Series`
-            new `Series` containing only the recovered peaks
-
-        See also
-        --------
-        scipy.signal.find_peaks_cwt
-            for details on the peak-finding algorithm
-        """
-        peaks = signal.find_peaks_cwt(self.data, widths, min_snr=min_snr,
-                                      min_length=min_length, **kwargs)
-        new = self[peaks]
-        new.index = self.index[peaks]
-        return new
-
-    # -------------------------------------------
-    # numpy.ndarray method modifiers
-    # all of these try to return Quantities rather than simple numbers
-
-    def max(self, *args, **kwargs):
-        return Quantity(super(Series, self).max(*args, **kwargs),
-                        unit=self.unit)
-    max.__doc__ = Array.max.__doc__
-
-    def min(self, *args, **kwargs):
-        return Quantity(super(Series, self).min(*args, **kwargs),
-                        unit=self.unit)
-    min.__doc__ = Array.min.__doc__
-
-    def mean(self, *args, **kwargs):
-        return Quantity(super(Series, self).mean(*args, **kwargs),
-                        unit=self.unit)
-    mean.__doc__ = Array.mean.__doc__
-
-    def median(self, *args, **kwargs):
-        return Quantity(super(Series, self).median(*args, **kwargs),
-                        unit=self.unit)
-    median.__doc__ = Array.median.__doc__
-
-    def __array_wrap__(self, obj, context=None):
-        """Wrap an array as a Array with metadata
-        """
-        result = super(Series, self).__array_wrap__(obj, context=context)
-        try:
-            result._index = self._index
+            x0 = self.x0
         except AttributeError:
-            pass
-        return result
+            del self.xindex
+        else:
+            if value is None or self.x0 is None or value != x0:
+                del self.xindex
+        self._x0 = value
+
+    @x0.deleter
+    def x0(self):
+        self._x0 = None
+
+    @property
+    def dx(self):
+        return self._dx
+
+    @dx.setter
+    def dx(self, value):
+        if not isinstance(value, Quantity) and value is not None:
+            value = Quantity(value).to(self.xunit)
+        try:
+            dx = self.dx
+        except AttributeError:
+            del self.xindex
+        else:
+            if value is None or self.dx is None or value != dx:
+                del self.xindex
+        self._dx = value
+
+    @dx.deleter
+    def dx(self):
+        self._dx = None
+
+    @property
+    def xunit(self):
+        return self.x0.unit
 
     def copy(self, order='C'):
         new = super(Series, self).copy(order=order)
         try:
-            new._index = self._index.copy()
+            new._xindex = self._xindex.copy()
         except AttributeError:
             pass
+        return new
+
+    def zip(self):
+        """Zip the `xindex` and `value` arrays of this `Series`
+
+        Returns
+        -------
+        stacked : 2-d `numpy.ndarray`
+            The array formed by stacking the the `xindex` and `value` of this
+            `Series`.
+
+        Examples
+        --------
+        >>> a = Series([0, 2, 4, 6, 8], xindex=[-5, -4, -3, -2, -1])
+        >>> a.zip()
+        array([[-5.,  0.],
+               [-4.,  2.],
+               [-3.,  4.],
+               [-2.,  6.],
+               [-1.,  8.]])
+
+        """
+        return numpy.column_stack((self.xindex.value, self.value))
+
+    def __array_finalize__(self, obj):
+        """Finalize a Array with metadata
+        """
+        super(Series, self).__array_finalize__(obj)
+        if hasattr(self, '_xindex'):
+            obj._xindex = self._xindex
+
+    def __getslice__(self, i, j):
+        new = super(Series, self).__getslice__(i, j)
+        new.__dict__ = self.__dict__.copy()
+        new.x0 = self.x0 + i * self.dx
+        return new
+
+    def __getitem__(self, item):
+        if isinstance(item, (float, int)):
+            return Quantity(self.value[item], unit=self.unit)
+        new = super(Series, self).__getitem__(item)
+        if isinstance(item, slice):
+            if item.start:
+                new.x0 = self.x0 + item.start * self.dx
+            if item.step:
+                new.dx = self.dx * item.step
+        elif isinstance(item, numpy.ndarray):
+            new.xindex = self.xindex[item]
         return new

--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -62,7 +62,7 @@ class Series(Array):
             return self._xindex
         except AttributeError:
             self._xindex = self.x0 + (
-                numpy.arange(self.shape[0], dtype=self.dtype) * self.dx)
+                numpy.arange(self.shape[0]) * self.dx)
             return self._xindex
 
     @xindex.setter

--- a/gwpy/io/ascii.py
+++ b/gwpy/io/ascii.py
@@ -46,7 +46,7 @@ def read_ascii(filepath, _obj=Series, xcol=0, ycol=1, delimiter=None,
             loadargs[kwarg] = kwargs.pop(kwarg)
     # read data, format and return
     x, y = loadtxt(filepath, delimiter=delimiter, **loadargs)
-    return _obj(y, index=x, **kwargs)
+    return _obj(y, xindex=x, **kwargs)
 
 
 def write_ascii(series, fobj, fmt='%.18e', delimiter=' ', newline='\n',
@@ -64,8 +64,8 @@ def write_ascii(series, fobj, fmt='%.18e', delimiter=' ', newline='\n',
     --------
     numpy.savetxt : for documentation of keyword arguments
     """
-    x = series.index.data
-    y = series.data
+    x = series.xindex.value
+    y = series.value
     return savetxt(fobj, zip(x, y), fmt=fmt, delimiter=delimiter,
                    newline=newline, header=header, footer=footer,
                    comments=comments)

--- a/gwpy/plotter/filter.py
+++ b/gwpy/plotter/filter.py
@@ -126,7 +126,7 @@ class BodePlot(Plot):
         # get xlim
         if (frequencies is None and len(filters) == 1 and
                 isinstance(filters[0], Spectrum)):
-            frequencies = filters[0].frequencies.data
+            frequencies = filters[0].frequencies.value
         if frequencies is not None:
             frequencies = frequencies[frequencies > 0]
             self.maxes.set_xlim(frequencies.min(), frequencies.max())
@@ -213,15 +213,15 @@ class BodePlot(Plot):
         # parse spectrum arguments
         kwargs.setdefault('label', spectrum.name)
         # get magnitude
-        mag = numpy.absolute(spectrum.data)
+        mag = numpy.absolute(spectrum.value)
         if dB:
             mag = to_db(mag)
             if not power:
                 mag *= 2.
         # get phase
-        phase = numpy.angle(spectrum.data, deg=True)
+        phase = numpy.angle(spectrum.value, deg=True)
         # plot
-        w = spectrum.frequencies.data
+        w = spectrum.frequencies.value
         lm = self.maxes.plot(w, mag, **kwargs)
         lp = self.paxes.plot(w, phase, **kwargs)
         return lm, lp

--- a/gwpy/plotter/histogram.py
+++ b/gwpy/plotter/histogram.py
@@ -61,7 +61,7 @@ class HistogramAxes(Axes):
         --------
         HistogramAxes.hist : for details on keyword arguments
         """
-        return self.hist(series.data, **kwargs)
+        return self.hist(series.value, **kwargs)
 
     def hist_table(self, table, column, **kwargs):
         """Add a histogram of the given :class:`~glue.ligolw.table.Table`.

--- a/gwpy/plotter/html.py
+++ b/gwpy/plotter/html.py
@@ -196,7 +196,7 @@ def map_data(data, axes, filename, mapname='points', shape='circle',
     so that the relevant DPI and figure size information is fixed.
     """
     if isinstance(data, Series):
-        data = numpy.vstack((data.index, data.data)).T
+        data = numpy.vstack((data.xindex.value, data.value)).T
     elif isinstance(data, numpy.ndarray):
         pass
     else:

--- a/gwpy/plotter/spectrum.py
+++ b/gwpy/plotter/spectrum.py
@@ -103,11 +103,12 @@ class SpectrumAxes(Axes):
             kwargs.setdefault('label', spectrum.name)
         if not kwargs.get('label', True):
             kwargs.pop('label')
-        line = self.plot(spectrum.frequencies, spectrum.data, **kwargs)
+        line = self.plot(spectrum.frequencies, spectrum.value, **kwargs)
         if len(self.lines) == 1:
             try:
-                self.set_xlim(spectrum.frequencies[0],
-                              spectrum.frequencies[-1] + spectrum.df.value)
+                self.set_xlim(spectrum.frequencies[0].value,
+                              spectrum.frequencies[-1].value +
+                              spectrum.df.value)
             except IndexError:
                 pass
         if 'label' in kwargs:
@@ -158,21 +159,21 @@ class SpectrumAxes(Axes):
         color = kwargs.pop('color', line1.get_color())
         linewidth = kwargs.pop('linewidth', line1.get_linewidth()) / 10
         if min_ is not None:
-            a = self.plot(min_.frequencies, min_.data, color=color,
+            a = self.plot(min_.frequencies, min_.value, color=color,
                           linewidth=linewidth, **kwargs)
             if alpha:
-                b = self.fill_between(min_.frequencies, mean_.data, min_.data,
-                                      alpha=alpha, color=color)
+                b = self.fill_between(min_.frequencies.value, mean_.value,
+                                      min_.value, alpha=alpha, color=color)
             else:
                 b = None
         else:
             a = b = None
         if max_ is not None:
-            c = self.plot(max_.frequencies, max_.data, color=color,
+            c = self.plot(max_.frequencies, max_.value, color=color,
                           linewidth=linewidth, **kwargs)
             if alpha:
-                d = self.fill_between(max_.frequencies, mean_.data, max_.data,
-                                      alpha=alpha, color=color)
+                d = self.fill_between(max_.frequencies, mean_.value,
+                                      max_.value, alpha=alpha, color=color)
             else:
                 d = None
         else:
@@ -180,7 +181,7 @@ class SpectrumAxes(Axes):
         return line1, a, b, c, d
 
     @auto_refresh
-    def plot_variance(self, specvar, **kwargs):
+    def plot_variance(self, specvar, norm='log', **kwargs):
         """Plot a :class:`~gwpy.spectrum.hist.SpectralVariance` onto
         these axes
 
@@ -207,21 +208,19 @@ class SpectrumAxes(Axes):
             cmap = copy.deepcopy(cm.jet)
             cmap.set_bad(cmap(0.0))
         kwargs['cmap'] = cmap
-        norm = kwargs.pop('norm', None)
-        if norm == 'log' or (norm is None and specvar.logy):
+        if norm == 'log':
             vmin = kwargs.pop('vmin', None)
             vmax = kwargs.pop('vmax', None)
             norm = colors.LogNorm(vmin=vmin, vmax=vmax)
         kwargs['norm'] = norm
-        x = numpy.concatenate((specvar.frequencies.data,
+        x = numpy.concatenate((specvar.frequencies.value,
                                [specvar.x0.value +
                                 specvar.dx.value * specvar.shape[0]]))
-        y = specvar.bins.data
+        y = specvar.bins.value
         X, Y = numpy.meshgrid(x, y)
-        mesh = self.pcolormesh(X, Y, specvar.data.T, **kwargs)
+        mesh = self.pcolormesh(X, Y, specvar.value.T, **kwargs)
         if len(self.collections) == 1:
-            if specvar.logy:
-                self.set_yscale('log', nonposy='mask')
+            self.set_yscale('log', nonposy='mask')
             self.set_xlim(x[0], x[-1])
             self.set_ylim(y[0], y[-1])
         return mesh

--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -187,7 +187,7 @@ class TimeSeriesAxes(Axes):
             kwargs.setdefault('label', timeseries.name)
         if not self.epoch:
             self.set_epoch(timeseries.x0)
-        line = self.plot(timeseries.times, timeseries.data, **kwargs)
+        line = self.plot(timeseries.times.value, timeseries.value, **kwargs)
         if len(self.lines) == 1 and timeseries.size:
             self.set_xlim(*timeseries.span)
         return line
@@ -232,17 +232,17 @@ class TimeSeriesAxes(Axes):
         color = kwargs.pop('color', line1.get_color())
         linewidth = kwargs.pop('linewidth', line1.get_linewidth()) / 2
         if min_ is not None:
-            a = self.plot(min_.times, min_.data, color=color,
+            a = self.plot(min_.times.value, min_.value, color=color,
                           linewidth=linewidth, **kwargs)
-            b = self.fill_between(min_.times, mean_.data, min_.data, alpha=0.1,
-                                  color=color)
+            b = self.fill_between(min_.times.value, mean_.value, min_.value,
+                                  alpha=0.1, color=color)
         else:
             a = b = None
         if max_ is not None:
-            c = self.plot(max_.times, max_.data, color=color,
+            c = self.plot(max_.times.value, max_.value, color=color,
                           linewidth=linewidth, **kwargs)
-            d = self.fill_between(max_.times, mean_.data, max_.data, alpha=0.1,
-                                  color=color)
+            d = self.fill_between(max_.times.value, mean_.value, max_.value,
+                                  alpha=0.1, color=color)
         else:
             c = d = None
         return line1, a, b, c, d
@@ -287,16 +287,15 @@ class TimeSeriesAxes(Axes):
         kwargs['norm'] = norm
         if not self.epoch:
             self.set_epoch(spectrogram.x0)
-        x = numpy.concatenate((spectrogram.times.data,
-                               [spectrogram.span_x[-1].value]))
-        y = numpy.concatenate((spectrogram.frequencies.data,
-                               [spectrogram.y0.value +
-                                spectrogram.dy.value * spectrogram.shape[1]]))
+        x = numpy.concatenate((spectrogram.times.value,
+                               [spectrogram.span[-1]]))
+        y = numpy.concatenate((spectrogram.frequencies.value,
+                               [spectrogram.band[-1]]))
         X, Y = numpy.meshgrid(x, y)
-        mesh = self.pcolormesh(X, Y, spectrogram.data.T, **kwargs)
+        mesh = self.pcolormesh(X, Y, spectrogram.value.T, **kwargs)
         if len(self.collections) == 1:
-            self.set_xlim(*map(numpy.float64, spectrogram.span_x))
-            self.set_ylim(*map(numpy.float64, spectrogram.span_y))
+            self.set_xlim(*spectrogram.span)
+            self.set_ylim(*spectrogram.band)
         if not self.get_ylabel():
             self.add_label_unit(spectrogram.yunit, axis='y')
 

--- a/gwpy/spectrogram/coherence.py
+++ b/gwpy/spectrogram/coherence.py
@@ -66,7 +66,7 @@ def _from_timeseries(ts1, ts2, stride, fftlength=None, overlap=None,
     dt = stride
     df = 1 / fftlength
 
-    stride *= sampling
+    stride = int(stride * sampling)
 
     # get size of spectrogram
     nsteps = int(ts1.size // stride)

--- a/gwpy/spectrogram/coherence.py
+++ b/gwpy/spectrogram/coherence.py
@@ -74,8 +74,7 @@ def _from_timeseries(ts1, ts2, stride, fftlength=None, overlap=None,
 
     # generate output spectrogram
     out = Spectrogram(zeros((nsteps, nfreqs)), epoch=ts1.epoch,
-                      f0=0, df=df, dt=dt, copy=True)
-    out.unit = 'coherence'
+                      f0=0, df=df, dt=dt, copy=True, unit='coherence')
 
     if not nsteps:
         return out
@@ -90,7 +89,7 @@ def _from_timeseries(ts1, ts2, stride, fftlength=None, overlap=None,
         stepcoh = stepseries1.coherence(stepseries2, fftlength=fftlength,
                                         overlap=overlap, window=window,
                                         **kwargs)
-        out.data[step] = stepcoh.data
+        out.value[step] = stepcoh.value
 
     return out
 

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -149,7 +149,6 @@ class Spectrogram(Array2D):
         dy = self.dy.to(self._default_yunit).value
         return Segment(y0, y0+self.shape[1]*dy)
 
-
     # -------------------------------------------
     # Spectrogram methods
 
@@ -159,8 +158,8 @@ class Spectrogram(Array2D):
 
         Parameters
         ----------
-        operand : `str`, `Spectrum`
-            `Spectrum` against which to weight, or one of
+        operand : `str`, `Spectrum`, `~astropy.units.Quantity`, `float`
+            `Spectrum` or `Quantity` against which to weight, or one of
 
             - ``'mean'`` : weight against the mean of each spectrum
               in this Spectrogram
@@ -173,21 +172,13 @@ class Spectrogram(Array2D):
             A new spectrogram
         """
         if operand == 'mean':
-            operand = self.mean(axis=0).value
-            unit = units.dimensionless_unscaled
+            operand = self.mean(axis=0)
         elif operand == 'median':
-            operand = self.median(axis=0).value
-            unit = units.dimensionless_unscaled
-        elif isinstance(operand, Spectrum):
-            unit = self.unit / operand.unit
-            operand = operand.value
-        elif isinstance(operand, numbers.Number):
-            unit = units.dimensionless_unscaled
-        else:
-            raise ValueError("operand '%s' unrecognised, please give Spectrum "
-                             "or one of: 'mean', 'median'" % operand)
+            operand = self.median(axis=0)
+        elif isinstance(operand, str):
+            raise ValueError("operand %r unrecognised, please give a Quantity"
+                             " or one of: 'mean', 'median'" % operand)
         out = self / operand
-        out.unit = unit
         return out
 
     def plot(self, **kwargs):

--- a/gwpy/spectrogram/spectrogram.py
+++ b/gwpy/spectrogram/spectrogram.py
@@ -82,7 +82,7 @@ def _from_timeseries(timeseries, stride, fftlength=None, fftstride=None,
         stepseries = timeseries[idx:idx_end]
         steppsd = stepseries.psd(fftlength, fftstride, method,
                                  window=window, plan=plan)
-        out[step] = steppsd.data
+        out.value[step] = steppsd.value
 
     return out
 

--- a/gwpy/spectrum/psd.py
+++ b/gwpy/spectrum/psd.py
@@ -256,7 +256,7 @@ def scipy_psd(timeseries, method, segmentlength, overlap,
         segmentlength = segmentlength.value
     if isinstance(overlap, units.Quantity):
         overlap = overlap.value
-    f, psd_ = signal.welch(timeseries.data, fs=timeseries.sample_rate.value,
+    f, psd_ = signal.welch(timeseries.value, fs=timeseries.sample_rate.value,
                            window=window, nperseg=segmentlength,
                            noverlap=(segmentlength-overlap))
     spec = psd_.view(Spectrum)

--- a/gwpy/spectrum/scipy_.py
+++ b/gwpy/spectrum/scipy_.py
@@ -38,18 +38,14 @@ def welch(timeseries, segmentlength, noverlap=None, **kwargs):
     # get module
     signal = import_method_dependency('scipy.signal')
     # calculate PSD
-    f, psd_ = signal.welch(timeseries.data, noverlap=noverlap,
+    f, psd_ = signal.welch(timeseries.value, noverlap=noverlap,
                            fs=timeseries.sample_rate.decompose().value,
                            nperseg=segmentlength, **kwargs)
     # generate Spectrum and return
-    spec = psd_.view(Spectrum)
-    spec.frequencies = f
-    spec.name = timeseries.name
-    spec.epoch = timeseries.epoch
-    spec.channel = timeseries.channel
-    spec.unit = scale_timeseries_units(timeseries.unit,
-                                       kwargs.get('scaling', 'density'))
-    return spec
+    unit = scale_timeseries_units(timeseries.unit,
+                                  kwargs.get('scaling', 'density'))
+    return Spectrum(psd_, unit=unit, frequencies=f, name=timeseries.name,
+                    epoch=timeseries.epoch, channel=timeseries.channel)
 
 register_method(welch)
 
@@ -77,7 +73,7 @@ def rayleigh(timeseries, segmentlength, noverlap=0, **kwargs):
         tmpdata[i, :] = welch(ts, segmentlength)
     std = tmpdata.std(axis=0)
     mean = tmpdata.mean(axis=0)
-    return Spectrum(std/mean, copy=False, f0=0,
+    return Spectrum(std/mean, unit='', copy=False, f0=0,
                     df=timeseries.sample_rate.value/segmentlength,
                     channel=timeseries.channel,
                     name='Rayleigh spectrum of %s' % timeseries.name)

--- a/gwpy/tests/array.py
+++ b/gwpy/tests/array.py
@@ -63,7 +63,7 @@ class CommonTests(object):
         # test with some data
         array = self.TEST_CLASS(self.data)
         nptest.assert_array_equal(array.value, self.data)
-        self.assertEqual(array.unit, units.Unit(''))
+        self.assertIsNone(array.unit)
         self.assertIsNone(array.name)
         self.assertIsNone(array.epoch)
         self.assertIsNone(array.channel)

--- a/gwpy/tests/array.py
+++ b/gwpy/tests/array.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit test for data classes
+"""
+
+import os
+import os.path
+import sys
+
+import numpy
+from numpy import testing as nptest
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+from astropy import units
+from astropy.time import Time
+
+from gwpy import version
+from gwpy.data import (Array, Series, Array2D)
+from gwpy.detector import Channel
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+GPS_EPOCH = 12345
+TIME_EPOCH = Time(12345, format='gps', scale='utc')
+CHANNEL_NAME = 'X1:TEST-CHANNEL'
+CHANNEL = Channel(CHANNEL_NAME)
+
+
+class CommonTests(object):
+    TEST_CLASS = Array
+
+    def setUp(self):
+        self.data = numpy.arange(10)
+        self.datasq = self.data ** 2
+
+    def test_init(self):
+        """Test Array creation
+        """
+        # test basic empty contructor
+        self.assertRaises(TypeError, Array)
+        self.assertRaises(IndexError, Array, [])
+        # test with some data
+        array = self.TEST_CLASS(self.data)
+        nptest.assert_array_equal(array.value, self.data)
+        self.assertEqual(array.unit, units.Unit(''))
+        self.assertIsNone(array.name)
+        self.assertIsNone(array.epoch)
+        self.assertIsNone(array.channel)
+        # test metadata
+        array = self.TEST_CLASS(self.data, 'Hz', name='TEST',
+                                channel=CHANNEL_NAME, epoch=GPS_EPOCH)
+        self.assertEqual(array.unit, units.Hz)
+        self.assertEqual(array.name, 'TEST')
+        self.assertEqual(array.epoch, TIME_EPOCH)
+        self.assertEqual(array.channel, CHANNEL)
+        return array
+
+    def test_math(self):
+        """Test Array math operations
+        """
+        array = self.TEST_CLASS(self.data, unit='Hz')
+        # test basic operations
+        arraysq = array ** 2
+        nptest.assert_array_equal(arraysq.value, self.datasq)
+        self.assertEqual(arraysq.unit, units.Hz ** 2)
+        self.assertEqual(arraysq.name, array.name)
+        self.assertEqual(arraysq.epoch, array.epoch)
+        self.assertEqual(arraysq.channel, array.channel)
+
+    def test_copy(self):
+        """Test Array.copy
+        """
+        array = self.TEST_CLASS(self.data, unit='Hz')
+        array2 = array.copy()
+        nptest.assert_array_equal(array.value, array2.value)
+        self.assertEqual(array.unit, array2.unit)
+
+
+class ArrayTestCase(CommonTests, unittest.TestCase):
+    pass
+
+
+class SeriesTestCase(CommonTests, unittest.TestCase):
+    TEST_CLASS = Series
+
+    def setUp(self):
+        super(SeriesTestCase, self).setUp()
+        self.index = units.Quantity(numpy.arange(10) * 4, units.m)
+
+    def test_init(self):
+        series = super(SeriesTestCase, self).test_init()
+        self.assertEqual(series.x0, units.Quantity(0))
+        self.assertEqual(series.dx, units.Quantity(1))
+        series = self.TEST_CLASS(self.data, 'Hz', dx=4*units.m)
+        self.assertEqual(series.x0, 0*units.m)
+        self.assertEqual(series.dx, 4*units.m)
+        self.assertFalse(hasattr(series, '_xindex'))
+        nptest.assert_array_equal(series.xindex, self.index)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gwpy/tests/astro.py
+++ b/gwpy/tests/astro.py
@@ -59,14 +59,14 @@ class AstroTests(unittest.TestCase):
         return r
 
     def test_burst_range(self):
-        r = astro.burst_range(self.psd[self.psd.frequencies.data < 1000])
+        r = astro.burst_range(self.psd[self.psd.frequencies.value < 1000])
         self.assertEqual(r.unit, units.Mpc)
         self.assertAlmostEqual(r.value, 13.813232309724613)
         return r
 
     def test_burst_range_spectrum(self):
         r = astro.burst_range_spectrum(
-            self.psd[self.psd.frequencies.data < 1000])
+            self.psd[self.psd.frequencies.value < 1000])
         self.assertEqual(r.unit, units.Mpc)
         self.assertAlmostEqual(r.max().value, 35.19303454822539)
         return r

--- a/gwpy/tests/timeseries.py
+++ b/gwpy/tests/timeseries.py
@@ -129,6 +129,16 @@ class TimeSeriesTests(unittest.TestCase):
                 if os.path.isfile(hdfout):
                     os.remove(hdfout)
 
+    def test_pickle(self):
+        """Check pickle-unpickle yields unchanged data
+        """
+        import cPickle
+        ts = TimeSeries(self.data, sample_rate=1, name='TEST CASE',
+                        epoch=0, channel='TEST CASE')
+        pickle = ts.dumps()
+        ts2 = cPickle.loads(pickle)
+        self.assertEqual(ts, ts2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/gwpy/timeseries/common.py
+++ b/gwpy/timeseries/common.py
@@ -127,7 +127,7 @@ def append(self, other, gap='raise', inplace=True, pad=0.0, resize=True):
                 raise
     elif other.shape[0] < new.shape[0]:
         N = other.shape[0]
-        new.data[:-N] = new.data[N:]
+        new.value[:-N] = new.value[N:]
     else:
         N = min(new.shape[0], other.shape[0])
 
@@ -152,7 +152,7 @@ def append(self, other, gap='raise', inplace=True, pad=0.0, resize=True):
         else:
             new.times[:-other.shape[0]] = new.times[other.shape[0]:]
         try:
-            new.times[-other.shape[0]:] = other.times.data
+            new.times[-other.shape[0]:] = other.times.value
         except AttributeError:
             del new.times
         try:
@@ -221,8 +221,8 @@ def prepend(self, other, gap='raise', inplace=True, pad=0.0):
     s = list(new.shape)
     s[0] = new.shape[0] + other.shape[0]
     new.resize(s, refcheck=False)
-    new[-N:] = new.data[:N]
-    new[:other.shape[0]] = other.data
+    new[-N:] = new.value[:N]
+    new[:other.shape[0]] = other.value
     return new
 
 

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -2014,10 +2014,8 @@ class TimeSeriesDict(OrderedDict):
                 for buffer_, c in zip(buffers, channels):
                     ts = cls.EntryClass.from_nds2_buffer(
                         buffer_, dtype=dtype.get(c))
-                    gprint('appending:')
                     out.append({c: ts}, pad=pad,
                                gap=pad is None and 'raise' or 'pad')
-                    gprint('complete.')
                 if not nsteps:
                     if have_minute_trends:
                         dur = buffer_.length * 60

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -445,7 +445,6 @@ class TimeSeries(Series):
                 (overlap * self.sample_rate).decompose().value)
         # calculate and return spectrum
         psd_ = method_func(self, nfft, **kwargs)
-        psd_.unit.__doc__ = 'Power spectral density'
         return psd_
 
     def asd(self, fftlength=None, overlap=None, method='welch', **kwargs):
@@ -478,7 +477,6 @@ class TimeSeries(Series):
         """
         asd_ = self.psd(method=method, fftlength=fftlength,
                         overlap=overlap, **kwargs) ** (1/2.)
-        asd_.unit.__doc__ = 'Amplitude spectral density'
         return asd_
 
     def spectrogram(self, stride, fftlength=None, overlap=0,
@@ -874,7 +872,6 @@ class TimeSeries(Series):
                 (overlap * self.sample_rate).decompose().value)
         # calculate and return spectrum
         spec_ = method_func(self, nfft, **kwargs)
-        spec_.unit.__doc__ = 'Rayleigh statistic'
         return spec_
 
     def rayleigh_spectrogram(self, stride, fftlength=None, overlap=0,
@@ -1323,6 +1320,7 @@ class TimeSeries(Series):
         out.xindex = f
         out.epoch = self.epoch
         out.name = 'Coherence between %s and %s' % (self.name, other.name)
+        out.unit = 'coherence'
         return out
 
     def auto_coherence(self, dt, fftlength=None, overlap=None,

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1585,7 +1585,6 @@ class TimeSeries(Series):
             except KeyError:
                 op_ = ufunc.__name__
             result = obj.view(StateTimeSeries)
-            result.unit = ""
             result.name = '%s %s %s' % (obj.name, op_, value)
             if hasattr(obj, 'unit') and str(obj.unit):
                 result.name += ' %s' % str(obj.unit)

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -257,7 +257,7 @@ def _read_frame(framefile, channels, type=None, dtype=None, verbose=False,
                 arr = vect.GetDataArray()
                 dx = vect.GetDim(0).dx
                 if ts is None:
-                    unit = vect.GetUnitY()
+                    unit = vect.GetUnitY() or None
                     ts = _SeriesClass(arr, epoch=thisepoch, dx=dx, name=name,
                                       channel=channel, unit=unit, dtype=dtype_,
                                       copy=False).copy()

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -260,7 +260,7 @@ def _read_frame(framefile, channels, type=None, dtype=None, verbose=False,
                     unit = vect.GetUnitY()
                     ts = _SeriesClass(arr, epoch=thisepoch, dx=dx, name=name,
                                       channel=channel, unit=unit, dtype=dtype_,
-                                      copy=True)
+                                      copy=False).copy()
                     if not ts.channel.dtype:
                         ts.channel.dtype = arr.dtype
                 elif dtype_:


### PR DESCRIPTION
This PR introduces a complete re-build of the `Array` class and all sub-classes, including `TimeSeries`, `Spectrum`, and `Spectrogram`. The changes are (at least) as follows:

- `Array` now inherits from `astropy.units.Quantity` rather than from `numpy.ndarray`,
    - all unit handing is now much easier, with most of it handled directly by `Quantity`,
    - the `unit` property cannot be set for an array that already has a unit, a notice has been added to the exception message to ask the user to use the `Array.to()` method, which properly converts between units,
    - the `data` property has been removed in favour of the `Quantity.value` property. `data` was a bad choice to begin with as it overrode a `numpy.ndarray` property,
- `Array2D` now inherits from `Series`,
- the `times` and `frequencies` indexes of the `TimeSeries`, `Spectrum`, and `Spectrogram` classes are now simply `Quantity` arrays, rather than `Series`, this means that they don't have the extra metadata they used to (`epoch`, `channel`, `name`), 

All downstream codes have been modified to handle the new base classes. 

This fixes #66.