### PR TITLE
Copy TimeSeries.__dict__ after view()

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1095,6 +1095,7 @@ class TimeSeries(Series):
             nsamp = int(self.shape[0] * self.dx.value * rate)
             new = signal.resample(self.value, nsamp,
                                   window=window).view(self.__class__)
+        new.__dict__ = self.__dict__.copy()
         new.sample_rate = rate
         return new
 
@@ -1495,6 +1496,7 @@ class TimeSeries(Series):
         if isinstance(pad_width, int):
             pad_width = (pad_width,)
         new = numpy.pad(self.value, pad_width, **kwargs).view(self.__class__)
+        new.__dict__ = self.__dict__.copy()
         new.epoch = self.epoch.gps - self.dt.value * pad_width[0]
         return new
 


### PR DESCRIPTION
This PR fixes bugs in the `TimeSeries.resample` and `TimeSeries.pad` methods where the metadata `__dict__` isn't copied over to the new array after a `view` is performed on a `numpy.ndarray`.