### PR TITLE
Workaround for numpy 1.7 not having rfftfreq

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -336,12 +336,15 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         ts = self._read()
         fs = ts.fft()
         self.assertEqual(fs.size, ts.size//2+1)
-        fs = ts.fft(nfft=256)
-        self.assertEqual(fs.size, 129)
         self.assertIsInstance(fs, Spectrum)
         self.assertEqual(fs.x0, 0*units.Hertz)
         self.assertEqual(fs.dx, 1*units.Hertz)
         self.assertIs(ts.channel, fs.channel)
+        # test with nfft arg
+        fs = ts.fft(nfft=256)
+        self.assertEqual(fs.size, 129)
+        self.assertEqual(fs.dx, ts.sample_rate / 256)
+        raise RuntimeError("")
 
     def test_average_fft(self):
         ts = self._read()

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -344,7 +344,6 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         fs = ts.fft(nfft=256)
         self.assertEqual(fs.size, 129)
         self.assertEqual(fs.dx, ts.sample_rate / 256)
-        raise RuntimeError("")
 
     def test_average_fft(self):
         ts = self._read()

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -153,7 +153,10 @@ class TimeSeries(TimeSeriesBase):
         dft[1:] *= 2.0
         new = Spectrum(dft, epoch=self.epoch, channel=self.channel,
                        unit=self.unit)
-        new.frequencies = npfft.rfftfreq(self.size, d=self.dx.value)
+        try:
+            new.frequencies = npfft.rfftfreq(nfft, d=self.dx.value)
+        except AttributeError:
+            new.frequencies = numpy.arange(0, new.size) / (nfft * self.dx.value)
         return new
 
     def average_fft(self, fftlength=None, overlap=0, window=None):


### PR DESCRIPTION
This PR introduces a workaround in `TimeSeries.fft` due to numpy 1.7 not having `numpy.fft.rfftfreq. It's a simple method, so this is preferred to bumping the numpy version to 1.8 (give than the new SL7 on LDAS finally has numpy 1.7).