### PR TITLE
Use fast_finish to ignore allowed_failures in travis report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
       env: STRICT=true PRE="--pre"
     - python: 3.5
       env: STRICT=false
+  fast_finish: true
 
 before_install:
   # update pip


### PR DESCRIPTION
This PR adds `fast_finish: true` to the `matrix` section of the travis config, meaning travis will report the build status back to github as soon as all non-`allowed_failure` build as complete.