### PR TITLE
New 'value_to' method for arrays

### DIFF
--- a/gwpy/data/__init__.py
+++ b/gwpy/data/__init__.py
@@ -31,5 +31,6 @@ from glue.lal import (Cache, CacheEntry)
 from .array import *
 from .array2d import *
 from .series import *
+import io
 
 __all__ = ['Array', 'Array2D', 'Series', 'Cache', 'CacheEntry']

--- a/gwpy/data/array.py
+++ b/gwpy/data/array.py
@@ -121,8 +121,6 @@ class Array(Quantity):
         new.name = name
         new.epoch = epoch
         new.channel = channel
-        if unit is None:
-            del new.unit
         return new
 
     # -------------------------------------------

--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -99,11 +99,11 @@ class Array2D(Series):
             x = item
             y = None
         # extract a Quantity
-        if isinstance(new, (float, int)):
+        if numpy.shape(new) == ():
             return Quantity(new, unit=self.unit)
         # unwrap a Series
         if len(new.shape) == 1:
-            new = new.value.view(Series)
+            new = new.view(Series)
             if isinstance(x, (float, int)):
                 new.dx = self.dy
                 new.x0 = self.y0

--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -243,6 +243,38 @@ class Array2D(Series):
             return Segment(self.yindex.value[0],
                            self.yindex.value[-1] + self.dy.value)
 
+    # -- Array2D methods ------------------------
+
+    def value_at(self, x, y):
+        """Return the value of this `Series` at the given `(x, y)` coordinates
+
+        Parameters
+        ----------
+        x : `float`, `~astropy.units.Quantity`
+            the `xindex` value at which to search
+        x : `float`, `~astropy.units.Quantity`
+            the `yindex` value at which to search
+
+        Returns
+        -------
+        z : `~astropy.units.Quantity`
+            the value of this Series at the given coordinates
+        """
+        x = Quantity(x, self.xindex.unit).value
+        y = Quantity(y, self.yindex.unit).value
+        try:
+            idx = (self.xindex.value == x).nonzero()[0][0]
+        except IndexError as e:
+            e.args = ("Value %r not found in array xindex",)
+            raise
+        try:
+            idy = (self.yindex.value == y).nonzero()[0][0]
+        except IndexError as e:
+            e.args = ("Value %r not found in array yindex",)
+            raise
+        print(idx, idy)
+        return self[idx, idy]
+
     # -------------------------------------------
     # numpy.ndarray method modifiers
     # all of these try to return Quantities rather than simple numbers

--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -203,6 +203,27 @@ class Series(Array):
 
     # -- series methods -------------------------
 
+    def value_at(self, x):
+        """Return the value of this `Series` at the given `xindex` value
+
+        Parameters
+        ----------
+        x : `float`, `~astropy.units.Quantity`
+            the `xindex` value at which to search
+
+        Returns
+        -------
+        y : `~astropy.units.Quantity`
+            the value of this Series at the given `xindex` value
+        """
+        x = Quantity(x, self.xindex.unit).value
+        try:
+            idx = (self.xindex.value == x).nonzero()[0][0]
+        except IndexError as e:
+            e.args = ("Value %r not found in array index",)
+            raise
+        return self[idx]
+
     def copy(self, order='C'):
         new = super(Series, self).copy(order=order)
         try:

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -345,6 +345,20 @@ class SeriesTestCase(CommonTests, unittest.TestCase):
         self.assertEqual(ts1.size - 3, diff.size)
         self.assertEqual(diff.x0, ts1.x0 + ts1.dx * 3)
 
+    def test_value_at(self):
+        ts1 = self.TEST_CLASS([1, 2, 3, 4, 5, 4, 3, 2, 1], dx=.5, unit='m')
+        self.assertEqual(ts1.value_at(1.5), 4 * ts1.unit)
+        self.assertEqual(ts1.value_at(1.5 * ts1.xunit), 4 * units.m)
+        self.assertRaises(IndexError, ts1.value_at, 1.6)
+        # test TimeSeries unit conversion
+        if ts1.xunit == units.s:
+            self.assertEqual(ts1.value_at(1500 * units.millisecond),
+                             4 * units.m)
+        # test Spectrum unit conversion
+        elif ts1.xunit == units.Hz:
+            self.assertEqual(ts1.value_at(1500 * units.milliHertz),
+                             4 * units.m)
+
 
 class Array2DTestCase(CommonTests, unittest.TestCase):
     TEST_CLASS = Array2D
@@ -364,6 +378,19 @@ class Array2DTestCase(CommonTests, unittest.TestCase):
         self.assertIsInstance(a[0][0], units.Quantity)
         self.assertEqual(a[0].unit, a.unit)
         self.assertEqual(a[0][0].unit, a.unit)
+
+    def test_value_at(self):
+        arr = numpy.arange(25).reshape((5, 5))
+        ts1 = self.TEST_CLASS(arr, dx=.5, dy=.25, unit='m')
+        self.assertEqual(ts1.value_at(1.5, .75), 18 * ts1.unit)
+        self.assertEqual(ts1.value_at(1.0 * ts1.xunit, .25 * ts1.yunit),
+                         11 * units.m)
+        self.assertRaises(IndexError, ts1.value_at, 1.6, 5.8)
+        # test Spectrogram unit conversion
+        if ts1.xunit == units.s and ts1.yunit == units.Hz:
+            self.assertEqual(ts1.value_at(1500 * units.millisecond,
+                                          750 * units.milliHertz),
+                             18 * units.m)
 
 
 if __name__ == '__main__':

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -91,7 +91,7 @@ class CommonTests(object):
 
     def test_unit(self):
         array = self.create()
-        self.assertIsNone(array.unit)
+        self.assertEqual(array.unit, units.dimensionless_unscaled)
         array = self.create(unit='m')
         self.assertEquals(array.unit, units.m)
 

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -49,6 +49,7 @@ class CommonTests(object):
     __metaclass_ = abc.ABCMeta
     TEST_CLASS = Array
     tmpfile = '%s.%%s' % tempfile.mktemp(prefix='gwpy_test_')
+    EMPTY_ARRAY_ERROR = IndexError
 
     def setUp(self, dtype=None):
         numpy.random.seed(SEED)
@@ -84,7 +85,7 @@ class CommonTests(object):
         """
         # test basic empty contructor
         self.assertRaises(TypeError, self.TEST_CLASS)
-        self.assertRaises(IndexError, self.TEST_CLASS, [])
+        self.assertRaises(self.EMPTY_ARRAY_ERROR, self.TEST_CLASS, [])
         # test with some data
         array = self.create()
         nptest.assert_array_equal(array.value, self.data)


### PR DESCRIPTION
This PR introduces a new method for 1- and 2-d arrays, `value_to`, designed to extract a value at a given index value, e.g. get the value of a `TimeSeries` at a given time.

To make that work, a small set of bug fixes have been made, with improvements to the unit tests. The biggest chance introduced is that the _default_ unit for an `Array` is now `dimensionless`, not `None`.

This fixes #158.