### PR TITLE
Series xindex fixes

### DIFF
--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -233,9 +233,15 @@ class Array2D(Series):
         :type: `~gwpy.segments.Segment`
         """
         from ..segments import Segment
-        y0 = self.y0.to(self._default_yunit).value
-        dy = self.dy.to(self._default_yunit).value
-        return Segment(y0, y0+self.shape[1]*dy)
+        try:
+            self._yindex
+        except AttributeError:
+            y0 = self.y0.to(self._default_yunit).value
+            dy = self.dy.to(self._default_yunit).value
+            return Segment(y0, y0+self.shape[0]*dy)
+        else:
+            return Segment(self.yindex.value[0],
+                           self.yindex.value[-1] + self.dy.value)
 
     # -------------------------------------------
     # numpy.ndarray method modifiers

--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -465,7 +465,8 @@ class Series(Array):
                     self.xindex.resize((s[0],), refcheck=False)
                 except ValueError as e:
                     if 'cannot resize' in str(e):
-                        self.xindex = numpy.resize(self.xindex, (s[0],))
+                        self.xindex = self.xindex.copy()
+                        self.xindex.resize((s[0],))
                     else:
                         raise
             else:

--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -191,9 +191,15 @@ class Series(Array):
         :type: `~gwpy.segments.Segment`
         """
         from ..segments import Segment
-        x0 = self.x0.to(self._default_xunit).value
-        dx = self.dx.to(self._default_xunit).value
-        return Segment(x0, x0+self.shape[0]*dx)
+        try:
+            self._xindex
+        except AttributeError:
+            x0 = self.x0.to(self._default_xunit).value
+            dx = self.dx.to(self._default_xunit).value
+            return Segment(x0, x0+self.shape[0]*dx)
+        else:
+            return Segment(self.xindex.value[0],
+                           self.xindex.value[-1] + self.dx.value)
 
     # -- series methods -------------------------
 


### PR DESCRIPTION
This PR introduces two fixes to the `Series` and `Array2D` objects related to handling the index arrays, mainly to support discontiguous indices.