### PR TITLE
table.io.trigfind: raise exception if no channel directory

### DIFF
--- a/gwpy/table/io/trigfind.py
+++ b/gwpy/table/io/trigfind.py
@@ -59,6 +59,13 @@ def find_trigger_urls(channel, etg, gpsstart, gpsend, verbose=False):
     trigform = ('%s-%s_%s-%s-*.xml*'
                 % (ifo, re_dash.sub('_', channel), etg.lower(), '[0-9]'*10))
 
+    # test for channel-level directory
+    if not os.path.isdir(searchbase):
+        raise ValueError("No channel-level directory found at %s. Either the "
+                         "channel name or ETG names are wrong, or this "
+                         "channel is not configured for this ETG."
+                         % searchbase)
+
     # perform and cache results
     out = Cache()
     append = out.append

--- a/gwpy/table/lsctables.py
+++ b/gwpy/table/lsctables.py
@@ -124,6 +124,12 @@ def _fetch_factory(table):
             a new `{0}` containing triggers read from the standard
             paths
 
+        Raises
+        ------
+        ValueError
+            if no channel-level directory is found for the given channel,
+            indicating that nothing has ever been processed for this channel.
+
         See also
         --------
         {0}.read :


### PR DESCRIPTION
This PR adds an error condition to `table.io.trigfind.find_trigger_urls` (used by `SnglBurstTable.fetch`) when a channel-level directory is not found, meaning this channel has never been processed by the given ETG.

This fixes #72.
