### PR TITLE
New TimeSeries.{find,get} methods

### DIFF
--- a/docs/timeseries/index.rst
+++ b/docs/timeseries/index.rst
@@ -43,17 +43,26 @@ As described above, the data from each instrument are archived for off-line stud
 To learn more about this particular data format, take a look at the specification document `LIGO-T970130 <https://dcc.ligo.org/LIGO-T970130/public>`_.
 These files are stored on disk by the LIGO Data Grid and can be either accessed either directly or remotely.
 
-The `TimeSeries` for a given :class:`~gwpy.detector.channel.Channel` can be read from disk using the :meth:`TimeSeries.read` `classmethod` as follows::
+The easiest way to access interferometer data is to use `TimeSeries.get`:
+
+.. automethod:: TimeSeries.get
+   :noindex:
+
+This method will try direct file access and remote NDS2 access in order to get you the data you want, with the minimum of inputs (direct file access is preferred)::
 
     >>> from gwpy.timeseries import TimeSeries
-    >>> data = TimeSeries.read('/archive/frames/A6/L0/LLO/L-R-10670/L-R-1067042880-32.gwf', 'L1:PSL-ODC_CHANNEL_OUT_DQ')
+    >>> data = TimeSeries.get('L1:PSL-ODC_CHANNEL_OUT_DQ', 1067042880, 1067042912)
 
-Alternatively, the data can be downloaded on-the-fly via the `Network Data Server <https://www.lsc-group.phys.uwm.edu/daswg/projects/nds-client.html>`_ using the :meth:`TimeSeries.fetch` `classmethod`::
+If you want to be more specific, there are three other methods that you can use that allow more control over the data access:
 
-    >>> from gwpy.timeseries import TimeSeries
-    >>> data = TimeSeries.fetch('L1:PSL-ODC_CHANNEL_OUT_DQ', 1067042880, 1067042912)
+.. autosummary::
 
-Both of the above snippets will return identical `TimeSeries`.
+   TimeSeries.fetch
+   TimeSeries.find
+   TimeSeries.read
+
+All of these should return identical `TimeSeries` objects.
+
 For more details on accessing data via either of these sources, or from publicly-released data files, please read the following tutorials:
 
 .. toctree::
@@ -87,7 +96,7 @@ The `TimeSeriesDict`
 --------------------
 
 The `TimeSeriesDict` does for multiple channels what the `TimeSeriesList` does for multiple epochs, allowing easy collection of `TimeSeries` from a single epochs but multiple sources.
-The most immediate itilities of this object are the :meth:`TimeSeriesDict.read` and :meth:`TimeSeriesDict.fetch` methods, allowing users to read and download respectively data for numerous channels in a single command.
+This class offers the same data access as for the `TimeSeries`, with the `TimeSeriesDict.get` the easiest way to load some data.
 See the full reference for what other functionality is available.
 
 .. _plotting-a-timeseries:

--- a/examples/spectrogram/coherence.py
+++ b/examples/spectrogram/coherence.py
@@ -34,9 +34,9 @@ __currentmodule__ = 'gwpy.timeseries'
 # First, we import the `TimeSeriesDict`
 from gwpy.timeseries import TimeSeriesDict
 
-# and then fetch both data sets:
-data = TimeSeriesDict.fetch(['L1:LSC-SRCL_IN1_DQ', 'L1:LSC-CARM_IN1_DQ'],
-                            'Feb 13 2015', 'Feb 13 2015 00:15')
+# and then :meth:`~TimeSeriesDict.get` both data sets:
+data = TimeSeriesDict.get(['L1:LSC-SRCL_IN1_DQ', 'L1:LSC-CARM_IN1_DQ'],
+                           'Feb 13 2015', 'Feb 13 2015 00:15')
 
 # We can then use the :meth:`~TimeSeries.coherence_spectrogram` method
 # of one `TimeSeries` to calcululate the time-varying coherence with

--- a/examples/spectrogram/plot.py
+++ b/examples/spectrogram/plot.py
@@ -25,10 +25,14 @@ I would like to study the gravitational wave strain spectrogram around the time 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.spectrogram'
 
-# First, we import the :class:`~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.fetch` the data:
+import os
+os.environ.pop('LIGO_DATAFIND_SERVER')
+
+# First, we import the :class:`~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.get` the data:
 from gwpy.timeseries import TimeSeries
-gwdata = TimeSeries.fetch(
-    'H1:LDAS-STRAIN,rds', 'September 16 2010 06:40', 'September 16 2010 06:50')
+gwdata = TimeSeries.get(
+    'H1:LDAS-STRAIN', 'September 16 2010 06:40', 'September 16 2010 06:50',
+    verbose=True)
 
 # Next, we can calculate a `Spectrogram` using the 
 # :meth:`~gwpy.timeseries.TimeSeries.spectrogram` method of the #

--- a/examples/spectrogram/ratio.py
+++ b/examples/spectrogram/ratio.py
@@ -27,10 +27,10 @@ __currentmodule__ = 'gwpy.spectrogram'
 
 # As with :doc:`previous example <plot>`, we import the
 # `~gwpy.timeseries.TimeSeries` class,
-# :meth:`~gwpy.timeseries.TimeSeries.fetch` the data, and calculate a 
+# :meth:`~gwpy.timeseries.TimeSeries.get` the data, and calculate a 
 # `Spectrogram`
 from gwpy.timeseries import TimeSeries
-gwdata = TimeSeries.fetch('H1:LDAS-STRAIN,rds', 'September 16 2010 06:40', 'September 16 2010 06:50')
+gwdata = TimeSeries.get('H1:LDAS-STRAIN,rds', 'September 16 2010 06:40', 'September 16 2010 06:50')
 specgram = gwdata.spectrogram(5, fftlength=2, overlap=1) ** (1/2.)
 
 # To whiten the `specgram` we can use the :meth:`~Spectrogram.ratio` method

--- a/examples/spectrogram/rayleigh.py
+++ b/examples/spectrogram/rayleigh.py
@@ -25,9 +25,9 @@ I would like to study the gravitational wave strain spectrogram around the time 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.spectrogram'
 
-# First, we import the :class:`~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.fetch` the data:
+# First, we import the :class:`~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.get` the data:
 from gwpy.timeseries import TimeSeries
-gwdata = TimeSeries.fetch(
+gwdata = TimeSeries.get(
     'H1:LDAS-STRAIN,rds', 'September 16 2010 06:40', 'September 16 2010 06:50')
 
 # Next, we can calculate a Rayleigh statistic `Spectrogram` using the 

--- a/examples/spectrogram/spectrogram2.py
+++ b/examples/spectrogram/spectrogram2.py
@@ -32,10 +32,10 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.timeseries'
 
 # As with the other `~gwpy.spectrogram.Spectrogram` examples, we import the
-# `TimeSeries` class, and :meth:`~TimeSeries.fetch` the data, but in this
+# `TimeSeries` class, and :meth:`~TimeSeries.get` the data, but in this
 # example we only need 5 seconds of datam,
 from gwpy.timeseries import TimeSeries
-gwdata = TimeSeries.fetch(
+gwdata = TimeSeries.get(
     'L1:OAF-CAL_DARM_DQ', 'Feb 28 2015 06:02:05', 'Feb 28 2015 06:02:10')
 
 # Now we can call the `~TimeSeries.spectrogram2` method of `gwdata` to

--- a/examples/spectrum/coherence.py
+++ b/examples/spectrum/coherence.py
@@ -38,9 +38,9 @@ __currentmodule__ = 'gwpy.timeseries'
 # First, we import the `TimeSeriesDict`
 from gwpy.timeseries import TimeSeriesDict
 
-# and then fetch both data sets:
-data = TimeSeriesDict.fetch(['L1:LSC-SRCL_IN1_DQ', 'L1:LSC-CARM_IN1_DQ'],
-                            'Feb 13 2015', 'Feb 13 2015 00:15')
+# and then :meth:`~TimeSeriesDict.get` both data sets:
+data = TimeSeriesDict.get(['L1:LSC-SRCL_IN1_DQ', 'L1:LSC-CARM_IN1_DQ'],
+                           'Feb 13 2015', 'Feb 13 2015 00:15')
 
 # We can then calculate the :meth:`~TimeSeries.coherence` of one
 # `TimeSeries` with respect to the other, using an 8-second Fourier

--- a/examples/spectrum/compare.py
+++ b/examples/spectrum/compare.py
@@ -36,9 +36,9 @@ goodtime = 1061800700
 badtime = 1061524816
 duration = 120
 
-# Next we get :meth:`~TimeSeries.fetch` the data:
-gooddata = TimeSeries.fetch('L1:PSL-ISS_PDB_OUT_DQ', goodtime, goodtime+duration)
-baddata = TimeSeries.fetch('L1:PSL-ISS_PDB_OUT_DQ', badtime, badtime+duration)
+# Next we :meth:`~TimeSeries.get` the data:
+gooddata = TimeSeries.get('L1:PSL-ISS_PDB_OUT_DQ', goodtime, goodtime+duration)
+baddata = TimeSeries.get('L1:PSL-ISS_PDB_OUT_DQ', badtime, badtime+duration)
 
 # and calculate an `amplitude spectral density (ASD) <TimeSeries.asd>` using a 4-second Fourier transform with a 2-second overlap:
 goodasd = gooddata.asd(4, 2)

--- a/examples/spectrum/hoff.py
+++ b/examples/spectrum/hoff.py
@@ -28,12 +28,12 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.spectrum'
 
 # In order to generate a `Spectrum` we need to import the
-# `~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.fetch()`
+# `~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.get`
 # the data:
 from gwpy.timeseries import TimeSeries
-lho = TimeSeries.fetch(
+lho = TimeSeries.get(
     'H1:LDAS-STRAIN,rds', 'August 1 2010', 'August 1 2010 00:02')
-llo = TimeSeries.fetch(
+llo = TimeSeries.get(
     'L1:LDAS-STRAIN,rds', 'August 1 2010', 'August 1 2010 00:02')
 
 # We can then call the :meth:`~gwpy.timeseries.TimeSeries.asd` method to

--- a/examples/spectrum/rayleigh.py
+++ b/examples/spectrum/rayleigh.py
@@ -24,9 +24,9 @@
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.spectrum'
 
-# First, we import the :class:`~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.fetch` the data:
+# First, we import the :class:`~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.get` the data:
 from gwpy.timeseries import TimeSeries
-gwdata = TimeSeries.fetch(
+gwdata = TimeSeries.get(
     'H1:LDAS-STRAIN,rds', 'September 16 2010 06:40', 'September 16 2010 06:50')
 
 # Next, we can calculate a Rayleigh statistic `Spectrum` using the 

--- a/examples/spectrum/transfer_function.py
+++ b/examples/spectrum/transfer_function.py
@@ -44,9 +44,9 @@ end = start + 1800
 gndchannel = 'L1:ISI-GND_STS_ITMY_Z_DQ'
 hpichannel = 'L1:HPI-ITMY_BLND_L4C_Z_IN1_DQ'
 
-# We can call the :meth:`~TimeSeriesDict.fetch` method of the `TimeSeriesDict`
+# We can call the :meth:`~TimeSeriesDict.get` method of the `TimeSeriesDict`
 # to retrieve all data in a single operation:
-data = TimeSeriesDict.fetch([gndchannel, hpichannel], start, end, verbose=True)
+data = TimeSeriesDict.get([gndchannel, hpichannel], start, end, verbose=True)
 gnd = data[gndchannel]
 hpi = data[hpichannel]
 

--- a/examples/spectrum/variance.py
+++ b/examples/spectrum/variance.py
@@ -24,10 +24,10 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.spectrum'
 
 # In order to generate a `SpectralVariance` histogram we need to import the
-# `~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.fetch()`
+# `~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.get`
 # the data:
 from gwpy.timeseries import TimeSeries
-llo = TimeSeries.fetch(
+llo = TimeSeries.get(
     'L1:LDAS-STRAIN,rds', 'August 1 2010', 'August 1 2010 00:10')
 
 # We can then call the :meth:`~gwpy.timeseries.TimeSeries.spectral_variance`

--- a/examples/timeseries/blrms.py
+++ b/examples/timeseries/blrms.py
@@ -41,12 +41,12 @@ channels = [
     '%s:ISI-BS_ST1_SENSCOR_GND_STS_Z_BLRMS_30M_100M.mean,s-trend',
 ]
 
-# At last we can fetch 12 hours of data for each interferometer using the
-# `TimeSeriesDict.fetch` method:
-lho = TimeSeriesDict.fetch([c % 'H1' for c in channels],
-                           'Feb 13 2015 16:00', 'Feb 14 2015 04:00')
-llo = TimeSeriesDict.fetch([c % 'L1' for c in channels],
-                           'Feb 13 2015 16:00', 'Feb 14 2015 04:00')
+# At last we can :meth:`~TimeSeriesDict.get` 12 hours of data for each
+# interferometer:
+lho = TimeSeriesDict.get([c % 'H1' for c in channels],
+                         'Feb 13 2015 16:00', 'Feb 14 2015 04:00', verbose=True)
+llo = TimeSeriesDict.get([c % 'L1' for c in channels],
+                         'Feb 13 2015 16:00', 'Feb 14 2015 04:00', verbose=True)
 
 # Next we can plot the data, with a separate `~gwpy.plotter.Axes` for each
 # instrument:

--- a/examples/timeseries/filter.py
+++ b/examples/timeseries/filter.py
@@ -30,9 +30,9 @@ whitening to show the physical content of these data.
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.timeseries'
 
-# First, we import the `TimeSeries` and `~TimeSeries.fetch` the data:
+# First, we import the `TimeSeries` and :meth:`~TimeSeries.get` the data:
 from gwpy.timeseries import TimeSeries
-white = TimeSeries.fetch(
+white = TimeSeries.get(
     'L1:OAF-CAL_DARM_DQ', 'March 2 2015 12:00', 'March 2 2015 12:30')
 
 # Now, we can re-calibrate these data into displacement units by first applying

--- a/examples/timeseries/statevector.py
+++ b/examples/timeseries/statevector.py
@@ -31,7 +31,7 @@ __currentmodule__ = 'gwpy.timeseries'
 from gwpy.timeseries import StateVector
 
 # Next, we define which bits we want to use, and can then
-# :meth:`~StateVector.fetch` the data:
+# :meth:`~StateVector.get` the data:
 bits = [
     'Summary state',
     'State 1 damped',
@@ -43,7 +43,7 @@ bits = [
     'Stage 2 WatchDog OK',
 ]
 
-data = StateVector.fetch('L1:ISI-ETMX_ODC_CHANNEL_OUT_DQ', 'May 22 2014 14:00', 'May 22 2014 15:00', bits=bits)
+data = StateVector.get('L1:ISI-ETMX_ODC_CHANNEL_OUT_DQ', 'May 22 2014 14:00', 'May 22 2014 15:00', bits=bits)
 data = data.astype('uint32')  # hide
 
 # For this example, we wish to :meth:`~StateVector.resample` the data to a

--- a/examples/timeseries/whiten.py
+++ b/examples/timeseries/whiten.py
@@ -35,9 +35,9 @@ a frequency of around 5-50Hz.
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.timeseries'
 
-# First, we import the `TimeSeries` and `~TimeSeries.fetch` the data:
+# First, we import the `TimeSeries` and :meth:`~TimeSeries.get` the data:
 from gwpy.timeseries import TimeSeries
-data = TimeSeries.fetch('H1:ASC-Y_TR_A_NSUM_OUT_DQ', 1123084670, 1123084800)
+data = TimeSeries.get('H1:ASC-Y_TR_A_NSUM_OUT_DQ', 1123084670, 1123084800)
 
 # Now, we can `~TimeSeries.whiten` the data to enhance the higher-frequency
 # content

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -47,7 +47,7 @@ except ImportError:
                              NDS2_CHANNEL_TYPESTR.iteritems())
 
 from .. import version
-from ..io import reader, writer
+from ..io import (reader, writer, datafind)
 from ..time import to_gps
 from ..utils.deps import with_import
 
@@ -555,6 +555,39 @@ class Channel(object):
             raise ValueError("Cannot parse channel name according to LIGO "
                              "channel-naming convention T990033")
         return match.groupdict()
+
+    def find_frametype(self, gpstime=None, frametype_match=None,
+                       host=None, port=None, return_all=False,
+                       exclude_tape=False):
+        """Find the containing frametype(s) for this `Channel`
+
+        Parameters
+        ----------
+        gpstime : `int`
+            a reference GPS time at which to search for frame files
+        frametype_match : `str`
+            a regular expression string to use to down-select from the
+            list of all available frametypes
+        host : `str`
+            the name of the datafind server to use for frame file discovery
+        port : `int`
+            the port of the datafind server on the given host
+        return_all: `bool`, default: `False`
+            return all matched frame types, otherwise only the first match is
+            returned
+        exclude_tape : `bool`, default: `False`
+            do not search frame files that appear to be on magnetic tape
+
+        Returns
+        -------
+        frametype : `str`, `list`
+            the first matching frametype containing the this channel
+            (`return_all=False`, or a `list` of all matches
+        """
+        return datafind.find_frametype(
+            self, gpstime=gpstime, frametype_match=frametype_match,
+            host=host, port=port, return_all=return_all,
+            exclude_tape=exclude_tape)
 
     def copy(self):
         return type(self)(self.name, unit=self.unit,

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -101,7 +101,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     elif len(found) == 0:
         raise ValueError("Cannot locate %r in any known frametype" % name)
     else:
-        return found[0]
+        return found
 
 
 @with_import('lalframe')
@@ -175,7 +175,8 @@ def find_best_frametype(channel, start, end, urltype='file',
             on_gaps='ignore')) for ft in alltypes]
         if not allow_tape:
             cache = [ftc for ftc in cache if not on_tape(*ftc[1])]
-        cache.sort(key=lambda x: -abs(x[0].to_segmentlistdict().values()[0]))
+        cache.sort(key=lambda x:
+            len(x[1]) and -abs(x[1].to_segmentlistdict().values()[0]) or 0)
         try:
             return cache[0][0]
         except IndexError:

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""User-friendly extensions to `glue.datafind`
+"""
+
+import os.path
+
+from glue import datafind
+from glue.lal import CacheEntry
+
+from .. import version
+from ..time import to_gps
+from ..utils import with_import
+
+__version__ = version.version
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def connect(host=None, port=None):
+    """Open a new datafind connection
+
+    Parameters
+    ----------
+    host : `str`
+        name of datafind server to query
+    port : `int`
+        port of datafind server on host
+
+    Returns
+    -------
+    connection : `~glue.datafind.GWDataFindHTTPConnection`
+        the new open connection
+    """
+    port = port and int(port)
+    if port is not None and port != 80:
+        cert, key = datafind.find_credential()
+        return datafind.GWDataFindHTTPSConnection(
+            host=host, port=port, cert_file=cert, key_file=key)
+    else:
+        return datafind.GWDataFindHTTPConnection(host=host, port=port)
+
+
+def find_frametype(channel, gpstime=None, frametype_match=None,
+                   host=None, port=None, return_all=False, exclude_tape=False):
+    """Find the frametype(s) that hold data for a given channel
+    """
+    from ..detector import Channel
+    channel = Channel(channel)
+    name = channel.name
+    ifo = channel.ifo
+    if gpstime is not None:
+        gpstime = to_gps(gpstime).seconds
+    connection = connect(host, port)
+    types = connection.find_types(channel.ifo[0], match=frametype_match)
+    # get reference frame for all types
+    frames = []
+    for ft in types:
+        try:
+            if gpstime is None:
+                frame = connection.find_latest(
+                    channel.ifo[0], ft, urltype='file')[0]
+            else:
+                frame = connection.find_frame_urls(
+                    channel.ifo[0], ft, gpstime, gpstime, urltype='file',
+                    on_gaps='ignore')[0]
+        except (IndexError, RuntimeError) as e:
+            continue
+        else:
+            if os.access(frame.path, os.R_OK) and (
+                    not exclude_tape or not on_tape(frame)):
+                frames.append((ft, frame.path))
+    # sort frames by allocated block size and regular size
+    # (to put frames on tape at the bottom of the list)
+    print(frames)
+    frames.sort(key=lambda x: (on_tape(x[1]), num_channels(x[1])))
+    # search each frametype for the given channel
+    found = []
+    for ft, path in frames:
+        if get_channel_type(name, path):
+            if not return_all:
+                return ft
+            else:
+                found.append(ft)
+    if len(found) == 0 and gpstime:
+        raise ValueError("Cannot locate %r in any known frametype at GPS=%d"
+                         % (name, gpstime))
+    elif len(found) == 0:
+        raise ValueError("Cannot locate %r in any known frametype" % name)
+    else:
+        return found[0]
+
+
+@with_import('lalframe')
+def num_channels(framefile):
+    """Find the total number of channels in this framefile
+    """
+    frfile = lalframe.FrameUFrFileOpen(framefile, "r")
+    frtoc = lalframe.FrameUFrTOCRead(frfile)
+    return sum(
+        getattr(lalframe, 'FrameUFrTOCQuery%sN' % type_.title())(frtoc) for
+        type_ in ['adc', 'proc', 'sim'])
+
+
+@with_import('lalframe')
+def get_channel_type(channel, framefile):
+    """Find the channel type in a given frame file
+
+    Parameters
+    ----------
+    channel : `str`, `~gwpy.detector.Channel`
+        name of data channel to find
+    framefile : `str`
+        path of GWF file in which to search
+
+    Returns
+    -------
+    ctype : `str`
+        the type of the channel ('adc', 'sim', or 'proc') if the
+        channel exists in the table-of-contents for the given frame,
+        otherwise `False`
+    """
+    name = str(channel)
+    # read frame and table of contents
+    frfile = lalframe.FrameUFrFileOpen(framefile, "r")
+    frtoc = lalframe.FrameUFrTOCRead(frfile)
+    for type_ in ['sim', 'proc', 'adc']:
+        query = getattr(lalframe, 'FrameUFrTOCQuery%sName' % type_.title())
+        i = 0
+        while True:
+            try:
+                c = query(frtoc, i)
+            except RuntimeError:
+                break
+            else:
+                if c == name:
+                    return type_
+            i += 1
+    return False
+
+
+def find_best_frametype(channel, start, end, urltype='file',
+                        host=None, port=None, allow_tape=True):
+    """Intelligently select the best frametype from which to read this channel
+    """
+    start = to_gps(start).seconds
+    end = to_gps(end).seconds
+    frametype = find_frametype(channel, gpstime=start, host=host, port=port,
+                               exclude_tape=not allow_tape)
+    connection = connect(host=host, port=port)
+    try:
+        cache = connection.find_frame_urls(channel[0], frametype,
+                                           start, end, urltype=urltype,
+                                           on_gaps='error')
+        if not allow_tape and on_tape(*cache):
+            raise RuntimeError()
+    except RuntimeError:
+        alltypes = find_frametype(channel, gpstime=start, host=host, port=port,
+                                  return_all=True, exclude_tape=not allow_tape)
+        cache = [(ft, connection.find_frame_urls(
+            channel[0], ft, start, end, urltype=urltype,
+            on_gaps='ignore')) for ft in alltypes]
+        if not allow_tape:
+            cache = [ftc for ftc in cache if not on_tape(*ftc[1])]
+        cache.sort(key=lambda x: -abs(x[0].to_segmentlistdict().values()[0]))
+        try:
+            return cache[0][0]
+        except IndexError as e:
+            raise ValueError("Cannot find any valid frametypes for %r"
+                             % channel)
+    else:
+        return frametype
+
+
+def on_tape(*files):
+    """Determine whether any of the given files are on tape
+
+    Parameters
+    ----------
+    *files : `str`, `~glue.lal.CacheEntry`
+        one or more paths to GWF files
+
+    Returns
+    -------
+    True/False : `bool`
+        `True` if any of the files are determined to be on tape,
+        otherwise `False`
+    """
+    for f in files:
+        if isinstance(f, CacheEntry):
+            f = f.path
+        if os.stat(f).st_blocks == 0:
+            return True
+    return False

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -87,7 +87,6 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
                 frames.append((ft, frame.path))
     # sort frames by allocated block size and regular size
     # (to put frames on tape at the bottom of the list)
-    print(frames)
     frames.sort(key=lambda x: (on_tape(x[1]), num_channels(x[1])))
     # search each frametype for the given channel
     found = []

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -63,7 +63,6 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     from ..detector import Channel
     channel = Channel(channel)
     name = channel.name
-    ifo = channel.ifo
     if gpstime is not None:
         gpstime = to_gps(gpstime).seconds
     connection = connect(host, port)
@@ -79,7 +78,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
                 frame = connection.find_frame_urls(
                     channel.ifo[0], ft, gpstime, gpstime, urltype='file',
                     on_gaps='ignore')[0]
-        except (IndexError, RuntimeError) as e:
+        except (IndexError, RuntimeError):
             continue
         else:
             if os.access(frame.path, os.R_OK) and (
@@ -179,7 +178,7 @@ def find_best_frametype(channel, start, end, urltype='file',
         cache.sort(key=lambda x: -abs(x[0].to_segmentlistdict().values()[0]))
         try:
             return cache[0][0]
-        except IndexError as e:
+        except IndexError:
             raise ValueError("Cannot find any valid frametypes for %r"
                              % channel)
     else:

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -49,6 +49,10 @@ TEST_GWF_FILE = os.path.join(os.path.split(__file__)[0], 'data',
                           'HLV-GW100916-968654552-1.gwf')
 TEST_HDF_FILE = '%s.hdf' % TEST_GWF_FILE[:-4]
 
+FIND_CHANNEL = 'L1:LDAS-STRAIN'
+FIND_GPS = 968654552
+FIND_FRAMETYPE = 'L1_LDAS_C02_L2'
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
 
@@ -73,6 +77,7 @@ class TimeSeriesTestMixin(object):
         self.assertTrue(ts.epoch == Time(968654552, format='gps', scale='utc'))
         self.assertTrue(ts.sample_rate == units.Quantity(16384, 'Hz'))
         self.assertTrue(ts.unit == units.Unit('strain'))
+        return ts
 
     def test_epoch(self):
         array = self.create()
@@ -105,6 +110,34 @@ class TimeSeriesTestMixin(object):
 
     def test_frame_read_framecpp(self):
         return self._test_frame_read_format('framecpp')
+
+    def test_find(self):
+        try:
+            ts = self.TEST_CLASS.find(FIND_CHANNEL, FIND_GPS, FIND_GPS+1,
+                                      frametype=FIND_FRAMETYPE)
+        except (ImportError, RuntimeError) as e:
+            self.skipTest(str(e))
+        else:
+            self.assertEqual(ts.x0.value, FIND_GPS)
+            self.assertEqual(abs(ts.span), 1)
+            try:
+                comp = self.frame_read()
+            except ImportError:
+                pass
+            else:
+                nptest.assert_array_almost_equal(ts.value, comp.value)
+
+    def test_find_best_frametype(self):
+        try:
+            ts = self.TEST_CLASS.find(FIND_CHANNEL, FIND_GPS, FIND_GPS+1)
+        except (ImportError, RuntimeError) as e:
+            self.skipTest(str(e))
+
+    def test_get(self):
+        try:
+            ts = self.TEST_CLASS.get(FIND_CHANNEL, FIND_GPS, FIND_GPS+1)
+        except (ImportError, RuntimeError) as e:
+            self.skipTest(str(e))
 
     def test_ascii_write(self, delete=True):
         self.ts = self.create()

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -977,7 +977,8 @@ class TimeSeriesBaseDict(OrderedDict):
             gprint("Attempting to access data from frames...")
             try:
                 return cls.find(channels, start, end, pad=pad, dtype=dtype,
-                                verbose=verbose, allow_tape=False, **kwargs)
+                                verbose=verbose, allow_tape=allow_tape,
+                                **kwargs)
             except (RuntimeError, ValueError) as e:
                 if verbose:
                     gprint("Failed to access data from frames, trying NDS...")

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -922,7 +922,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 gprint("Reading data from %s frames..." % ft, end=' ')
             # find frames
             channellist = ChannelList.from_names(*clist)
-            ifos = ' '.join(sorted(c.ifo[0] for c in channellist))
+            ifos = ''.join(sorted(set(c.ifo[0] for c in channellist)))
             connection = datafind.connect()
             cache = connection.find_frame_urls(ifos, ft, start, end,
                                                urltype='file')

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -335,7 +335,7 @@ class TimeSeriesBase(Series):
         """
         return cls.DictClass.get(
             [channel], start, end, pad=pad, dtype=dtype, verbose=verbose,
-            **kwargs)
+            **kwargs)[str(channel)]
 
     # -------------------------------------------
     # Utilities
@@ -900,9 +900,9 @@ class TimeSeriesBaseDict(OrderedDict):
                     frametypes[ft].append(c)
                 except KeyError:
                     frametypes[ft] = [c]
-            if len(frametypes) > 1:
+            if verbose and len(frametypes) > 1:
                 gprint("Determined %d frametypes to read" % len(frametypes))
-            else:
+            elif verbose:
                 gprint("Determined best frametype as %r"
                        % frametypes.keys()[0])
         else:
@@ -983,8 +983,8 @@ class TimeSeriesBaseDict(OrderedDict):
                     gprint("Failed to access data from frames, trying NDS...")
         # otherwise fetch from NDS
         try:
-            cls.fetch(channels, start, end, pad=pad, dtype=dtype,
-                      verbose=verbose, **kwargs)
+            return cls.fetch(channels, start, end, pad=pad, dtype=dtype,
+                             verbose=verbose, **kwargs)
         except RuntimeError:
             # if all else fails, try and get each channel individually
             return cls(

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -920,7 +920,7 @@ class TimeSeriesBaseDict(OrderedDict):
                                                urltype='file')
             # read data
             out.append(cls.read(cache, clist, start=start, end=end, pad=pad,
-                                dtype=dtype, nproc=nproc))
+                                dtype=dtype, nproc=nproc, format='gwf'))
             if verbose:
                 gprint("Done")
         return out

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -305,7 +305,10 @@ class TimeSeriesBase(Series):
     @interpolate_docstring
     def get(cls, channel, start, end, pad=None, dtype=None, verbose=False,
             **kwargs):
-        """Get data for this channel
+        """Get data for this channel from frames or NDS
+
+        This method dynamically accesses either frames on disk, or a
+        remote NDS2 server to find and return data for the given interval
 
         Parameters
         ----------
@@ -313,7 +316,7 @@ class TimeSeriesBase(Series):
 
         pad : `float`, optional
             value with which to fill gaps in the source data, only used if
-            gap is not given, or `gap='pad'` is given
+            gap is not given, or ``gap='pad'`` is given
         dtype : `numpy.dtype`, `str`, `type`, or `dict`
             numeric data type for returned data, e.g. `numpy.float`, or
             `dict` of (`channel`, `dtype`) pairs
@@ -323,8 +326,8 @@ class TimeSeriesBase(Series):
         verbose : `bool`, optional
             print verbose output about NDS progress.
         **kwargs            other keyword arguments to pass to either
-            `TimeSeriesBaseDict.find` (for direct GWF file access) or
-            `TimeSeriesBaseDict.fetch` for remote NDS2 access
+            :meth:`.find` (for direct GWF file access) or
+            :meth:`.fetch` for remote NDS2 access
 
         See Also
         --------
@@ -928,7 +931,7 @@ class TimeSeriesBaseDict(OrderedDict):
     @classmethod
     def get(cls, channels, start, end, pad=None, dtype=None, verbose=False,
             allow_tape=False, **kwargs):
-        """Get the data for the multiple channels
+        """Retrieve data for multiple channels from frames or NDS
 
         This method dynamically accesses either frames on disk, or a
         remote NDS2 server to find and return data for the given interval

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -977,7 +977,8 @@ class TimeSeriesBaseDict(OrderedDict):
             try_frames = False
         # try and find from frames
         if try_frames:
-            gprint("Attempting to access data from frames...")
+            if verbose:
+                gprint("Attempting to access data from frames...")
             try:
                 return cls.find(channels, start, end, pad=pad, dtype=dtype,
                                 verbose=verbose, allow_tape=allow_tape,

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -691,6 +691,10 @@ class TimeSeriesBaseDict(OrderedDict):
         istart = start.seconds
         iend = ceil(end)
 
+        # test S6 h(t) channel
+        if any(re.match('[HL]1:LDAS-STRAIN\Z', str(c)) for c in channels):
+            verify = True
+
         # parse dtype
         if isinstance(dtype, (tuple, list)):
             dtype = [numpy.dtype(r) if r is not None else None for r in dtype]

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -271,7 +271,7 @@ class TimeSeriesBase(Series):
     @classmethod
     @interpolate_docstring
     def find(cls, channel, start, end, frametype=None,
-             pad=None, dtype=None, nproc=1, verbose=False):
+             pad=None, dtype=None, nproc=1, verbose=False, **readargs):
         """Find and read data from frames for a channel
 
         Parameters
@@ -296,10 +296,13 @@ class TimeSeriesBase(Series):
 
         verbose : `bool`, optional
             print verbose output about NDS progress.
+
+        **readargs
+            any other keyword arguments to be passed to `.read()`
         """
         return cls.DictClass.find(
             [channel], start, end, frametype=frametype, verbose=verbose,
-            pad=pad, dtype=dtype, nproc=nproc)[str(channel)]
+            pad=pad, dtype=dtype, nproc=nproc, **readargs)[str(channel)]
 
     @classmethod
     @interpolate_docstring
@@ -863,7 +866,7 @@ class TimeSeriesBaseDict(OrderedDict):
     @classmethod
     def find(cls, channels, start, end, frametype=None,
              pad=None, dtype=None, nproc=1, verbose=False,
-             allow_tape=True):
+             allow_tape=True, **readargs):
         """Find and read data from frames for a number of channels.
 
         Parameters
@@ -890,6 +893,8 @@ class TimeSeriesBaseDict(OrderedDict):
             print verbose output about NDS progress.
         allow_tape : `bool`, optional, default: `True`
             allow reading from frames on tape
+        **readargs
+            any other keyword arguments to be passed to `.read()`
         """
         start = to_gps(start)
         end = to_gps(end)
@@ -922,8 +927,9 @@ class TimeSeriesBaseDict(OrderedDict):
             cache = connection.find_frame_urls(ifos, ft, start, end,
                                                urltype='file')
             # read data
+            readargs.setdefault('format', 'gwf')
             out.append(cls.read(cache, clist, start=start, end=end, pad=pad,
-                                dtype=dtype, nproc=nproc, format='gwf'))
+                                dtype=dtype, nproc=nproc, **readargs))
             if verbose:
                 gprint("Done")
         return out

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -991,17 +991,25 @@ class TimeSeriesBaseDict(OrderedDict):
                                 **kwargs)
             except (RuntimeError, ValueError) as e:
                 if verbose:
+                    gprint(str(e), file=sys.stderr)
                     gprint("Failed to access data from frames, trying NDS...")
         # otherwise fetch from NDS
         try:
             return cls.fetch(channels, start, end, pad=pad, dtype=dtype,
                              verbose=verbose, **kwargs)
-        except RuntimeError:
+        except RuntimeError as e:
             # if all else fails, try and get each channel individually
-            return cls(
-                (c, cls.EntryClass.get(c, start, end, pad=pad, dtype=dtype,
-                                       verbose=verbose, **kwargs))
-                for c in channels)
+            if len(channels) == 1:
+                raise
+            else:
+                if verbose:
+                    gprint(str(e), file=sys.stderr)
+                    gprint("Failed to access data for all channels as a "
+                           "group, tryging individually:")
+                return cls(
+                    (c, cls.EntryClass.get(c, start, end, pad=pad, dtype=dtype,
+                                           verbose=verbose, **kwargs))
+                    for c in channels)
 
     def plot(self, label='key', **kwargs):
         """Plot the data for this `TimeSeriesBaseDict`.


### PR DESCRIPTION
This PR introduces two new data access methods for the `TimeSeries`, `TimeSeriesDict`, and friends:

- `.find()`: use the datafind server to locate frame files containing this channel, then `.read()` them
- `.get()`: intelligently select between `.find()` and `.fetch()` to retrieve the relevant data however possible

Included are tests for these new methods (for the series classes, not the dict classes), and an associated method for the `Channel` class: `Channel.find_frametype` to return those available frametypes that represent the channel.