### PR TITLE
Improvements to GWF reading

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -77,7 +77,9 @@ def file_list(flist):
     """Parse a number of possible input types into a list of filepaths.
     """
     # format list of files
-    if isinstance(flist, CacheEntry):
+    if isinstance(flist, file):
+        return [flist.name]
+    elif isinstance(flist, CacheEntry):
         return [flist.path]
     elif (isinstance(flist, string_types) and
           flist.endswith(('.cache', '.lcf'))):

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -39,6 +39,8 @@ from ....utils import with_import
 from ....version import version
 from ... import (TimeSeries, TimeSeriesDict, StateVector, StateVectorDict)
 
+from .identify import *
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version
 

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -100,7 +100,18 @@ def register_gwf_io_library(library, package='gwpy.timeseries.io.gwf'):
     # import library
     lib = importlib.import_module('.%s' % library, package=package)
     dependency = lib.DEPENDS
-    read_timeseriesdict = lib.read_timeseriesdict
+    reader = lib.read_timeseriesdict
+
+    def read_timeseriesdict(*args, **kwargs):
+        """Read `TimeSeriesDict` from GWF source
+        """
+        nproc = kwargs.pop('nproc', 1)
+        if nproc > 1:
+            from ..cache import read_cache
+            kwargs['target'] = TimeSeriesDict
+            return read_cache(*args, **kwargs)
+        else:
+            return reader(*args, **kwargs)
 
     @with_import(dependency)
     def read_timeseries(source, channel, **kwargs):

--- a/gwpy/timeseries/io/gwf/identify.py
+++ b/gwpy/timeseries/io/gwf/identify.py
@@ -42,11 +42,7 @@ def identify_gwf(*args, **kwargs):
     else:
         return False
 
-
-def register_identifier(format='gwf'):
-    """Register a frame-file identifier for the given format.
-    """
-    registry.register_identifier(format, TimeSeries, identify_gwf)
-    registry.register_identifier(format, TimeSeriesDict, identify_gwf)
-    registry.register_identifier(format, StateVector, identify_gwf)
-    registry.register_identifier(format, StateVectorDict, identify_gwf)
+registry.register_identifier('gwf', TimeSeries, identify_gwf)
+registry.register_identifier('gwf', TimeSeriesDict, identify_gwf)
+registry.register_identifier('gwf', StateVector, identify_gwf)
+registry.register_identifier('gwf', StateVectorDict, identify_gwf)


### PR DESCRIPTION
This PR introduces two enhancements to the `TimeSeries.read()` functionality for GWF input

- added the `format` kwarg to the `timeseries.io.cache.read_cache` method, allowing the frame library readers to call back to the cache reader when a user specifies `nproc > 1`
- re-enabled auto-identification of GWF files, the order of library imports means frameCPP will be used by default for GWF reading