### PR TITLE
Q-transform with a single Q

### DIFF
--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -207,6 +207,41 @@ class QPlane(QBase):
         bandwidths = 2 * pi ** (1/2.) * f / self.q
         return f - bandwidths / 2.
 
+    def transform(self, fseries, normalized=True, epoch=None):
+        """Calculate the energy `TimeSeries` for the given fseries
+
+        Parameters
+        ----------
+        fseries : `~gwpy.spectrum.Spectrum`
+            the complex FFT of a time-series data set
+        normalized : `bool`, optional
+            normalize the energy of the output, if `False` the output
+            is the complex `~numpy.fft.ifft` output of the Q-tranform
+        epoch : `~gwpy.time.LIGOTimeGPS`, `float`, optional
+            the epoch of these data, only used for metadata in the output
+            `TimeSeries`, and not requires if the input `fseries` has the
+            epoch populated.
+
+        Returns
+        -------
+        frequencies : `numpy.ndarray`
+            array of frequencies for this `QPlane`
+        transforms : `list` of `~gwpy.timeseries.TimeSeries`
+            the complex energies of the Q-transform of the input `fseries`
+            at each frequency
+
+        See Also
+        --------
+        QTile.transform
+            for details on the transform for a single `(Q, frequency)` tile
+        """
+        out = []
+        for qtile in self:
+            # get energy from transform
+            out.append(qtile.transform(fseries, normalized=normalized,
+                                       epoch=epoch))
+        return self.frequencies, out
+
 
 class QTile(QBase):
     """Representation of a tile with fixed Q and frequency

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -136,7 +136,7 @@ class QPlane(QBase):
     """Iterable representation of a Q-transform plane
 
     For a given Q, an array of frequencies can be iterated over, yielding
-    a `QRow` each time.
+    a `QTile` each time.
 
     Parameters
     ----------
@@ -163,11 +163,11 @@ class QPlane(QBase):
     def __iter__(self):
         """Iterate over this `QPlane`
 
-        Yields a `QRow` at each frequency
+        Yields a `QTile` at each frequency
         """
-        # for each frequency, yield a QRow
+        # for each frequency, yield a QTile
         for f in self._iter_frequencies():
-            yield QRow(self.q, f, self.duration, self.sampling,
+            yield QTile(self.q, f, self.duration, self.sampling,
                        mismatch=self.mismatch)
         raise StopIteration()
 
@@ -180,7 +180,7 @@ class QPlane(QBase):
         nfreq = int(max(1, ceil(fcum_mismatch / self.deltam)))
         fstep = fcum_mismatch / nfreq
         fstepmin = 1 / self.duration
-        # for each frequency, yield a QRow
+        # for each frequency, yield a QTile
         for i in xrange(nfreq):
             yield (minf * exp(2 / (2 + self.q**2)**(1/2.) * (i + .5) * fstep)
                  // fstepmin * fstepmin)
@@ -205,11 +205,11 @@ class QPlane(QBase):
         return f - bandwidths / 2.
 
 
-class QRow(QBase):
-    """Representation of a set of tiles with fixed Q and frequency
+class QTile(QBase):
+    """Representation of a tile with fixed Q and frequency
     """
     def __init__(self, q, frequency, duration, sampling, mismatch=.2):
-        super(QRow, self).__init__(q, duration, sampling, mismatch=mismatch)
+        super(QTile, self).__init__(q, duration, sampling, mismatch=mismatch)
         self.frequency = frequency
 
     @property

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -277,6 +277,22 @@ class QTile(QBase):
 
     def transform(self, fseries, epoch=None):
         """Calculate the energy `TimeSeries` for the given fseries
+
+        Parameters
+        ----------
+        fseries : `~gwpy.spectrum.Spectrum`
+            the complex FFT of a time-series data set
+        epoch : `~gwpy.time.LIGOTimeGPS`, `float`, optional
+            the epoch of these data, only used for metadata in the output
+            `TimeSeries`, and not requires if the input `fseries` has the
+            epoch populated.
+
+        Returns
+        -------
+        energy : `~gwpy.timeseries.TimeSeries`
+            a `TimeSeries` of the complex energy from the Q-transform of
+            this tile against the data. Basically just the raw output
+            of the :meth:`~numpy.fft.ifft`
         """
         windowed = fseries[self.get_data_indices()] * self.get_window()
         # pad data, move negative frequencies to the end, and IFFT

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1601,21 +1601,16 @@ class TimeSeries(TimeSeriesBase):
         peakq = None
         peakenergy = 0
 
-        # Q-transform data for each `(Q, frequency)` row
+        # Q-transform data for each `(Q, frequency)` tile
         for plane in planes:
             normenergies = []
-            for row in plane:
-                # window data
-                windowed = fdata[row.get_data_indices()] * row.get_window()
-                # pad data, move negative frequencies to the end, and IFFT
-                padded = numpy.pad(windowed, row.padding, mode='constant')
-                wenergy = npfft.ifftshift(padded)
-                cenergy = npfft.ifft(wenergy)
+            for qtile in plane:
+                # get energy from transform
+                cenergy = qtile.transform(fdata, epoch=self.x0)
                 # calculate normalized energy
                 energy = TimeSeries(
-                    cenergy.real ** 2. + cenergy.imag ** 2.,
-                    x0=self.x0, dx=self.duration/cenergy.size,
-                    copy=False)
+                    cenergy.value.real ** 2. + cenergy.value.imag ** 2.,
+                    x0=cenergy.x0, dx=cenergy.dx, copy=False)
                 meanenergy = energy.mean()
                 normenergies.append(energy / meanenergy)
                 # calculate the peak energy


### PR DESCRIPTION
This PR introduces `transform` instance methods for both the `QPlane` and `QTile` (formerly `QRow`) objects, and uses them in the `TimeSeries.q_transform` method to simplify it.

This should make it easier for the user to transform over a single `QTile` if they want, but doesn't quite provide the nice spectrogram interpolations to get all the way to the end.