### PR TITLE
Fixed bug in `TimeSeries.spectrogram`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
   - pip install -q --upgrade pip
 
   # build and install numpy first
-  - pip install -q numpy>=1.9.1
+  - pip install -q "numpy>=1.9.1"
 
   # set paths for PKG_CONFIG
   - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
@@ -76,7 +76,7 @@ before_install:
   - travis_retry pip install -q --install-option="--no-cython-compile" Cython
 
   # install testing dependencies
-  - pip install -q coveralls pytest unittest2
+  - pip install -q coveralls "pytest>=2.8" unittest2
 
 install:
   - pip install -r requirements.txt

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -20,6 +20,7 @@
 """
 
 import os
+import pytest
 
 from compat import unittest
 
@@ -383,6 +384,9 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         # test multiprocessing
         sg2 = ts.csd_spectrogram(ts, 0.5, fftlength=0.2, overlap=0.1, nproc=2)
         self.assertArraysEqual(sg, sg2)
+        # test method not 'welch' raises warning
+        with pytest.warns(UserWarning):
+           ts.csd_spectrogram(ts, 0.5, method='median-mean')
 
     def test_notch_design(self):
         # test simple notch

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -405,7 +405,7 @@ class TimeSeries(TimeSeriesBase):
 
         # generate window and plan if needed
         method_func = get_method(method)
-        if method_func.__module__.endswith('lal_'):
+        if method_func.__module__.endswith('lal_') and cross is None:
             safe_import('lal', method)
             from ..spectrum.lal_ import (generate_lal_fft_plan,
                                          generate_lal_window)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -21,6 +21,7 @@
 
 from __future__ import (division, print_function)
 
+from warnings import warn
 from math import (ceil, pi)
 from multiprocessing import (Process, Queue as ProcessQueue)
 
@@ -445,8 +446,8 @@ class TimeSeries(TimeSeriesBase):
 
             # stride through TimeSeries, calculating PSDs or CSDs
             if cts is not None and method not in (None, 'welch'):
-                print("Warning: cannot calculate cross spectral density using "
-                      "the %s method. Using 'welch' instead..." % method)
+                warn("Cannot calculate cross spectral density using "
+                     "the %r method. Using 'welch' instead..." % method)
             for step in range(nsteps_):
                 # find step TimeSeries
                 idx = nsamp * step


### PR DESCRIPTION
This PR fixes a corner-case bug in the `TimeSeries.spectrogram` function raised when `cross` is used and `method` is not 'welch'.