### PR TITLE
timeseries.whiten: don't produce NaN when zeros in asd

### DIFF
--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1422,6 +1422,9 @@ class TimeSeries(TimeSeriesBase):
                            method=method, window=window, **kwargs)
         if isinstance(asd, units.Quantity):
             asd = asd.value
+ 
+        # remove zeros from asd before inverting - replace with min of asd
+        asd[asd==0.] = asd[asd>0.].min()
         invasd = 1. / asd
         # build window
         nfft = int((fftlength * self.sample_rate).decompose().value)


### PR DESCRIPTION
timeseries.whiten: don't produce NaN when zeros in asd

I ran into trouble in q_transform due to NaNs in the whitened data. This was happening because some values of the asd were zero, making the inverse blow up. The patch deals with this the simplest way, just replacing all zero values with the minimum positive value.
