### PR TITLE
Bug fixes in Series xindex setting

### DIFF
--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -67,19 +67,17 @@ class Series(Array):
 
     @xindex.setter
     def xindex(self, index):
-        if isinstance(index, Quantity):
-            self._xindex = index
-        elif index is None:
+        if index is None:
             del self.xindex
             return
-        else:
+        elif not isinstance(index, Quantity):
             index = Quantity(index, unit=self._default_xunit)
-            self._xindex = index
         self.x0 = index[0]
         if index.size:
             self.dx = index[1] - index[0]
         else:
             self.dx = None
+        self._xindex = index
 
     @xindex.deleter
     def xindex(self):

--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -73,6 +73,8 @@ class Spectrum(Series):
                        Channel(channel))
             name = name or channel.name
             unit = unit or channel.unit
+        if frequencies is None and 'xindex' in kwargs:
+            frequencies = kwargs.pop('xindex')
         # generate Spectrum
         return super(Spectrum, cls).__new__(cls, data, name=name, unit=unit,
                                             channel=channel, x0=f0, dx=df,

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -113,7 +113,7 @@ class TimeSeries(Series):
     _default_xunit = units.second
     _metadata_slots = ['name', 'channel', 'epoch', 'sample_rate']
 
-    def __new__(cls, data, unit=None, times=None, epoch=0, channel=None,
+    def __new__(cls, data, unit=None, times=None, epoch=None, channel=None,
                 sample_rate=None, name=None, **kwargs):
         """Generate a new TimeSeries.
         """
@@ -124,11 +124,16 @@ class TimeSeries(Series):
             name = name or channel.name
             unit = unit or channel.unit
             sample_rate = sample_rate or channel.sample_rate
-        elif sample_rate is None and 'dt' not in kwargs:
+        if times is None and 'xindex' in kwargs:
+            times = kwargs.pop('xindex')
+        if sample_rate is None and times is None and 'dt' not in kwargs:
             sample_rate = 1
+        if epoch is None and times is None and 't0' not in kwargs:
+            epoch = 0
         # generate TimeSeries
         new = super(TimeSeries, cls).__new__(cls, data, name=name, unit=unit,
-                                             channel=channel, **kwargs)
+                                             xindex=times, channel=channel,
+                                             **kwargs)
         if epoch is not None:
             new.epoch = epoch
         if sample_rate is not None:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -126,9 +126,9 @@ class TimeSeries(Series):
             sample_rate = sample_rate or channel.sample_rate
         if times is None and 'xindex' in kwargs:
             times = kwargs.pop('xindex')
-        if sample_rate is None and times is None and 'dt' not in kwargs:
+        if sample_rate is None and times is None and 'dx' not in kwargs:
             sample_rate = 1
-        if epoch is None and times is None and 't0' not in kwargs:
+        if epoch is None and times is None and 'x0' not in kwargs:
             epoch = 0
         # generate TimeSeries
         new = super(TimeSeries, cls).__new__(cls, data, name=name, unit=unit,


### PR DESCRIPTION
This PR fixes problems with passing the `xindex` kwarg to a `Series`, or equivalently `frequencies` to a `Spectrum` or `times` to a `TimeSeries.