### PR TITLE
Patched TimeSeries.read to pad gaps in cache

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -229,6 +229,18 @@ class TimeSeries(Series):
                is only available when giving a :class:`~glue.lal.Cache` of
                frames, or using the ``format='cache'`` keyword argument.
 
+        gap : `str`, optional
+            how to handle gaps in the cache, one of
+
+            - 'ignore': do nothing, let the undelying reader method handle it
+            - 'warn': do nothing except print a warning to the screen
+            - 'raise': raise an exception upon finding a gap (default)
+            - 'pad': insert a value to fill the gaps
+
+        pad : `float`, optional
+            value with which to fill gaps in the source data, only used if
+            gap is not given, or `gap='pad'` is given
+
         Returns
         -------
         timeseries : `TimeSeries`
@@ -1795,6 +1807,18 @@ class TimeSeriesDict(OrderedDict):
                Parallel frame reading, via the ``nproc`` keyword argument,
                is only available when giving a :class:`~glue.lal.Cache` of
                frames, or using the ``format='cache'`` keyword argument.
+
+        gap : `str`, optional
+            how to handle gaps in the cache, one of
+
+            - 'ignore': do nothing, let the undelying reader method handle it
+            - 'warn': do nothing except print a warning to the screen
+            - 'raise': raise an exception upon finding a gap (default)
+            - 'pad': insert a value to fill the gaps
+
+        pad : `float`, optional
+            value with which to fill gaps in the source data, only used if
+            gap is not given, or `gap='pad'` is given
 
         Returns
         -------

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -39,7 +39,7 @@ MAX_LALFRAME_CHANNELS = 4
 
 
 def read_cache(cache, channel, start=None, end=None, resample=None,
-               gap='raise', nproc=1, format=None, **kwargs):
+               gap=None, pad=None, nproc=1, format=None, **kwargs):
     """Read a `TimeSeries` from a cache of data files using
     multiprocessing.
 
@@ -64,6 +64,17 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
     nproc : `int`, default: ``1``
         maximum number of independent frame reading processes, default
         is set to single-process file reading.
+    gap : `str`, optional
+        how to handle gaps in the cache, one of
+
+        - 'ignore': do nothing, let the undelying reader method handle it
+        - 'warn': do nothing except print a warning to the screen
+        - 'raise': raise an exception upon finding a gap (default)
+        - 'pad': insert a value to fill the gaps
+
+    pad : `float`, optional
+        value with which to fill gaps in the source data, only used if
+        gap is not given, or `gap='pad'` is given
 
     Notes
     -----
@@ -102,19 +113,23 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
     cspan = Segment(cache[0].segment[0], cache[-1].segment[1])
 
     # check for gaps
-    segs = cache_segments(cache, on_missing='ignore')
-    if len(segs) != 1:
+    if gap is None and pad is not None:
+        gap = 'pad'
+    elif gap is None:
+        gap = 'raise'
+    segs = cache_segments(cache, on_missing='ignore') & SegmentList([span])
+    if len(segs) != 1 and gap.lower() == 'ignore' or gap.lower() == 'pad':
+        pass
+    elif len(segs) != 1:
         gaps = SegmentList([cspan]) - segs
-        if gap.lower() == 'ignore':
-            pass
+        msg = ("The cache given to %s.read has gaps in it in the "
+               "following segments:\n    %s"
+               % (cls.__name__, '\n    '.join(map(str, gaps))))
+        if gap.lower() == 'warn':
+            warnings.warn(msg)
         else:
-            msg = ("The cache given to %s.read has gaps in it in the "
-                   "following segments:\n    %s"
-                   % (cls.__name__, '\n    '.join(map(str, gaps))))
-            if gap.lower() == 'warn':
-                warnings.warn(msg)
-            else:
-                raise ValueError(msg)
+            raise ValueError(msg)
+        segs = type(segs)([span])
 
     # if reading a small number of channels, try to use lalframe, its faster
     if format is None and (
@@ -130,6 +145,23 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
     # otherwise use the file extension as the format
     elif format is None:
         format = os.path.splitext(cache[0].path)[1][1:]
+
+    # -- process multiple cache segments --------
+    # this entry point loops this method for each segment
+
+    if len(segs) > 1:
+        out = None
+        for seg in segs:
+            new = read_cache(cache, channel, start=seg[0], end=seg[1],
+                             resample=resample, nproc=nproc, format=format,
+                             **kwargs)
+            if out is None:
+                out = new.copy()
+            else:
+                out.append(new, gap='pad', pad=pad)
+        return out
+
+    # -- process single cache segment
 
     # force one frame per process minimum
     nproc = min(nproc, len(cache))

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -154,7 +154,7 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
         for seg in segs:
             new = read_cache(cache, channel, start=seg[0], end=seg[1],
                              resample=resample, nproc=nproc, format=format,
-                             **kwargs)
+                             target=cls, **kwargs)
             if out is None:
                 out = new.copy()
             else:

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -121,28 +121,28 @@ def register_gwf_io_library(library, package='gwpy.timeseries.io.gwf'):
             return reader(source, *args, **kwargs)
 
     @with_import(dependency)
-    def read_timeseries(source, channel, **kwargs):
+    def read_timeseries(source, channel, *args, **kwargs):
         """Read `TimeSeries` from GWF source
         """
-        return read_timeseriesdict(source, [channel], **kwargs)[channel]
+        return read_timeseriesdict(source, [channel], *args, **kwargs)[channel]
 
     @with_import(dependency)
-    def read_statevector(source, channel, bits=None,
-                         _SeriesClass=StateVector, **kwargs):
+    def read_statevector(source, channel, *args, **kwargs):
         """Read `StateVector` from GWF source
         """
-        sv = read_timeseries(
-            source, channel, _SeriesClass=_SeriesClass, **kwargs)
+        bits = kwargs.pop('bits', None)
+        kwargs.setdefault('_SeriesClass', StateVector)
+        sv = read_timeseries(source, channel, *args, **kwargs)
         sv.bits = bits
         return sv
 
     @with_import(dependency)
-    def read_statevectordict(source, channels, bitss=[],
-                             _SeriesClass=StateVector, **kwargs):
+    def read_statevectordict(source, channels, *args, **kwargs):
         """Read `StateVectorDict` from GWF source
         """
-        svd = StateVectorDict(read_timeseriesdict(
-            source, channels, _SeriesClass=_SeriesClass, **kwargs))
+        bitss.pop('bitss', [])
+        kwargs.setdefault('_SeriesClass', StateVector)
+        svd = StateVectorDict(read_timeseriesdict(source, channels, **kwargs))
         for (channel, bits) in zip(channels, bitss):
             svd[channel].bits = bits
         return svd

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -115,6 +115,7 @@ def register_gwf_io_library(library, package='gwpy.timeseries.io.gwf'):
         if nproc > 1 or pad is not None:
             from ..cache import read_cache
             kwargs['target'] = TimeSeriesDict
+            kwargs['nproc'] = nproc
             kwargs['pad'] = pad
             return read_cache(source, *args, **kwargs)
         else:

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -106,16 +106,19 @@ def register_gwf_io_library(library, package='gwpy.timeseries.io.gwf'):
     dependency = lib.DEPENDS
     reader = lib.read_timeseriesdict
 
-    def read_timeseriesdict(*args, **kwargs):
+    def read_timeseriesdict(source, *args, **kwargs):
         """Read `TimeSeriesDict` from GWF source
         """
+        # use multiprocessing or padding
         nproc = kwargs.pop('nproc', 1)
-        if nproc > 1:
+        pad = kwargs.pop('pad', None)
+        if nproc > 1 or pad is not None:
             from ..cache import read_cache
             kwargs['target'] = TimeSeriesDict
-            return read_cache(*args, **kwargs)
+            kwargs['pad'] = pad
+            return read_cache(source, *args, **kwargs)
         else:
-            return reader(*args, **kwargs)
+            return reader(source, *args, **kwargs)
 
     @with_import(dependency)
     def read_timeseries(source, channel, **kwargs):

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -419,6 +419,18 @@ class StateVector(TimeSeries):
                is only available when giving a :class:`~glue.lal.Cache` of
                frames, or using the ``format='cache'`` keyword argument.
 
+        gap : `str`, optional
+            how to handle gaps in the cache, one of
+
+            - 'ignore': do nothing, let the undelying reader method handle it
+            - 'warn': do nothing except print a warning to the screen
+            - 'raise': raise an exception upon finding a gap (default)
+            - 'pad': insert a value to fill the gaps
+
+        pad : `float`, optional
+            value with which to fill gaps in the source data, only used if
+            gap is not given, or `gap='pad'` is given
+
         Returns
         -------
         statevector : `StateVector`
@@ -674,6 +686,20 @@ class StateVectorDict(TimeSeriesDict):
                Parallel frame reading, via the ``nproc`` keyword argument,
                is only available when giving a :class:`~glue.lal.Cache` of
                frames, or using the ``format='cache'`` keyword argument.
+
+        gap : `str`, optional
+            how to handle gaps in the cache, one of
+
+            - 'ignore': do nothing, let the undelying reader method handle it
+            - 'warn': do nothing except print a warning to the screen
+            - 'raise': raise an exception upon finding a gap (default)
+            - 'pad': insert a value to fill the gaps
+
+        pad : `float`, optional
+            value with which to fill gaps in the source data, only used if
+            gap is not given, or `gap='pad'` is given
+
+
 
         Returns
         -------


### PR DESCRIPTION
This PR introduces an extension to the `TimeSeries.read()` cache methods to pad gaps in the cache with a given value.

This PR fixes #69 and fixes #97.