### PR TITLE
Bug in bartlett window for spectrograms

### DIFF
--- a/gwpy/spectrum/scipy_.py
+++ b/gwpy/spectrum/scipy_.py
@@ -54,6 +54,7 @@ def bartlett(timeseries, segmentlength, **kwargs):
     """Calculate a PSD using the Bartlett average method.
     """
     import_method_dependency('scipy.signal')
+    kwargs.pop('noverlap', None) 
     return welch(timeseries, segmentlength, noverlap=0, **kwargs)
 
 register_method(bartlett)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -277,6 +277,8 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         # test multiprocessing
         sg2 = ts.spectrogram(0.5, fftlength=0.2, overlap=0.1, nproc=2)
         self.assertArraysEqual(sg, sg2)
+        # test methods
+        ts.spectrogram(0.5, fftlength=0.2, method='bartlett')
 
     def test_spectrogram2(self):
         ts = self._read()


### PR DESCRIPTION
Fixes #186 which would raise a TypeError when using the bartlett window to make a spectrogram.