### PR TITLE
Update travis-ci integration to new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,39 +2,30 @@ language: python
 python:
   - "2.6"
   - "2.7"
+addons:
+  apt:
+    packages:
+      - libc6
+      - fftw3
+      - libfftw3-3
+      - libgsl0ldbl
+      - zlib1g
+      - libgsl0
+      - libgsl0ldbl
 before_install:
-  - mkdir builds
-  - pushd builds
-  # install numpy non-python dependencies
-  - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
-  # add LSCSoft sources
-  - echo "deb http://software.ligo.org/lscsoft/debian wheezy contrib" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update -qq
-  - sudo apt-get --assume-yes --allow-unauthenticated install lscsoft-archive-keyring
-  - sudo apt-get update -qq
-  - sudo apt-get --assume-yes install libhdf5-dev lal-python lalframe-python ldas-tools-framecpp-python
-  - sudo apt-get --assume-yes install python-nds2-client
-  # install build dependencies
+  - . .travis/build_lal.sh
   - travis_retry pip install -q tornado jinja2 GitPython
-  # install cython
   - travis_retry pip install --install-option="--no-cython-compile" Cython
-  # install numpy
-  - travis_retry pip install -q numpy==1.9.1
-  # install scipy
-  - travis_wait pip install -q scipy==0.16
-  # install matplotlib
-  - travis_retry pip install -q matplotlib==1.3.1
-  # install astropy
-  - travis_retry pip install -q astropy==1.0
-  # install GLUE
+  - travis_retry pip install -q numpy>=1.9.1
+  - travis_wait pip install -q scipy>=0.16
+  - travis_retry pip install -q matplotlib>=1.3.1
+  - travis_retry pip install -q astropy>=1.0
+  - travis_retry pip install -q h5py
+  - travis_retry pip install -q unittest2
+  - travis_retry pip install -q importlib
+  - travis_retry pip install -q pytest
+  - travis_retry pip install -q coveralls
   - travis_retry pip install -q --egg https://www.lsc-group.phys.uwm.edu/daswg/download/software/source/glue-1.48.tar.gz#egg=glue-1.48
-  # install h5py
-  - pip install -q h5py
-  - pip install -q unittest2
-  - pip install -q importlib
-  - pip install -q pytest
-  - pip install -q coveralls
-  - popd
 install:
   - python setup.py build
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ addons:
       - zlib1g
       - libgsl0
       - libgsl0ldbl
+cache:
+  directories:
+    - lscsoft/libframe-8.20
+    - lscsoft/ldas-tools-2.4.1
+    - lscsoft/lal-6.15.0
+    - lscsoft/lalframe-1.3.0
 before_install:
   - . .travis/build_lal.sh
   - travis_retry pip install -q tornado jinja2 GitPython

--- a/.travis/build_lal.sh
+++ b/.travis/build_lal.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+LSCSOFT_LOCATION=${HOME}/lscsoft
+mkdir -p ${LSCSOFT_LOCATION}
+
+LSCSOFT_SOURCE_URL="http://software.ligo.org/lscsoft/source"
+
+[[ -z ${PYTHON_VERSION} ]] && PYTHON_VERSION=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+
+build_lscsoft_package() {
+    local package=$1
+    local path=$2
+    if [ -d ${LSCSOFT_LOCATION}/${package} ]; then
+        return 0
+    else
+        # install
+        rm -f ${package}.tar.gz
+        if [ -n "$path" ]; then
+            wget --quiet ${LSCSOFT_SOURCE_URL}/$path/${package}.tar.gz
+        else
+            wget --quiet ${LSCSOFT_SOURCE_URL}/${package}.tar.gz
+        fi
+        tar -zxf ${package}.tar.gz
+        cd ${package}
+        ./configure --quiet --enable-silent-rules --prefix ${LSCSOFT_LOCATION}/${package} && make && make install && cd -
+    fi
+}
+
+get_python_path() {
+    local package=$1
+    echo ${LSCSOFT_LOCATION}/${package}/lib/python${PYTHON_VERSION}/site-packages
+}
+
+get_pkgconfig_path() {
+    local package=$1
+    echo ${LSCSOFT_LOCATION}/${package}/lib/pkgconfig
+}
+
+# list packages
+PACKAGES="
+libframe-8.20
+ldas-tools-2.4.1
+lal-6.15.0
+lalframe-1.3.0
+"
+
+# build all packages
+for _package in ${PACKAGES}; do
+    [[ ${_package} == "lal"* ]] && _path="lalsuite" || _path=""
+    build_lscsoft_package ${_package} ${_path}
+    if [ -d `get_pkgconfig_path ${_package}` ]; then
+        export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:`get_pkgconfig_path ${_package}`
+    fi
+    PYTHONPATH=${PYTHONPATH}:`get_python_path ${_package}`
+done
+
+export PYTHONPATH


### PR DESCRIPTION
This PR attempts to update the CI configuration to the new travis-ci.org infrastructure.

The new `build_lal.sh` script build's the LSCSoft dependencies from source, instead of using custom apt installs.

This may be deprecated if the lscsoft deb source gets whitelisted.