### PR TITLE
New TimeSeries.fetch_open_data classmethod

### DIFF
--- a/examples/timeseries/public.py
+++ b/examples/timeseries/public.py
@@ -27,21 +27,18 @@ These data are public, so we can load them directly from the web.
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.timeseries'
 
-# First: import everything we need (and nothing we don't need)
-from urllib2 import urlopen
-from numpy import asarray
+# The `TimeSeries` object has a `classmethod` dedicated to fetching open-access
+# data hosted by the LIGO Open Science Center, so we can just import that
+# object
 from gwpy.timeseries import TimeSeries
 
-# Next, download the data as a string of text
-data = urlopen('http://www.ligo.org/science/GW100916/L-strain_hp30-968654552-10.txt').read()
+# then call the `~TimeSeries.fetch_open_data` method, passing it the prefix
+# for the interferometer we want ('L1'), and the GPS start and stop times of
+# our query:
+data = TimeSeries.fetch_open_data('L1', 968654552, 968654562)
 
-# We can now parse the text as a list of floats, and generate a `TimeSeries`
-# by supplying the necessary metadata
-ts = TimeSeries(asarray(data.splitlines(), dtype=float),
-                epoch=968654552, sample_rate=16384, unit='strain')
-
-# Finally, we can make a plot:
-plot = ts.plot()
+# and then we can make a plot:
+plot = data.plot()
 plot.set_title('LIGO Livingston Observatory data for GW100916')
 plot.set_ylabel('Gravitational-wave strain amplitude')
-plot.show()
+plot.show(block=True)

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -269,6 +269,42 @@ class TimeSeriesBase(Series):
             pad=pad, type=type, dtype=dtype)[str(channel)]
 
     @classmethod
+    def fetch_open_data(cls, ifo, start, end, name='strain/Strain',
+                        sample_rate=4096, host='https://losc.ligo.org'):
+        """Fetch open-access data from the LIGO Open Science Center
+
+        Parameters
+        ----------
+        ifo : `str`
+            the two-character prefix of the IFO in which you are interested,
+            e.g. `'L1'`
+
+        start : `~gwpy.time.LIGOTimeGPS`, `float`, `str`, optional
+            GPS start time of required data, defaults to start of data found;
+            any input parseable by `~gwpy.time.to_gps` is fine
+
+        end : `~gwpy.time.LIGOTimeGPS`, `float`, `str`, optional
+            GPS end time of required data, defaults to end of data found;
+            any input parseable by `~gwpy.time.to_gps` is fine
+
+        name : `str`, optional
+            the full name of HDF5 dataset that represents the data you want,
+            e.g. `'strain/Strain'` for _h(t)_ data, or `'quality/simple'`
+            for basic data-quality information
+
+        sample_rate : `float`, optional, default: `4096`
+            the sample rate of desired data. Most data are stored
+            by LOSC at 4096 Hz, however there may be event-related
+            data releases with a 16384 Hz rate
+
+        host : `str`, optional
+            HTTP host name of LOSC server to access
+        """
+        from .io.losc import fetch_losc_data
+        return fetch_losc_data(ifo, start, end, channel=name, cls=cls,
+                               sample_rate=sample_rate, host=host)
+
+    @classmethod
     @interpolate_docstring
     def find(cls, channel, start, end, frametype=None,
              pad=None, dtype=None, nproc=1, verbose=False, **readargs):

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -513,6 +513,37 @@ class StateVector(TimeSeriesBase):
         return new
 
     @classmethod
+    def fetch_open_data(cls, ifo, start, end, name='quality/simple',
+                        host='https://losc.ligo.org'):
+        """Fetch open-access data from the LIGO Open Science Center
+
+        Parameters
+        ----------
+        ifo : `str`
+            the two-character prefix of the IFO in which you are interested,
+            e.g. `'L1'`
+
+        start : `~gwpy.time.LIGOTimeGPS`, `float`, `str`, optional
+            GPS start time of required data, defaults to start of data found;
+            any input parseable by `~gwpy.time.to_gps` is fine
+
+        end : `~gwpy.time.LIGOTimeGPS`, `float`, `str`, optional
+            GPS end time of required data, defaults to end of data found;
+            any input parseable by `~gwpy.time.to_gps` is fine
+
+        name : `str`, optional
+            the full name of HDF5 dataset that represents the data you want,
+            e.g. `'strain/Strain'` for _h(t)_ data, or `'quality/simple'`
+            for basic data-quality information
+
+        host : `str`, optional
+            HTTP host name of LOSC server to access
+        """
+        from .io.losc import fetch_losc_data
+        return fetch_losc_data(ifo, start, end, channel=name, cls=cls,
+                               host=host)
+
+    @classmethod
     @interpolate_docstring
     def get(cls, channel, start, end, bits=None, **kwargs):
         """Get data for this channel from frames or NDS


### PR DESCRIPTION
This PR introduces the `TimeSeries.fetch_open_data` class method, which automatically locates, downloads, and reads HDF5 files hosted on losc.ligo.org to return the requested data.