### PR TITLE
Fixed bugs in TimeSeries.find and io.datafind

### DIFF
--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -141,11 +141,14 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
             return ft
         elif inframe:
             found.append(ft)
-    if len(found) == 0 and gpstime:
-        raise ValueError("Cannot locate %r in any known frametype at GPS=%d"
-                         % (name, gpstime))
-    elif len(found) == 0:
-        raise ValueError("Cannot locate %r in any known frametype" % name)
+    if exclude_tape:
+        msg = "Cannot locate %r in any known frametype that isn't on tape"
+    else:
+        msg = "Cannot locate %r in any known frametype"
+    if gpstime:
+        msg += " at GPS=%d" % gpstime
+    if len(found) == 0:
+        raise ValueError(msg % name)
     else:
         return found
 

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -33,8 +33,8 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 S6_HOFT_NAME = re.compile('\A(H|L)1:LDAS-STRAIN\Z')
 S6_RECOLORED_TYPE = re.compile('\AT1200307_V4_EARLY_RECOLORED_V2\Z')
-SECOND_TREND_TYPE = re.compile('\A([A-Z][0-9]_)?T\Z')
-MINUTE_TREND_TYPE = re.compile('\A([A-Z][0-9]_)?M\Z')
+SECOND_TREND_TYPE = re.compile('\A(.*_)?T\Z')  # T or anything ending in _T
+MINUTE_TREND_TYPE = re.compile('\A(.*_)?M\Z')  # M or anything ending in _M
 
 
 @with_import('glue.datafind')
@@ -120,10 +120,18 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     # if looking for LDAS-STRAIN, put recoloured types at the end
     if S6_HOFT_NAME.match(name):
         frames.sort(key=lambda x: S6_RECOLORED_TYPE.match(x[0]) and 2 or 1)
+
+    # need to handle trends as a special case
     if channel.type == 'm-trend':
         frames.sort(key=lambda x: MINUTE_TREND_TYPE.match(x[0]) and 1 or 2)
+        # if no minute-trend types found, force an error
+        if frames and not MINUTE_TREND_TYPE.match(frames[0][0]):
+            frames = []
     elif channel.type == 's-trend':
         frames.sort(key=lambda x: SECOND_TREND_TYPE.match(x[0]) and 1 or 2)
+        # if no second-trend types found, force an error
+        if frames and not SECOND_TREND_TYPE.match(frames[0][0]):
+            frames = []
 
     # search each frametype for the given channel
     found = []

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -206,6 +206,18 @@ class TimeSeriesTestMixin(object):
                               observatory='X')
 
     def test_find_best_frametype(self):
+        from gwpy.io import datafind
+        # test a few (channel, frametype) pairs
+        for channel, target in [
+                ('H1:GDS-CALIB_STRAIN', 'H1_HOFT_C00'),
+                ('L1:IMC-ODC_CHANNEL_OUT_DQ', 'L1_R'),
+                ('H1:ISI-GND_STS_ITMY_X_BLRMS_30M_100M.mean,s-trend', 'H1_T'),
+                ('H1:ISI-GND_STS_ITMY_X_BLRMS_30M_100M.mean,m-trend', 'H1_M')]:
+            ft = datafind.find_best_frametype(
+                channel, 1143504017, 1143504017+100)
+            self.assertEqual(ft, target)
+
+        # test that this works end-to-end as part of a TimeSeries.find
         try:
             ts = self.TEST_CLASS.find(FIND_CHANNEL, FIND_GPS, FIND_GPS+1)
         except (ImportError, RuntimeError) as e:

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -207,6 +207,11 @@ class TimeSeriesTestMixin(object):
 
     def test_find_best_frametype(self):
         from gwpy.io import datafind
+        # check we can actually run this test here
+        try:
+            os.environ['LIGO_DATAFIND_SERVER']
+        except KeyError as e:
+            self.skipTest(str(e))
         # test a few (channel, frametype) pairs
         for channel, target in [
                 ('H1:GDS-CALIB_STRAIN', 'H1_HOFT_C00'),

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -973,7 +973,7 @@ class TimeSeriesBaseDict(OrderedDict):
             # parse as a ChannelList
             channellist = ChannelList.from_names(*clist)
             # strip trend tags from channel names
-            clist = [c.name for c in channellist]
+            names = [c.name for c in channellist]
             # find observatory for this group
             if observatory is None:
                 try:
@@ -991,8 +991,11 @@ class TimeSeriesBaseDict(OrderedDict):
                                    % (observatory, ft, start, end))
             # read data
             readargs.setdefault('format', 'gwf')
-            out.append(cls.read(cache, clist, start=start, end=end, pad=pad,
-                                dtype=dtype, nproc=nproc, **readargs))
+            new = cls.read(cache, names, start=start, end=end, pad=pad,
+                           dtype=dtype, nproc=nproc, **readargs)
+            # map back to user-given channel name and append
+            out.append(type(new)((key, new[c]) for
+                                 (key, c) in zip(clist, names)))
             if verbose:
                 gprint("Done")
         return out


### PR DESCRIPTION
This PR further improves the `TimeSeriesDict.find` and the underlying `io.datafind` infrastructure to automatically determine the best frametype for a given channel.