### PR TITLE
New cWB->SnglBurstTable ASCII parser

### DIFF
--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -22,8 +22,7 @@ All specific unified input/output for class objecst should be placed in
 an 'io' subdirectory of the containing directory for that class.
 """
 
-from gzip import GzipFile
-from astropy.utils.compat.gzip import GzipFile as AstroGzipFile
+from .utils import GzipFile
 
 from glue.lal import CacheEntry
 from glue.ligolw.ligolw import (Document, LIGOLWContentHandler,
@@ -123,7 +122,7 @@ def table_from_file(f, tablename, columns=None, filt=None,
         tableclass.loadcolumns = columns
 
     # generate Document and populate
-    files = [fp.name if isinstance(fp, (file, GzipFile, AstroGzipFile)) else
+    files = [fp.name if isinstance(fp, (file, GzipFile)) else
              fp for fp in file_list(f)]
     xmldoc = Document()
     ligolw_add(xmldoc, files, non_lsc_tables_ok=True,

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -19,7 +19,7 @@
 """Utilities for unified input/output
 """
 
-from gzip import GzipFile
+import gzip
 
 from astropy.utils.compat.gzip import GzipFile as AstroGzipFile
 
@@ -36,7 +36,7 @@ def identify_factory(*extensions):
         """Identify the given extensions in a file object/path
         """
         fp = args[3]
-        if isinstance(fp, (file, GzipFile, AstroGzipFile)):
+        if isinstance(fp, (file, gzip.GzipFile, AstroGzipFile)):
             fp = fp.name
         elif isinstance(fp, CacheEntry):
             fp = fp.path
@@ -46,3 +46,20 @@ def identify_factory(*extensions):
         else:
             return False
     return identify
+
+
+def gopen(name, *args, **kwargs):
+    """Open a file handling optional gzipping
+
+    Parameters
+    ----------
+    name : `str`
+        path (name) of file to open
+    *args, **kwargs
+        other arguments to pass to either `open` for regular files, or
+        `gzip.open` for files with a `name` ending in `.gz`
+    """
+    if name.endswith('.gz'):
+        return gzip.open(name, *args, **kwargs)
+    else:
+        return open(name, *args, **kwargs)

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -19,9 +19,7 @@
 """Utilities for unified input/output
 """
 
-import gzip
-
-from astropy.utils.compat.gzip import GzipFile as AstroGzipFile
+from astropy.utils.compat.gzip import GzipFile
 
 from glue.lal import CacheEntry
 
@@ -36,7 +34,7 @@ def identify_factory(*extensions):
         """Identify the given extensions in a file object/path
         """
         fp = args[3]
-        if isinstance(fp, (file, gzip.GzipFile, AstroGzipFile)):
+        if isinstance(fp, (file, GzipFile)):
             fp = fp.name
         elif isinstance(fp, CacheEntry):
             fp = fp.path
@@ -60,6 +58,6 @@ def gopen(name, *args, **kwargs):
         `gzip.open` for files with a `name` ending in `.gz`
     """
     if name.endswith('.gz'):
-        return gzip.open(name, *args, **kwargs)
+        return GzipFile(name, *args, **kwargs)
     else:
         return open(name, *args, **kwargs)

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -26,13 +26,12 @@ from glue.ligolw.ligolw import (Document, LIGO_LW)
 from glue.ligolw.utils import write_filename
 from glue.ligolw.utils.ligolw_add import ligolw_add
 
-from gzip import GzipFile
-from astropy.utils.compat.gzip import GzipFile as AstroGzipFile
 
 from astropy.time import Time
 from astropy.io import registry
 
 from ... import version
+from ...io.utils import GzipFile
 from ...io.ligolw import (identify_ligolw, GWpyContentHandler)
 from ...io.cache import file_list
 from ...segments import (Segment, DataQualityFlag, DataQualityDict)
@@ -69,7 +68,7 @@ def read_flag_dict(f, flags=None, gpstype=LIGOTimeGPS, coalesce=False,
 
     # generate Document and populate
     xmldoc = Document()
-    files = [fp.name if isinstance(fp, (file, GzipFile, AstroGzipFile))
+    files = [fp.name if isinstance(fp, (file, GzipFile))
              else fp for fp in file_list(f)]
     ligolw_add(xmldoc, files, non_lsc_tables_ok=True,
                contenthandler=contenthandler)

--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -38,5 +38,8 @@ from .omicron import *
 # import omega I/O
 from .omega import *
 
+# import cWB I/O
+from .cwb import *
+
 # import cache I/O
 from .cache import *

--- a/gwpy/table/io/ascii.py
+++ b/gwpy/table/io/ascii.py
@@ -121,7 +121,12 @@ def table_from_ascii_factory(table, format, trig_func, cols=None, **kwargs):
         else:
             columns = list(columns)
         # and translate them into LIGO_LW columns (only for 'time')
-        ligolwcolumns = list(columns)
+        try:
+            ligolwcolumns = list(columns)
+        except TypeError as e:
+            e.args = ('This ascii format requires the column list to be given '
+                      'manually, please give the `columns` keyword argument',)
+            raise
         if 'time' in columns and table.tableName in TIME_COLUMN:
             ligolwcolumns.remove('time')
             ligolwcolumns.extend(TIME_COLUMN[table.tableName])

--- a/gwpy/table/io/cwb.py
+++ b/gwpy/table/io/cwb.py
@@ -22,7 +22,6 @@
 import os.path
 import re
 import warnings
-from gzip import GzipFile
 
 from astropy.io.registry import (register_reader, register_identifier)
 
@@ -31,7 +30,7 @@ from glue.lal import CacheEntry
 from .ascii import return_reassign_ids
 from ..lsctables import SnglBurstTable
 from ...io.cache import (file_list, read_cache)
-from ...io.utils import gopen
+from ...io.utils import (gopen, GzipFile)
 from ... import version
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/table/io/cwb.py
+++ b/gwpy/table/io/cwb.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read events from an Omega-format ASCII file.
+"""
+
+import os.path
+import re
+import warnings
+from gzip import GzipFile
+
+from astropy.io.registry import (register_reader, register_identifier)
+
+from glue.lal import CacheEntry
+
+from .ascii import return_reassign_ids
+from ..lsctables import SnglBurstTable
+from ...io.cache import (file_list, read_cache)
+from ...io.utils import gopen
+from ... import version
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+SNGL_BURST_COLUMNS = SnglBurstTable.validcolumns.keys()
+CWB_ASCII_SNGL_BURST_COLUMN_MAP = {
+    'central frequency': 'central_freq',
+    'low frequency': 'flow',
+    'high frequency': 'fhigh',
+    'effective correlated amplitude rho': 'amplitude',
+    'likelhood': 'confidence',
+    'sSNR': 'snr',
+    'time': 'time',
+    'time shift': 'time_lag',
+}
+RE_CWB_ASCII_COLNAME = re.compile('\A#\s+(?P<index>\d+) - (?P<colname>(.*))\Z')
+RE_SNGL_COLNAME = re.compile('(?P<name>\w+) for (?P<ifo>[A-Z][0-9]) detector')
+
+
+def get_column_list(filename, ifo, comments='#'):
+    """Read the column list from a cWB ASCII file
+
+    Parameters
+    ----------
+    filename : `str`
+        path of file to read
+    ifo : `str`
+        prefix of IFO for which to find columns
+    comments : `str`, optional, default: '#'
+        comment character used for this file
+
+    Returns
+    -------
+    usecols : `list` of `int`
+        the list of column positions to pass to :meth:`numpy.loadtxt`
+    columns : `list` of `str`
+        the list of column names corresponding to the `usecols` list
+
+    Notes
+    -----
+    The cWB 'EVENTS.txt' files give a header of (number, name) column
+    definitions, however the numbers don't actually match up to the
+    actual position of the relevant column when counting from zero, so the
+    numbers given in the file are ignored.
+    """
+    columns = []
+    plus2 = 0
+    foundifo = False
+    with gopen(filename, 'rb') as f:
+        while True:
+            line = f.readline()
+            # stop when the header finishes
+            if not line.startswith(comments):
+                break
+            # work out whether there are + - columns (that aren't counted)
+            elif line.startswith('%s -/+' % comments):
+                plus2 = 2
+                continue
+            # parse line, or move on
+            try:
+                match = RE_CWB_ASCII_COLNAME.match(line.rstrip()).groupdict()
+            except AttributeError:
+                continue
+            colname = match['colname']
+            # try and match as a ifo-specific parameter
+            try:
+                sngl = RE_SNGL_COLNAME.match(colname).groupdict()
+            except AttributeError:
+                pass
+            else:
+                colname = sngl['name']
+                if sngl['ifo'].lower() != ifo.lower():
+                    columns.append(None)
+                    continue
+                else:
+                    foundifo = True
+            # otherwise try the custom mapping, then just the sngl_burst name
+            try:
+                columns.append(CWB_ASCII_SNGL_BURST_COLUMN_MAP[colname])
+            except KeyError:
+                if colname in SNGL_BURST_COLUMNS:
+                    columns.append(colname)
+                else:
+                    columns.append(None)
+    if not foundifo:
+        warnings.warn("No %s-specific columns were found in %s"
+                      % (ifo, filename), stacklevel=2)
+    usecols, names = zip(*[(i+plus2, c) for (i, c) in enumerate(columns)
+                           if c is not None])
+    return usecols, names
+
+
+def sngl_burst_table_from_cwb_ascii(f, columns=None, ifo=None, filt=None,
+                                    usecols=None, nproc=1, **loadtxtkwargs):
+    """Read a `SnglBurstTable` from a cWB-format ASCII file
+
+    Parameters
+    ----------
+    f : `file`, `str`, `~glue.lal.CacheEntry`, `list`, `~glue.lal.Cache`
+        object representing one or more files. One of
+
+        - an open `file`
+        - a `str` pointing to a file path on disk
+        - a formatted `~glue.lal.CacheEntry` representing one file
+        - a `list` of `str` file paths
+        - a formatted `~glue.lal.Cache` representing many files
+
+    columns : `list`, optional
+        list of column name strings to read, default all.
+
+    ifo : `str`, required
+        prefix of IFO to read, required for 'cwb-ascii' format
+        (but not for others)
+
+    usecols : `list` of `int`
+        the list of column indices to read (absolute, zero-indexed)
+
+    **loadtxtkwargs
+        other keyword arguments are passed to `numpy.loadtxt`
+
+    Returns
+    -------
+    table : `SnglBurstTable`
+        a new `SnglBurstTable` filled with data read from the file(s)
+
+    Raises
+    ------
+    ValueError
+        if `ifo` is not given, OR
+
+        if `columns` is given (and not `usecols`) and that column is not
+        detected in the file, OR
+
+        if `usecols` is given (and not `columns`) and that column isn't
+        parseable from the given file (no `sngl_burst` equivalent)
+    """
+    # allow multiprocessing
+    if nproc != 1:
+        return read_cache(f, SnglBurstTable, nproc, return_reassign_ids,
+                          columns=columns, usecols=usecols, ifo=ifo,
+                          filt=filt, format='cwb-ascii', **loadtxtkwargs)
+
+    comments = loadtxtkwargs.pop('comments', '#')
+    files = file_list(f)
+    if ifo is None:
+        raise ValueError("ifo keyword argument must be given to read cWB "
+                         "events from ASCII")
+    # parse columns from file header
+    allusecols, allcolumns = get_column_list(files[0], ifo, comments=comments)
+    # work out which columns the user asked for
+    if columns and not usecols:
+        given = list(columns)
+        columns = []
+        usecols = []
+        for c in given:
+            if c.lower().startswith('peak_time') and 'time' in columns:
+                continue
+            elif c.lower().startswith('peak_time'):
+                c = 'time'
+            try:
+                index = allcolumns.index(c)
+            except ValueError as e:
+                e.args = ('Column %r not found in %s for %s'
+                          % (c, files[0], ifo),)
+                raise
+            else:
+                columns.append(c)
+                usecols.append(allusecols[index])
+    elif usecols and not columns:
+        columns = []
+        for coln in usecols:
+            try:
+                index = allusecols.index(coln)
+            except ValueError as e:
+                e.args = ('Column %d not parseable in %s for %s\n'
+                          'Note: when reading cWB ASCII files, usecols is the '
+                          'list of absolute zero-indexed column positions, not'
+                          ' necessarily what is given in the cWB file header'
+                          % (coln, files[0], ifo),)
+                raise
+            else:
+                columns.append(allcolumns[index])
+    # or use all columns
+    elif not columns and not usecols:
+        columns = allcolumns
+        usecols = allusecols
+    # read data
+    out = SnglBurstTable.read(files, columns, usecols=usecols, format='ascii',
+                              comments=comments, filt=filt, **loadtxtkwargs)
+    # append search information and fix SNR
+    out.appendColumn('ifo')
+    out.appendColumn('search')
+    for t in out:
+        t.ifo = ifo
+        t.search = 'cwb'
+        if 'snr' in columns:
+            t.snr **= 1/2.
+    return out
+
+
+def identify_cwb_ascii(origin, path, fileobj, *args, **kwargs):
+    """Automatically identify a fileobj as 'cwb-ascii' format
+
+    Notes
+    -----
+    This method won't actually let you automatically identify and
+    read cwb-ascii files, because the basic 'ascii' format will also
+    identify as valid for 'EVENTS.txt' files.
+
+    This function means that when someone runs
+    SnglBurstTable.read('EVENTS.txt') an exception will be raised with a
+    a sensible error message prompting them to manually specify
+    `format='cwb-ascii'`.
+    """
+    # get file path and filobj
+    if isinstance(fileobj, (file, GzipFile)):
+        fp = fileobj.name
+        pos = fileobj.tell()
+        close = False
+    elif isinstance(fileobj, CacheEntry):
+        fp = fileobj.path
+        fileobj = gopen(fp, 'rb')
+        close = True
+    else:
+        fp = fileobj
+        fileobj = gopen(fp, 'rb')
+        close = True
+    # identify by name
+    if not os.path.basename(fp) in ['EVENTS.txt', 'EVENTS.txt.gz']:
+        return False
+    # verify contents
+    pos = fileobj.tell()
+    try:
+        fileobj.seek(0)
+        if fileobj.readline().startswith('# correlation threshold'):
+            return True
+        else:
+            return False
+    finally:
+        fileobj.seek(pos)
+        if close:
+            fileobj.close()
+
+
+register_identifier('cwb-ascii', SnglBurstTable, identify_cwb_ascii)
+register_reader('cwb-ascii', SnglBurstTable, sngl_burst_table_from_cwb_ascii)

--- a/gwpy/table/lsctables.py
+++ b/gwpy/table/lsctables.py
@@ -167,6 +167,15 @@ for table in TableByName.itervalues():
         columns : `list`, optional
             list of column name strings to read, default all.
 
+        ifo : `str`, optional
+            prefix of IFO to read
+
+            .. warning::
+
+               the ``ifo`` keyword argument is only applicable (but is
+               required) when reading single-interferometer data from
+               a multi-interferometer file
+
         filt : `function`, optional
             function by which to `filter` events. The callable must
             accept as input a row of the table event and return

--- a/gwpy/tests/table.py
+++ b/gwpy/tests/table.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit test for table module
+"""
+
+import os.path
+import tempfile
+import unittest
+
+from gwpy import version
+from gwpy.table import lsctables
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+SNGL_BURST_XML_FILE = os.path.join(
+    os.path.split(__file__)[0], 'data', 'H1-LDAS_STRAIN-968654552-10.xml.gz')
+
+
+class TableTestMixin(object):
+    TABLE_CLASS = None
+
+    def test_has_gwpy_methods(self):
+        for method in ['read', 'plot']:
+            self.assertTrue(hasattr(self.TABLE_CLASS, method))
+
+
+class SnglBurstTableTestCase(TableTestMixin, unittest.TestCase):
+    """`TestCase` for `SnglBurstTable`
+    """
+    TABLE_CLASS = lsctables.SnglBurstTable
+
+    def test_read_ligolw(self):
+        table = self.TABLE_CLASS.read(SNGL_BURST_XML_FILE)
+        table = self.TABLE_CLASS.read(SNGL_BURST_XML_FILE, format='ligolw')
+        table = self.TABLE_CLASS.read(SNGL_BURST_XML_FILE, format='sngl_burst')
+        self.assertEquals(len(table), 2052)
+
+    def test_write_ligolw(self):
+        # read table
+        table = self.TABLE_CLASS.read(SNGL_BURST_XML_FILE)
+        tmpxml = tempfile.mktemp(suffix='.xml.gz')
+        # write table
+        try:
+            table.write(open(tmpxml, 'w'))
+            table2 = self.TABLE_CLASS.read(tmpxml)
+        finally:
+            if os.path.isfile(tmpxml):
+                os.remove(tmpxml)
+        self.assertEquals(len(table), len(table2))
+        self.assertEquals(table[0].get_peak(), table2[0].get_peak())
+        self.assertEquals(table[0].snr, table2[0].snr)


### PR DESCRIPTION
This PR introduces a new 'cwb-ascii' I/O format for the `SnglBurstTable` to read `EVENTS.txt`-format files from the coherent waveburst analysis.

Attached are some improvements to the associated `gwpy.table` module, and a new test case.