### PR TITLE
New utils.compat module

### DIFF
--- a/gwpy/io/nds.py
+++ b/gwpy/io/nds.py
@@ -31,14 +31,10 @@ import nds2
 from .. import version
 from ..time import to_gps
 from .kerberos import *
+from ..utils.compat import OrderedDict
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __version__ = version.version
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
 
 DEFAULT_HOSTS = OrderedDict([
     (None, ('nds.ligo.caltech.edu', 31200)),

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -35,11 +35,6 @@ from math import (floor, ceil)
 from threading import Thread
 from Queue import Queue
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
-
 from numpy import inf
 
 from glue.segments import PosInfinity
@@ -47,6 +42,7 @@ from glue.segments import PosInfinity
 from .. import version
 from ..time import to_gps
 from ..utils.deps import with_import
+from ..utils.compat import OrderedDict
 from ..io import (reader, writer)
 from .segments import Segment, SegmentList
 

--- a/gwpy/spectrum/registry.py
+++ b/gwpy/spectrum/registry.py
@@ -23,11 +23,7 @@ an average power spectral density. Users can define their own through
 the registry method `register_method`.
 """
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
-
+from ..utils.compat import OrderedDict
 from .. import version
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __version__ = version.version

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -28,11 +28,6 @@ from math import ceil
 
 import numpy
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
-
 from astropy import units
 
 try:
@@ -52,6 +47,7 @@ from ..io import reader
 from ..time import (Time, to_gps)
 from ..utils import (gprint, with_import)
 from ..utils.docstring import interpolate_docstring
+from ..utils.compat import OrderedDict
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -28,11 +28,6 @@ import numpy
 from numpy import fft as npfft
 from scipy import signal
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
-
 from astropy import units
 
 try:
@@ -50,6 +45,7 @@ from .. import version
 from ..io import reader
 from ..utils import with_import
 from ..utils.docstring import interpolate_docstring
+from ..utils.compat import OrderedDict
 from .core import (TimeSeriesBase, TimeSeriesBaseDict, TimeSeriesBaseList,
                    as_series_dict_class)
 

--- a/gwpy/utils/compat.py
+++ b/gwpy/utils/compat.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Python version compatibilities
+"""
+
+from __future__ import print_function
+
+from .. import version
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+# OrderedDict isn't bundled with python < 2.7
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict


### PR DESCRIPTION
This PR introduces the `gwpy.utils.compat` module to help package objects that are incompatible between python versions.

The only content at this time is the `OrderedDict`, which requires an `ImportError` check for python2.6. All other modules have been modified to import `OrderedDict` from this new module, rather than checking the import themselves.