### PR TITLE
Bug fix for multisegment dqsegdb query

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -499,13 +499,14 @@ class DataQualityFlag(object):
         request = kwargs.pop('request', 'metadata,active,known')
 
         # process query
-        new = cls(name=flag)
+        out = cls(name=flag)
         for start, end in qsegs:
             if end == PosInfinity or float(end) == +inf:
                 end = to_gps('now').seconds
             data, uri = apicalls.dqsegdbQueryTimes(protocol, server, ifo,
                                                    name, version, request,
                                                    start, end)
+            new = cls(name=flag)
             for s2 in data['active']:
                 new.active.append(Segment(*s2))
             for s2 in data['known']:
@@ -513,12 +514,13 @@ class DataQualityFlag(object):
             segl = SegmentList([Segment(start, end)])
             new.known &= segl
             new.active &= segl
-            new.description = data['metadata'].get('flag_description', None)
-            new.isgood = not data['metadata'].get(
+            out += new
+            out.description = data['metadata'].get('flag_description', None)
+            out.isgood = not data['metadata'].get(
                 'active_indicates_ifo_badness', False)
-        new.coalesce()
+        out.coalesce()
 
-        return new
+        return out
 
     # use input/output registry to allow multi-format reading
     read = classmethod(reader(doc="""

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -186,6 +186,19 @@ class DataQualityFlagTests(unittest.TestCase):
             self.assertEqual(flag.known, QUERY_KNOWN)
             self.assertEqual(flag.active, QUERY_ACTIVE)
 
+    def test_query_dqsegdb_multi(self):
+        querymid = int(QUERY_START + (QUERY_END - QUERY_START) /2.)
+        segs = SegmentList([Segment(QUERY_START, querymid),
+                            Segment(querymid, QUERY_END)])
+        try:
+            flag = DataQualityFlag.query_dqsegdb(
+                QUERY_FLAG, segs, url=QUERY_URL)
+        except (ImportError, URLError) as e:
+            self.skipTest(str(e))
+        else:
+            self.assertEqual(flag.known, QUERY_KNOWN)
+            self.assertEqual(flag.active, QUERY_ACTIVE)
+
 
 class DataQualityDictTestCase(unittest.TestCase):
     tmpfile = '%s.%%s' % tempfile.mktemp(prefix='gwpy_test_dqdict')


### PR DESCRIPTION
This PR fixes a critical bug in `DataQualityFlag.query_dqsegdb` where the results for a multi-segment query would only return those for the final segment.

This PR includes a simple unit test to protect against regression.