### PR TITLE
Added `observatory` kwarg for TimeSeries.find

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -144,6 +144,14 @@ class TimeSeriesTestMixin(object):
                 pass
             else:
                 nptest.assert_array_almost_equal(ts.value, comp.value)
+            # test observatory
+            ts2 = self.TEST_CLASS.find(FIND_CHANNEL, FIND_GPS, FIND_GPS+1,
+                                      frametype=FIND_FRAMETYPE,
+                                      observatory=FIND_CHANNEL[0])
+            self.assertArraysEqual(ts, ts2)
+            self.assertRaises(RuntimeError, self.TEST_CLASS.find, FIND_CHANNEL,
+                              FIND_GPS, FIND_GPS+1, frametype=FIND_FRAMETYPE,
+                              observatory='X')
 
     def test_find_best_frametype(self):
         try:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -941,6 +941,9 @@ class TimeSeriesBaseDict(OrderedDict):
             connection = datafind.connect()
             cache = connection.find_frame_urls(observatory, ft, start, end,
                                                urltype='file')
+            if len(cache) == 0:
+                raise RuntimeError("No %s-%s frame files found for [%d, %d)"
+                                   % (observatory, ft, start, end))
             # read data
             readargs.setdefault('format', 'gwf')
             out.append(cls.read(cache, clist, start=start, end=end, pad=pad,


### PR DESCRIPTION
This PR introduces the `observatory=None` kwarg for `TimeSeries.find`, allowing users to manually specify the observatory used for the datafind call.