### PR TITLE
New DataQualityFlag.pad method

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -649,7 +649,7 @@ class DataQualityFlag(object):
         return self.active
 
     def pad(self, *args):
-        """Apply a padding to each `active` segment in this `DataQualityFlag`
+        """Apply a padding to each segment in this `DataQualityFlag`
 
         This method either takes no arguments, in which case the value of
         the :attr:`~DataQualityFlag.padding` attribute will be used,
@@ -661,9 +661,9 @@ class DataQualityFlag(object):
         `end` padding will contract a segment at one or both ends,
         and vice-versa.
 
-        This method only pads the :attr:`~DataQualityFlag.active` list,
-        as applying a padding should not enhance the
-        :attr:`~DataQualityFlag.known` information for this flag.
+        This method will apply the same padding to both the
+        `~DataQualityFlag.known` and `~DataQualityFlag.active` lists,
+        but will not :meth:`~DataQualityFlag.coalesce` the result.
 
         Parameters
         ----------
@@ -685,6 +685,7 @@ class DataQualityFlag(object):
             raise ValueError("Cannot parse (start, end) padding from %r"
                              % args)
         new = self.copy()
+        new.known = [(s[0]+start, s[1]+end) for s in self.known]
         new.active = [(s[0]+start, s[1]+end) for s in self.active]
         return new
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -649,24 +649,28 @@ class DataQualityFlag(object):
         return self.active
 
     def pad(self, *args):
-        """Apply a padding to each segment in this `DataQualityFlag`
+        """Apply a padding to each `active` segment in this `DataQualityFlag`
 
         This method either takes no arguments, in which case the value of
         the :attr:`~DataQualityFlag.padding` attribute will be used,
         or two values representing the padding for the start and end of
         each segment.
 
-        This `DataQualityFlag` is modified in-place.
+        For both the `start` and `end` paddings, a positive value means
+        pad forward in time, so that a positive `start` pad or negative
+        `end` padding will contract a segment at one or both ends,
+        and vice-versa.
+
+        This method only pads the :attr:`~DataQualityFlag.active` list,
+        as applying a padding should not enhance the
+        :attr:`~DataQualityFlag.known` information for this flag.
 
         Parameters
         ----------
         start : `float`
-            padding to apply to the start of the each segment, a positive
-            number means pad outwards (protract), otherwise a negative
-            means to pad inwards (contract)
+            padding to apply to the start of the each segment
         end : `float`
-            padding to apply to the end of each segment, using the same
-            logic as for `start`
+            padding to apply to the end of each segment
 
         Returns
         -------
@@ -680,9 +684,9 @@ class DataQualityFlag(object):
         else:
             raise ValueError("Cannot parse (start, end) padding from %r"
                              % args)
-        self.active = [(s[0]-start, s[1]+end) for s in self.active]
-        self.known = [(s[0]-start, s[1]+end) for s in self.known]
-        return self
+        new = self.copy()
+        new.active = [(s[0]+start, s[1]+end) for s in self.active]
+        return new
 
     def round(self):
         """Round this flag to integer segments.

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -648,6 +648,42 @@ class DataQualityFlag(object):
         self.active = self.active.protract(x)
         return self.active
 
+    def pad(self, *args):
+        """Apply a padding to each segment in this `DataQualityFlag`
+
+        This method either takes no arguments, in which case the value of
+        the :attr:`~DataQualityFlag.padding` attribute will be used,
+        or two values representing the padding for the start and end of
+        each segment.
+
+        This `DataQualityFlag` is modified in-place.
+
+        Parameters
+        ----------
+        start : `float`
+            padding to apply to the start of the each segment, a positive
+            number means pad outwards (protract), otherwise a negative
+            means to pad inwards (contract)
+        end : `float`
+            padding to apply to the end of each segment, using the same
+            logic as for `start`
+
+        Returns
+        -------
+        paddedflag : `DataQualityFlag`
+            a view of the modified flag
+        """
+        if len(args) == 0:
+            start, end = self.padding
+        elif len(args) == 2:
+            start, end = args
+        else:
+            raise ValueError("Cannot parse (start, end) padding from %r"
+                             % args)
+        self.active = [(s[0]-start, s[1]+end) for s in self.active]
+        self.known = [(s[0]-start, s[1]+end) for s in self.known]
+        return self
+
     def round(self):
         """Round this flag to integer segments.
 

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -55,6 +55,18 @@ ACTIVE2 = SegmentList([
     Segment(110, 120),
 ])
 
+# get padding stuff
+PADDING = (0.5, 1)
+KNOWNPAD = SegmentList([
+    Segment(-.5, 4),
+    Segment(5.5, 8),
+])
+ACTIVEPAD = SegmentList([
+    Segment(.5, 3),
+    Segment(2.5, 5),
+    Segment(4.5, 8),
+])
+
 SEGXML = os.path.join(os.path.split(__file__)[0], 'data',
                       'X1-GWPY_TEST_SEGMENTS-0-10.xml.gz')
 SEGWIZ = os.path.join(os.path.split(__file__)[0], 'data',
@@ -194,6 +206,12 @@ class DataQualityFlagTests(unittest.TestCase):
         else:
             self.assertEqual(flag.known, QUERY_KNOWN)
             self.assertEqual(flag.active, QUERY_ACTIVE)
+
+    def test_pad(self):
+        flag = DataQualityFlag(FLAG1, active=ACTIVE, known=KNOWN)
+        padded = flag.pad(*PADDING)
+        self.assertListEqual(padded.active, ACTIVEPAD)
+        self.assertListEqual(padded.known, KNOWNPAD)
 
 
 class DataQualityDictTestCase(unittest.TestCase):

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -56,15 +56,15 @@ ACTIVE2 = SegmentList([
 ])
 
 # get padding stuff
-PADDING = (0.5, 1)
-KNOWNPAD = SegmentList([
-    Segment(-.5, 4),
-    Segment(5.5, 8),
-])
+PADDING = (-0.5, 1)
 ACTIVEPAD = SegmentList([
     Segment(.5, 3),
     Segment(2.5, 5),
     Segment(4.5, 8),
+])
+ACTIVEPADC = SegmentList([
+    Segment(.5, 3),
+    Segment(6, 7),
 ])
 
 SEGXML = os.path.join(os.path.split(__file__)[0], 'data',
@@ -209,9 +209,23 @@ class DataQualityFlagTests(unittest.TestCase):
 
     def test_pad(self):
         flag = DataQualityFlag(FLAG1, active=ACTIVE, known=KNOWN)
-        padded = flag.pad(*PADDING)
+        # test without arguments (and no padding)
+        padded = flag.pad()
+        self.assertListEqual(padded.known, flag.known)
+        self.assertListEqual(padded.active, flag.active)
+        # test without arguments (and no padding)
+        flag.padding = PADDING
+        padded = flag.pad()
+        self.assertListEqual(padded.known, flag.known)
         self.assertListEqual(padded.active, ACTIVEPAD)
-        self.assertListEqual(padded.known, KNOWNPAD)
+        # test with arguments
+        flag = DataQualityFlag(FLAG1, active=ACTIVE, known=KNOWN)
+        padded = flag.pad(*PADDING)
+        self.assertListEqual(padded.known, flag.known)
+        self.assertListEqual(padded.active, ACTIVEPAD)
+        # test coalesce
+        padded.coalesce()
+        self.assertListEqual(padded.active, ACTIVEPADC)
 
 
 class DataQualityDictTestCase(unittest.TestCase):

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -57,14 +57,18 @@ ACTIVE2 = SegmentList([
 
 # get padding stuff
 PADDING = (-0.5, 1)
+KNOWNPAD = SegmentList([
+    Segment(-.5, 4),
+    Segment(5.5, 8),
+])
 ACTIVEPAD = SegmentList([
     Segment(.5, 3),
     Segment(2.5, 5),
     Segment(4.5, 8),
 ])
 ACTIVEPADC = SegmentList([
-    Segment(.5, 3),
-    Segment(6, 7),
+    Segment(.5, 4),
+    Segment(5.5, 8),
 ])
 
 SEGXML = os.path.join(os.path.split(__file__)[0], 'data',
@@ -216,12 +220,12 @@ class DataQualityFlagTests(unittest.TestCase):
         # test without arguments (and no padding)
         flag.padding = PADDING
         padded = flag.pad()
-        self.assertListEqual(padded.known, flag.known)
+        self.assertListEqual(padded.known, KNOWNPAD)
         self.assertListEqual(padded.active, ACTIVEPAD)
         # test with arguments
         flag = DataQualityFlag(FLAG1, active=ACTIVE, known=KNOWN)
         padded = flag.pad(*PADDING)
-        self.assertListEqual(padded.known, flag.known)
+        self.assertListEqual(padded.known, KNOWNPAD)
         self.assertListEqual(padded.active, ACTIVEPAD)
         # test coalesce
         padded.coalesce()


### PR DESCRIPTION
This PR introduces the `DataQualityFlag.pad` method, and an associated test case.

This method applies either a `(start, end)` tuple, or reads such a tuple from the `DataQualityFlag.padding` property.