### PR TITLE
Removed copy in flag.pad() when running dict.populate()

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -654,7 +654,7 @@ class DataQualityFlag(object):
         self.active = self.active.protract(x)
         return self.active
 
-    def pad(self, *args):
+    def pad(self, *args, **kwargs):
         """Apply a padding to each segment in this `DataQualityFlag`
 
         This method either takes no arguments, in which case the value of
@@ -677,6 +677,9 @@ class DataQualityFlag(object):
             padding to apply to the start of the each segment
         end : `float`
             padding to apply to the end of each segment
+        inplace : `bool`, optional, default: `False`
+            modify this object in-place, default is `False`, i.e. return
+            a copy of the original object with padded segments
 
         Returns
         -------
@@ -690,7 +693,13 @@ class DataQualityFlag(object):
         else:
             raise ValueError("Cannot parse (start, end) padding from %r"
                              % args)
-        new = self.copy()
+        if kwargs.pop('inplace', False):
+            new = self
+        else:
+            new = self.copy()
+        if kwargs:
+            raise TypeError("unexpected keyword argument %r"
+                            % kwargs.keys()[0])
         new.known = [(s[0]+start, s[1]+end) for s in self.known]
         new.active = [(s[0]+start, s[1]+end) for s in self.active]
         return new

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -31,7 +31,7 @@ import re
 import warnings
 import tempfile
 from urlparse import urlparse
-from copy import copy as shallowcopy
+from copy import (copy as shallowcopy, deepcopy)
 from math import (floor, ceil)
 from threading import Thread
 from Queue import Queue
@@ -763,16 +763,7 @@ class DataQualityFlag(object):
         flag2 : `DataQualityFlag`
             a copy of the original flag, but with a fresh memory address.
         """
-        new = self.__class__()
-        new.ifo = self.ifo
-        new.name = self.name
-        new.version = self.version
-        new.description = self.description
-        new.known = self._ListClass([self._EntryClass(s[0], s[1]) for
-                                    s in self.known])
-        new.active = self._ListClass([self._EntryClass(s[0], s[1]) for
-                                     s in self.active])
-        return new
+        return deepcopy(self)
 
     def plot(self, **kwargs):
         """Plot this flag.

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1279,7 +1279,7 @@ class DataQualityDict(OrderedDict):
             self[key].known &= tmp[key].known
             self[key].active = tmp[key].active
             if pad:
-                self[key] = self[key].pad()
+                self[key] = self[key].pad(inplace=True)
                 if segments is not None:
                     self[key].known &= segments
                     self[key].active &= segments

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -405,6 +405,14 @@ class DataQualityFlagTests(unittest.TestCase, TestCaseWithQueryMixin):
         # test coalesce
         padded.coalesce()
         self.assertListEqual(padded.active, ACTIVEPADC)
+        # test in-place
+        flag = DataQualityFlag(FLAG1, active=ACTIVE, known=KNOWN)
+        padded = flag.pad(*PADDING)
+        self.assertIsNot(flag, padded)
+        padded = flag.pad(*PADDING, inplace=True)
+        self.assertIs(flag, padded)
+        # test other kwargs fail
+        self.assertRaises(TypeError, flag.pad, *PADDING, kwarg='test')
 
     def test_io_identify(self):
         common.test_io_identify(DataQualityFlag, ['xml', 'xml.gz', 'txt'])


### PR DESCRIPTION
This PR fixes a bug in `DataQualityFlag.copy()` that would miss attributes that weren't explicitly named, and adds an `inplace` kwarg to `DataQualityFlag.pad` to modify the `active and `known` segmentlists in place, instead of returning a copy of the flag.

This is done to allow `DataQualityDict.populate` to not copy flags when padding is used, meaning the values are the same objects before and after this method is used.