### PR TITLE
New TimeSeries.q_transform method

### DIFF
--- a/examples/timeseries/qscan.py
+++ b/examples/timeseries/qscan.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Generate the Q-transform of a `TimeSeries`
+
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+__currentmodule__ = 'gwpy.timeseries'
+
+# First, we identify the GPS time of interest:
+gps = 968654558
+
+# and use that to define the start and end times of our required data
+duration = 32
+start = int(round(gps - duration/2.))
+end = start + duration
+
+# next, we import the `TimeSeries` and :meth:`~TimeSeries.get` the data:
+from gwpy.timeseries import TimeSeries
+data = TimeSeries.get('H1:LDAS-STRAIN', start, end)
+
+# In order to speed up the operation, we choose to downsample our data
+data = data.resample(4096)
+
+# and next we generate the `~TimeSeries.q_transform` of these data:
+qspecgram = data.q_transform()
+
+# Now, we can plot the resulting `~gwpy.spectrogram.Spectrogram`, focusing on a
+# specific window around the interesting time
+# .. note::
+#
+#    Using `~gwpy.spectrogram.Spectrogram.crop` is highly recommended at this stage
+#    because rendering the high-resolution spectrogram as it is done here is very
+#    slow (for experts this is because we're using `~matplotlib.axes.Axes.pcolormesh`
+#    and not any sort of image interpolation, mainly to support both linear and #
+#    log scaling nicely)
+plot = qspecgram.crop(gps-.3, gps+.1).plot(figsize=[8, 6])
+ax = plot.gca()
+ax.set_epoch(gps)
+ax.set_yscale('log')
+ax.set_xlabel('Time [milliseconds]')
+ax.set_ylim(50, 1000)
+ax.grid(True, axis='y', which='both')
+plot.add_colorbar(clim=[0, 25], cmap='viridis', label='Normalized energy')
+plot.show()
+
+# I think we just detected a gravitational wave signal! But, before you get too exited, this is an example of a 'blind
+# injection', a simulated signal introduced into the interferometer(s) in order to test the detection process end-to-end.
+# For more details, see `here <http://www.ligo.org/scientists/GW100916/>`_.

--- a/gwpy/signal/__init__.py
+++ b/gwpy/signal/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2016)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The `gwpy.signal` module provides signal-processing utilities that
+extend the functionality of `scipy.signal` (and others) for specific GW data
+applications.
+"""
+
+from .. import version
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__version__ = version.version

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2016)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Python implementation of the tiled Q-transform scan.
+
+This is a re-implementation of the original Q-transform scan from the Omega
+pipeline, all credits for the original algorithm go to its
+authors.
+"""
+
+from __future__ import division
+
+from math import (log, ceil, pi, isinf, exp)
+
+from six.moves import xrange
+
+import numpy
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Scott Coughlin <scott.coughlin@ligo.org>'
+
+
+class QObject(object):
+    """Base class for Q-transform objects
+
+    This object exists just to provide basic methods for all other
+    Q-transform objects.
+    """
+    def __init__(self, duration, sampling, mismatch=.2):
+        self.duration = float(duration)
+        self.sampling = float(sampling)
+        self.mismatch = float(mismatch)
+
+    @property
+    def deltam(self):
+        """Fractional mismatch between neighbouring tiles
+
+        :type: `float`
+        """
+        return 2 * (self.mismatch / 3.) ** (1/2.)
+
+
+class QBase(QObject):
+    """Base class for Q-transform objects with fixed Q
+
+    This class just provides a property for Q-prime = Q / sqrt(11)
+    """
+    def __init__(self, q, duration, sampling, mismatch=.2):
+        super(QBase, self).__init__(duration, sampling, mismatch=mismatch)
+        self.q = float(q)
+
+    @property
+    def qprime(self):
+        """Normalized Q `(q/sqrt(11))`
+        """
+        return self.q / 11**(1/2.)
+
+
+class QTiling(QObject):
+    """Iterable constructor of `QPlane` objects
+
+    For a given Q-range, each of the resulting `QPlane` objects can
+    be iterated over.
+
+    Parameters
+    ----------
+    duration : `float`
+        the duration of the data to be Q-transformed
+    qrange : `tuple` of `float`
+        `(low, high)` pair of Q extrema
+    frange : `tuple` of `float`
+        `(low, high)` pair of frequency extrema
+    sampling : `float`
+        sampling rate (in Hertz) of data to be Q-transformed
+    mismatch : `float`
+        maximum fractional mismatch between neighbouring tiles
+    """
+    def __init__(self, duration, sampling,
+                 qrange=(4, 64), frange=(0, numpy.inf), mismatch=.2):
+        super(QTiling, self).__init__(duration, sampling, mismatch=mismatch)
+        self.qrange = (float(qrange[0]), float(qrange[1]))
+        self.frange = [float(frange[0]), float(frange[1])]
+
+        qs = list(self._iter_qs())
+        if self.frange[0] == 0:  # set non-zero lower frequency
+            self.frange[0] = 50 * max(qs) / (2 * pi * self.duration)
+        if isinf(self.frange[1]):  # set non-infinite upper frequency
+            self.frange[1] = self.sampling / 2 / (1 + 11**(1/2.) / min(qs))
+
+    @property
+    def qs(self):
+        """Array of Q values for this `QTiling`
+
+        :type: `numpy.ndarray`
+        """
+        return numpy.array(list(self._iter_qs()))
+
+    def _iter_qs(self):
+        """Iterate over the Q values
+        """
+        # work out how many Qs we need
+        cumum = log(self.qrange[1] / self.qrange[0]) / 2**(1/2.)
+        nplanes = int(max(ceil(cumum / self.deltam), 1))
+        dq = cumum / nplanes
+        for i in xrange(nplanes):
+            yield self.qrange[0] * exp(2**(1/2.) * dq * (i + .5))
+        raise StopIteration()
+
+    def __iter__(self):
+        """Iterate over this `QTiling`
+
+        Yields a `QPlane` at each Q value
+        """
+        for q in self._iter_qs():
+            yield QPlane(q, self.frange, self.duration, self.sampling,
+                         mismatch=self.mismatch)
+        raise StopIteration()
+
+
+class QPlane(QBase):
+    """Iterable representation of a Q-transform plane
+
+    For a given Q, an array of frequencies can be iterated over, yielding
+    a `QRow` each time.
+
+    Parameters
+    ----------
+    q : `float`
+        the Q-value for this plane
+    frange : `tuple` of `float`
+        `(low, high)` range of frequencies for this plane
+    duration : `float`
+        the duration of the data to be Q-transformed
+    sampling : `float`
+        sampling rate (in Hertz) of data to be Q-transformed
+    mismatch : `float`
+        maximum fractional mismatch between neighbouring tiles
+    """
+    def __init__(self, q, frange, duration, sampling, mismatch=.2):
+        super(QPlane, self).__init__(q, duration, sampling, mismatch=mismatch)
+        self.frange = [float(frange[0]), float(frange[1])]
+
+        if self.frange[0] == 0:  # set non-zero lower frequency
+            self.frange[0] = 50 * self.q / (2 * pi * self.duration)
+        if isinf(self.frange[1]):  # set non-infinite upper frequency
+            self.frange[1] = self.sampling / 2 / (1 + 1/self.qprime)
+
+    def __iter__(self):
+        """Iterate over this `QPlane`
+
+        Yields a `QRow` at each frequency
+        """
+        # for each frequency, yield a QRow
+        for f in self._iter_frequencies():
+            yield QRow(self.q, f, self.duration, self.sampling,
+                       mismatch=self.mismatch)
+        raise StopIteration()
+
+    def _iter_frequencies(self):
+        """Iterate over the frequencies of this `QPlane`
+        """
+        # work out how many frequencies we need
+        minf, maxf = self.frange
+        fcum_mismatch = log(maxf / minf) * (2 + self.q**2)**(1/2.) / 2.
+        nfreq = int(max(1, ceil(fcum_mismatch / self.deltam)))
+        fstep = fcum_mismatch / nfreq
+        fstepmin = 1 / self.duration
+        # for each frequency, yield a QRow
+        for i in xrange(nfreq):
+            yield (minf * exp(2 / (2 + self.q**2)**(1/2.) * (i + .5) * fstep)
+                 // fstepmin * fstepmin)
+        raise StopIteration()
+
+    @property
+    def frequencies(self):
+        """Array of central frequencies for this `QPlane`
+
+        :type: `numpy.ndarray`
+        """
+        return numpy.array(list(self._iter_frequencies()))
+
+    @property
+    def farray(self):
+        """Array of frequencies for the lower-edge of each frequency bin
+
+        :type: `numpy.ndarray`
+        """
+        f = self.frequencies
+        bandwidths = 2 * pi ** (1/2.) * f / self.q
+        return f - bandwidths / 2.
+
+
+class QRow(QBase):
+    """Representation of a set of tiles with fixed Q and frequency
+    """
+    def __init__(self, q, frequency, duration, sampling, mismatch=.2):
+        super(QRow, self).__init__(q, duration, sampling, mismatch=mismatch)
+        self.frequency = frequency
+
+    @property
+    def bandwidth(self):
+        """The bandwidth for tiles in this row
+
+        :type: `float`
+        """
+        return 2 * pi ** (1/2.) * self.frequency / self.q;
+
+    @property
+    def ntiles(self):
+        """The number of tiles in this row
+
+        :type: `int`
+        """
+        tcum_mismatch = self.duration * 2 * pi * self.frequency / self.q
+        return next_power_of_two(tcum_mismatch / self.deltam)
+
+    @property
+    def windowsize(self):
+        """The size of the frequency-domain window for this row
+
+        :type: `int`
+        """
+        return 2 * int(self.frequency / self.qprime * self.duration) + 1
+
+    def _get_indices(self):
+        half = int((self.windowsize - 1) / 2)
+        return numpy.arange(-half, half + 1)
+
+    def get_window(self):
+        """Generate the bi-square window for this row
+
+        Returns
+        -------
+        window : `numpy.ndarray`
+        """
+        # real frequencies
+        wfrequencies = self._get_indices() / self.duration
+        # dimensionless frequencies
+        xfrequencies = wfrequencies * self.qprime / self.frequency
+        # normalize and generate bi-square window
+        norm = self.ntiles / (self.duration * self.sampling) * (
+            315 * self.qprime / (128 * self.frequency)) ** (1/2.)
+        return (1 - xfrequencies ** 2) ** 2 * norm
+
+    def get_data_indices(self):
+        """Returns the index array of interesting frequencies for this row
+        """
+        return numpy.round(self._get_indices() + 1 +
+                           self.frequency * self.duration).astype(int)
+
+    @property
+    def padding(self):
+        """The `(left, right)` padding required for the IFFT
+
+        :type: `tuple` of `int`
+        """
+        pad = self.ntiles - self.windowsize
+        return (int((pad - 1)/2.), int((pad + 1)/2.))
+
+
+def next_power_of_two(x):
+    """Return the smallest power of two greater than or equal to `x`
+    """
+    return 2**(ceil(log(x, 2)))

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -498,6 +498,22 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         self.assertEqual(ts.dx, units.Quantity(0.000244140625, 's'))
         self.assertEqual(ts.name, 'Strain')
 
+    def test_q_transform(self):
+        gps = 968654558
+        duration = 32
+        start = int(round(gps - duration/2.))
+        end = start + duration
+        try:
+            ts = self.TEST_CLASS.get('H1:LDAS-STRAIN', start, end)
+        except (ImportError, RuntimeError) as e:
+            self.skipTest(str(e))
+        else:
+            qspecgram = ts.resample(4096).q_transform()
+            self.assertIsInstance(qspecgram, Spectrogram)
+            self.assertTupleEqual(qspecgram.shape, (32000, 2560))
+            self.assertAlmostEqual(qspecgram.q, 11.313708499)
+            self.assertAlmostEqual(qspecgram.value.max(), 37.7381136725)
+
 
 class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):
     """`~unittest.TestCase` for the `~gwpy.timeseries.StateVector` object


### PR DESCRIPTION
This PR introduces a gwpy implementation to the original-MATLAB Q-transform scan, via the `TimeSeries.q_transform` instance method. Included are tests and an example, which produces this image:

![qscan](https://cloud.githubusercontent.com/assets/1618530/14476789/817ee896-00cf-11e6-892d-8e0ea4dc6a38.png)

**[NB: these data are from the S6 blind injection, and do not contain an astrophysical signal]**

Thanks to @scottcoughlin2014 for the original MATLAB-python conversion as part of the [GravitySpy](//github.com/mzevin1/GravitySpy/commits/PyOmega) project