### PR TITLE
Improvements to HDF5-based data I/O

### DIFF
--- a/gwpy/data/array.py
+++ b/gwpy/data/array.py
@@ -351,144 +351,34 @@ class Array(Quantity):
     read = classmethod(reader())
     write = writer()
 
-    @with_import('h5py')
-    def to_hdf5(self, output, name=None, group=None, compression='gzip',
-                **kwargs):
+    def to_hdf5(self, *args, **kwargs):
         """Convert this array to a :class:`h5py.Dataset`.
 
-        This allows writing to an HDF5-format file.
+        This method has been deprecated in favour of the unified I/O method:
 
-        Parameters
-        ----------
-        output : `str`, :class:`h5py.Group`
-            path to new output file, or open h5py `Group` to write to.
-
-        name : `str`, optional
-            custom name for this `Array` in the HDF hierarchy, defaults
-            to the `name` attribute of the `Array`.
-
-        group : `str`, optional
-            group to create for this time-series.
-
-        compression : `str`, optional
-            name of compression filter to use
-
-        **kwargs
-            other keyword arguments passed to
-            :meth:`h5py.Group.create_dataset`.
-
-        Returns
-        -------
-        dset : :class:`h5py.Dataset`
-            HDF dataset containing these data.
+        Class.write(..., format='hdf5')
         """
-        # create output object
-        if isinstance(output, h5py.Group):
-            h5file = output
-        else:
-            h5file = h5py.File(output, 'w')
-
-        try:
-            # if group
-            if group:
-                try:
-                    h5group = h5file[group]
-                except KeyError:
-                    h5group = h5file.create_group(group)
-            else:
-                h5group = h5file
-
-            # create dataset
-            name = name or self.name
-            if name is None:
-                raise ValueError("Cannot store Array without a name. "
-                                 "Either assign the name attribute of the "
-                                 "array itself, or given name= as a keyword "
-                                 "argument to write().")
-            try:
-                dset = h5group.create_dataset(
-                    name or self.name, data=self.value,
-                    compression=compression, **kwargs)
-            except ValueError as e:
-                if 'Name already exists' in str(e):
-                    e.args = (str(e) + ': %s' % (name or self.name),)
-                raise
-
-            # store metadata
-            for attr in self._metadata_slots:
-                mdval = getattr(self, attr)
-                if mdval is None:
-                    continue
-                if isinstance(mdval, Quantity):
-                    dset.attrs[attr] = mdval.value
-                elif isinstance(mdval, Channel):
-                    dset.attrs[attr] = mdval.ndsname
-                elif isinstance(mdval, UnitBase):
-                    dset.attrs[attr] = str(mdval)
-                elif isinstance(mdval, Time):
-                    dset.attrs[attr] = mdval.utc.gps
-                else:
-                    try:
-                        dset.attrs[attr] = mdval
-                    except ValueError as e:
-                        e.args = ("Failed to store %s (%s) for %s: %s"
-                                  % (attr, type(mdval).__name__,
-                                     type(self).__name__, str(e)),)
-                        raise
-
-        finally:
-            if not isinstance(output, h5py.Group):
-                h5file.close()
-
-        return dset
+        warnings.warn("The {0}.to_hdf5 and {0}.from_hdf5 methods have been "
+                      "deprecated and will be removed in an upcoming release. "
+                      "Please use the unified I/O methods {0}.read() and "
+                      "{0}.write() with the `format='hdf5'` keyword "
+                      "argument".format(type(self).__name__),
+                      DeprecationWarning)
+        kwargs.setdefault('format', 'hdf5')
+        return self.write(*args, **kwargs)
 
     @classmethod
-    @with_import('h5py')
-    def from_hdf5(cls, f, name=None):
+    def from_hdf5(cls, *args, **kwargs):
         """Read an array from the given HDF file.
 
-        Parameters
-        ----------
-        f : `str`, :class:`h5py.HLObject`
-            path to HDF file on disk, or open `h5py.HLObject`.
+        This method has been deprecated in favour of the unified I/O method:
 
-        type_ : `type`
-            target class to read
-
-        name : `str`
-            path in HDF hierarchy of dataset.
+        Class.write(..., format='hdf5')
         """
-        from ..io.hdf5 import open_hdf5
-
-        h5file = open_hdf5(f)
-
-        if name is None and not isinstance(h5file, h5py.Dataset):
-            if len(h5file) == 1:
-                name = h5file.keys()[0]
-            else:
-                raise ValueError("Multiple data sets found in HDF structure, "
-                                 "please give name='...' to specify")
-
-        try:
-            # find dataset
-            if isinstance(h5file, h5py.Dataset):
-                dataset = h5file
-            else:
-                try:
-                    dataset = h5file[name]
-                except KeyError:
-                    if name.startswith('/'):
-                        raise
-                    name2 = '/%s/%s' % (cls.__name__.lower(), name)
-                    if name2 in h5file:
-                        dataset = h5file[name2]
-                    else:
-                        raise
-
-            # read array, close file, and return
-            out = cls(dataset[()], **dict(dataset.attrs))
-        finally:
-            if not isinstance(f, (h5py.Dataset, h5py.Group)):
-                h5file.close()
-
-        return out
+        warnings.warn("The {0}.to_hdf5 and {0}.from_hdf5 methods have been "
+                      "deprecated and will be removed in an upcoming release. "
+                      "Please use the unified I/O methods {0}.read() and "
+                      "{0}.write() with the `format='hdf5'` keyword "
+                      "argument".format(cls.__name__), DeprecationWarning)
+        kwargs.setdefault('format', 'hdf5')
+        return self.read(*args, **kwargs)

--- a/gwpy/data/io/__init__.py
+++ b/gwpy/data/io/__init__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Input/Output routines for the Array and its sub-classes.
+"""
+
+from .. import version
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+__version__ = version.version
+
+from .. import (Array, Series, Array2D)
+
+# register ASCII
+from ...io.ascii import register_ascii
+register_ascii(Series)
+
+# register HDF5
+from . import hdf5

--- a/gwpy/data/io/hdf5.py
+++ b/gwpy/data/io/hdf5.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Input/output utilities for the `Array`
+"""
+
+from astropy.units import Quantity, UnitBase
+from astropy.io import registry
+from astropy.time import Time
+
+from ... import version
+from ...detector import Channel
+from ...io import hdf5 as hdf5io
+from ...utils.deps import with_import
+from .. import (Array, Series, Array2D)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+
+@with_import('h5py')
+def array_from_hdf5(f, name=None, array_type=Array):
+    """Read an `Array` from the given HDF5 object
+
+    Parameters
+    ----------
+    f : `str`, :class:`h5py.HLObject`
+        path to HDF file on disk, or open `h5py.HLObject`.
+
+    type_ : `type`
+        target class to read
+
+    name : `str`
+        path in HDF hierarchy of dataset.
+    """
+    h5file = hdf5io.open_hdf5(f)
+
+    if name is None and not isinstance(h5file, h5py.Dataset):
+        if len(h5file) == 1:
+            name = h5file.keys()[0]
+        else:
+            raise ValueError("Multiple data sets found in HDF structure, "
+                             "please give name='...' to specify")
+
+    try:
+        # find dataset
+        if isinstance(h5file, h5py.Dataset):
+            dataset = h5file
+        else:
+            try:
+                dataset = h5file[name]
+            except KeyError:
+                if name.startswith('/'):
+                    raise
+                name2 = '/%s/%s' % (array_type.__name__.lower(), name)
+                if name2 in h5file:
+                    dataset = h5file[name2]
+                else:
+                    raise
+
+        # read array, close file, and return
+        out = array_type(dataset[()], **dict(dataset.attrs))
+    finally:
+        if not isinstance(f, (h5py.Dataset, h5py.Group)):
+            h5file.close()
+
+    return out
+
+
+@with_import('h5py')
+def array_to_hdf5(array, output, name=None, group=None, compression='gzip',
+                  array_type=Array, **kwargs):
+    """Convert this array to a :class:`h5py.Dataset`.
+
+    This allows writing to an HDF5-format file.
+
+    Parameters
+    ----------
+    output : `str`, :class:`h5py.Group`
+        path to new output file, or open h5py `Group` to write to.
+
+    name : `str`, optional
+        custom name for this `Array` in the HDF hierarchy, defaults
+        to the `name` attribute of the `Array`.
+
+    group : `str`, optional
+        group to create for this time-series.
+
+    compression : `str`, optional
+        name of compression filter to use
+
+    **kwargs
+        other keyword arguments passed to
+        :meth:`h5py.Group.create_dataset`.
+
+    Returns
+    -------
+    dset : :class:`h5py.Dataset`
+        HDF dataset containing these data.
+    """
+    # create output object
+    if isinstance(output, h5py.Group):
+        h5file = output
+    else:
+        h5file = h5py.File(output, 'w')
+
+    try:
+        # if group
+        if group:
+            try:
+                h5group = h5file[group]
+            except KeyError:
+                h5group = h5file.create_group(group)
+        else:
+            h5group = h5file
+
+        # create dataset
+        name = name or array.name
+        if name is None:
+            raise ValueError("Cannot store %s without a name. "
+                             "Either assign the name attribute of the "
+                             "array itarray, or given name= as a keyword "
+                             "argument to write()." % type(array).__name__)
+        try:
+            dset = h5group.create_dataset(
+                name or array.name, data=array.value,
+                compression=compression, **kwargs)
+        except ValueError as e:
+            if 'Name already exists' in str(e):
+                e.args = (str(e) + ': %s' % (name or array.name),)
+            raise
+
+        # store metadata
+        for attr in ['unit'] + array._metadata_slots:
+            mdval = getattr(array, attr)
+            if mdval is None:
+                continue
+            if isinstance(mdval, Quantity):
+                dset.attrs[attr] = mdval.value
+            elif isinstance(mdval, Channel):
+                dset.attrs[attr] = mdval.ndsname
+            elif isinstance(mdval, UnitBase):
+                dset.attrs[attr] = str(mdval)
+            elif isinstance(mdval, Time):
+                dset.attrs[attr] = mdval.utc.gps
+            else:
+                try:
+                    dset.attrs[attr] = mdval
+                except ValueError as e:
+                    e.args = ("Failed to store %s (%s) for %s: %s"
+                              % (attr, type(mdval).__name__,
+                                 type(array).__name__, str(e)),)
+                    raise
+
+    finally:
+        if not isinstance(output, h5py.Group):
+            h5file.close()
+
+    return dset
+
+
+def register_hdf5_array_io(array_type, format='hdf5'):
+    """Registry read() and write() methods for the HDF5 format
+    """
+    def from_hdf5(*args, **kwargs):
+        kwargs.setdefault('array_type', array_type)
+        return array_from_hdf5(*args, **kwargs)
+    def to_hdf5(*args, **kwargs):
+        kwargs.setdefault('array_type', array_type)
+        return array_to_hdf5(*args, **kwargs)
+    registry.register_reader(format, array_type, from_hdf5)
+    registry.register_writer(format, array_type, to_hdf5)
+    registry.register_identifier(format, array_type, hdf5io.identify_hdf5)
+
+
+# register for basic types
+for array_type in (Array, Series, Array2D):
+    register_hdf5_array_io(array_type)

--- a/gwpy/data/io/hdf5.py
+++ b/gwpy/data/io/hdf5.py
@@ -174,7 +174,7 @@ def array_to_hdf5(array, output, name=None, group=None, compression='gzip',
     return dset
 
 
-def register_hdf5_array_io(array_type, format='hdf5'):
+def register_hdf5_array_io(array_type, format='hdf5', identify=True):
     """Registry read() and write() methods for the HDF5 format
     """
     def from_hdf5(*args, **kwargs):
@@ -185,9 +185,11 @@ def register_hdf5_array_io(array_type, format='hdf5'):
         return array_to_hdf5(*args, **kwargs)
     registry.register_reader(format, array_type, from_hdf5)
     registry.register_writer(format, array_type, to_hdf5)
-    registry.register_identifier(format, array_type, hdf5io.identify_hdf5)
+    if identify:
+        registry.register_identifier(format, array_type, hdf5io.identify_hdf5)
 
 
 # register for basic types
 for array_type in (Array, Series, Array2D):
     register_hdf5_array_io(array_type)
+    register_hdf5_array_io(array_type, format='hdf', identify=False)

--- a/gwpy/segments/io/hdf5.py
+++ b/gwpy/segments/io/hdf5.py
@@ -239,10 +239,16 @@ def segmentlist_to_hdf5(seglist, output, name, group=None,
     return dset
 
 
+# register HDF5 format
 register_reader('hdf5', SegmentList, segmentlist_from_hdf5)
 register_writer('hdf5', SegmentList, segmentlist_to_hdf5)
 register_identifier('hdf5', SegmentList, identify_hdf5)
-
 register_reader('hdf5', DataQualityFlag, flag_from_hdf5)
 register_writer('hdf5', DataQualityFlag, flag_to_hdf5)
 register_identifier('hdf5', DataQualityFlag, identify_hdf5)
+
+# register generic HDF format to HDF5
+register_reader('hdf', SegmentList, segmentlist_from_hdf5)
+register_writer('hdf', SegmentList, segmentlist_to_hdf5)
+register_reader('hdf', DataQualityFlag, flag_from_hdf5)
+register_writer('hdf', DataQualityFlag, flag_to_hdf5)

--- a/gwpy/segments/io/hdf5.py
+++ b/gwpy/segments/io/hdf5.py
@@ -239,10 +239,10 @@ def segmentlist_to_hdf5(seglist, output, name, group=None,
     return dset
 
 
-register_reader('hdf', SegmentList, segmentlist_from_hdf5)
-register_writer('hdf', SegmentList, segmentlist_to_hdf5)
-register_identifier('hdf', SegmentList, identify_hdf5)
+register_reader('hdf5', SegmentList, segmentlist_from_hdf5)
+register_writer('hdf5', SegmentList, segmentlist_to_hdf5)
+register_identifier('hdf5', SegmentList, identify_hdf5)
 
-register_reader('hdf', DataQualityFlag, flag_from_hdf5)
-register_writer('hdf', DataQualityFlag, flag_to_hdf5)
-register_identifier('hdf', DataQualityFlag, identify_hdf5)
+register_reader('hdf5', DataQualityFlag, flag_from_hdf5)
+register_writer('hdf5', DataQualityFlag, flag_to_hdf5)
+register_identifier('hdf5', DataQualityFlag, identify_hdf5)

--- a/gwpy/spectrogram/io/hdf5.py
+++ b/gwpy/spectrogram/io/hdf5.py
@@ -17,22 +17,13 @@
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module attaches the HDF5 input output methods to the Spectrogram.
-
-While these methods are avialable as methods of the class itself,
-this module attaches them to the unified I/O registry, making it a bit
-cleaner.
 """
 
-from astropy.io.registry import (register_reader, register_writer,
-                                 register_identifier)
-
 from ... import version
-from ...io.hdf5 import identify_hdf5
-from ..core import Spectrogram
+from ...data.io import hdf5
+from .. import Spectrogram
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
 
-register_reader('hdf', Spectrogram, Spectrogram.from_hdf5)
-register_writer('hdf', Spectrogram, Spectrogram.to_hdf5)
-register_identifier('hdf', Spectrogram, identify_hdf5)
+hdf5.register_hdf5_array_io(Spectrogram)

--- a/gwpy/spectrogram/io/hdf5.py
+++ b/gwpy/spectrogram/io/hdf5.py
@@ -27,3 +27,4 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
 
 hdf5.register_hdf5_array_io(Spectrogram)
+hdf5.register_hdf5_array_io(Spectrogram, format='hdf', identify=False)

--- a/gwpy/spectrum/io/hdf5.py
+++ b/gwpy/spectrum/io/hdf5.py
@@ -17,22 +17,14 @@
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module attaches the HDF5 input output methods to the Spectrum.
-
-While these methods are available as methods of the class itself,
-this module attaches them to the unified I/O registry, making it a bit
-cleaner.
 """
 
-from astropy.io.registry import (register_reader, register_writer,
-                                 register_identifier)
-
 from ... import version
-from ...io.hdf5 import identify_hdf5
-from ..core import Spectrum
+from ...data.io import hdf5
+from .. import (Spectrum, SpectralVariance)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
 
-register_reader('hdf', Spectrum, Spectrum.from_hdf5)
-register_writer('hdf', Spectrum, Spectrum.to_hdf5)
-register_identifier('hdf', Spectrum, identify_hdf5)
+for array_type in (Spectrum, SpectralVariance):
+    hdf5.register_hdf5_array_io(array_type)

--- a/gwpy/spectrum/io/hdf5.py
+++ b/gwpy/spectrum/io/hdf5.py
@@ -28,3 +28,4 @@ __version__ = version.version
 
 for array_type in (Spectrum, SpectralVariance):
     hdf5.register_hdf5_array_io(array_type)
+    hdf5.register_hdf5_array_io(array_type, format='hdf', identify=False)

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -135,26 +135,36 @@ class CommonTests(object):
 
     # -- test I/O -------------------------------
 
-    def test_hdf5_write(self, delete=True):
+    def test_hdf5_write(self, delete=True, format=[None, 'hdf5', 'hdf']):
+        if isinstance(format, (list, tuple)):
+            formats = format
+        else:
+            formats = [format]
         hdfout = self.tmpfile % 'hdf'
-        try:
-            self.TEST_ARRAY.write(hdfout)
-        except ImportError as e:
-            self.skipTest(str(e))
-        finally:
-            if delete and os.path.isfile(hdfout):
-                os.remove(hdfout)
+        for format in formats:
+            try:
+                self.TEST_ARRAY.write(hdfout, format=format)
+            except ImportError as e:
+                self.skipTest(str(e))
+            finally:
+                if delete and os.path.isfile(hdfout):
+                    os.remove(hdfout)
         return hdfout
 
-    def test_hdf5_read(self):
+    def test_hdf5_read(self, format=[None, 'hdf5', 'hdf']):
         try:
-            hdfout = self.test_hdf5_write(delete=False)
+            hdfout = self.test_hdf5_write(delete=False, format='hdf5')
         except ImportError as e:
             self.skipTest(str(e))
         else:
+            if isinstance(format, (list, tuple)):
+                formats = format
+            else:
+                formats = [format]
             try:
-                ts = self.TEST_CLASS.read(hdfout)
-                self.assertArraysEqual(self.TEST_ARRAY, ts)
+                for format in formats:
+                    ts = self.TEST_CLASS.read(hdfout, format=format)
+                    self.assertArraysEqual(self.TEST_ARRAY, ts)
             finally:
                 if os.path.isfile(hdfout):
                     os.remove(hdfout)

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -20,6 +20,8 @@
 """
 
 import abc
+import os
+import tempfile
 
 from compat import unittest
 
@@ -46,6 +48,7 @@ CHANNEL = Channel(CHANNEL_NAME)
 class CommonTests(object):
     __metaclass_ = abc.ABCMeta
     TEST_CLASS = Array
+    tmpfile = '%s.%%s' % tempfile.mktemp(prefix='gwpy_test_')
 
     def setUp(self, dtype=None):
         numpy.random.seed(SEED)
@@ -57,7 +60,9 @@ class CommonTests(object):
         try:
             return self._TEST_ARRAY
         except AttributeError:
-            self._TEST_ARRAY = self.create()
+            self._TEST_ARRAY = self.create(name='test', unit='meter',
+                                           channel=CHANNEL_NAME,
+                                           epoch=TIME_EPOCH)
             return self.TEST_ARRAY
 
     def create(self, *args, **kwargs):
@@ -67,7 +72,7 @@ class CommonTests(object):
     def assertArraysEqual(self, ts1, ts2, *args):
         nptest.assert_array_equal(ts1.value, ts2.value)
         if not args:
-            args = self.TEST_CLASS._metadata_slots
+            args = ['units'] + self.TEST_CLASS._metadata_slots
         for attr in args:
             self.assertEqual(getattr(ts1, attr, None),
                              getattr(ts2, attr, None))
@@ -91,7 +96,7 @@ class CommonTests(object):
         self.assertEquals(array.unit, units.m)
 
     def test_name(self):
-        array = self.create()
+        array = self.create(name=None)
         self.assertIsNone(array.name)
         array = self.create(name='TEST CASE')
         self.assertEquals(array.name, 'TEST CASE')
@@ -127,6 +132,32 @@ class CommonTests(object):
         array2 = array.copy()
         nptest.assert_array_equal(array.value, array2.value)
         self.assertEqual(array.unit, array2.unit)
+
+    # -- test I/O -------------------------------
+
+    def test_hdf5_write(self, delete=True):
+        hdfout = self.tmpfile % 'hdf'
+        try:
+            self.TEST_ARRAY.write(hdfout)
+        except ImportError as e:
+            self.skipTest(str(e))
+        finally:
+            if delete and os.path.isfile(hdfout):
+                os.remove(hdfout)
+        return hdfout
+
+    def test_hdf5_read(self):
+        try:
+            hdfout = self.test_hdf5_write(delete=False)
+        except ImportError as e:
+            self.skipTest(str(e))
+        else:
+            try:
+                ts = self.TEST_CLASS.read(hdfout)
+                self.assertArraysEqual(self.TEST_ARRAY, ts)
+            finally:
+                if os.path.isfile(hdfout):
+                    os.remove(hdfout)
 
 
 class ArrayTestCase(CommonTests, unittest.TestCase):

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -20,8 +20,6 @@
 """
 
 import os
-import os.path
-import tempfile
 
 from compat import unittest
 
@@ -61,8 +59,6 @@ class TimeSeriesTestMixin(object):
     """`~unittest.TestCase` for the `~gwpy.timeseries.TimeSeries` class
     """
     channel = 'L1:LDAS-STRAIN'
-    tmpfile = '%s.%%s' % tempfile.mktemp(prefix='gwpy_test_')
-    TEST_CLASS = None
 
     def test_creation_with_metadata(self):
         self.ts = self.create()
@@ -125,30 +121,6 @@ class TimeSeriesTestMixin(object):
         finally:
             if os.path.isfile(fp):
                 os.remove(fp)
-
-    def test_hdf5_write(self, delete=True):
-        self.ts = self.create(name=self.channel)
-        hdfout = self.tmpfile % 'hdf'
-        try:
-            self.ts.write(hdfout)
-        except ImportError as e:
-            self.skipTest(str(e))
-        finally:
-            if delete and os.path.isfile(hdfout):
-                os.remove(hdfout)
-        return hdfout
-
-    def test_hdf5_read(self):
-        try:
-            hdfout = self.test_hdf5_write(delete=False)
-        except ImportError as e:
-            self.skipTest(str(e))
-        else:
-            try:
-                self.TEST_CLASS.read(hdfout, self.channel)
-            finally:
-                if os.path.isfile(hdfout):
-                    os.remove(hdfout)
 
     def test_resample(self):
         """Test the `TimeSeries.resample` method

--- a/gwpy/timeseries/io/hdf5.py
+++ b/gwpy/timeseries/io/hdf5.py
@@ -28,3 +28,4 @@ __version__ = version.version
 
 for array_type in (TimeSeries, StateVector, StateTimeSeries):
     hdf5.register_hdf5_array_io(array_type)
+    hdf5.register_hdf5_array_io(array_type, format='hdf', identify=False)

--- a/gwpy/timeseries/io/hdf5.py
+++ b/gwpy/timeseries/io/hdf5.py
@@ -17,26 +17,14 @@
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """This module attaches the HDF5 input output methods to the TimeSeries.
-
-While these methods are avialable as methods of the class itself,
-this module attaches them to the unified I/O registry, making it a bit
-cleaner.
 """
 
-from astropy.io.registry import (register_reader, register_writer,
-                                 register_identifier)
-
 from ... import version
-from ...io.hdf5 import identify_hdf5
-from .. import (TimeSeries, StateVector)
+from ...data.io import hdf5
+from .. import (TimeSeries, StateVector, StateTimeSeries)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
 
-register_reader('hdf', TimeSeries, TimeSeries.from_hdf5)
-register_writer('hdf', TimeSeries, TimeSeries.to_hdf5)
-register_identifier('hdf', TimeSeries, identify_hdf5)
-
-register_reader('hdf', StateVector, StateVector.from_hdf5)
-register_writer('hdf', StateVector, StateVector.to_hdf5)
-register_identifier('hdf', StateVector, identify_hdf5)
+for array_type in (TimeSeries, StateVector, StateTimeSeries):
+    hdf5.register_hdf5_array_io(array_type)


### PR DESCRIPTION
This PR improves the HDF5-based I/O of `Array` types, mainly by moving the worker code into the new `data.io` module similar to how these things are done for higher-level types.

The subclass types have been modified to import their HDF5 I/O method from this new location, and DeprecationWarnings have been added to the old `Array.to_hdf5` and `Array.from_hdf5` methods.

Finally, the HDF5 I/O tests for the `TimeSeries` have been moved to the `Array` test suite for inheritance by all Array subclasses.