### PR TITLE
Fixed unit imcompatibility in TimeSeries.whiten

### DIFF
--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1442,7 +1442,7 @@ class TimeSeries(TimeSeriesBase):
              i0 = i * nstride
              i1 = i0 + nfft
              in_ = self[i0:i1].detrend(detrend) * window
-             out[i0:i1] += npfft.irfft(in_.fft().value * invasd)
+             out.value[i0:i1] += npfft.irfft(in_.fft().value * invasd)
         return out
 
     def detrend(self, detrend='constant'):


### PR DESCRIPTION
This fixes a problem with `TimeSeries.whiten` where the result of the IFFT was being applied directly to the `TimeSeries` with no units, resulting in a `UnitsError`.