### PR TITLE
Add rasterized as kwarg parseable in Plot()

### DIFF
--- a/gwpy/plotter/utils.py
+++ b/gwpy/plotter/utils.py
@@ -40,10 +40,10 @@ AXES_PARAMS = [
     'xscale', 'yscale', 'title',
 ]
 LINE_PARAMS = [
-    'linewidth', 'linestyle', 'color', 'label', 'alpha',
+    'linewidth', 'linestyle', 'color', 'label', 'alpha', 'rasterized',
 ]
 COLLECTION_PARAMS = [
-    'cmap', 'vmin', 'vmax', 'marker', 's', 'norm',
+    'cmap', 'vmin', 'vmax', 'marker', 's', 'norm', 'rasterized',
 ]
 ARTIST_PARAMS = set(LINE_PARAMS + COLLECTION_PARAMS)
 LEGEND_PARAMS = [

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -249,6 +249,8 @@ class TimeSeriesPlotTestCase(TimeSeriesMixin, PlotTestCase):
         for ax in fig.axes:
             self.assertEqual(len(ax.lines), 1)
         self.assertIs(fig.axes[1]._sharex, fig.axes[0])
+        # test kwarg parsing
+        fig = self.FIGURE_CLASS(self.ts, figsize=[12, 6], rasterized=True)
 
     def test_add_colorbar(self):
         def make_fig():


### PR DESCRIPTION
This PR fixes #224 by adding `'rasterized'` as a keyword argument in `gwpy.plotter.utils` that is used by `Plot.__init__` to separate kwargs between plots and axes.

I also added a unit test against regression.