### PR TITLE
TimeSeries.whiten: new method

### DIFF
--- a/examples/timeseries/whiten.py
+++ b/examples/timeseries/whiten.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Whitening a `TimeSeries`
+
+Most data recorded from a gravitational-wave interferometer carry information
+across a wide band of frequencies, typically up to a few kiloHertz, but
+often it is the case that the low-frequency amplitude dwarfs that of the
+high-frequency content, making discerning high-frequency features difficult.
+
+We employ a technique called 'whitening' to normalize the power at all
+frequencies so that excess power at any frequency is more obvious.
+
+We demonstrate below with an auxiliary signal recording transmitted power
+in one of the interferometer arms, which recorded two large glitches with
+a frequency of around 5-50Hz.
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+__currentmodule__ = 'gwpy.timeseries'
+
+# First, we import the `TimeSeries` and `~TimeSeries.fetch` the data:
+from gwpy.timeseries import TimeSeries
+data = TimeSeries.fetch('H1:ASC-Y_TR_A_NSUM_OUT_DQ', 1123084670, 1123084800)
+
+# Now, we can `~TimeSeries.whiten` the data to enhance the higher-frequency
+# content
+white = data.whiten(4, 2)
+
+# and can `~TimeSeries.plot` both the original and whitened data
+epoch = 1123084687.570
+plot = data.plot()
+plot.axes[0].set_ylabel('Y-arm power [counts]', fontsize=16)
+plot.add_timeseries(white, newax=True, sharex=plot.axes[0])
+plot.axes[1].set_ylabel('Whitened amplitude', fontsize=16)
+plot.axes[0].set_epoch(epoch)
+plot.axes[1].set_epoch(epoch)
+plot.axes[0].set_xlim(epoch-8, epoch+8)
+plot.axes[1].set_xlim(epoch-8, epoch+8)
+plot.show()
+
+# Here we see two large spikes that are completely undetected in the raw
+# `TimeSeries`, but are very obvious in the whitened data.

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -39,6 +39,7 @@ from gwpy.spectrogram import Spectrogram
 from test_array import SeriesTestCase
 
 SEED = 1
+numpy.random.seed(SEED)
 GPS_EPOCH = Time(0, format='gps', scale='utc')
 ONE_HZ = units.Quantity(1, 'Hz')
 ONE_SECOND = units.Quantity(1, 'second')
@@ -151,6 +152,12 @@ class TimeSeriesTestMixin(object):
 
 class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
     TEST_CLASS = TimeSeries
+
+    def setUp(self):
+        super(TimeSeriesTestCase, self).setUp()
+        self.random = self.TEST_CLASS(
+            numpy.random.normal(loc=1, size=16384 * 10), sample_rate=16384,
+            epoch=-5)
 
     def _read(self):
         return self.TEST_CLASS.read(TEST_HDF_FILE, self.channel)
@@ -269,6 +276,11 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         self.assertEqual(sg.df, 5 * units.Hertz)
         # note: bizarre stride length because 16384/100 gets rounded
         self.assertEqual(sg.dt, 0.010009765625 * units.second)
+
+    def test_detrend(self):
+        self.assertNotAlmostEqual(self.random.mean(), 0.0)
+        detrended = self.random.detrend()
+        self.assertAlmostEqual(detrended.mean(), 0.0)
 
 
 class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1270,6 +1270,32 @@ class TimeSeries(TimeSeriesBase):
         return self.__class__(data, channel=self.channel, epoch=self.epoch,
                               name=name, sample_rate=(1/float(stride)))
 
+    def detrend(self, detrend='constant'):
+        """Remove the trend from this `TimeSeries`
+
+        This method just wraps :meth:`scipy.signal.detrend` to return
+        an object of the same type as the input.
+
+        Parameters
+        ----------
+        detrend : `str`, optional, default: `constant`
+            the type of detrending.
+
+        Returns
+        -------
+        detrended : `TimeSeries`
+            the detrended input series
+
+        See Also
+        --------
+        scipy.signal.detrend
+            for details on the options for the `detrend` argument, and
+            how the operation is done
+        """
+        data = signal.detrend(self.value, type=detrend).view(type(self))
+        data.__dict__ = self.copy_metadata()
+        return data
+
     def plot(self, **kwargs):
         """Plot the data for this TimeSeries.
         """

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1270,6 +1270,68 @@ class TimeSeries(TimeSeriesBase):
         return self.__class__(data, channel=self.channel, epoch=self.epoch,
                               name=name, sample_rate=(1/float(stride)))
 
+    def whiten(self, fftlength, overlap=0, method='welch', window='hanning',
+               detrend='constant', **kwargs):
+        """White this `TimeSeries` against its own ASD
+
+        Parameters
+        ----------
+        fftlength : `float`
+            number of seconds in single FFT
+
+        overlap : `float`, optional, default: 0
+            numbers of seconds by which to overlap neighbouring FFTs,
+            by default, no overlap is used.
+
+        method : `str`, optional, default: `welch`
+            average spectrum method
+
+        window : `str`, :class:`numpy.ndarray`
+            name of the window function to use, or an array of length
+            ``fftlength * TimeSeries.sample_rate`` to use as the window.
+
+        **kwargs
+            other keyword arguments are passed to the `TimeSeries.asd`
+            method to estimate the amplitude spectral density `Spectrum`
+            of this `TimeSeries.
+
+        Returns
+        -------
+        out : `TimeSeries`
+            a whitened version of the input data
+
+        See Also
+        --------
+        TimeSeries.asd
+            for details on the ASD calculation
+        numpy.fft
+            for details on the Fourier transform algorithm used her
+        scipy.signal
+        """
+        # build whitener
+        invasd = 1. / self.asd(fftlength, overlap=overlap,
+                               method=method, window=window, **kwargs)
+        # build window
+        nfft = int((fftlength * self.sample_rate).decompose().value)
+        noverlap = int((overlap * self.sample_rate).decompose().value)
+        # format window
+        if type(window).__module__ == 'lal.lal':
+            window = window.data.data
+        elif not isinstance(window, numpy.ndarray):
+            window = signal.get_window(window, nfft)
+        # create output series
+        nstride = nfft - noverlap
+        nsteps = 1 + int((self.size - nfft) / nstride)
+        out = type(self)(numpy.zeros(nsteps * nstride + noverlap))
+        out.__dict__ = self.copy_metadata()
+        # loop over ffts and whiten each one
+        for i in range(nsteps):
+             i0 = i * nstride
+             i1 = i0 + nfft
+             in_ = self[i0:i1].detrend(detrend) * window
+             out[i0:i1] += npfft.irfft(in_.fft().value * invasd)
+        return out
+
     def detrend(self, detrend='constant'):
         """Remove the trend from this `TimeSeries`
 


### PR DESCRIPTION
This PR introduces two new methods for the `TimeSeries`:

- `TimeSeries.detrend`: a simple wrapper around `scipy.signal.detrend` to return a `TimeSeries`
- `TimeSeries.whiten`: a function to whiten a `TimeSeries` against its own ASD

The new methods are accompanied by unit tests and a new example for whitening a `TimeSeries` to see glitches at higher frequency.

The example reads in some data from NDS, and whitens it to show two glitches at high frequency, the resulting image is:

![whiten](https://cloud.githubusercontent.com/assets/1618530/9233041/7df26214-40f6-11e5-8318-32e7723f964f.png)