### PR TITLE
Miscellaneous optimisations

### DIFF
--- a/gwpy/plotter/spectrum.py
+++ b/gwpy/plotter/spectrum.py
@@ -212,7 +212,7 @@ class SpectrumAxes(Axes):
                                [specvar.x0.value +
                                 specvar.dx.value * specvar.shape[0]]))
         y = specvar.bins.value
-        X, Y = numpy.meshgrid(x, y)
+        X, Y = numpy.meshgrid(x, y, copy=False)
         mesh = self.pcolormesh(X, Y, specvar.value.T, **kwargs)
         if len(self.collections) == 1:
             self.set_yscale('log', nonposy='mask')

--- a/gwpy/plotter/spectrum.py
+++ b/gwpy/plotter/spectrum.py
@@ -212,7 +212,7 @@ class SpectrumAxes(Axes):
                                [specvar.x0.value +
                                 specvar.dx.value * specvar.shape[0]]))
         y = specvar.bins.value
-        X, Y = numpy.meshgrid(x, y, copy=False)
+        X, Y = numpy.meshgrid(x, y, copy=False, sparse=True)
         mesh = self.pcolormesh(X, Y, specvar.value.T, **kwargs)
         if len(self.collections) == 1:
             self.set_yscale('log', nonposy='mask')

--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -286,7 +286,7 @@ class TimeSeriesAxes(Axes):
                                [spectrogram.span[-1]]))
         y = numpy.concatenate((spectrogram.frequencies.value,
                                [spectrogram.band[-1]]))
-        X, Y = numpy.meshgrid(x, y, copy=False)
+        X, Y = numpy.meshgrid(x, y, copy=False, sparse=True)
         mesh = self.pcolormesh(X, Y, spectrogram.value.T, **kwargs)
         if len(self.collections) == 1:
             self.set_xlim(*spectrogram.span)

--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -286,7 +286,7 @@ class TimeSeriesAxes(Axes):
                                [spectrogram.span[-1]]))
         y = numpy.concatenate((spectrogram.frequencies.value,
                                [spectrogram.band[-1]]))
-        X, Y = numpy.meshgrid(x, y)
+        X, Y = numpy.meshgrid(x, y, copy=False)
         mesh = self.pcolormesh(X, Y, spectrogram.value.T, **kwargs)
         if len(self.collections) == 1:
             self.set_xlim(*spectrogram.span)

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -393,8 +393,12 @@ class TimeSeriesBase(Series):
             unit = None
         channel = Channel(lalts.name, sample_rate=1/lalts.deltaT, unit=unit,
                           dtype=lalts.data.data.dtype)
-        return cls(lalts.data.data, channel=channel, epoch=float(lalts.epoch),
-                   copy=copy, dtype=lalts.data.data.dtype)
+        out = cls(lalts.data.data, channel=channel, epoch=float(lalts.epoch),
+                  copy=False)
+        if copy:
+            return out.copy()
+        else:
+            return out
 
     @with_import('lal')
     def to_lal(self):

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -156,7 +156,7 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
                              resample=resample, nproc=nproc, format=format,
                              target=cls, **kwargs)
             if out is None:
-                out = new.copy()
+                out = new
             else:
                 out.append(new, gap='pad', pad=pad)
         return out

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -169,7 +169,7 @@ def read_timeseriesdict(source, channels, start=None, end=None, type=None,
             for channel, ts in new.iteritems():
                 type[channel] = ts.channel._ctype
         # store
-        out.append(new)
+        out.append(new, copy=False)
         if verbose is not False:
             gprint("%sReading %d channels from frames... %d/%d (%.1f%%)\r"
                    % (verbose, len(channels), i+1, N, (i+1)/N * 100), end='')
@@ -185,6 +185,8 @@ def read_timeseriesdict(source, channels, start=None, end=None, type=None,
         # crop data
         if start is not None or end is not None:
             out[channel] = out[channel].crop(start=start, end=end)
+        # copy into fresh memory if needed
+        out[channel] = numpy.require(out[channel], requirements=['O'])
     return out
 
 

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -162,8 +162,7 @@ def read_timeseriesdict(source, channels, start=None, end=None, type=None,
     for i, fp in enumerate(filelist):
         # read frame
         new = _read_frame(fp, channels, start=start, end=end, ctype=type,
-                          dtype=dtype, verbose=verbose,
-                          _SeriesClass=_SeriesClass)
+                          dtype=dtype, _SeriesClass=_SeriesClass)
         ## get channel type for next frame (means we only query the TOC once)
         if not i:
             for channel, ts in new.iteritems():
@@ -191,7 +190,7 @@ def read_timeseriesdict(source, channels, start=None, end=None, type=None,
 
 
 def _read_frame(framefile, channels, start=None, end=None, ctype=None,
-                dtype=None, verbose=False, _SeriesClass=TimeSeries):
+                dtype=None, _SeriesClass=TimeSeries):
     """Internal function to read data from a single frame.
 
     All users should be using the wrapper `read_timeseriesdict`.
@@ -209,8 +208,6 @@ def _read_frame(framefile, channels, start=None, end=None, ctype=None,
     ctype : `str`, optional
         channel data type to read, one of: ``'adc'``, ``'proc'``.
     dtype : `numpy.dtype`, `str`, `type`, `dict`
-    verbose : `bool`, optional
-        print verbose output, optional, default: `False`
     _SeriesClass : `type`, optional
         class object to use as the data holder for a single channel,
         default is :class:`~gwpy.timeseries.TimeSeries`

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -301,14 +301,16 @@ def _read_frame(framefile, channels, start=None, end=None, ctype=None,
                        arr, dtype=NUMPY_TYPE_FROM_FRVECT[vect.GetType()])
                 dx = vect.GetDim(0).dx
                 if ts is None:
+                    # create array
                     unit = vect.GetUnitY() or None
-                    ts = _SeriesClass(arr, epoch=thisepoch, dx=dx, name=name,
-                                      channel=channel, unit=unit, dtype=dtype_,
-                                      copy=False).copy()
+                    ts = numpy.require(
+                        _SeriesClass(arr, epoch=thisepoch, dx=dx, name=name,
+                                     channel=channel, unit=unit, dtype=dtype_,
+                                     copy=False), requirements=['O'])
                     if not ts.channel.dtype:
                         ts.channel.dtype = arr.dtype
                     ts.channel._ctype = ctype[channel]
-                elif dtype_:
+                elif arr.dtype != ts.dtype:
                     ts.append(arr.astype(dtype_))
                 else:
                     ts.append(arr)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -437,7 +437,7 @@ class TimeSeries(TimeSeriesBase):
             dtype = numpy.float64 if cts is None else complex
             out = Spectrogram(numpy.zeros((nsteps_, nfreqs)), dtype=dtype,
                               unit=unit, channel=ts.channel, epoch=ts.epoch,
-                              f0=0, df=df, dt=dt, copy=True)
+                              f0=0, df=df, dt=dt, copy=False)
 
             if not nsteps_:
                 return out
@@ -649,7 +649,7 @@ class TimeSeries(TimeSeriesBase):
         dtype = numpy.complex
         out = Spectrogram(numpy.zeros((nsteps, nfreqs), dtype=dtype),
                           name=self.name, epoch=self.epoch, f0=0, df=df,
-                          dt=dt, copy=True, unit=self.unit, dtype=dtype)
+                          dt=dt, copy=False, unit=self.unit, dtype=dtype)
         # stride through TimeSeries, recording FFTs as columns of Spectrogram
         for step in range(nsteps):
             # find step TimeSeries


### PR DESCRIPTION
This PR introduces a few optimisations mainly to do with frame reading and spectrogram visualisation:

- `copy()` arrays only when necessary
- use `sparse=True` for meshgrid to save memory