### PR TITLE
TimeSeries.read: fix bug in reading with default GWF format lalframe

### DIFF
--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -77,7 +77,9 @@ def read_timeseriesdict(source, channels, start=None, end=None, dtype=None,
     """
     lal = import_method_dependency('lal.lal')
     from gwpy.utils.lal import to_lal_ligotimegps
-    # parse input arguments
+    # parse input arguments (astropy insists on opening files)
+    if isinstance(source, file):
+        source = source.name
     filelist = file_list(source)
     try:
         frametype = CacheEntry.from_T050017(filelist[0]).description


### PR DESCRIPTION
This PR improves the unit tests for `TimeSeries.read()` to check that each GWF format works with and without the `format` keyword argument being given.

Given that this test currently fails for `format='lalframe'`, subsequent commits will fix the problems with that format.

Thanks to @mattpitkin for his patience in reporting and helping me diagnose the problem.
