### PR TITLE
Fix Jupyter ShimWarnings - bump astropy version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 six>=1.5
 numpy>=1.7
 scipy>=0.16
-astropy>=1.0
+astropy>=1.0.5
 matplotlib>=1.4.1
 gitpython
 h5py>=1.3


### PR DESCRIPTION
There are a lot of warnings when using jupyter. According to https://github.com/astropy/astropy/issues/4169 , this was fixed in astropy 1.0.5. I've tested that upgrading astropy directly using pip fixes the problem, but I haven't tested a clean install.