### PR TITLE
TimeSeries.coherence_spectrogram: fixed bug for nproc

### DIFF
--- a/gwpy/spectrogram/coherence.py
+++ b/gwpy/spectrogram/coherence.py
@@ -135,7 +135,7 @@ def from_timeseries(ts1, ts2, stride, fftlength=None, overlap=None,
                                 overlap=overlap, window=window, **kwargs)
 
     # wrap spectrogram generator
-    def _specgram(q, ts):
+    def _specgram(q, ts, ts2):
         try:
             q.put(_from_timeseries(ts, ts2, stride, fftlength=fftlength,
                                    overlap=overlap, window=window,


### PR DESCRIPTION
This commit fixes #179 by fixing a bug in `gwpy.spectrogram.coherence.from_timeseries`.