### PR TITLE
Fixed bug in Series.append dealing with xindex

### DIFF
--- a/gwpy/data/series.py
+++ b/gwpy/data/series.py
@@ -502,11 +502,14 @@ class Series(Array):
                 self.xindex[-other.shape[0]:] = other._xindex
             except AttributeError:
                 del self.xindex
-            try:
-                self.dx = self.xindex[1] - self.xindex[0]
-            except IndexError:
-                pass
-            self.epoch = self.xindex[0]
+                if not resize:
+                    self.x0 = self.x0 + self.dx * other.shape[0]
+            else:
+                try:
+                    self.dx = self.xindex[1] - self.xindex[0]
+                except IndexError:
+                    pass
+                self.x0 = self.xindex[0]
         return self
 
     def prepend(self, other, gap='raise', inplace=True, pad=0.0, resize=True):

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -270,19 +270,20 @@ class SeriesTestCase(CommonTests, unittest.TestCase):
         nptest.assert_array_equal(ts3.value[-ts2.size:], ts2.value)
         # test appending with one xindex deletes it in the output
         ts1.xindex
-        ts4 = ts1.append(ts2, inplace=False)
-        self.assertTrue(hasattr(ts4, '_xindex'))
-        nptest.assert_array_equal(
-            ts4.xindex.value,
-            numpy.concatenate((ts1.xindex.value, ts2.xindex.value)))
+        ts3 = ts1.append(ts2, inplace=False)
+        self.assertFalse(hasattr(ts3, '_xindex'))
         # test appending with both xindex appends as well
         ts1.xindex
         ts2.xindex
-        ts5 = ts1.append(ts2, inplace=False)
-        self.assertTrue(hasattr(ts5, '_xindex'))
+        ts3 = ts1.append(ts2, inplace=False)
+        self.assertTrue(hasattr(ts3, '_xindex'))
         nptest.assert_array_equal(
-            ts5.xindex.value,
+            ts3.xindex.value,
             numpy.concatenate((ts1.xindex.value, ts2.xindex.value)))
+        # test appending with one only and not resize
+        del ts2.xindex
+        ts3 = ts1.append(ts2, inplace=False, resize=False)
+        self.assertEqual(ts3.x0, ts1.x0 + ts1.dx * ts2.size)
 
     def test_prepend(self):
         """Test the `Series.prepend` method


### PR DESCRIPTION
This PR fixes a bug in `Series.append` when dealing with `xindex` by deleting the input `xindex` unless we have all the information we need, and updating the test suite.