### PR TITLE
Improved compatibility with matplotlib 1.5

### DIFF
--- a/gwpy/plotter/__init__.py
+++ b/gwpy/plotter/__init__.py
@@ -23,7 +23,7 @@ all be easily visualised using the relevant plotting objects, with
 many configurable parameters both interactive, and in saving to disk.
 """
 
-from matplotlib import (rcParams, pyplot)
+from matplotlib import (rcParams, pyplot, __version__ as mpl_version)
 
 from .. import version
 
@@ -43,21 +43,8 @@ from .filter import *
 from .table import *
 from .histogram import *
 
+# set default params
 GWPY_PLOT_PARAMS = {
-    "axes.color_cycle": [
-        (0.0, 0.4, 1.0),  # blue
-        'r',              # red
-        (0.2, 0.8, 0.2),  # green
-        (1.0, 0.7, 0.0),  # yellow(ish)
-        (0.5, 0., 0.75),  # magenta
-        'gray',
-        (0.3, 0.7, 1.0),  # light blue
-        'pink',
-        (0.13671875, 0.171875, 0.0859375),  # dark green
-        (1.0, 0.4, 0.0),  # orange
-        'saddlebrown',
-        'navy',
-    ],
     "axes.grid": True,
     "axes.axisbelow": False,
     "axes.formatter.limits": (-3, 4),
@@ -73,6 +60,33 @@ GWPY_PLOT_PARAMS = {
     "xtick.labelsize": 20,
     "ytick.labelsize": 20,
 }
+
+# construct new default color cycle
+GWPY_COLOR_CYCLE = [
+    (0.0, 0.4, 1.0),  # blue
+    'r',              # red
+    (0.2, 0.8, 0.2),  # green
+    (1.0, 0.7, 0.0),  # yellow(ish)
+    (0.5, 0., 0.75),  # magenta
+    'gray',
+    (0.3, 0.7, 1.0),  # light blue
+    'pink',
+    (0.13671875, 0.171875, 0.0859375),  # dark green
+    (1.0, 0.4, 0.0),  # orange
+    'saddlebrown',
+    'navy',
+]
+
+# set mpl version dependent stuff
+if mpl_version < '1.5':
+    GWPY_PLOT_PARAMS['axes.color_cycle'] = GWPY_COLOR_CYCLE
+else:
+    from matplotlib import cycler
+    GWPY_PLOT_PARAMS.update({
+        'axes.prop_cycle': cycler('color', GWPY_COLOR_CYCLE),
+    })
+
+# set latex options
 if rcParams['text.usetex'] or USE_TEX:
     GWPY_PLOT_PARAMS.update({
         "text.usetex": True,
@@ -80,6 +94,8 @@ if rcParams['text.usetex'] or USE_TEX:
         "font.serif": ["Computer Modern"],
         "text.latex.preamble": MACROS,
     })
+
+# update matplotlib rcParams with new settings
 rcParams.update(GWPY_PLOT_PARAMS)
 
 # fix matplotlib issue #3470

--- a/gwpy/plotter/segments.py
+++ b/gwpy/plotter/segments.py
@@ -428,14 +428,27 @@ class SegmentAxes(TimeSeriesAxes):
         # inset the labels if requested
         for tick in self.get_yaxis().get_ticklabels():
             if self._insetlabels:
+                # record parameters we are changing
+                tick._orig_bbox = tick.get_bbox_patch()
+                tick._orig_ha = tick.get_ha()
+                tick._orig_pos = tick.get_position()
+                # modify tick
                 tick.set_horizontalalignment('left')
                 tick.set_position((0.01, tick.get_position()[1]))
                 tick.set_bbox({'alpha': 0.5, 'facecolor': 'white',
                                'edgecolor': 'none'})
             elif self._insetlabels is False:
-                tick.set_horizontalalignment('right')
-                tick.set_position((0, tick.get_position()[1]))
-                tick.set_bbox({})
+                # if label has been moved, reset things
+                try:
+                    tick.set_bbox(tick._orig_bbox)
+                except AttributeError:
+                    pass
+                else:
+                    tick.set_horizontalalignment(tick._orig_ha)
+                    tick.set_position(tick._orig_pos)
+                    del tick._orig_bbox
+                    del tick._orig_ha
+                    del tick._orig_pos
         return super(SegmentAxes, self).draw(*args, **kwargs)
 
     draw.__doc__ = TimeSeriesAxes.draw.__doc__

--- a/gwpy/plotter/spectrum.py
+++ b/gwpy/plotter/spectrum.py
@@ -26,7 +26,7 @@ import numpy
 from matplotlib.projections import register_projection
 from matplotlib import (cm, colors)
 
-from . import tex
+from . import (tex, rcParams)
 from .utils import *
 from .core import Plot
 from .axes import Axes
@@ -203,11 +203,6 @@ class SpectrumAxes(Axes):
         :meth:`matplotlib.axes.Axes.pcolormesh`
             for a full description of acceptable ``*args` and ``**kwargs``
         """
-        cmap = kwargs.pop('cmap', None)
-        if cmap is None:
-            cmap = copy.deepcopy(cm.jet)
-            cmap.set_bad(cmap(0.0))
-        kwargs['cmap'] = cmap
         if norm == 'log':
             vmin = kwargs.pop('vmin', None)
             vmax = kwargs.pop('vmax', None)

--- a/gwpy/plotter/table.py
+++ b/gwpy/plotter/table.py
@@ -212,7 +212,7 @@ class EventTableAxes(TimeSeriesAxes):
             raise ValueError("Unrecognised tile anchor '%s'." % anchor)
 
         # build collection
-        cmap = kwargs.pop('cmap', cm.jet)
+        cmap = kwargs.pop('cmap', pyplot.rcParams['image.cmap'])
         coll = collections.PolyCollection(verts, edgecolors=edgecolors,
                                           linewidth=linewidth, **kwargs)
         if color:

--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -274,11 +274,6 @@ class TimeSeriesAxes(Axes):
         grid = (self.xaxis._gridOnMajor, self.xaxis._gridOnMinor,
                 self.yaxis._gridOnMajor, self.yaxis._gridOnMinor)
 
-        cmap = kwargs.pop('cmap', None)
-        if cmap is None:
-            cmap = copy.deepcopy(cm.jet)
-            cmap.set_bad(cmap(0.0))
-        kwargs['cmap'] = cmap
         norm = kwargs.pop('norm', None)
         if norm == 'log':
             vmin = kwargs.get('vmin', None)


### PR DESCRIPTION
Matplotlib 1.5 introduces a bunch of new colormaps, and some other changes to setting colors. This PR removes all explicit references to the 'jet' colormap in favour of whatever the default is in the `rcParams` structure ('jet' for mpl 1.x, 'viridis' for mpl 2.0).

This PR also fixes a quirk in the `SegmentAxes.draw` meaning mpl 1.5 would draw blue boxes around tick labels.