### PR TITLE
Fixed bug in `HistogramAxes.hist` parsing of weights as float or int

### DIFF
--- a/gwpy/plotter/histogram.py
+++ b/gwpy/plotter/histogram.py
@@ -90,12 +90,13 @@ class HistogramAxes(Axes):
         bins = kwargs.get('bins', 30)
         weights = kwargs.get('weights', None)
         if isinstance(weights, (float, int)):
-            kwargs['weights'] = []
             if isinstance(x, numpy.ndarray) or not iterable(x[0]):
-                kwargs['weights'].append(numpy.ones_like(x) * weights)
+                kwargs['weights'] = numpy.ones_like(x) * weights
             else:
+                kwargs['weights'] = []
                 for x2 in x:
                     kwargs['weights'].append(numpy.ones_like(x2) * weights)
+                kwargs['weights'] = numpy.asarray(kwargs['weights'])
         if logbins and (bins is None or isinstance(bins, (float, int))):
             bins = bins or 30
             range_ = kwargs.pop('range', self.common_limits(x))

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -574,6 +574,11 @@ class HistogramAxesTestCase(HistogramMixin, AxesTestCase):
                                   [1, 10., 100.])
         self.assertRaises(ValueError, ax.bin_boundaries, 0, 100, 2, log=True)
 
+    def test_histogram_weights(self):
+        fig, ax = self.new()
+        ax.hist(numpy.random.random(1000), weights=10.)
+        fig.close()
+
 
 # -- Filter plotter -----------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes #220 with a change to the way `float`/`int` weights are parsed in `HistogramAxes.hist`, and adds a test against regression.