### PR TITLE
spectrum/core.py: add ifft method

### DIFF
--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -159,6 +159,9 @@ class Spectrum(Series):
         from ..timeseries import TimeSeries
         nout = (self.size - 1) * 2
         # Undo normalization from TimeSeries.fft
+        # The DC component does not have the factor of two applied
+        # so we account for it here
+        dift[0] *= 2
         dift = npfft.irfft(self.value * nout / 2)
         new = TimeSeries(dift, epoch=self.epoch, channel=self.channel,
                        unit=self.unit * units.Hertz, dx=1/self.dx/nout)

--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -133,6 +133,42 @@ class Spectrum(Series):
         from ..plotter import SpectrumPlot
         return SpectrumPlot(self, **kwargs)
 
+    def ifft(self, nfft=None):
+        """Compute the one-dimensional discrete inverse Fourier
+        transform of this `Spectrum`.
+
+        Parameters
+        ----------
+        nfft : `int`, optional
+            length of the desired Fourier transform.
+            Input will be cropped or padded to match the desired length.
+            If nfft is not given, the length of the `Spectrum`
+            will be used
+
+        Returns
+        -------
+        out : :class:`~gwpy.timeseries.TimeSeries`
+            the normalised, real-valued `TimeSeries`.
+
+        See Also
+        --------
+        :mod:`scipy.fftpack` for the definition of the DFT and conventions
+        used.
+
+        Notes
+        -----
+        This method, in constrast to the :meth:`numpy.fft.rfft` method
+        it calls, applies the necessary normalisation such that the
+        amplitude of the output :class:`~gwpy.spectrum.Spectrum` is
+        correct.
+        """
+        from ..timeseries import TimeSeries
+        dift = npfft.irfft(self.value)
+        nout = (len(dft) - 1) * 2
+        new = TimeSeries(dift, epoch=self.epoch, channel=self.channel,
+                       unit=self.unit, dx=1/self.dx/nout)
+        return new
+
     def zpk(self, zeros, poles, gain):
         """Filter this `Spectrum` by applying a zero-pole-gain filter
 


### PR DESCRIPTION
Fixes #234 . I've tested that this returns almost what we want with two issues:

 * I'm having trouble setting the sample rate from `df`, so I set `dx` instead, but the units come out as inverse Hz. Not ideal.
 * I'm struggling to understand the normalization convention used in `TimeSeries.fft`, so the output of `ifft` is not currently normalized correctly.