### PR TITLE
Statevector fixes

### DIFF
--- a/gwpy/timeseries/common.py
+++ b/gwpy/timeseries/common.py
@@ -131,7 +131,14 @@ def append(self, other, gap='raise', inplace=True, pad=0.0, resize=True):
     else:
         N = min(new.shape[0], other.shape[0])
 
-    new[-N:] = other[-N:]
+    # if units are the same, can shortcut
+    if type(other) == type(new) and other.unit == new.unit:
+        new.value[-N:] = other.value[-N:]
+    # otherwise if its just a numpy array
+    elif type(other) == type(new.value):
+        new.value[-N:] = other[-N:]
+    else:
+        new[-N:] = other[-N:]
     try:
         if isinstance(self, Series):
             self._index

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -309,7 +309,7 @@ class StateVector(TimeSeries):
         """
         try:
             return self._bits
-        except KeyError as e:
+        except AttributeError as e:
             if self.dtype.name.startswith(('uint', 'int')):
                 nbits = self.itemsize * 8
                 self.bits = Bits(['Bit %d' % b for b in range(nbits)],
@@ -319,10 +319,7 @@ class StateVector(TimeSeries):
                 self.bits = self.channel.bits
                 return self.bits
             else:
-                e.args = ("No bit listing given for StateVector, and data "
-                          "type doesn't determine how many bits there should "
-                          "be, please give bits manually.",)
-                raise e
+                return None
 
     @bits.setter
     def bits(self, mask):

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -295,7 +295,7 @@ class StateVector(TimeSeries):
                                               sample_rate=sample_rate,
                                               times=times,
                                               **kwargs)
-        new.bits = new
+        new.bits = bits
         return new
 
     # -------------------------------------------


### PR DESCRIPTION
This PR fixes some bugs with the new `Quantity`-based `StateVector`.

Astropy doesn't like setting `Quantity` array values via slices with `uint32`, so we can circumvent that for now.