### PR TITLE
Added unit tests for the Spectrum and SpectralVariance

### DIFF
--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -289,7 +289,11 @@ class Spectrum(Series):
         except TypeError:
             unit = lal.lalDimensionlessUnit
         create = getattr(lal, 'Create%sFrequencySeries' % typestr.upper())
-        lalfs = create(self.name, lal.LIGOTimeGPS(self.epoch.gps),
+        if self.epoch is None:
+            epoch = 0
+        else:
+            epoch = self.epoch.gps
+        lalfs = create(self.name, lal.LIGOTimeGPS(epoch),
                        self.f0.value, self.df.value, unit, self.size)
         lalfs.data.data = self.value
         return lalfs
@@ -327,5 +331,9 @@ class Spectrum(Series):
         frequencyseries : `pycbc.types.frequencyseries.FrequencySeries`
             a PyCBC representation of this `Spectrum`
         """
+        if self.epoch is None:
+            epoch = None
+        else:
+            epoch = self.epoch.gps
         return types.FrequencySeries(self.data, delta_f=self.df.to('Hz').value,
-                                     epoch=self.epoch.gps, copy=copy)
+                                     epoch=epoch, copy=copy)

--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -93,7 +93,8 @@ class Spectrum(Series):
         # generate Spectrum
         return super(Spectrum, cls).__new__(cls, data, name=name, unit=unit,
                                             channel=channel, x0=f0, dx=df,
-                                            xindex=frequencies, **kwargs)
+                                            epoch=epoch, xindex=frequencies,
+                                            **kwargs)
 
     # -------------------------------------------
     # Spectrum properties

--- a/gwpy/spectrum/core.py
+++ b/gwpy/spectrum/core.py
@@ -90,6 +90,9 @@ class Spectrum(Series):
             unit = unit or channel.unit
         if frequencies is None and 'xindex' in kwargs:
             frequencies = kwargs.pop('xindex')
+        # allow use of x0 and dx
+        f0 = kwargs.pop('x0', f0)
+        df = kwargs.pop('dx', df)
         # generate Spectrum
         return super(Spectrum, cls).__new__(cls, data, name=name, unit=unit,
                                             channel=channel, x0=f0, dx=df,

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -80,7 +80,8 @@ class CommonTests(object):
             if isinstance(a, numpy.ndarray) and isinstance(b, numpy.ndarray):
                 nptest.assert_array_equal(a, b)
             else:
-                self.assertEqual(a, b)
+                self.assertEqual(a, b,
+                    msg="%r attribute doesn't match: %s != %s" % (attr, a, b))
 
     # -- test methods ---------------------------
 

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -382,17 +382,16 @@ class Array2DTestCase(CommonTests, unittest.TestCase):
         self.assertEqual(a[0][0].unit, a.unit)
 
     def test_value_at(self):
-        arr = numpy.arange(25).reshape((5, 5))
-        ts1 = self.TEST_CLASS(arr, dx=.5, dy=.25, unit='m')
-        self.assertEqual(ts1.value_at(1.5, .75), 18 * ts1.unit)
+        ts1 = self.create(dx=.5, dy=.25, unit='m')
+        self.assertEqual(ts1.value_at(1.5, .75), self.data[3][3] * ts1.unit)
         self.assertEqual(ts1.value_at(1.0 * ts1.xunit, .25 * ts1.yunit),
-                         11 * units.m)
+                         self.data[2][1] * units.m)
         self.assertRaises(IndexError, ts1.value_at, 1.6, 5.8)
         # test Spectrogram unit conversion
         if ts1.xunit == units.s and ts1.yunit == units.Hz:
             self.assertEqual(ts1.value_at(1500 * units.millisecond,
                                           750 * units.milliHertz),
-                             18 * units.m)
+                             self.data[3][3] * units.m)
 
 
 if __name__ == '__main__':

--- a/gwpy/tests/test_spectrum.py
+++ b/gwpy/tests/test_spectrum.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit test for spectrum module
+"""
+
+from tempfile import NamedTemporaryFile
+
+from numpy import (testing as nptest, arange)
+
+from scipy import signal
+
+from astropy import units
+
+from gwpy import version
+from gwpy.spectrum import Spectrum
+from gwpy.plotter import SpectrumPlot
+
+from test_array import SeriesTestCase
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version
+
+
+# -----------------------------------------------------------------------------
+
+class SpectrumTestCase(SeriesTestCase):
+    """`~unittest.TestCase` for the `~gwpy.spectrum.Spectrum` class
+    """
+    TEST_CLASS = Spectrum
+
+    def test_f0_df(self):
+        array = self.create()
+        self.assertEqual(array.f0, array.x0)
+        self.assertEqual(array.df, array.dx)
+        self.assertEqual(array.f0, 0 * units.Hertz)
+        self.assertEqual(array.df, 1 * units.Hertz)
+
+    def test_frequencies(self):
+        array = self.create()
+        self.assertArraysEqual(array.frequencies,
+                               arange(array.size) * array.df + array.f0)
+
+    def test_plot(self):
+        array = self.create()
+        plot = array.plot()
+        self.assertIsInstance(plot, SpectrumPlot)
+
+    def test_filter(self):
+        array = self.create()
+        a2 = array.filter([100], [1], 1e-2)
+        self.assertIsInstance(a2, type(array))
+        self.assertArraysEqual(a2.frequencies, array.frequencies)
+        # manually rebuild the filter to test it works
+        b, a, = signal.zpk2tf([100], [1], 1e-2)
+        fresp = abs(signal.freqs(b, a, array.frequencies.value)[1])
+        nptest.assert_array_equal(a2.value, fresp * array.value)
+
+    def test_zpk(self):
+        array = self.create()
+        # just test that it works
+        array2 = array.zpk([100], [1], 1e-2)
+        self.assertIsInstance(array2, type(array))
+        self.assertArraysEqual(array2.frequencies, array.frequencies)
+
+    def test_to_from_lal(self):
+        array = self.create()
+        try:
+            lalarray = array.to_lal()
+        except ImportError as e:
+            self.skipTest(str(e))
+        nptest.assert_array_equal(lalarray.data.data, array.value)
+        array2 = type(array).from_lal(lalarray)
+        self.assertArraysEqual(array, array2, 'units', 'df', 'f0')
+
+    def test_to_from_pycbc(self):
+        array = self.create()
+        try:
+            pycbcarray = array.to_pycbc()
+        except ImportError as e:
+            self.skipTest(str(e))
+        nptest.assert_array_equal(pycbcarray.data, array.value)
+        array2 = type(array).from_pycbc(pycbcarray)
+        self.assertArraysEqual(array, array2, 'units', 'df', 'f0')
+
+    def _test_read_write(self, extension, fmt=None, **metadata):
+        if fmt is None:
+            fmt = extension.strip('.')
+        if not extension.startswith('.'):
+            extension = '.%s' % extension
+        array = self.create(**metadata)
+        with NamedTemporaryFile(suffix=extension, delete=True) as f:
+            array.write(f.name, format=fmt)
+            f.seek(0)
+            array2 = self.TEST_CLASS.read(f.name, format=fmt)
+        self.assertArraysEqual(array, array2)
+
+    def test_read_write_hdf5(self):
+        self.assertRaises(ValueError, self._test_read_write, 'hdf', fmt='hdf')
+        self._test_read_write('hdf', fmt='hdf', name='Array name')
+        self._test_read_write('hdf', name='Array name')
+
+    def test_read_write_txt(self):
+        self._test_read_write('txt', fmt='txt')
+        self._test_read_write('txt')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -41,7 +41,7 @@ from gwpy.time import Time
 from gwpy import version
 from gwpy.timeseries import (TimeSeries, StateVector, TimeSeriesDict,
                              StateVectorDict)
-from gwpy.spectrum import Spectrum
+from gwpy.spectrum import (Spectrum, SpectralVariance)
 from gwpy.spectrogram import Spectrogram
 from gwpy.io.cache import Cache
 
@@ -415,6 +415,11 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         self.assertEqual(sg.df, 5 * units.Hertz)
         # note: bizarre stride length because 16384/100 gets rounded
         self.assertEqual(sg.dt, 0.010009765625 * units.second)
+
+    def test_spectral_variance(self):
+        ts = self._read()
+        variance = ts.spectral_variance(.5)
+        self.assertIsInstance(variance, SpectralVariance)
 
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz


### PR DESCRIPTION
This PR introduces a new `TestSuite` for the `Spectrum` object, then fixes a few bugs in that object uncovered by the unit tests (fixes #236), and does the same for `SpectralVariance`.