### PR TITLE
.landscape.yml: added ignore for super-on-old-class

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -7,3 +7,8 @@ ignore-paths:
     - docs
     - examples
     - ez_setup.py
+
+# ignore errors
+pylint:
+  disable:
+    - super-on-old-class

--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -158,7 +158,6 @@ class Coherence(CliProduct):
                              ' problems (avaiability or constant values)')
         # if the specified frequency limits adjust our ymin and ymax values
         # at this point self.ymin and self.ymax represent the full spectra
-        import numpy
         mymin = cohs[0].value.min()
         mymax = cohs[0].value.max()
         myfmin = 1/self.secpfft * cohs[0].frequencies.unit


### PR DESCRIPTION
This PR modifies the landscape.io configuration to ignore errors it doesn't understand in the code.