### PR TITLE
Update travis-ci build to new containter infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ before_install:
   - pip install --upgrade pip
 
   # build FFTW3 (double and float)
-  - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION}
-  - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-float
+  - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-shared=yes
+  - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-shared=yes --enable-float
 
   # build LAL packages
   - echo ${PKG_CONFIG_PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_install:
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-shared=yes --enable-float
 
   # build LAL packages
-  - pkg-config --debug --libs gsl
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}
   #- source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ addons:
       - python-m2crypto
       # misc python dependencies
       - texlive-latex-extra
-      - libhdf5-dev
+      - libhdf5-serial-dev
 
 before_install:
   # update pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ before_install:
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-shared=yes
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-shared=yes --enable-float
 
+  # build frame libraries
+  - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/libframe-${LIBFRAME_VERSION}.tar.gz ./libframe-${LIBFRAME_VERSION}
+
   # build LAL packages
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}
   #- source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,16 +44,16 @@ before_install:
   # build FFTW3
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION}
 
-  # build numpy and scipy
-  - travis_retry pip install --install-option="--no-cython-compile" Cython
-  - travis_retry pip install -q numpy==1.9.1
-  - travis_wait pip install -q scipy==0.16
-
   # build LAL packages
   - echo ${PKG_CONFIG_PATH}
   - ls ./fftw-${FFTW_VERSION}/lib/pkgconfig
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
+
+  # build numpy and scipy
+  - travis_retry pip install --install-option="--no-cython-compile" Cython
+  - travis_retry pip install -q numpy==1.9.1
+  - travis_wait pip install -q scipy==0.16
 
   # install build dependencies
   - travis_retry pip install tornado jinja2 GitPython

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,8 @@ before_install:
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-shared=yes --enable-float
 
   # build LAL packages
-  - echo ${PKG_CONFIG_PATH}
-  - ls ./fftw-${FFTW_VERSION}/lib/pkgconfig
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}
-  - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
+  #- source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
 
   # build numpy and scipy
   - travis_retry pip install --install-option="--no-cython-compile" Cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ before_install:
   # update pip
   - pip install --upgrade pip
 
-  # build FFTW3
+  # build FFTW3 (double and float)
+  - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION}
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-float
 
   # build LAL packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ addons:
       - python-numpy
       - python-scipy
       - bc
-      - libgsl0ldbl
       # glue dependencies
       - python-m2crypto
       # misc python dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
 
   # build numpy and scipy
   - travis_retry pip install -q numpy==1.9.1
-  - travis_wait pip install -q scipy==0.16
+  - travis_wait pip install scipy==0.16
 
   # build LAL packages
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ addons:
       - bc
       # glue dependencies
       - python-m2crypto
-      # misc python packages
-      - python-matplotlib
+      # misc python dependencies
       - texlive-latex-extra
+      - libhdf5-dev
 
 before_install:
   # update pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_install:
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-shared=yes --enable-float
 
   # build LAL packages
+  - pkg-config --debug --libs gsl
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}
   #- source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,12 @@ before_install:
 
   # build numpy and scipy
   - travis_retry pip install --install-option="--no-cython-compile" Cython
-  - travis_retry pip install numpy==1.9.1
-  - travis_wait pip install scipy==0.16
+  - travis_retry pip install -q numpy==1.9.1
+  - travis_wait pip install -q scipy==0.16
 
   # build LAL packages
+  - echo ${PKG_CONFIG_PATH}
+  - ls ./fftw-${FFTW_VERSION}/lib/pkgconfig
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
       - python-dev
       - libblas-dev
       - liblapack-dev
-      - cython
       # lal dependencies
       - pkg-config
       - python-all-dev
@@ -46,6 +45,7 @@ before_install:
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION}
 
   # build numpy and scipy
+  - travis_retry pip install --install-option="--no-cython-compile" Cython
   - travis_retry pip install numpy==1.9.1
   - travis_wait pip install scipy==0.16
 
@@ -55,9 +55,6 @@ before_install:
 
   # install build dependencies
   - travis_retry pip install tornado jinja2 GitPython
-
-  # install cython
-  - travis_retry pip install --install-option="--no-cython-compile" Cython
 
   # install python dependencies
   - travis_retry pip install matplotlib==1.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ env:
 addons:
   apt:
     packages:
+      # generic packages
+      - gcc
+      - gfortran
+      - python-dev
+      - libblas-dev
+      - liblapack-dev
+      - cython
       # lal dependencies
       - pkg-config
       - python-all-dev
@@ -33,13 +40,13 @@ addons:
 
 before_install:
   # update pip
-  - pip install -q --upgrade pip
+  - pip install --upgrade pip
 
   # build FFTW3
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION}
 
   # build numpy and scipy
-  - travis_retry pip install -q numpy==1.9.1
+  - travis_retry pip install numpy==1.9.1
   - travis_wait pip install scipy==0.16
 
   # build LAL packages
@@ -47,26 +54,26 @@ before_install:
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
 
   # install build dependencies
-  - travis_retry pip install -q tornado jinja2 GitPython
+  - travis_retry pip install tornado jinja2 GitPython
 
   # install cython
-  - travis_retry pip install -q --install-option="--no-cython-compile" Cython
+  - travis_retry pip install --install-option="--no-cython-compile" Cython
 
   # install python dependencies
-  - travis_retry pip install -q matplotlib==1.3.1
-  - travis_retry pip install -q astropy==1.0
-  - travis_retry pip install -q h5py
-  - travis_retry pip install -q unittest2
-  - travis_retry pip install -q importlib
-  - travis_retry pip install -q pytest
-  - travis_retry pip install -q coveralls
+  - travis_retry pip install matplotlib==1.3.1
+  - travis_retry pip install astropy==1.0
+  - travis_retry pip install h5py
+  - travis_retry pip install unittest2
+  - travis_retry pip install importlib
+  - travis_retry pip install pytest
+  - travis_retry pip install coveralls
 
   # install LSCSoft python packages
-  - travis_retry pip install -q M2Crypto
-  - travis_retry pip install -q kerberos
-  - travis_retry pip install -q python-cjson
-  - travis_retry pip install -q http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
-  - travis_retry pip install -q http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
+  - travis_retry pip install M2Crypto
+  - travis_retry pip install kerberos
+  - travis_retry pip install python-cjson
+  - travis_retry pip install http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
+  - travis_retry pip install http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
 
 install:
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - LALFRAME_VERSION="1.3.0"
     - LIBFRAME_VERSION="8.20"
     - LDAS_TOOLS_VERSION="2.4.1"
+    - NDS2_CLIENT_VERSION="0.10.4"
 
 addons:
   apt:
@@ -31,6 +32,8 @@ addons:
       - python-numpy
       - python-scipy
       - bc
+      # nds2 dependencies
+      - libsasl2-2
       # glue dependencies
       - python-m2crypto
       # misc python dependencies
@@ -50,7 +53,10 @@ before_install:
 
   # build LAL packages
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}
-  #- source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
+  - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
+
+  # build NDS2 client
+  - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz ./nds2-client-${NDS2_CLIENT_VERSION} --disable-swig-java --disable-mex-matlab
 
   # build numpy and scipy
   - travis_retry pip install --install-option="--no-cython-compile" Cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,58 @@
 language: python
+
 virtualenv:
   system_site_packages: true
+
+sudo: false
+
+env:
+  global:
+    - FFTW_VERSION="3.3.4"
+    - LAL_VERSION="6.15.0"
+    - LALFRAME_VERSION="1.3.0"
+    - LIBFRAME_VERSION="8.20"
+    - LDAS_TOOLS_VERSION="2.4.1"
+
+addons:
+  apt:
+    packages:
+      # lal dependencies
+      - pkg-config
+      - python-all-dev
+      - zlib1g-dev
+      - libgsl0-dev
+      - swig
+      - python-numpy
+      - python-scipy
+      - bc
+      # glue dependencies
+      - python-cjson
+      - python-m2crypto
+      # misc python packages
+      - python-matplotlib
+
 before_install:
-  - mkdir builds
-  - pushd builds
   # update pip
   - pip install -q --upgrade pip
-  # install numpy non-python dependencies
-  - sudo apt-get install -qq libatlas-dev libatlas-base-dev gfortran
-  # add LSCSoft sources
-  - echo "deb http://software.ligo.org/lscsoft/debian wheezy contrib" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update -qq
-  - sudo apt-get -y -qq --allow-unauthenticated install lscsoft-archive-keyring
-  - sudo apt-get update -qq
-  - sudo apt-get -y -qq install libhdf5-dev lal-python lalframe-python ldas-tools-framecpp-python
-  - sudo apt-get -y -qq install krb5-user python-nds2-client
-  # install build dependencies
-  - travis_retry pip install -q tornado jinja2 GitPython
-  # install cython
-  - travis_retry pip install -q --install-option="--no-cython-compile" Cython
-  # install python dependencies
+
+  # build FFTW3
+  - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION}
+
+  # build numpy and scipy
   - travis_retry pip install -q numpy==1.9.1
   - travis_wait pip install -q scipy==0.16
+
+  # build LAL packages
+  - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz ./lal-${LAL_VERSION}
+  - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz ./lalframe-${LALFRAME_VERSION}
+
+  # install build dependencies
+  - travis_retry pip install -q tornado jinja2 GitPython
+
+  # install cython
+  - travis_retry pip install -q --install-option="--no-cython-compile" Cython
+
+  # install python dependencies
   - travis_retry pip install -q matplotlib==1.3.1
   - travis_retry pip install -q astropy==1.0
   - travis_retry pip install -q h5py
@@ -29,21 +60,24 @@ before_install:
   - travis_retry pip install -q importlib
   - travis_retry pip install -q pytest
   - travis_retry pip install -q coveralls
+
   # install LSCSoft python packages
-  - sudo apt-get -y -qq install python-m2crypto
   - travis_retry pip install -q M2Crypto
   - travis_retry pip install -q kerberos
   - travis_retry pip install -q python-cjson
   - travis_retry pip install -q http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
   - travis_retry pip install -q http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz
-  - popd
+
 install:
   - python setup.py build
+
 script:
   - coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*,gwpy/utils/sphinx/*" -m py.test -v
   - pip install .
+
 after_success:
   - coveralls
+
 notifications:
   slack:
     secure: jQdoSpwNbUnq0Eo7o6Ko7vuhu58LQdfy8jFKxLUnUjv/GLezK/PPAQCU9SgmyDPh1yD8sb5Xa8UtbNfGtpYdwBAGwZxPHz3oQQAflivFwcF6UP7/NlAB9muSOOnL0QfQyX1I4sIKOkX+gkl+TBciX4v58B8NUU02dDkwDqTLUqQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ addons:
       - python-numpy
       - python-scipy
       - bc
+      - libgsl0ldbl
       # glue dependencies
       - python-m2crypto
       # misc python dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_install:
   - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-shared=yes --enable-float
 
   # build frame libraries
+  - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/ldas-tools-${LDAS_TOOLS_VERSION}.tar.gz ./ldas-tools-${LDAS_TOOLS_VERSION}
   - source .travis/build-with-autotools.sh http://software.ligo.org/lscsoft/source/libframe-${LIBFRAME_VERSION}.tar.gz ./libframe-${LIBFRAME_VERSION}
 
   # build LAL packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ addons:
       - python-scipy
       - bc
       # glue dependencies
-      - python-cjson
       - python-m2crypto
       # misc python packages
       - python-matplotlib
+      - texlive-latex-extra
 
 before_install:
   # update pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   - pip install --upgrade pip
 
   # build FFTW3
-  - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION}
+  - source .travis/build-with-autotools.sh http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz ./fftw-${FFTW_VERSION} --enable-float
 
   # build LAL packages
   - echo ${PKG_CONFIG_PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,3 +95,12 @@ after_success:
 notifications:
   slack:
     secure: jQdoSpwNbUnq0Eo7o6Ko7vuhu58LQdfy8jFKxLUnUjv/GLezK/PPAQCU9SgmyDPh1yD8sb5Xa8UtbNfGtpYdwBAGwZxPHz3oQQAflivFwcF6UP7/NlAB9muSOOnL0QfQyX1I4sIKOkX+gkl+TBciX4v58B8NUU02dDkwDqTLUqQ=
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - ./fftw-${FFTW_VERSION}
+    - ./libframe-${LIBFRAME_VERSION}
+    - ./lal-${LAL_VERSION}
+    - ./lalframe-${LALFRAME_VERSION}
+    - ./nds2-client-${NDS2_CLIENT_VERSION}

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -5,7 +5,7 @@
 set -e
 
 tarball=$1
-target=$2
+target=`readlink -f $2`
 
 builddir="build_$RANDOM"
 mkdir -p $builddir
@@ -17,7 +17,7 @@ cd $builddir
 if [ -f ./00boot ]; then
     ./00boot
 fi
-./configure --prefix=`readlink -f $target` --enable-silent-rules --quiet
+./configure --prefix=$target --enable-silent-rules --quiet
 make
 make install
 

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -23,3 +23,4 @@ make install
 
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${target}/lib/pkgconfig
 cd -
+rm -rf ${builddir}

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -31,5 +31,8 @@ make install
 
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${target}/lib/pkgconfig
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${target}/lib
+if [ -d ${target}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages ]; then
+  export PYTHONPATH=${PYTHONPATH}:${target}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages
+fi
 cd -
 rm -rf ${builddir}

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -10,6 +10,11 @@ target=`readlink -f $1`
 shift
 configargs="$@"
 
+if [ "$(ls -A ${target}/lib/pkconfig)" ]; then
+    echo "Target pkg-config directory is not empty, presuming successful cached build, will not build this package"
+    exit 0
+fi
+
 builddir="build_$RANDOM"
 mkdir -p $builddir
 echo "Building into $builddir"

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -12,7 +12,7 @@ configargs="$@"
 
 if [ "$(ls -A ${target}/lib/pkconfig)" ]; then
     echo "Target pkg-config directory is not empty, presuming successful cached build, will not build this package"
-    exit 0
+    return 0
 fi
 
 builddir="build_$RANDOM"

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -5,7 +5,10 @@
 set -e
 
 tarball=$1
-target=`readlink -f $2`
+shift
+target=`readlink -f $1`
+shift
+configargs="$@"
 
 builddir="build_$RANDOM"
 mkdir -p $builddir
@@ -17,7 +20,7 @@ cd $builddir
 if [ -f ./00boot ]; then
     ./00boot
 fi
-./configure --prefix=$target --enable-silent-rules --quiet
+./configure --prefix=$target --enable-silent-rules --quiet $@
 make
 make install
 

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -22,3 +22,4 @@ make
 make install
 
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${target}/lib/pkgconfig
+cd -

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -30,7 +30,7 @@ if [ -f ./00boot ]; then
     ./00boot
 fi
 ./configure --prefix=$target $@
-make -j
+make #-j
 make install
 
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${target}/lib/pkgconfig

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -11,13 +11,13 @@ builddir="build_$RANDOM"
 mkdir -p $builddir
 echo "Building into $builddir"
 # untar
-wget $tarball -O `basename $tarball`
+wget $tarball --quiet -O `basename $tarball`
 tar -zxf `basename $tarball` -C $builddir --strip-components=1
 cd $builddir
 if [ -f ./00boot ]; then
     ./00boot
 fi
-./configure --prefix=`greadlink -f $target` --enable-silent-rules --quiet
+./configure --prefix=`readlink -f $target` --enable-silent-rules --quiet
 make
 make install
 

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -46,3 +46,5 @@ make install
 
 cd -
 rm -rf ${builddir}
+echo "Updated PYTHONPATH to"
+echo ${PYTHONPATH}

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# build a package with autotools
+
+set -e
+
+tarball=$1
+target=$2
+
+builddir="build_$RANDOM"
+mkdir -p $builddir
+echo "Building into $builddir"
+# untar
+wget $tarball -O `basename $tarball`
+tar -zxf `basename $tarball` -C $builddir --strip-components=1
+cd $builddir
+if [ -f ./00boot ]; then
+    ./00boot
+fi
+./configure --prefix=`greadlink -f $target` --enable-silent-rules --quiet
+make
+make install
+
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${target}/lib/pkgconfig

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -23,9 +23,11 @@ for libd in "lib lib64"; do
 done
 
 # check for cached build
-if [ -d ${target}/lib/pkgconfig ] && [ "$(ls -A ${target}/lib/pkconfig)" ]; then
-    echo "Target pkg-config directory is not empty, presuming successful cached build, will not build this package"
-    return 0
+if [ -d ${target}/lib/pkgconfig ]; then
+    if [ "$(ls -A ${target}/lib/pkconfig)" ]; then
+        echo "Target pkg-config directory is not empty, presuming successful cached build, will not build this package"
+        return 0
+    fi
 fi
 
 builddir="build_$RANDOM"

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -20,7 +20,7 @@ cd $builddir
 if [ -f ./00boot ]; then
     ./00boot
 fi
-./configure --prefix=$target --enable-silent-rules --quiet $@
+./configure --prefix=$target --enable-silent-rules $@
 make
 make install
 

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -29,7 +29,7 @@ cd $builddir
 if [ -f ./00boot ]; then
     ./00boot
 fi
-./configure --prefix=$target --enable-silent-rules --quiet $@
+./configure --prefix=$target $@
 make -j
 make install
 

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -25,5 +25,6 @@ make
 make install
 
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${target}/lib/pkgconfig
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${target}/lib
 cd -
 rm -rf ${builddir}

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -20,7 +20,7 @@ cd $builddir
 if [ -f ./00boot ]; then
     ./00boot
 fi
-./configure --prefix=$target --enable-silent-rules $@
+./configure --prefix=$target --enable-silent-rules --quiet $@
 make
 make install
 

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -26,7 +26,7 @@ if [ -f ./00boot ]; then
     ./00boot
 fi
 ./configure --prefix=$target --enable-silent-rules --quiet $@
-make
+make -j
 make install
 
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${target}/lib/pkgconfig

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -90,6 +90,11 @@ class ChannelTests(unittest.TestCase):
         except ImportError as e:
             self.skipTest(str(e))
         try:
+            from gwpy.io import kerberos
+            kerberos.which('kinit')
+        except ValueError as e:
+            self.skipTest(str(e))
+        try:
             new = Channel.query_nds2(self.channel, host=NDSHOST,
                                      type=nds2.channel.CHANNEL_TYPE_RAW)
         except IOError as e:


### PR DESCRIPTION
This PR make a new attempt to update the travis-ci.org build configuration to use the new container infrastructure.

Currently we have to build FFTW and LALSuite from source.