### PR TITLE
New methods for LIGO_LW Table <-> numpy.recarray conversions

### DIFF
--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -126,13 +126,11 @@ def table_from_file(f, tablename, columns=None, filt=None,
                contenthandler=contenthandler, verbose=verbose)
 
     # extract table
-    try:
-        out = tableclass.get_table(xmldoc)
-    except ValueError:
-        out = lsctables.New(tableclass, columns=columns)
+    out = tableclass.get_table(xmldoc)
     if verbose:
         gprint('%d rows found in %s table' % (len(out), out.tableName))
 
+    # filter output
     if filt:
         if verbose:
             gprint('filtering rows ...', end=' ')
@@ -144,8 +142,11 @@ def table_from_file(f, tablename, columns=None, filt=None,
         out = out_
         if verbose:
             gprint('%d rows remaining\n' % len(out))
+
+    # reset loadcolumns and return
     if columns is not None:
         tableclass.loadcolumns = _oldcols
+
     return out
 
 


### PR DESCRIPTION
This PR introduces two new methods attached to the `glue.ligolw.table.Table` and subclasses,

- `Table.to_recarray` : convert this table to a `numpy.recarray`
- `Table.from_recarray` : create a new table from a `numpy.recarray`