### PR TITLE
vcs.py: moved to module gwpy._version_helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - pip install h5py
   - popd
 install:
-  - pip install -q .
+  - pip install .
 script:
   - python setup.py test
 notifications:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include LICENSE README.rst MANIFEST.in
 recursive-include gwpy/tests/data *gwf *xml.gz *xml *txt *hdf
 recursive-include examples/ *py
-include vcs.py
 include ez_setup.py

--- a/gwpy/__init__.py
+++ b/gwpy/__init__.py
@@ -39,10 +39,17 @@ warnings.filterwarnings("ignore", "The oldnumeric module",
                         DeprecationWarning)
 
 # set metadata
-from . import version
+try:
+    from . import version
+except ImportError:
+    # this _should_ fail only during a clean build
+    __version__ = 'build'
+    __date__ = ''
+else:
+    __version__ = version.version
+    __date__ = version.__date__
+
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-__version__ = version.version
-__date__ = version.__date__
 __credits__ = "The LIGO Scientific Collaboration and the Virgo Collaboration"
 
 __import__('pkg_resources').declare_namespace(__name__)

--- a/gwpy/_version_helper.py
+++ b/gwpy/_version_helper.py
@@ -16,8 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>
 
-"""Git version generator
+"""Git version generator for GWpy (or any package, for that matter)
 """
+
+from __future__ import absolute_import
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Adam Mercer <adam.mercer@ligo.org>'

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ class GitVersionMixin(object):
         """Generate target file with versioning information from git VCS
         """
         log.info("generating %s" % pyfile)
-        import vcs
+        import gwpy._version_helper as vcs
         gitstatus = vcs.GitStatus()
         try:
             with open(pyfile, 'w') as fobj:


### PR DESCRIPTION
This commit moves the vcs.py version generator into a package module, which means it's now importable by other packages