### PR TITLE
Fixed missing import

### DIFF
--- a/gwpy/plotter/frequencyseries.py
+++ b/gwpy/plotter/frequencyseries.py
@@ -21,6 +21,8 @@
 """
 
 import copy
+import warnings
+
 import numpy
 
 from matplotlib.projections import register_projection


### PR DESCRIPTION
This PR fixes a missing `warnings` module import in `gwpy.plotter.frequencyseries`.