### PR TITLE
Added new Series.diff method to correctly set metadata

### DIFF
--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -228,6 +228,39 @@ class Series(Array):
         """
         return numpy.column_stack((self.xindex.value, self.value))
 
+    def diff(self, n=1, axis=-1):
+        """Calculate the n-th order discrete difference along given axis.
+
+        The first order difference is given by ``out[n] = a[n+1] - a[n]`` along
+        the given axis, higher order differences are calculated by using `diff`
+        recursively.
+
+        Parameters
+        ----------
+        n : int, optional
+            The number of times values are differenced.
+        axis : int, optional
+            The axis along which the difference is taken, default is the
+            last axis.
+
+        Returns
+        -------
+        diff : `Series`
+            The `n` order differences. The shape of the output is the same
+            as the input, except along `axis` where the dimension is
+            smaller by `n`.
+
+        See Also
+        --------
+        numpy.diff
+            for documentation on the underlying method
+        """
+        out = super(Array, self).diff(n=n, axis=axis)
+        out.x0 = self.x0 + self.dx * n
+        return out
+
+    diff.__doc__ = numpy.diff.__doc__
+
     def __array_finalize__(self, obj):
         super(Series, self).__array_finalize__(obj)
         if hasattr(self, '_xindex'):

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -316,6 +316,24 @@ class SeriesTestCase(CommonTests, unittest.TestCase):
         # test bogus input
         self.assertRaises(ValueError, ts1.pad, -1)
 
+    def test_diff(self):
+        """Test the `Series.diff` method
+
+        This just ensures that the returned `Series` has the right length
+        and the right x0
+        """
+        ts1 = self.create()
+        diff = ts1.diff()
+        self.assertIsInstance(diff, type(ts1))
+        self.assertEqual(ts1.size - 1, diff.size)
+        self.assertEqual(diff.x0, ts1.x0 + ts1.dx)
+        self.assertEqual(diff.xspan[1], ts1.xspan[1])
+        self.assertEqual(diff.channel, ts1.channel)
+        # test n=3
+        diff = ts1.diff(n=3)
+        self.assertEqual(ts1.size - 3, diff.size)
+        self.assertEqual(diff.x0, ts1.x0 + ts1.dx * 3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements an override of `Quantity.diff` in the `Series` class to correctly set the `x0` attribute for the returned array, and so fixes #159, and adds a test of the new method.