### PR TITLE
Bump SciPy requirement to 0.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   # install numpy
   - travis_retry pip install -q numpy==1.9.1
   # install scipy
-  - travis_wait pip install -q scipy==0.13
+  - travis_wait pip install -q scipy==0.16
   # install matplotlib
   - travis_retry pip install -q matplotlib==1.3.1
   # install astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -39,12 +39,12 @@ Linux
 
 The GWpy package has the following build-time dependencies (i.e. required for installation):
 
-* `glue <https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html>`_
+* `glue <https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html>`_ >= 1.48
 * `python-dateutil <https://pypi.python.org/pypi/python-dateutil/>`_
 * `NumPy <http://www.numpy.org>`_ >= 1.5
-* `SciPy <http://www.scipy.org>`_
+* `SciPy <http://www.scipy.org>`_ >= 0.16
 * `Matplotlib <http://matplotlib.org>`_ >= 1.3.0
-* `Astropy <http://astropy.org>`_ >= 0.3
+* `Astropy <http://astropy.org>`_ >= 1.0
 
 You should install these packages on your system using the instructions provided by their authors.
 

--- a/setup.py
+++ b/setup.py
@@ -334,9 +334,9 @@ setup(name=PACKAGENAME,
       install_requires=[
           'python-dateutil',
           'numpy >= 1.7',
-          'scipy >= 0.11',
+          'scipy >= 0.16.0',
           'matplotlib >= 1.3.0',
-          'astropy >= 0.4',
+          'astropy >= 1.0',
           'six >= 1.5',
       ] + extra_install_requires,
       tests_require=[


### PR DESCRIPTION
This PR bumps the minimum required scipy version to 0.16, and astropy to 1.0.

[Scipy 0.16](https://pypi.python.org/pypi/scipy/) is the first version to support second-order-section filter decomposition, so is critical for proper time-domain filtering.

@areeda: can you please review the implications for LDVW and let me know if this change is ok?