### PR TITLE
Segment query selection improvements

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -368,7 +368,7 @@ class DataQualityFlag(object):
             Either, two `float`-like numbers indicating the
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments
-        url : `str`, optional, default: ``'https://segdb.ligo.caltech.edu'``
+        url : `str`, optional, default: ``'https://segments.ligo.org'``
             URL of the segment database
 
         See Also
@@ -384,7 +384,7 @@ class DataQualityFlag(object):
             A new `DataQualityFlag`, with the `known` and `active` lists
             filled appropriately.
         """
-        url = kwargs.get('url', 'https://segdb.ligo.caltech.edu')
+        url = kwargs.get('url', 'https://segments.ligo.org')
         if 'dqsegdb' in url or re.match('https://[a-z1-9-]+.ligo.org', url):
             return cls.query_dqsegdb(flag, *args, **kwargs)
         else:
@@ -402,7 +402,7 @@ class DataQualityFlag(object):
             Either, two `float`-like numbers indicating the
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments
-        url : `str`, optional, default: ``'https://segdb.ligo.caltech.edu'``
+        url : `str`, optional, default: ``'https://segments.ligo.org'``
             URL of the segment database
 
         Returns
@@ -574,7 +574,7 @@ class DataQualityFlag(object):
 
     write = writer()
 
-    def populate(self, source='https://segdb.ligo.caltech.edu', segments=None,
+    def populate(self, source='https://segments.ligo.org', segments=None,
                  pad=True, **kwargs):
         """Query the segment database for this flag's active segments.
 
@@ -944,7 +944,7 @@ class DataQualityDict(OrderedDict):
             Either, two `float`-like numbers indicating the
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments
-        url : `str`, optional, default: ``'https://segdb.ligo.caltech.edu'``
+        url : `str`, optional, default: ``'https://segments.ligo.org'``
             URL of the segment database
 
         See Also
@@ -960,7 +960,7 @@ class DataQualityDict(OrderedDict):
             A new `DataQualityFlag`, with the `known` and `active` lists
             filled appropriately.
         """
-        url = kwargs.get('url', 'https://segdb.ligo.caltech.edu')
+        url = kwargs.get('url', 'https://segments.ligo.org')
         if 'dqsegdb' in url:
             return cls.query_dqsegdb(flag, *args, **kwargs)
         else:
@@ -978,7 +978,7 @@ class DataQualityDict(OrderedDict):
             Either, two `float`-like numbers indicating the
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments.
-        url : `str`, optional, default: ``'https://segdb.ligo.caltech.edu'``
+        url : `str`, optional, default: ``'https://segments.ligo.org'``
             URL of the segment database.
 
         Returns
@@ -998,7 +998,7 @@ class DataQualityDict(OrderedDict):
             raise ValueError("DataQualityDict.query_segdb must be called with "
                              "a list of flag names, and either GPS start and "
                              "stop times, or a SegmentList of query segments")
-        url = kwargs.pop('url', 'https://segdb.ligo.caltech.edu')
+        url = kwargs.pop('url', 'https://segments.ligo.org')
         if kwargs.pop('on_error', None) is not None:
             warnings.warn("DataQualityDict.query_segdb doesn't accept the "
                           "on_error keyword argument")
@@ -1197,7 +1197,7 @@ class DataQualityDict(OrderedDict):
 
     write = writer()
 
-    def populate(self, source='https://segdb.ligo.caltech.edu',
+    def populate(self, source='https://segments.ligo.org',
                  segments=None, pad=True, **kwargs):
         """Query the segment database for each flag's active segments.
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -385,7 +385,7 @@ class DataQualityFlag(object):
             filled appropriately.
         """
         url = kwargs.get('url', 'https://segdb.ligo.caltech.edu')
-        if 'dqsegdb' in url:
+        if 'dqsegdb' in url or re.match('https://[a-z1-9-]+.ligo.org', url):
             return cls.query_dqsegdb(flag, *args, **kwargs)
         else:
             return cls.query_segdb(flag, *args, **kwargs)


### PR DESCRIPTION
This PR improves the automagic segment query method selection based on the url of the segment URL. This is done in two parts

- improve the logic on method selection to use dqsegdb methods for `*.ligo.org` URLs [https://github.com/gwpy/gwpy/commit/5b7d0fe625245b76a9cdb822bb31e4cacf063594]
- move the default server to `https://segments.ligo.org` [https://github.com/gwpy/gwpy/commit/480213ab720920c6609c7e5b4d4fc162ef9f80ac]