### PR TITLE
Added DQSegDB install to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,23 +18,19 @@ before_install:
   - travis_retry pip install -q tornado jinja2 GitPython
   # install cython
   - travis_retry pip install --install-option="--no-cython-compile" Cython
-  # install numpy
+  # install python dependencies
   - travis_retry pip install -q numpy==1.9.1
-  # install scipy
   - travis_wait pip install -q scipy==0.16
-  # install matplotlib
   - travis_retry pip install -q matplotlib==1.3.1
-  # install astropy
   - travis_retry pip install -q astropy==1.0
+  - travis_retry pip install -q h5py
+  - travis_retry pip install -q unittest2
+  - travis_retry pip install -q importlib
+  - travis_retry pip install -q pytest
+  - travis_retry pip install -q coveralls
   # install GLUE
   - travis_retry pip install -q kerberos
   - travis_retry pip install -q --egg https://www.lsc-group.phys.uwm.edu/daswg/download/software/source/glue-1.48.tar.gz#egg=glue-1.48
-  # install h5py
-  - pip install -q h5py
-  - pip install -q unittest2
-  - pip install -q importlib
-  - pip install -q pytest
-  - pip install -q coveralls
   - popd
 install:
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - travis_retry pip install -q coveralls
   # install LSCSoft python packages
   - travis_retry pip install -q kerberos
-  - travis_retry pip install -q cjson
+  - travis_retry pip install -q python-cjson
   - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "2.7_with_system_site_packages"
 before_install:
   - mkdir builds
   - pushd builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_install:
   - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q kerberos
   - travis_retry pip install -q python-cjson
-  - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
-  - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2
+  - travis_retry pip install -q --egg --no-use-wheel http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
+  - travis_retry pip install -q --egg --no-use-wheel http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2
   - popd
 install:
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   # install LSCSoft python packages
   - travis_retry pip install -q kerberos
   - travis_retry pip install -q python-cjson
+  - sudo apt-get --assume-yes python-m2crypto
   - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,10 @@ before_install:
   - travis_retry pip install -q importlib
   - travis_retry pip install -q pytest
   - travis_retry pip install -q coveralls
-  # install GLUE
+  # install LSCSoft python packages
   - travis_retry pip install -q kerberos
-  - travis_retry pip install -q --egg https://www.lsc-group.phys.uwm.edu/daswg/download/software/source/glue-1.48.tar.gz#egg=glue-1.48
+  - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
+  - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2
   - popd
 install:
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_install:
   - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q kerberos
   - travis_retry pip install -q python-cjson
-  - travis_retry pip install -q --egg --no-use-wheel http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
-  - travis_retry pip install -q --egg --no-use-wheel http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2
+  - travis_retry pip install -q http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
+  - travis_retry pip install -q http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
   - popd
 install:
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 install:
   - python setup.py build
 script:
-  - coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*" -m py.test -v
+  - coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*,gwpy/utils/sphinx/*" -m py.test -v
   - pip install .
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - travis_retry pip install -q tornado jinja2 GitPython
   # install M2Crypto for glue/dqsegdb
   - sudo apt-get --assume-yes install python-m2crypto
+  - export PATH=$PATH:/usr/bin
   - travis_retry pip install M2Crypto
   # install cython
   - travis_retry pip install --install-option="--no-cython-compile" Cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ before_install:
   - sudo apt-get --assume-yes install krb5-user python-nds2-client
   # install build dependencies
   - travis_retry pip install -q tornado jinja2 GitPython
+  # install M2Crypto for glue/dqsegdb
+  - sudo apt-get --assume-yes install python-m2crypto
+  - travis_retry pip install M2Crypto
   # install cython
   - travis_retry pip install --install-option="--no-cython-compile" Cython
   # install python dependencies
@@ -32,8 +35,6 @@ before_install:
   # install LSCSoft python packages
   - travis_retry pip install -q kerberos
   - travis_retry pip install -q python-cjson
-  - sudo apt-get --assume-yes install python-m2crypto
-  - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sudo apt-get --assume-yes --allow-unauthenticated install lscsoft-archive-keyring
   - sudo apt-get update -qq
   - sudo apt-get --assume-yes install libhdf5-dev lal-python lalframe-python ldas-tools-framecpp-python
-  - sudo apt-get --assume-yes install python-nds2-client
+  - sudo apt-get --assume-yes install krb5-user python-nds2-client
   # install build dependencies
   - travis_retry pip install -q tornado jinja2 GitPython
   # install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,14 @@ before_install:
   # add LSCSoft sources
   - echo "deb http://software.ligo.org/lscsoft/debian wheezy contrib" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
-  - sudo apt-get --assume-yes --allow-unauthenticated install lscsoft-archive-keyring
+  - sudo apt-get -y -qq --allow-unauthenticated install lscsoft-archive-keyring
   - sudo apt-get update -qq
-  - sudo apt-get --assume-yes install libhdf5-dev lal-python lalframe-python ldas-tools-framecpp-python
-  - sudo apt-get --assume-yes install krb5-user python-nds2-client
+  - sudo apt-get -y -qq install libhdf5-dev lal-python lalframe-python ldas-tools-framecpp-python
+  - sudo apt-get -y -qq install krb5-user python-nds2-client
   # install build dependencies
   - travis_retry pip install -q tornado jinja2 GitPython
-  # install M2Crypto for glue/dqsegdb
-  - sudo apt-get --assume-yes install python-m2crypto
-  - travis_retry pip install M2Crypto
   # install cython
-  - travis_retry pip install --install-option="--no-cython-compile" Cython
+  - travis_retry pip install -q --install-option="--no-cython-compile" Cython
   # install python dependencies
   - travis_retry pip install -q numpy==1.9.1
   - travis_wait pip install -q scipy==0.16
@@ -37,6 +34,8 @@ before_install:
   - travis_retry pip install -q pytest
   - travis_retry pip install -q coveralls
   # install LSCSoft python packages
+  - sudo apt-get -y -qq install python-m2crypto
+  - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q kerberos
   - travis_retry pip install -q python-cjson
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ before_install:
   - travis_retry pip install -q coveralls
   # install LSCSoft python packages
   - travis_retry pip install -q kerberos
+  - travis_retry pip install -q cjson
+  - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   # install LSCSoft python packages
   - travis_retry pip install -q kerberos
   - travis_retry pip install -q python-cjson
-  - sudo apt-get --assume-yes python-m2crypto
+  - sudo apt-get --assume-yes install python-m2crypto
   - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz#egg=glue-1.49.1
   - travis_retry pip install -q --egg http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz#egg=dqsegdb-1.2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: python
 virtualenv:
   system_site_packages: true
-python:
-  - "2.6"
-  - "2.7"
-  - "2.7_with_system_site_packages"
 before_install:
   - mkdir builds
   - pushd builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+virtualenv:
+  system_site_packages: true
 python:
   - "2.6"
   - "2.7"
@@ -19,7 +21,6 @@ before_install:
   - travis_retry pip install -q tornado jinja2 GitPython
   # install M2Crypto for glue/dqsegdb
   - sudo apt-get --assume-yes install python-m2crypto
-  - export PATH=$PATH:/usr/bin
   - travis_retry pip install M2Crypto
   # install cython
   - travis_retry pip install --install-option="--no-cython-compile" Cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
 before_install:
   - mkdir builds
   - pushd builds
+  # update pip
+  - pip install -q --upgrade pip
   # install numpy non-python dependencies
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
   # add LSCSoft sources

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -89,8 +89,11 @@ class ChannelTests(unittest.TestCase):
             import nds2
         except ImportError as e:
             self.skipTest(str(e))
-        new = Channel.query_nds2(self.channel, host=NDSHOST,
-                                 type=nds2.channel.CHANNEL_TYPE_RAW)
+        try:
+            new = Channel.query_nds2(self.channel, host=NDSHOST,
+                                     type=nds2.channel.CHANNEL_TYPE_RAW)
+        except IOError as e:
+            self.skipTest(str(e))
         self.assertTrue(str(new) == self.channel)
         self.assertTrue(new.ifo == self.channel.split(':', 1)[0])
         self.assertTrue(new.sample_rate == units.Quantity(32768, 'Hz'))


### PR DESCRIPTION
This PR adds the `dqsegdb` package to the travis build, and updates the URLs for lscsoft packages to point to http://software.ligo.org.

Also included are some trivial travis build changes