### PR TITLE
Fixed problem adding new axes to figures with colorbars

### DIFF
--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -405,6 +405,8 @@ class Plot(figure.Figure):
         projection = kwargs.pop('projection', None)
         ax = kwargs.pop('ax', None)
         newax = kwargs.pop('newax', False)
+        sharex = kwargs.pop('sharex', None)
+        sharey = kwargs.pop('sharey', None)
 
         # set kwargs
         kwargs.setdefault("linestyle", "-")
@@ -418,7 +420,8 @@ class Plot(figure.Figure):
             except IndexError:
                 newax = True
         if newax:
-            ax = self._add_new_axes(projection=projection)
+            ax = self._add_new_axes(projection=projection,
+                                    sharex=sharex, sharey=sharey)
         # plot on axes
         return ax.plot(numpy.asarray(x), numpy.asarray(y), **kwargs)[0]
 
@@ -454,6 +457,8 @@ class Plot(figure.Figure):
         """
         # set kwargs
         kwargs.setdefault("s", 20)
+        sharex = kwargs.pop('sharex', None)
+        sharey = kwargs.pop('sharey', None)
 
         # find relevant axes
         if ax is None and not newax:
@@ -462,7 +467,8 @@ class Plot(figure.Figure):
             except IndexError:
                 newax = True
         if newax:
-            ax = self._add_new_axes(projection=projection)
+            ax = self._add_new_axes(projection=projection,
+                                    sharex=sharex, sharey=sharey)
         # plot on axes
         return ax.scatter(numpy.asarray(x), numpy.asarray(y), **kwargs)
 
@@ -494,6 +500,8 @@ class Plot(figure.Figure):
         Collection
             the :class:`~matplotlib.image.AxesImage` for this image
         """
+        sharex = kwargs.pop('sharex', None)
+        sharey = kwargs.pop('sharey', None)
         # find relevant axes
         if ax is None and not newax:
             try:
@@ -501,7 +509,8 @@ class Plot(figure.Figure):
             except IndexError:
                 newax = True
         if newax:
-            ax = self._add_new_axes(projection=projection)
+            ax = self._add_new_axes(projection=projection,
+                                    sharex=sharex, sharey=sharey)
         # plot on axes
         return ax.imshow(image, **kwargs)
 
@@ -586,7 +595,8 @@ class Plot(figure.Figure):
 
     @auto_refresh
     def add_timeseries(self, timeseries, projection='timeseries',
-                       ax=None, newax=False, **kwargs):
+                       ax=None, newax=False, sharex=None, sharey=None,
+                       **kwargs):
         """Add a :class:`~gwpy.timeseries.core.TimeSeries` trace to this plot
 
         Parameters
@@ -609,12 +619,12 @@ class Plot(figure.Figure):
         Line2D
             the :class:`~matplotlib.lines.Line2D` for this line layer
         """
-        return self.add_array(timeseries, 'timeseries',
-                              ax=ax, newax=newax, **kwargs)
+        return self.add_array(timeseries, 'timeseries', ax=ax, newax=newax,
+                              sharex=sharex, sharey=sharey, **kwargs)
 
     @auto_refresh
     def add_spectrum(self, spectrum, projection='spectrum', ax=None,
-                     newax=False, **kwargs):
+                     newax=False, sharex=None, sharey=None, **kwargs):
         """Add a :class:`~gwpy.spectrum.core.Spectrum` trace to this plot
 
         Parameters
@@ -637,12 +647,13 @@ class Plot(figure.Figure):
         Line2D
             the :class:`~matplotlib.lines.Line2D` for this line layer
         """
-        return self.add_array(spectrum, 'spectrum',
-                              ax=ax, newax=newax, **kwargs)
+        return self.add_array(spectrum, 'spectrum', ax=ax, newax=newax,
+                              sharex=sharex, sharey=sharey, **kwargs)
 
     @auto_refresh
     def add_spectrogram(self, spectrogram, projection='timeseries',
-                        ax=None, newax=False, **kwargs):
+                        ax=None, newax=False, sharex=None, sharey=None,
+                        **kwargs):
         """Add a :class:`~gwpy.spectrogram.core.Spectrogram` trace to
         this plot
 
@@ -666,11 +677,12 @@ class Plot(figure.Figure):
         Line2D
             the :class:`~matplotlib.lines.Line2D` for this line layer
         """
-        return self.add_array(spectrogram, 'timeseries',
-                              ax=ax, newax=newax, **kwargs)
+        return self.add_array(spectrogram, 'timeseries', ax=ax, newax=newax,
+                              sharex=sharex, sharey=sharey, **kwargs)
 
     @auto_refresh
-    def add_array(self, array, projection, ax=None, newax=False, **kwargs):
+    def add_array(self, array, projection, ax=None, newax=False,
+                  sharex=None, sharey=None, **kwargs):
         """Add a :class:`~gwpy.data.array.Array` to this plot
 
         Parameters
@@ -699,12 +711,13 @@ class Plot(figure.Figure):
             except IndexError:
                 newax = True
         if newax:
-            ax = self._add_new_axes(projection=projection)
+            ax = self._add_new_axes(projection=projection,
+                                    sharex=sharex, sharey=sharey)
         # plot on axes
         return ax.plot(array, **kwargs)
 
     def add_dataqualityflag(self, flag, projection=None, ax=None, newax=False,
-                            **kwargs):
+                            sharex=None, sharey=None, **kwargs):
         """Add a :class:`~gwpy.segments.flag.DataQualityFlag` to this plot
 
         Parameters
@@ -720,7 +733,8 @@ class Plot(figure.Figure):
             except IndexError:
                 newax = True
         if newax:
-            ax = self._add_new_axes(projection=projection)
+            ax = self._add_new_axes(projection=projection,
+                                    sharex=sharex, sharey=sharey)
         # plot on axes
         return ax.plot(flag, **kwargs)
 


### PR DESCRIPTION
This PR fixes #85 whereby calling `Plot.add_timeseries` or similar on a `Plot` with axes that weren't subplots (e.g. colorbars) raised an exception.

Additionally, this PR implements `sharex` and `sharey` kwargs to the `Plot.add_*` methods.