### PR TITLE
Improved unit parsing

### DIFF
--- a/gwpy/data/array.py
+++ b/gwpy/data/array.py
@@ -28,11 +28,12 @@ from copy import deepcopy
 
 import numpy
 
-from astropy.units import (Unit, Quantity)
+from astropy.units import Quantity
 from ..io import (reader, writer)
 
 from .. import version
 from ..detector import Channel
+from ..detector.units import parse_unit
 from ..time import (Time, to_gps)
 from ..utils.docstring import interpolate_docstring
 
@@ -114,6 +115,7 @@ class Array(Quantity):
         if dtype is None and isinstance(value, numpy.ndarray):
             dtype = value.dtype
 
+        unit = parse_unit(unit, parse_strict='warn')
         new = super(Array, cls).__new__(cls, value, dtype=dtype, copy=copy,
                                         subok=subok, order=order, unit=unit)
         new.name = name
@@ -295,7 +297,7 @@ class Array(Quantity):
     @unit.setter
     def unit(self, unit):
         if not hasattr(self, '_unit') or self._unit is None:
-            self._unit = Unit(unit)
+            self._unit = parse_unit(unit)
         else:
             raise AttributeError(
                 "Can't set attribute. To change the units of this %s, use the "
@@ -323,7 +325,7 @@ class Array(Quantity):
                 value, check_precision=check_precision)
     _to_own_unit.__doc__ = Quantity._to_own_unit.__doc__
 
-    def override_unit(self, unit):
+    def override_unit(self, unit, parse_strict='raise'):
         """Forcefully reset the unit of these data
 
         Use of this method is discouraged in favour of `to()`,
@@ -341,7 +343,7 @@ class Array(Quantity):
         ValueError
             if a `str` cannot be parsed as a valid unit
         """
-        self._unit = Unit(unit)
+        self._unit = parse_unit(unit, parse_strict=parse_strict)
 
     # -------------------------------------------
     # extras

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -50,6 +50,7 @@ from .. import version
 from ..io import (reader, writer, datafind)
 from ..time import to_gps
 from ..utils.deps import with_import
+from .units import parse_unit
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
@@ -196,7 +197,7 @@ class Channel(object):
         if u is None:
             self._unit = None
         else:
-            self._unit = units.Unit(u)
+            self._unit = parse_unit(u)
 
     @property
     def frequency_range(self):

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -28,6 +28,46 @@ from astropy import units
 # enable imperial units
 units.add_enabled_units(units.imperial)
 
+
+def parse_unit(name, parse_strict='warn'):
+    """Attempt to intelligently parse a `str` as a `~astropy.units.Unit`
+
+    Parameters
+    ----------
+    name : `str`
+        unit name to parse
+    parse_strict : `str`
+        one of 'silent', 'warn', or 'raise' depending on how pedantic
+        you want the parser to be
+
+    Returns
+    -------
+    unit : `~astropy.units.UnitBase`
+        the unit parsed by `~astropy.units.Unit`
+
+    Raises
+    ------
+    ValueError
+        if the unit cannot be parsed and `parse_strict='raise'`
+    """
+    if name is None or isinstance(name, units.UnitBase):
+        return name
+    name = str(name)
+    # try simple parse
+    try:
+        return units.Unit(name)
+    except ValueError:
+        pass
+    # try plural parsing
+    if name.endswith('s'):
+        try:
+            return units.Unit(name[:-1])
+        except ValueError:
+            pass
+    # otherwise allow a loose parsing
+    return units.Unit(name, parse_strict=parse_strict)
+
+
 # -----------------------------------------------------------------------------
 # instrumental units
 

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -84,6 +84,7 @@ class CommonTests(object):
         """
         # test basic empty contructor
         self.assertRaises(TypeError, self.TEST_CLASS)
+        self.assertRaises(IndexError, self.TEST_CLASS, [])
         # test with some data
         array = self.create()
         nptest.assert_array_equal(array.value, self.data)

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -84,7 +84,6 @@ class CommonTests(object):
         """
         # test basic empty contructor
         self.assertRaises(TypeError, self.TEST_CLASS)
-        self.assertRaises(IndexError, self.TEST_CLASS, [])
         # test with some data
         array = self.create()
         nptest.assert_array_equal(array.value, self.data)

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -21,6 +21,8 @@
 
 from urllib2 import URLError
 
+import pytest
+
 from compat import unittest
 
 import numpy
@@ -30,6 +32,7 @@ from astropy import units
 from gwpy import version
 from gwpy.detector import Channel
 from gwpy.utils import with_import
+from gwpy.detector.units import parse_unit
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
@@ -128,6 +131,24 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(new.name, 'LVE-EX:X3_810BTORR.mean')
         self.assertEqual(new.trend, 'mean')
         self.assertEqual(new.type, 'm-trend')
+
+
+class UnitTest(unittest.TestCase):
+    def test_parse_unit(self):
+        # check None
+        self.assertIsNone(parse_unit(None))
+        # check unit in, unit out
+        u = units.Unit('m')
+        self.assertIs(parse_unit(u), u)
+        # check normal string
+        self.assertEqual(parse_unit('meter'), units.Unit('meter'))
+        # check plural
+        self.assertEqual(parse_unit('Volts'), units.Unit('V'))
+        # check warning
+        with pytest.warns(units.UnitsWarning):
+            self.assertIsInstance(parse_unit('blah'), units.UnrecognizedUnit)
+        # check error
+        self.assertRaises(ValueError, parse_unit, 'blah', parse_strict='raise')
 
 
 if __name__ == '__main__':

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -24,12 +24,13 @@ For more details, see https://losc.ligo.org
 from glue.lal import CacheEntry
 
 from astropy.io import registry
-from astropy.units import (Unit, Quantity)
+from astropy.units import Quantity
 
 from .. import (StateVector, TimeSeries, TimeSeriesList)
 from ...utils.deps import with_import
 from ...io.cache import file_list
 from ...io.hdf5 import open_hdf5
+from ...detector.units import parse_unit
 
 
 def read_losc_data(filename, channel, group=None, copy=False):
@@ -62,10 +63,10 @@ def read_losc_data(filename, channel, group=None, copy=False):
     # read data
     nddata = dataset.value
     # read metadata
-    xunit = Unit(dataset.attrs['Xunits'])
+    xunit = parse_unit(dataset.attrs['Xunits'])
     epoch = dataset.attrs['Xstart']
     dt = Quantity(dataset.attrs['Xspacing'], xunit)
-    unit = Unit(dataset.attrs['Yunits'])
+    unit = dataset.attrs['Yunits']
     # build and return
     return TimeSeries(nddata, epoch=epoch, sample_rate=(1/dt).to('Hertz'),
                       unit=unit, name=channel.rsplit('/', 1)[0], copy=copy)
@@ -148,7 +149,7 @@ def read_losc_state(filename, channel, group=None, start=None, end=None,
     except KeyError:
         dt = Quantity(1, 's')
     else:
-        xunit = Unit(dataset.attrs['Xunit'])
+        xunit = parse_unit(dataset.attrs['Xunit'])
         dt = Quantity(dt, xunit)
     return StateVector(nddata, bits=bits, epoch=epoch, name='Data quality',
                        sample_rate=(1/dt).to('Hertz'), copy=copy)


### PR DESCRIPTION
This PR introduces an improvement to unit parsing via `astropy.units`. The main addition is a new method `detector.units.parse_unit` which attempts to create a `~astropy.units.Unit` as follows

- as is,
- if it looks like a plural, use the singular
- otherwise attempt to create an `UnrecognizedUnit`

This fixes #176.