### PR TITLE
Plot.close: add cla() for each set of axes

### DIFF
--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -150,6 +150,8 @@ class Plot(figure.Figure):
     def close(self):
         """Close the plot and release its memory.
         """
+        for ax in self.axes:
+            ax.cla()
         pyplot.close(self)
 
     # -----------------------------------------------


### PR DESCRIPTION
This PR adds an explicit call to `ax.cla()` for each `Axes` in a given `Plot` when the `Plot.close()` method is called, this might fix a memory leak seen through `gwsumm`.