### PR TITLE
table/io/omicron: Fix bug reading triggers in ROOT file

### DIFF
--- a/gwpy/table/io/omicron.py
+++ b/gwpy/table/io/omicron.py
@@ -160,8 +160,8 @@ def table_from_root(f, columns=OMICRON_COLUMNS, filt=None, nproc=1):
 
     # iterate over events
     nevents = tree.GetEntries()
-    for i in range(nevents):
-        tree.GetEntry()
+    for i in xrange(nevents):
+        tree.GetEntry(i)
         burst = sngl_burst_from_root(tree, columns=columns)
         if filt is None or filt(burst):
             append(burst)


### PR DESCRIPTION
This tries to fix a bug in the code that reads triggers from Omicron's ROOT format. The GetEntry method in ROOT needs to be given an index. As it is now, it just gets the same trigger (probably the first, by default) repeatedly.

The fix is simple, but I don't have a good development install of gwpy so I haven't been able to test it.