### PR TITLE
Fixed possible TypeError in EventTableAxes.add_loudest

### DIFF
--- a/gwpy/plotter/table.py
+++ b/gwpy/plotter/table.py
@@ -265,7 +265,7 @@ class EventTableAxes(TimeSeriesAxes):
                 scat.append([float(val)])
             column = get_column_string(column)
             if pyplot.rcParams['text.usetex'] and column.endswith('Time'):
-                disp += (r" %s$= %s$" % (column, LIGOTimeGPS(val)))
+                disp += (r" %s$= %s$" % (column, LIGOTimeGPS(float(val))))
             elif pyplot.rcParams['text.usetex']:
                 disp += (r" %s$=$ %s" % (column, float_to_latex(val, '%.3g')))
             else:


### PR DESCRIPTION
This PR fixes a possible `TypeError` when converting a `lal.LIGOTimeGPS` to `glue.lal.LIGOTimeGPS`. This is only manifest when `pylal` is not present on the system.