### PR TITLE
Raise ValueError for empty cache in TimeSeries.read and friends

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -37,6 +37,7 @@ from gwpy import version
 from gwpy.timeseries import (TimeSeries, StateVector)
 from gwpy.spectrum import Spectrum
 from gwpy.spectrogram import Spectrogram
+from gwpy.io.cache import Cache
 from test_array import SeriesTestCase
 
 SEED = 1
@@ -99,6 +100,9 @@ class TimeSeriesTestMixin(object):
                     self.frame_read()
                 finally:
                     register_reader('gwf', TimeSeries, read_, force=True)
+            # test errors
+            self.assertRaises(ValueError, self.TEST_CLASS.read, Cache(),
+                              self.channel, format=format)
 
     def test_frame_read_lalframe(self):
         return self._test_frame_read_format('lalframe')

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -109,6 +109,9 @@ def register_gwf_io_library(library, package='gwpy.timeseries.io.gwf'):
     def read_timeseriesdict(source, *args, **kwargs):
         """Read `TimeSeriesDict` from GWF source
         """
+        if isinstance(source, list) and not len(source):
+            raise ValueError("Cannot read from empty %s"
+                             % type(source).__name__)
         # use multiprocessing or padding
         nproc = kwargs.pop('nproc', 1)
         pad = kwargs.pop('pad', None)


### PR DESCRIPTION
This PR fixes #163 by adding an explicit exception when encountering an empty `Cache` or `list` in `TimeSeries.read` and friends.