### PR TITLE
Multiple optimisations for TimeSeries methods

### DIFF
--- a/examples/timeseries/statevector.py
+++ b/examples/timeseries/statevector.py
@@ -44,6 +44,7 @@ bits = [
 ]
 
 data = StateVector.fetch('L1:ISI-ETMX_ODC_CHANNEL_OUT_DQ', 'May 22 2014 14:00', 'May 22 2014 15:00', bits=bits)
+data = data.astype('uint32')  # hide
 
 # For this example, we wish to :meth:`~StateVector.resample` the data to a
 # much lower rate, to make visualising the state much easier:

--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -32,7 +32,6 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 from .array import Array
 from .series import Series
-from ..segments import Segment
 
 
 class Array2D(Series):

--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -110,6 +110,7 @@ class Array2D(Series):
         # unwrap a Spectrogram
         else:
             new = new.value.view(type(self))
+            new.__dict__ = self.__dict__.copy()
         # update metadata
         if isinstance(x, slice):
             if x.start:

--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -38,8 +38,8 @@ class Series(Array):
     def __new__(cls, value, unit=None, xindex=None, x0=0, dx=1, **kwargs):
         shape = numpy.shape(value)
         if len(shape) != cls._ndim:
-            raise ValueError("Cannot generate Series with %d-dimensional data"
-                             % len(shape))
+            raise ValueError("Cannot generate %s with %d-dimensional data"
+                             % (cls.__name__, len(shape)))
         new = super(Series, cls).__new__(cls, value, unit=unit, **kwargs)
         if isinstance(x0, Quantity):
             xunit = x0.unit

--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -95,7 +95,10 @@ class Series(Array):
     @x0.setter
     def x0(self, value):
         if not isinstance(value, Quantity) and value is not None:
-            value = Quantity(value, self._default_xunit)
+            try:
+                value = Quantity(value, self._default_xunit)
+            except TypeError:
+                value = Quantity(float(value), self._default_xunit)
         try:
             x0 = self.x0
         except AttributeError:

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -47,7 +47,6 @@ except ImportError:
                              NDS2_CHANNEL_TYPESTR.iteritems())
 
 from .. import version
-from ..segments import (Segment, SegmentList, SegmentListDict)
 from ..time import to_gps
 from ..utils.deps import with_import
 
@@ -789,6 +788,7 @@ class ChannelList(list):
             a `dict` of (channel, `dict`) pairs where the nested `dict`
             is over (frametype, SegmentList) segment-availability pairs
         """
+        from ..segments import (Segment, SegmentList, SegmentListDict)
         names = []
         for c in channels:
             name = str(c)

--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -235,7 +235,7 @@ class Spectrum(Series):
 
     @classmethod
     @with_import('lal')
-    def from_lal(cls, lalfs):
+    def from_lal(cls, lalfs, copy=True):
         """Generate a new `Spectrum` from a LAL `FrequencySeries` of any type
         """
         from ..utils.lal import from_lal_unit
@@ -246,7 +246,8 @@ class Spectrum(Series):
         channel = Channel(lalfs.name, unit=unit,
                           dtype=lalfs.data.data.dtype)
         return cls(lalfs.data.data, channel=channel, f0=lalfs.f0,
-                   df=lalfs.deltaF, epoch=float(lalfs.epoch))
+                   df=lalfs.deltaF, epoch=float(lalfs.epoch),
+                   dtype=lalfs.data.data.dtype, copy=copy)
 
     @with_import('lal')
     def to_lal(self):

--- a/gwpy/spectrum/lal_.py
+++ b/gwpy/spectrum/lal_.py
@@ -208,7 +208,7 @@ def lal_psd(timeseries, segmentlength, noverlap=None, method='welch',
     # format and return
     spec = Spectrum.from_lal(lalfs)
     spec.channel = timeseries.channel
-    spec.unit = scale_timeseries_units(timeseries.unit, scaling='density')
+    spec._unit = scale_timeseries_units(timeseries.unit, scaling='density')
     return spec
 
 

--- a/gwpy/time/__init__.py
+++ b/gwpy/time/__init__.py
@@ -26,7 +26,6 @@ All other time conversions can be easily completed using the `Time`
 object.
 """
 
-from dateutil import parser as dateparser
 from astropy.time import Time
 
 try:

--- a/gwpy/timeseries/__init__.py
+++ b/gwpy/timeseries/__init__.py
@@ -27,5 +27,3 @@ __version__ = version.version
 from .core import *
 from .statevector import *
 from .io import *
-
-from ..spectrum.registry import get_method as get_spectrum_method

--- a/gwpy/timeseries/common.py
+++ b/gwpy/timeseries/common.py
@@ -20,16 +20,14 @@
 """
 
 import warnings
-from math import (ceil, floor)
+from math import floor
 
 import numpy
 
-from astropy import units
 from astropy.time import Time
 
 from .. import version
 from ..data import Series
-from ..segments import Segment
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -31,8 +31,6 @@ import numpy
 from numpy import fft as npfft
 from scipy import signal
 
-from matplotlib import mlab
-
 try:
     from collections import OrderedDict
 except ImportError:
@@ -52,10 +50,9 @@ else:
 
 
 from .. import version
-from ..data import (Array, Array2D, Series)
+from ..data import (Array2D, Series)
 from ..detector import (Channel, ChannelList)
 from ..io import reader
-from ..segments import (Segment, SegmentList)
 from ..time import (Time, to_gps)
 from ..utils import (gprint, update_docstrings, with_import)
 from . import common
@@ -180,6 +177,7 @@ class TimeSeries(Series):
     def span(self):
         """Time Segment encompassed by thie `TimeSeries`.
         """
+        from ..segments import Segment
         x0 = self.x0.to(self._default_xunit).value
         dx = self.dx.to(self._default_xunit).value
         return Segment(x0, x0+self.shape[0]*dx)
@@ -1290,6 +1288,7 @@ class TimeSeries(Series):
         :func:`matplotlib.mlab.cohere`
             for details of the coherence calculator
         """
+        from matplotlib import mlab
         from ..spectrum import Spectrum
         # check sampling rates
         if self.sample_rate.to('Hertz') != other.sample_rate.to('Hertz'):
@@ -1680,6 +1679,7 @@ class TimeSeriesList(list):
 
     @property
     def segments(self):
+        from ..segments import SegmentList
         return SegmentList([item.span for item in self])
 
     def append(self, item):
@@ -1898,6 +1898,7 @@ class TimeSeriesDict(OrderedDict):
             a new `TimeSeriesDict` of (`str`, `TimeSeries`) pairs fetched
             from NDS.
         """
+        from ..segments import (Segment, SegmentList)
         from ..io import nds as ndsio
         # parse times
         start = to_gps(start)

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1567,7 +1567,7 @@ class TimeSeries(Series):
         typestr = LAL_TYPE_STR_FROM_NUMPY[self.dtype.type]
         try:
             unit = to_lal_unit(self.unit)
-        except TypeError:
+        except (TypeError, AttributeError):
             try:
                 unit = lal.DimensionlessUnit
             except AttributeError:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1546,7 +1546,7 @@ class TimeSeries(Series):
 
     @classmethod
     @with_import('lal')
-    def from_lal(cls, lalts):
+    def from_lal(cls, lalts, copy=True):
         """Generate a new TimeSeries from a LAL TimeSeries of any type.
         """
         from ..utils.lal import from_lal_unit
@@ -1557,7 +1557,7 @@ class TimeSeries(Series):
         channel = Channel(lalts.name, 1/lalts.deltaT, unit=unit,
                           dtype=lalts.data.data.dtype)
         return cls(lalts.data.data, channel=channel, epoch=float(lalts.epoch),
-                   copy=True)
+                   copy=copy, dtype=lalts.data.data.dtype)
 
     @with_import('lal.lal')
     def to_lal(self):

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -547,7 +547,11 @@ class TimeSeries(Series):
                 kwargs['window'] = generate_lal_window(nfft, dtype=self.dtype)
             if kwargs.get('plan', None) is None:
                 kwargs['plan'] = generate_lal_fft_plan(nfft, dtype=self.dtype)
-        elif window is not None:
+        else:
+            if window is None:
+                window = 'hanning'
+            if isinstance(window, str) or type(window) is tuple:
+                window = signal.get_window(window, nfft)
             kwargs['window'] = window
 
         # set up single process Spectrogram generation
@@ -700,6 +704,12 @@ class TimeSeries(Series):
                           epoch=self.epoch, channel=self.channel,
                           name=self.name, unit=unit, dt=fftlength-overlap,
                           f0=0, df=1/fftlength)
+
+        # get window
+        if window is None:
+            window = 'boxcar'
+        if isinstance(window, (str, tuple)):
+            window = signal.get_window(window, nfft)
 
         # calculate overlapping periodograms
         for i in xrange(nsteps):

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1746,7 +1746,7 @@ class TimeSeriesList(list):
              in this list
         """
         if len(self) == 0:
-            return self.EntryClass([])
+            return self.EntryClass(numpy.empty((0,0)))
         self.sort(key=lambda t: t.epoch.gps)
         out = self[0].copy()
         for ts in self[1:]:

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -23,7 +23,6 @@ from __future__ import division
 
 import os
 import warnings
-from decimal import _Infinity as infinity
 from math import ceil
 from multiprocessing import (Process, Queue as ProcessQueue)
 
@@ -31,7 +30,6 @@ from astropy.io import registry
 
 from glue.lal import Cache
 
-from ...segments import (Segment, SegmentList)
 from ...io.cache import cache_segments
 from .. import (TimeSeries, TimeSeriesList, TimeSeriesDict,
                 StateVector, StateVectorDict)
@@ -74,6 +72,8 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
     data : :class:`~gwpy.timeseries.core.TimeSeries`
         a new `TimeSeries` containing the data read from disk
     """
+    from gwpy.segments import (Segment, SegmentList)
+
     cls = kwargs.pop('target', TimeSeries)
     # open cache from file if given
     if isinstance(cache, (unicode, str, file)):

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -34,6 +34,9 @@ from ...io.cache import cache_segments
 from .. import (TimeSeries, TimeSeriesList, TimeSeriesDict,
                 StateVector, StateVectorDict)
 
+# set maximum number of channels with which to still use lalframe
+MAX_LALFRAME_CHANNELS = 4
+
 
 def read_cache(cache, channel, start=None, end=None, resample=None,
                gap='raise', nproc=1, **kwargs):
@@ -113,9 +116,9 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
             else:
                 raise ValueError(msg)
 
-    # if reading one channel, try to use lalframe, its faster
-    if (isinstance(channel, str) or
-            (isinstance(channel, (list, tuple)) and len(channel) == 1)):
+    # if reading a small number of channels, try to use lalframe, its faster
+    if (isinstance(channel, str) or (isinstance(channel, (list, tuple)) and
+                                     len(channel) <= MAX_LALFRAME_CHANNELS)):
         try:
             from lalframe import frread
         except ImportError:

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -213,10 +213,12 @@ def _read_frame(framefile, channels, ctype=None, dtype=None, verbose=False,
     stream = frameCPP.IFrameFStream(fp)
 
     # interpolate frame epochs from CacheEntry
-    # FIXME: update when new frameCPP is released
-    nframe = 0  # int(stream.GetNumberOfFrames())
+    try:
+        nframe = int(stream.GetNumberOfFrames())
+    except (AttributeError, ValueError):
+        nframe = None
     if isinstance(framefile, CacheEntry) and nframe == 1:
-        epochs = [framefile.segment[0]]
+        epochs = [float(framefile.segment[0])]
     else:
         epochs = None
 

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -124,6 +124,13 @@ def read_timeseriesdict(source, channels, start=None, end=None, type=None,
     elif not isinstance(resample, dict):
         raise ValueError("Cannot parse resample request, please review "
                          "documentation for that argument")
+    # parse type
+    if isinstance(type, str):
+        type = dict((channel, type) for channel in channels)
+    elif isinstance(type, (tuple, list)):
+        type = dict(zip(channels, type))
+    elif type is None:
+        type = {}
     # read each individually and append
     N = len(filelist)
     if verbose:
@@ -134,8 +141,12 @@ def read_timeseriesdict(source, channels, start=None, end=None, type=None,
     out = TimeSeriesDict()
     for i, fp in enumerate(filelist):
         # read frame
-        new = _read_frame(fp, channels, type=type, dtype=dtype,
+        new = _read_frame(fp, channels, ctype=type, dtype=dtype,
                           verbose=verbose, _SeriesClass=_SeriesClass)
+        ## get channel type for next frame (means we only query the TOC once)
+        if not i:
+            for channel, ts in new.iteritems():
+                type[channel] = ts.channel._ctype
         # store
         out.append(new)
         if verbose is not False:
@@ -156,7 +167,7 @@ def read_timeseriesdict(source, channels, start=None, end=None, type=None,
     return out
 
 
-def _read_frame(framefile, channels, type=None, dtype=None, verbose=False,
+def _read_frame(framefile, channels, ctype=None, dtype=None, verbose=False,
                 _SeriesClass=TimeSeries):
     """Internal function to read data from a single frame.
 
@@ -168,7 +179,7 @@ def _read_frame(framefile, channels, type=None, dtype=None, verbose=False,
         path to GWF-format frame file on disk.
     channels : `list`
         list of channels to read.
-    type : `str`, optional
+    ctype : `str`, optional
         channel data type to read, one of: ``'adc'``, ``'proc'``.
     dtype : `numpy.dtype`, `str`, `type`, `dict`
     verbose : `bool`, optional
@@ -210,15 +221,13 @@ def _read_frame(framefile, channels, type=None, dtype=None, verbose=False,
         epochs = None
 
     # load table of contents if needed
-    if epochs is None or not type:
+    if epochs is None or not ctype:
         toc = stream.GetTOC()
     # get list of frame epochs
     if epochs is None:
         epochs = toc.GTimeS
     # work out channel types
-    if type:
-        ctype = dict((str(channel), type) for channel in channels)
-    else:
+    if not ctype:
         try:
             adcs = toc.GetADC().keys()
         except AttributeError:
@@ -263,6 +272,7 @@ def _read_frame(framefile, channels, type=None, dtype=None, verbose=False,
                                       copy=False).copy()
                     if not ts.channel.dtype:
                         ts.channel.dtype = arr.dtype
+                    ts.channel._ctype = ctype[name]
                 elif dtype_:
                     ts.append(arr.astype(dtype_))
                 else:

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -242,9 +242,9 @@ def _read_frame(framefile, channels, ctype=None, dtype=None, verbose=False,
         for channel in channels:
             name = str(channel)
             if name in adcs:
-                ctype[name] = 'adc'
+                ctype[channel] = 'adc'
             elif name in procs:
-                ctype[name] = 'proc'
+                ctype[channel] = 'proc'
             else:
                 raise ValueError("Channel %s not found in frame table of "
                                  "contents" % name)
@@ -253,7 +253,7 @@ def _read_frame(framefile, channels, ctype=None, dtype=None, verbose=False,
     out = TimeSeriesDict()
     for channel in channels:
         name = str(channel)
-        read_ = getattr(stream, 'ReadFr%sData' % ctype[name].title())
+        read_ = getattr(stream, 'ReadFr%sData' % ctype[channel].title())
         ts = None
         i = 0
         dtype_ = dtype.get(channel, None)
@@ -274,7 +274,7 @@ def _read_frame(framefile, channels, ctype=None, dtype=None, verbose=False,
                                       copy=False).copy()
                     if not ts.channel.dtype:
                         ts.channel.dtype = arr.dtype
-                    ts.channel._ctype = ctype[name]
+                    ts.channel._ctype = ctype[channel]
                 elif dtype_:
                     ts.append(arr.astype(dtype_))
                 else:

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -42,7 +42,6 @@ from .core import (TimeSeries, TimeSeriesDict, ArrayTimeSeries,
                    NDS2_FETCH_TYPE_MASK)
 from ..detector import Channel
 from ..time import Time
-from ..segments import *
 from ..utils import update_docstrings
 from ..io import reader
 from .. import version
@@ -125,6 +124,7 @@ class StateTimeSeries(TimeSeries):
             defines the `known` segments, while the contiguous `True`
             sets defined each of the `active` segments
         """
+        from ..segments import (Segment, SegmentList)
         start = self.x0.value
         dt = self.dx.value
         active = from_bitstream(self.value, start, dt, minlen=int(minlen))

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -614,7 +614,7 @@ class StateVector(TimeSeries):
             for x, y in it:
                 y[...] = numpy.sum([type_((x >> bit & 1).all() * (2 ** bit))
                                     for bit in bits], dtype=self.dtype)
-            new = StateVector(it.operands[1])
+            new = StateVector(it.operands[1], dtype=dtype)
             new.__dict__ = self.__dict__.copy()
             new.sample_rate = rate2
             return new

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -124,7 +124,7 @@ class StateTimeSeries(TimeSeries):
             defines the `known` segments, while the contiguous `True`
             sets defined each of the `active` segments
         """
-        from ..segments import (Segment, SegmentList)
+        from ..segments import (Segment, SegmentList, DataQualityFlag)
         start = self.x0.value
         dt = self.dx.value
         active = from_bitstream(self.value, start, dt, minlen=int(minlen))
@@ -467,6 +467,7 @@ class StateVector(TimeSeries):
             for details on the segment representation method for
             `StateVector` bits
         """
+        from ..segments import DataQualityDict
         out = DataQualityDict()
         bitseries = self.get_bit_series(bits=bits)
         for bit, sts in bitseries.iteritems():


### PR DESCRIPTION
This PR introduces a number of critical optimisations for routines in GWpy. The summary is as follows:

- `gwpy.segments` is now only imported at the function level for `Channel` objects and all `Array` sub-classes (include, e.g, `TimeSeries`) - this import is slow because it relies on `gwpy.table.ligolw` imports
- `TimeSeries.read(format='framecpp') now intelligently handles accessing the TOC for a frame, and does it as seldom as possible
- `TimeSeries.spectrogram` now calculates a single window function up-front, rather than passing the default argument and having `scipy` recalculate the window function every time `welch` is called
- `TimeSeries.read(cache)` will now try to use `lalframe`-based serial access for up to 4 channels since `lalframe` is much faster than `frameCPP.py` - this is set in `gwpy.timeseries.io.cache.MAX_LALFRAME_CHANNELS`

Additionally, a number of bugs have been squashed as they were discovered.