### PR TITLE
Fixed typo in Series.value_at error message

### DIFF
--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -220,7 +220,7 @@ class Series(Array):
         try:
             idx = (self.xindex.value == x).nonzero()[0][0]
         except IndexError as e:
-            e.args = ("Value %r not found in array index",)
+            e.args = ("Value %r not found in array index" % x,)
             raise
         return self[idx]
 


### PR DESCRIPTION
[ci skip]

This PR fixes a trivial problem with the error message reported when a `ValueError` is raised in `Series.value_at`.