### PR TITLE
Improved default handling for EventTableAxes

### DIFF
--- a/gwpy/plotter/table.py
+++ b/gwpy/plotter/table.py
@@ -58,6 +58,15 @@ class EventTableAxes(TimeSeriesAxes):
     """
     name = 'triggers'
 
+    def __init__(self, fig, *args, **kwargs):
+        tsp = isinstance(fig, TimeSeriesPlot)
+        if not tsp:
+            kwargs.setdefault('xscale', 'linear')
+        super(EventTableAxes, self).__init__(fig, *args, **kwargs)
+        if not tsp:
+            self.set_xlabel('')
+            self.fmt_xdata = None
+
     def plot(self, *args, **kwargs):
         """Plot data onto these axes
 


### PR DESCRIPTION
This PR fixes a problem with the `EventTableAxes` class whereby it would inherit all defaults from `TimeSeriesAxes`, even if not being displayed on a `TimeSeriesPlot`.