### PR TITLE
Add strict build to find warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,31 +5,6 @@ virtualenv:
 
 sudo: false
 
-env:
-  global:
-    - SWIG_VERSION="3.0.8"
-    - FFTW_VERSION="3.3.4"
-    - LAL_VERSION="6.15.0"
-    - LALFRAME_VERSION="1.3.0"
-    - LIBFRAME_VERSION="8.20"
-    - LDAS_TOOLS_VERSION="2.4.1"
-    - NDS2_CLIENT_VERSION="0.10.4"
-    # tarballs
-    - SWIG_="https://github.com/swig/swig/archive/rel-${SWIG_VERSION}.tar.gz"
-    - FFTW="http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz"
-    - LDAS_TOOLS="http://software.ligo.org/lscsoft/source/ldas-tools-${LDAS_TOOLS_VERSION}.tar.gz"
-    - LIBFRAME="http://software.ligo.org/lscsoft/source/libframe-${LIBFRAME_VERSION}.tar.gz"
-    - LAL="http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz"
-    - LALFRAME="http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz"
-    - NDS2_CLIENT="http://software.ligo.org/lscsoft/source/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz"
-  matrix:
-    - STRICT=false
-    - STRICT=true
-
-matrix:
-  allow_failures:
-    - env: STRICT=true
-
 addons:
   apt:
     packages:
@@ -56,42 +31,56 @@ addons:
       - texlive-latex-extra
       - libhdf5-serial-dev
 
+
+env:
+  global:
+    - SWIG_VERSION="3.0.8"
+    - FFTW_VERSION="3.3.4"
+    - LAL_VERSION="6.15.0"
+    - LALFRAME_VERSION="1.3.0"
+    - LIBFRAME_VERSION="8.20"
+    - LDAS_TOOLS_VERSION="2.4.1"
+    - NDS2_CLIENT_VERSION="0.10.4"
+    # tarballs
+    - SWIG_="https://github.com/swig/swig/archive/rel-${SWIG_VERSION}.tar.gz"
+    - FFTW="http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz"
+    - LDAS_TOOLS="http://software.ligo.org/lscsoft/source/ldas-tools-${LDAS_TOOLS_VERSION}.tar.gz"
+    - LIBFRAME="http://software.ligo.org/lscsoft/source/libframe-${LIBFRAME_VERSION}.tar.gz"
+    - LAL="http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz"
+    - LALFRAME="http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz"
+    - NDS2_CLIENT="http://software.ligo.org/lscsoft/source/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz"
+
+matrix:
+  include:
+    - python: 2.6
+      env: STRICT=false
+    - python: 2.7
+      env: STRICT=false
+    - python: 2.7
+      env: STRICT=false PRE="--pre"
+  allow_failures:
+    - python: 2.6
+    - python: 2.7
+      env: STRICT=false PRE="--pre"
+
 before_install:
   # update pip
-  - pip install -q --upgrade pip
+  - pip install -q ${PRE} --upgrade pip
 
   # build and install numpy first
-  - pip install -q "numpy>=1.9.1"
+  - pip install -q ${PRE} "numpy>=1.9.1"
 
-  # set paths for PKG_CONFIG
-  - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
-
-  # build a newer version of swig
-  - source .travis/build-with-autotools.sh swig-${SWIG_VERSION} ${SWIG_}
-
-  # build FFTW3 (double and float)
-  - source .travis/build-with-autotools.sh fftw-${FFTW_VERSION} ${FFTW} --enable-shared=yes
-  - source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-float ${FFTW} --enable-shared=yes --enable-float
-
-  # build frame libraries
-  - source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION} ${LDAS_TOOLS}
-  - source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION} ${LIBFRAME}
-
-  # build LAL packages
-  - source .travis/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python
-  - source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
-
-  # build NDS2 client
-  - source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab
+  # build src packages
+  - source .travis/build-src-dependencies.sh
 
   # install cython to speed up scipy build
-  - travis_retry pip install -q --install-option="--no-cython-compile" Cython
+  - travis_retry pip install -q ${PRE} --install-option="--no-cython-compile" Cython
 
   # install testing dependencies
-  - pip install -q coveralls "pytest>=2.8" unittest2
+  - pip install -q ${PRE} coveralls "pytest>=2.8" unittest2
 
 install:
-  - pip install -r requirements.txt
+  - pip install ${PRE} -r requirements.txt
   - python setup.py build
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,11 +91,11 @@ cache:
     # cache pip wheels
     - $HOME/.cache/pip
     # cache src builds
-    - ./swig-${SWIG_VERSION}-${TRAVIS_PYTHON_VERSION}
-    - ./fftw-${FFTW_VERSION}-${TRAVIS_PYTHON_VERSION}
-    - ./fftw-${FFTW_VERSION}-float-${TRAVIS_PYTHON_VERSION}
-    - ./ldas-tools-${LDAS_TOOLS_VERSION}-${TRAVIS_PYTHON_VERSION}
-    - ./libframe-${LIBFRAME_VERSION}-${TRAVIS_PYTHON_VERSION}
-    - ./lal-${LAL_VERSION}-${TRAVIS_PYTHON_VERSION}
-    - ./lalframe-${LALFRAME_VERSION}-${TRAVIS_PYTHON_VERSION}
-    - ./nds2-client-${NDS2_CLIENT_VERSION}-${TRAVIS_PYTHON_VERSION}
+    - ./swig-${SWIG_VERSION}
+    - ./fftw-${FFTW_VERSION}
+    - ./fftw-${FFTW_VERSION}-float
+    - ./ldas-tools-${LDAS_TOOLS_VERSION}
+    - ./libframe-${LIBFRAME_VERSION}
+    - ./lal-${LAL_VERSION}
+    - ./lalframe-${LALFRAME_VERSION}
+    - ./nds2-client-${NDS2_CLIENT_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,11 @@ matrix:
     - python: 2.7
       env: STRICT=false
     - python: 2.7
-      env: STRICT=false PRE="--pre"
+      env: STRICT=true PRE="--pre"
   allow_failures:
     - python: 2.6
     - python: 2.7
-      env: STRICT=false PRE="--pre"
+      env: STRICT=true PRE="--pre"
 
 before_install:
   # update pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,15 +48,20 @@ env:
 matrix:
   include:
     - python: 2.6
+      env: STRICT=false
     - python: 2.7
+      env: STRICT=false
     - python: 3.5
+      env: STRICT=false
     - python: 2.7
       env: STRICT=true PRE="--pre"
   allow_failures:
     - python: 2.6
+      env: STRICT=false
     - python: 2.7
       env: STRICT=true PRE="--pre"
     - python: 3.5
+      env: STRICT=false
 
 before_install:
   # update pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,6 @@ matrix:
     - python: 2.7
       env: STRICT=true PRE="--pre"
   allow_failures:
-    - python: 2.6
-      env: STRICT=false
     - python: 2.7
       env: STRICT=true PRE="--pre"
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,9 +87,9 @@ notifications:
 
 cache:
   apt: true
+  pip: true
+  ccache: true
   directories:
-    # cache pip wheels
-    - $HOME/.cache/pip
     # cache src builds
     - ./swig-${SWIG_VERSION}
     - ./fftw-${FFTW_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,15 +48,15 @@ env:
 matrix:
   include:
     - python: 2.6
-      env: STRICT=false
     - python: 2.7
-      env: STRICT=false
+    - python: 3.5
     - python: 2.7
       env: STRICT=true PRE="--pre"
   allow_failures:
     - python: 2.6
     - python: 2.7
       env: STRICT=true PRE="--pre"
+    - python: 3.5
 
 before_install:
   # update pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: python
 
-virtualenv:
-  system_site_packages: true
-
-sudo: false
-
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,26 +6,19 @@ addons:
       # generic packages
       - gcc
       - gfortran
-      - python-dev
       - libblas-dev
       - liblapack-dev
       # lal dependencies
       - pkg-config
-      - python-all-dev
       - zlib1g-dev
       - libgsl0-dev
       - swig
-      - python-numpy
-      - python-scipy
       - bc
       # nds2 dependencies
       - libsasl2-2
-      # glue dependencies
-      - python-m2crypto
       # misc python dependencies
       - texlive-latex-extra
       - libhdf5-serial-dev
-
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
   - python setup.py build
 
 script:
-  - . ./travis/run-tests.sh
+  - . .travis/run-tests.sh
   - pip install .
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,13 @@ env:
     - LAL="http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz"
     - LALFRAME="http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz"
     - NDS2_CLIENT="http://software.ligo.org/lscsoft/source/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz"
+  matrix:
+    - STRICT=false
+    - STRICT=true
+
+matrix:
+  allow_failures:
+    - env: STRICT=true
 
 addons:
   apt:
@@ -88,7 +95,7 @@ install:
   - python setup.py build
 
 script:
-  - coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*,gwpy/utils/sphinx/*" -m py.test -v gwpy/
+  - . ./travis/run-tests.sh
   - pip install .
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,11 +95,11 @@ cache:
     # cache pip wheels
     - $HOME/.cache/pip
     # cache src builds
-    - ./swig-${SWIG_VERSION}
-    - ./fftw-${FFTW_VERSION}
-    - ./fftw-${FFTW_VERSION}-float
-    - ./ldas-tools-${LDAS_TOOLS_VERSION}
-    - ./libframe-${LIBFRAME_VERSION}
-    - ./lal-${LAL_VERSION}
-    - ./lalframe-${LALFRAME_VERSION}
-    - ./nds2-client-${NDS2_CLIENT_VERSION}
+    - ./swig-${SWIG_VERSION}-${TRAVIS_PYTHON_VERSION}
+    - ./fftw-${FFTW_VERSION}-${TRAVIS_PYTHON_VERSION}
+    - ./fftw-${FFTW_VERSION}-float-${TRAVIS_PYTHON_VERSION}
+    - ./ldas-tools-${LDAS_TOOLS_VERSION}-${TRAVIS_PYTHON_VERSION}
+    - ./libframe-${LIBFRAME_VERSION}-${TRAVIS_PYTHON_VERSION}
+    - ./lal-${LAL_VERSION}-${TRAVIS_PYTHON_VERSION}
+    - ./lalframe-${LALFRAME_VERSION}-${TRAVIS_PYTHON_VERSION}
+    - ./nds2-client-${NDS2_CLIENT_VERSION}-${TRAVIS_PYTHON_VERSION}

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -2,19 +2,19 @@
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
 
 # build a newer version of swig
-source .travis/build-with-autotools.sh swig-${SWIG_VERSION} ${SWIG_}
+source .travis/build-with-autotools.sh swig-${SWIG_VERSION}-${TRAVIS_PYTHON_VERSION} ${SWIG_}
 
 # build FFTW3 (double and float)
-source .travis/build-with-autotools.sh fftw-${FFTW_VERSION} ${FFTW} --enable-shared=yes
-source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-float ${FFTW} --enable-shared=yes --enable-float
+source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes
+source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-float-${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes --enable-float
 
 # build frame libraries
-source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION} ${LDAS_TOOLS}
-source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION} ${LIBFRAME}
+source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION}-${TRAVIS_PYTHON_VERSION} ${LDAS_TOOLS}
+source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LIBFRAME}
 
 # build LAL packages
-source .travis/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python
-source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
+source .travis/build-with-autotools.sh lal-${LAL_VERSION} ${LAL}-${TRAVIS_PYTHON_VERSION} --enable-swig-python
+source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LALFRAME} --enable-swig-python
 
 # build NDS2 client
-source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab
+source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION}-${TRAVIS_PYTHON_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -1,0 +1,19 @@
+# set paths for PKG_CONFIG
+export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
+
+# build a newer version of swig
+source .travis/build-with-autotools.sh swig-${SWIG_VERSION} ${SWIG_}
+
+# build FFTW3 (double and float)
+source .travis/build-with-autotools.sh fftw-${FFTW_VERSION} ${FFTW} --enable-shared=yes
+source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-float ${FFTW} --enable-shared=yes --enable-float
+
+# build frame libraries
+source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION} ${LDAS_TOOLS}
+source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION} ${LIBFRAME}
+
+# build LAL packages
+source .travis/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python  - source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
+
+# build NDS2 client
+source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -13,7 +13,8 @@ source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION} ${LDAS_T
 source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION} ${LIBFRAME}
 
 # build LAL packages
-source .travis/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python  - source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
+source .travis/build-with-autotools.sh lal-${LAL_VERSION} ${LAL} --enable-swig-python
+source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION} ${LALFRAME} --enable-swig-python
 
 # build NDS2 client
 source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -1,20 +1,33 @@
+#!/bin/bash
+
 # set paths for PKG_CONFIG
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
 
+FAILURES=""
+
 # build a newer version of swig
-source .travis/build-with-autotools.sh swig-${SWIG_VERSION}-${TRAVIS_PYTHON_VERSION} ${SWIG_}
+source .travis/build-with-autotools.sh swig-${SWIG_VERSION}-${TRAVIS_PYTHON_VERSION} ${SWIG_} || FAILURES="$FAILURES swig"
 
 # build FFTW3 (double and float)
-source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes
-source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-float-${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes --enable-float
+source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes || FAILURES="$FAILURES fftw"
+source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-float-${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes --enable-float || FAILURES="$FAILURES fftw-float"
+
 
 # build frame libraries
-source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION}-${TRAVIS_PYTHON_VERSION} ${LDAS_TOOLS}
-source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LIBFRAME}
+source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION}-${TRAVIS_PYTHON_VERSION} ${LDAS_TOOLS} || FAILURES="$FAILURES ldas-tools"
+
+source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LIBFRAME} || FAILURES="$FAILURES libframe"
+
+
 
 # build LAL packages
-source .travis/build-with-autotools.sh lal-${LAL_VERSION}-${TRAVIS_PYTHON_VERSION} ${LAL} --enable-swig-python
-source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LALFRAME} --enable-swig-python
+source .travis/build-with-autotools.sh lal-${LAL_VERSION}-${TRAVIS_PYTHON_VERSION} ${LAL} --enable-swig-python || FAILURES="$FAILURES lal"
+
+source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LALFRAME} --enable-swig-python || FAILURES="$FAILURES lalframe"
 
 # build NDS2 client
-source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION}-${TRAVIS_PYTHON_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab
+source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION}-${TRAVIS_PYTHON_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab || FAILURES="$FAILURES nds2-client"
+
+if [[ -n "${FAILURES+x}" ]]; then
+    echo "The following builds failed: ${FAILURES}"
+fi

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -6,27 +6,27 @@ export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
 FAILURES=""
 
 # build a newer version of swig
-source .travis/build-with-autotools.sh swig-${SWIG_VERSION}-${TRAVIS_PYTHON_VERSION} ${SWIG_} || FAILURES="$FAILURES swig"
+source .travis/build-with-autotools.sh swig-${SWIG_VERSION}/${TRAVIS_PYTHON_VERSION} ${SWIG_} || FAILURES="$FAILURES swig"
 
 # build FFTW3 (double and float)
-source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes || FAILURES="$FAILURES fftw"
-source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-float-${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes --enable-float || FAILURES="$FAILURES fftw-float"
+source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}/${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes || FAILURES="$FAILURES fftw"
+source .travis/build-with-autotools.sh fftw-${FFTW_VERSION}-float/${TRAVIS_PYTHON_VERSION} ${FFTW} --enable-shared=yes --enable-float || FAILURES="$FAILURES fftw-float"
 
 
 # build frame libraries
-source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION}-${TRAVIS_PYTHON_VERSION} ${LDAS_TOOLS} || FAILURES="$FAILURES ldas-tools"
+source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION}/${TRAVIS_PYTHON_VERSION} ${LDAS_TOOLS} || FAILURES="$FAILURES ldas-tools"
 
-source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LIBFRAME} || FAILURES="$FAILURES libframe"
+source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION}/${TRAVIS_PYTHON_VERSION} ${LIBFRAME} || FAILURES="$FAILURES libframe"
 
 
 
 # build LAL packages
-source .travis/build-with-autotools.sh lal-${LAL_VERSION}-${TRAVIS_PYTHON_VERSION} ${LAL} --enable-swig-python || FAILURES="$FAILURES lal"
+source .travis/build-with-autotools.sh lal-${LAL_VERSION}/${TRAVIS_PYTHON_VERSION} ${LAL} --enable-swig-python || FAILURES="$FAILURES lal"
 
-source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LALFRAME} --enable-swig-python || FAILURES="$FAILURES lalframe"
+source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION}/${TRAVIS_PYTHON_VERSION} ${LALFRAME} --enable-swig-python || FAILURES="$FAILURES lalframe"
 
 # build NDS2 client
-source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION}-${TRAVIS_PYTHON_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab || FAILURES="$FAILURES nds2-client"
+source .travis/build-with-autotools.sh nds2-client-${NDS2_CLIENT_VERSION}/${TRAVIS_PYTHON_VERSION} ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab || FAILURES="$FAILURES nds2-client"
 
 if [[ -n "${FAILURES+x}" ]]; then
     echo "The following builds failed: ${FAILURES}"

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -13,7 +13,7 @@ source .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION}-${TRAVIS
 source .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LIBFRAME}
 
 # build LAL packages
-source .travis/build-with-autotools.sh lal-${LAL_VERSION} ${LAL}-${TRAVIS_PYTHON_VERSION} --enable-swig-python
+source .travis/build-with-autotools.sh lal-${LAL_VERSION}-${TRAVIS_PYTHON_VERSION} ${LAL} --enable-swig-python
 source .travis/build-with-autotools.sh lalframe-${LALFRAME_VERSION}-${TRAVIS_PYTHON_VERSION} ${LALFRAME} --enable-swig-python
 
 # build NDS2 client

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -35,6 +35,6 @@ elif [ -f ./autogen.sh ]; then
     ./autogen.sh
 fi
 ./configure --enable-silent-rules --prefix=$target $@
-make -j 2 || make
-make install
+make -j 2 --silent || make --silent
+make install --silent
 cd -

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# enable strict test flags
+if [ "$STRICT" = true ]; then
+    _strict="-x --strict"
+else
+    _strict=""
+fi
+
+coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*,gwpy/utils/sphinx/*" -m py.test -v ${_strict} gwpy/

--- a/gwpy/tests/test_cli.py
+++ b/gwpy/tests/test_cli.py
@@ -24,6 +24,9 @@ import tempfile
 import importlib
 import argparse
 
+from matplotlib import use
+use('agg')
+
 from compat import unittest
 
 from gwpy import version


### PR DESCRIPTION
This PR enables a 'strict' build mode where `py.test` will fail tests that include warnings, and will also stop at the first failure.