### PR TITLE
Fixes for DataQualityDict.from_veto_definer_file

### DIFF
--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -105,6 +105,10 @@ def table_from_file(f, tablename, columns=None, filt=None,
     # find table class
     tableclass = lsctables.TableByName[table.StripTableName(tablename)]
 
+    # get content handler
+    if contenthandler is None:
+        contenthandler = get_partial_contenthandler(tableclass)
+
     # allow cache multiprocessing
     if nproc != 1:
         return tableclass.read(f, columns=columns,

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -42,6 +42,8 @@ __version__ = version.version
 
 
 class GWpyContentHandler(LIGOLWContentHandler):
+    """Empty sub-class of `~glue.ligolw.ligolw.LIGOLWContentHandler`
+    """
     pass
 
 
@@ -73,8 +75,8 @@ def get_partial_contenthandler(table):
 
 
 def table_from_file(f, tablename, columns=None, filt=None,
-                    contenthandler=GWpyContentHandler, nproc=1, verbose=False):
-    """Read a :class:`~glue.ligolw.table.Table` from a LIGO_LW file.
+                    contenthandler=None, nproc=1, verbose=False):
+    """Read a `~glue.ligolw.table.Table` from a LIGO_LW file.
 
     Parameters
     ----------
@@ -83,9 +85,9 @@ def table_from_file(f, tablename, columns=None, filt=None,
 
         - an open `file`
         - a `str` pointing to a file path on disk
-        - a formatted :class:`~glue.lal.CacheEntry` representing one file
+        - a formatted `~glue.lal.CacheEntry` representing one file
         - a `list` of `str` file paths
-        - a formatted :class:`~glue.lal.Cache` representing many files
+        - a formatted `~glue.lal.Cache` representing many files
 
     tablename : `str`
         name of the table to read.
@@ -94,12 +96,12 @@ def table_from_file(f, tablename, columns=None, filt=None,
     filt : `function`, optional
         function by which to `filter` events. The callable must accept as
         input a row of the table event and return `True`/`False`.
-    contenthandler : :class:`~glue.ligolw.ligolw.LIGOLWContentHandler`
+    contenthandler : `~glue.ligolw.ligolw.LIGOLWContentHandler`
         SAX content handler for parsing LIGO_LW documents.
 
     Returns
     -------
-    table : :class:`~glue.ligolw.table.Table`
+    table : `~glue.ligolw.table.Table`
         `Table` of data with given columns filled
     """
     # find table class

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -62,7 +62,7 @@ def get_partial_contenthandler(table):
         read only the given `table`
     """
     def _filter_func(name, attrs):
-        if name == table.tagName and 'Name' in attrs:
+        if name == table.tagName and attrs.has_key('Name'):
             return compare_table_names(attrs.get('Name'), table.tableName) == 0
         else:
             return False

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -62,7 +62,7 @@ def get_partial_contenthandler(table):
         read only the given `table`
     """
     def _filter_func(name, attrs):
-        if name == table.tagName and attrs.has_key('Name'):
+        if name == table.tagName and 'Name' in attrs:
             return compare_table_names(attrs.get('Name'), table.tableName) == 0
         else:
             return False

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -556,7 +556,7 @@ class DataQualityFlag(object):
         except TypeError:
             pass
         known = Segment(veto.start_time, veto.end_time)
-        pad = Segment(veto.start_pad, veto.end_pad)
+        pad = (veto.start_pad, veto.end_pad)
         return cls(name=name, known=[known], category=veto.category,
                    description=veto.comment, padding=pad)
 
@@ -1102,14 +1102,12 @@ class DataQualityDict(OrderedDict):
     def from_veto_definer_file(cls, fp, start=None, end=None, ifo=None):
         """Read a `DataQualityDict` from a LIGO_LW XML VetoDefinerTable.
         """
-        # open file
-        if isinstance(fp, (str, unicode)):
-            fobj = open(fp, 'r')
-        else:
-            fobj = fp
-        xmldoc = ligolw_utils.load_fileobj(fobj)[0]
-        # read veto definers
-        veto_def_table = VetoDefTable.get_table(xmldoc)
+        start = to_gps(start)
+        end = to_gps(end)
+        # read veto definer file
+        from gwpy.table.lsctables import VetoDefTable
+        veto_def_table = VetoDefTable.read(fp)
+        # parse flag definitions
         out = cls()
         for row in veto_def_table:
             if ifo and row.ifo != ifo:

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -42,7 +42,7 @@ except ImportError:
 
 from numpy import inf
 
-from glue.segments import (infinity, PosInfinity)
+from glue.segments import PosInfinity
 
 from .. import version
 from ..time import to_gps

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1107,14 +1107,17 @@ class DataQualityDict(OrderedDict):
     """))
 
     @classmethod
-    def from_veto_definer_file(cls, fp, start=None, end=None, ifo=None):
+    def from_veto_definer_file(cls, fp, start=None, end=None, ifo=None,
+                               format='ligolw'):
         """Read a `DataQualityDict` from a LIGO_LW XML VetoDefinerTable.
         """
-        start = to_gps(start)
-        end = to_gps(end)
+        if start is not None:
+            start = to_gps(start)
+        if end is not None:
+            end = to_gps(end)
         # read veto definer file
         from gwpy.table.lsctables import VetoDefTable
-        veto_def_table = VetoDefTable.read(fp)
+        veto_def_table = VetoDefTable.read(fp, format=format)
         # parse flag definitions
         out = cls()
         for row in veto_def_table:

--- a/gwpy/tests/segments.py
+++ b/gwpy/tests/segments.py
@@ -23,12 +23,14 @@ import sys
 import os.path
 import tempfile
 import StringIO
-from urllib2 import URLError
+from urllib2 import (urlopen, URLError)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
+
+from glue.segments import PosInfinity
 
 from .. import version
 from ..segments import (Segment, SegmentList, DataQualityFlag, DataQualityDict)
@@ -69,6 +71,11 @@ QUERY_KNOWN = SegmentList([(1108598416, 1108632895), (1108632901, 1108684816)])
 QUERY_ACTIVE = SegmentList([(1108623497, 1108624217)])
 QUERY_FLAG = 'L1:DMT-DC_READOUT:1'
 QUERY_URL = 'https://dqsegdb5.phy.syr.edu'
+
+VETO_DEFINER_FILE = ('https://www.lsc-group.phys.uwm.edu/ligovirgo/cbc/public/'
+                     'segments/ER7/H1L1V1-ER7_CBC_OFFLINE.xml')
+ER7_START = 'June 3'
+ER7_END = 'June 14'
 
 
 class SegmentListTests(unittest.TestCase):
@@ -177,6 +184,55 @@ class DataQualityFlagTests(unittest.TestCase):
         else:
             self.assertEqual(flag.known, QUERY_KNOWN)
             self.assertEqual(flag.active, QUERY_ACTIVE)
+
+
+class DataQualityDictTestCase(unittest.TestCase):
+    tmpfile = '%s.%%s' % tempfile.mktemp(prefix='gwpy_test_dqdict')
+    VETO_DEFINER = tmpfile % 'vdf.xml'
+
+    def setUp(self):
+        # download veto definer
+        vdffile = urlopen(VETO_DEFINER_FILE)
+        with open(self.VETO_DEFINER, 'w') as f:
+            f.write(vdffile.read())
+
+    def tearDown(self):
+        if os.path.isfile(self.VETO_DEFINER):
+            os.remove(self.VETO_DEFINER)
+
+    def test_from_veto_definer_file(self):
+        vdf = DataQualityDict.from_veto_definer_file(self.VETO_DEFINER)
+        self.assertNotEqual(len(vdf.keys()), 0)
+        # test missing h(t) flag
+        self.assertIn('H1:DCH-MISSING_H1_HOFT_C00:1', vdf)
+        self.assertEquals(vdf['H1:DCH-MISSING_H1_HOFT_C00:1'].known[0][0],
+                          1073779216)
+        self.assertEquals(vdf['H1:DCH-MISSING_H1_HOFT_C00:1'].known[0][-1],
+                          PosInfinity)
+        self.assertEquals(vdf['H1:DCH-MISSING_H1_HOFT_C00:1'].category, 1)
+        # test injections padding
+        self.assertEquals(vdf['H1:ODC-INJECTION_CBC:1'].padding, Segment(-8, 8))
+
+    def test_read_ligolw(self):
+        flags = DataQualityDict.read(SEGXML)
+        self.assertEquals(len(flags.keys()), 2)
+        self.assertIn(FLAG1, flags)
+        self.assertIn(FLAG2, flags)
+        flags = DataQualityDict.read(SEGXML, [FLAG2])
+        self.assertEquals(len(flags.keys()), 1)
+        self.assertEquals(flags[FLAG2].known, KNOWN2)
+        self.assertEquals(flags[FLAG2].active, ACTIVE2)
+
+    def test_write_ligolw(self):
+        tmpfile = self.tmpfile % 'xml.gz'
+        try:
+            flags = DataQualityDict.read(SEGXML)
+        except Exception:
+            self.skipTest(str(e))
+        try:
+            flags.write(tmpfile)
+        finally:
+            os.remove(tmpfile)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes a few problems with parsing and operating on veto definer files via the `DataQualityDict` object.

Most of the changes are to enable handling infinities in the query methods, by default a `veto_definer` entry may have an `end_time` of 0 meaning 'endless definition', but the segment logic will always reverse that, which is a bit annoying.