### PR TITLE
Handle Quantities in gwpy.time.tconvert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - travis_retry pip install -q numpy==1.9.1
   - travis_wait pip install -q scipy==0.16
   - travis_retry pip install -q matplotlib==1.3.1
-  - travis_retry pip install -q astropy==1.0
+  - travis_retry pip install -q "astropy>=1.0"
   - travis_retry pip install -q h5py
   - travis_retry pip install -q unittest2
   - travis_retry pip install -q importlib

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -26,6 +26,8 @@ import datetime
 
 from dateutil import parser as dateparser
 
+from astropy.units import Quantity
+
 from .. import version
 from . import (Time, LIGOTimeGPS)
 
@@ -127,6 +129,9 @@ def to_gps(t, *args, **kwargs):
     # and then into LIGOTimeGPS
     if isinstance(t, Time):
         return time_to_gps(t)
+    # extract quantity to a float in seconds
+    if isinstance(t, Quantity):
+        t = t.to('second').value
     # if all else fails...
     return LIGOTimeGPS(t)
 


### PR DESCRIPTION
This PR fixes #164 by supporting conversion of `astropy.units.Quantity` objects into floats in seconds before casting to `LIGOTimeGPS`.

I also added new tests for this error, and a bunch of other test lines to improve coverage.