### PR TITLE
Bypass `ImportError` in TimeSeries.get from missing frame library

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1055,7 +1055,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 return cls.find(channels, start, end, pad=pad, dtype=dtype,
                                 verbose=verbose, allow_tape=allow_tape,
                                 **kwargs)
-            except (RuntimeError, ValueError) as e:
+            except (ImportError, RuntimeError, ValueError) as e:
                 if verbose:
                     gprint(str(e), file=sys.stderr)
                     gprint("Failed to access data from frames, trying NDS...")


### PR DESCRIPTION
This PR adds protection against `ImportError` in `TimeSeries.get` coming from having no frame library installed - this should get picked up by `TimeSeries.fetch` with the nds2 client.