### PR TITLE
DataQualityFlag.coalesce: coalesce each list before &

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -730,6 +730,7 @@ class DataQualityFlag(object):
             a view of this flag, not a copy.
         """
         self.known = self.known.coalesce()
+        self.active = self.active.coalesce()
         self.active = (self.known & self.active).coalesce()
         return self
 


### PR DESCRIPTION
This PR fixes the behaviour of coalesce when working with overlapping segments in a list.