### PR TITLE
Fixed PyCBC TimeSeries conversion

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -433,7 +433,7 @@ class TimeSeriesBase(Series):
         timeseries : `TimeSeries`
             a GWpy version of the input timeseries
         """
-        return cls(ts.data, epoch=ts.epoch, sample_rate=1/ts.delta_t)
+        return cls(ts.data, epoch=ts.start_time, sample_rate=1/ts.delta_t)
 
     @with_import('pycbc.types')
     def to_pycbc(self, copy=True):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1455,41 +1455,6 @@ class TimeSeries(TimeSeriesBase):
         from ..plotter import TimeSeriesPlot
         return TimeSeriesPlot(self, **kwargs)
 
-    @classmethod
-    def from_pycbc(cls, ts):
-        """Convert a `pycbc.types.timeseries.TimeSeries` into a `TimeSeries`
-
-        Parameters
-        ----------
-        ts : `pycbc.types.timeseries.TimeSeries`
-            the input PyCBC `~pycbc.types.timeseries.TimeSeries` array
-
-        Returns
-        -------
-        timeseries : `TimeSeries`
-            a GWpy version of the input timeseries
-        """
-        return cls(ts.data, epoch=ts.epoch, sample_rate=1/ts.delta_t)
-
-    @with_import('pycbc.types')
-    def to_pycbc(self, copy=True):
-        """Convert this `TimeSeries` into a PyCBC
-        `~pycbc.types.timeseries.TimeSeries`
-
-        Parameters
-        ----------
-        copy : `bool`, optional, default: `True`
-            if `True`, copy these data to a new array
-
-        Returns
-        -------
-        timeseries : `~pycbc.types.timeseries.TimeSeries`
-            a PyCBC representation of this `TimeSeries`
-        """
-        return types.TimeSeries(self.data,
-                                delta_t=self.dx.to('s').value,
-                                epoch=self.epoch.gps, copy=copy)
-
 
 @as_series_dict_class(TimeSeries)
 class TimeSeriesDict(TimeSeriesBaseDict):


### PR DESCRIPTION
This PR removes unnecessary copies of the `TimeSeriesBase.{to,from}_pycbc` methods present in the `TimeSeries` class, and fixes the properties used to extract metadata from the `pycbc.types.TimeSeries` object.