### PR TITLE
Return more default hosts

### DIFF
--- a/gwpy/io/nds.py
+++ b/gwpy/io/nds.py
@@ -123,20 +123,19 @@ def host_resolution_order(ifo, env='NDSSERVER', epoch='now',
                 port = int(port)
             if (host, port) not in hosts:
                 hosts.append((host, port))
-    # otherwise, return the server for this IFO and the backup at CIT
+    # If that host fails, return the server for this IFO and the backup at CIT
+    if to_gps('now') - to_gps(epoch) > lookback:
+        ifolist = [None, ifo]
     else:
-        if to_gps('now') - to_gps(epoch) > lookback:
-            ifolist = [None, ifo]
+        ifolist = [ifo, None]
+    for difo in ifolist:
+        try:
+            host, port = DEFAULT_HOSTS[difo]
+        except KeyError:
+            warnings.warn('No default host found for ifo %r' % ifo)
         else:
-            ifolist = [ifo, None]
-        for difo in ifolist:
-            try:
-                host, port = DEFAULT_HOSTS[difo]
-            except KeyError:
-                warnings.warn('No default host found for ifo %r' % ifo)
-            else:
-                if (host, port) not in hosts:
-                    hosts.append((host, port))
+            if (host, port) not in hosts:
+                hosts.append((host, port))
     return list(hosts)
 
 

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -66,10 +66,13 @@ class IoTests(unittest.TestCase):
         os.environ['NDSSERVER'] = 'test1.ligo.org:80,test2.ligo.org:43'
         hro = nds.host_resolution_order(None)
         self.assertListEqual(
-            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
+                  ('nds.ligo.caltech.edu', 31200)])
         hro = nds.host_resolution_order('L1')
         self.assertListEqual(
-            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
+                  ('nds.ligo-la.caltech.edu', 31200),
+                  ('nds.ligo.caltech.edu', 31200)])
 
     def test_nds2_host_order_env(self):
         """Test `host_resolution_order` with non-default env set
@@ -81,7 +84,8 @@ class IoTests(unittest.TestCase):
         os.environ['TESTENV'] = 'test1.ligo.org:80,test2.ligo.org:43'
         hro = nds.host_resolution_order(None, env='TESTENV')
         self.assertListEqual(
-            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
+                  ('nds.ligo.caltech.edu', 31200)])
 
     def test_nds2_host_order_epoch(self):
         """Test `host_resolution_order` with old GPS epoch
@@ -91,12 +95,12 @@ class IoTests(unittest.TestCase):
         except ImportError as e:
             self.skipTest(str(e))
         # test kwarg doesn't change anything
-        hro = nds.host_resolution_order('L1', epoch='now')
+        hro = nds.host_resolution_order('L1', epoch='now', env=None)
         self.assertListEqual(
             hro, [('nds.ligo-la.caltech.edu', 31200),
                   ('nds.ligo.caltech.edu', 31200)])
         # test old epoch puts CIT ahead of LLO
-        hro = nds.host_resolution_order('L1', epoch='Jan 1 2015')
+        hro = nds.host_resolution_order('L1', epoch='Jan 1 2015', env=None)
         self.assertListEqual(
             hro, [('nds.ligo.caltech.edu', 31200),
                   ('nds.ligo-la.caltech.edu', 31200)])
@@ -104,7 +108,9 @@ class IoTests(unittest.TestCase):
         os.environ['TESTENV'] = 'test1.ligo.org:80,test2.ligo.org:43'
         hro = nds.host_resolution_order('L1', epoch='now', env='TESTENV')
         self.assertListEqual(
-            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+            hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
+                  ('nds.ligo-la.caltech.edu', 31200),
+                  ('nds.ligo.caltech.edu', 31200)])
 
     @staticmethod
     def make_cache():


### PR DESCRIPTION
This just removes the polling of the default host list from the conditional that checks for the `$NDSSERVER` environment variable, to fix #170.

I think this should be harmless to other users, but I could be wrong. 