### PR TITLE
Fixed FutureWarning in Spectrogram.ratio

### DIFF
--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -21,6 +21,8 @@
 
 import warnings
 
+from six import string_types
+
 import numpy
 
 import scipy
@@ -176,13 +178,15 @@ class Spectrogram(Array2D):
         spectrogram : `Spectrogram`
             a new `Spectrogram`
         """
-        if operand == 'mean':
-            operand = self.mean(axis=0)
-        elif operand == 'median':
-            operand = self.median(axis=0)
-        elif isinstance(operand, str):
-            raise ValueError("operand %r unrecognised, please give a Quantity"
-                             " or one of: 'mean', 'median'" % operand)
+        if isinstance(operand, string_types):
+            if operand == 'mean':
+                operand = self.mean(axis=0)
+            elif operand == 'median':
+                operand = self.median(axis=0)
+            else:
+                raise ValueError("operand %r unrecognised, please give a "
+                                 "Quantity or one of: 'mean', 'median'"
+                                 % operand)
         out = self / operand
         return out
 

--- a/gwpy/tests/test_spectrogram.py
+++ b/gwpy/tests/test_spectrogram.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit test for spectrogram module
+"""
+
+from numpy import testing as nptest
+
+from gwpy import version
+from gwpy.spectrogram import Spectrogram
+
+from test_array import Array2DTestCase
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+
+# -----------------------------------------------------------------------------
+
+class SpectrogramTestCase(Array2DTestCase):
+    """`~unittest.TestCase` for the `~gwpy.spectrogram.Spectrogram` class
+    """
+    TEST_CLASS = Spectrogram
+
+    def test_epoch(self):
+        array = self.create()
+        self.assertEquals(array.epoch.gps, array.x0.value)
+
+    def test_ratio(self):
+        mean_ = self.TEST_ARRAY.ratio('mean')
+        nptest.assert_array_equal(
+            mean_.value,
+            self.TEST_ARRAY.value / self.TEST_ARRAY.mean(axis=0).value)
+        median_ = self.TEST_ARRAY.ratio('median')
+        nptest.assert_array_equal(
+            median_.value,
+            self.TEST_ARRAY.value / self.TEST_ARRAY.median(axis=0).value)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes the `FutureWarning` in `Spectrogram.ratio` when comparing an array to a string.

Also I added a dedicated `TestCase` for the `Spectrogram` that doesn't do much yet.