### PR TITLE
Workaround frameCPP not picking up numpy headers

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -70,7 +70,7 @@ else:
         2: numpy.float64,
         3: numpy.float32,
         4: numpy.int32,
-        5: numpy.in64,
+        5: numpy.int64,
         6: numpy.complex64,
         7: numpy.complex128,
         8: numpy.string_,


### PR DESCRIPTION
This PR adds a workaround to failures when frameCPP fails to find the `numpy/arrayobject.h` headers. In this case `FrVect.GetDataArray()` just returns a raw `buffer` so we need to convert into an `ndarray` by hand.

This PR adds the following:

- `FrVect` -> `numpy` type mapping `dict`
- `isinstance` check for output of `GetDataArray` and subsequent call to `numpy.frombuffer`