### PR TITLE
TimeSeries.q_transform: improved frequency recovery

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -565,7 +565,7 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
             self.assertIsInstance(qspecgram, Spectrogram)
             self.assertTupleEqual(qspecgram.shape, (32000, 2560))
             self.assertAlmostEqual(qspecgram.q, 11.31370849898476)
-            self.assertAlmostEqual(qspecgram.value.max(), 37.158404056005764)
+            self.assertAlmostEqual(qspecgram.value.max(), 37.157012691452067)
 
 
 class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1627,7 +1627,7 @@ class TimeSeries(TimeSeriesBase):
             # if this Q-plane is louder than the others, record its energies
             if peakq == plane.q:
                 norms = normenergies
-                frequencies = plane.farray
+                frequencies = plane.frequencies
 
         # build regular Spectrogram from peak-Q data by interpolating each
         # (Q, frequency) `TimeSeries` to have the same time resolution
@@ -1654,7 +1654,7 @@ class TimeSeries(TimeSeriesBase):
             interp = interp2d(out.times.value, frequencies, out.value.T,
                               kind='cubic')
             f2 = numpy.arange(planes.frange[0], planes.frange[1], fres)
-            new = Spectrogram(interp(out.times.value, f2).T,
+            new = Spectrogram(interp(out.times.value, f2 + fres/2.).T,
                               x0=outseg[0], dx=tres,
                               f0=planes.frange[0], df=fres)
             new.q = peakq


### PR DESCRIPTION
interpolation happens at exact frequencies, so need to operate on proper frequencies for both the `QRow` and the desired frequencies, then shift down by `fres/2.` for the output `Spectrogram` bins

Fixes #265. With this code, I get the following equivalent output for the example given in #265:

![figure_1](https://cloud.githubusercontent.com/assets/1618530/14613807/beead5b2-0563-11e6-9ee7-d2b9eaf09bc1.png)