### PR TITLE
Fixed reading timeseries from cache file path

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -23,6 +23,7 @@ from __future__ import division
 from math import ceil
 from multiprocessing import (cpu_count, Process, Queue as ProcessQueue)
 from six import string_types
+import tempfile
 import warnings
 
 from glue.lal import (Cache, CacheEntry)
@@ -35,6 +36,14 @@ from .utils import GzipFile
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __version__ = version.version
+
+# build list of file-like types
+FILE_LIKE = [file, GzipFile]
+try:  # protect against private member being removed
+    FILE_LIKE.append(tempfile._TemporaryFileWrapper)
+except AttributeError:
+    pass
+FILE_LIKE = tuple(FILE_LIKE)
 
 
 def open_cache(lcf):
@@ -74,7 +83,7 @@ def file_list(flist):
         if the input `flist` cannot be interpreted as any of the above inputs
     """
     # detect open files
-    if isinstance(flist, (file, GzipFile)):
+    if isinstance(flist, FILE_LIKE):
         flist = flist.name
     # then format list of file paths
     if isinstance(flist, CacheEntry):

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -73,10 +73,11 @@ def file_list(flist):
     ValueError
         if the input `flist` cannot be interpreted as any of the above inputs
     """
-    # format list of files
+    # detect open files
     if isinstance(flist, (file, GzipFile)):
-        return [flist.name]
-    elif isinstance(flist, CacheEntry):
+        flist = flist.name
+    # then format list of file paths
+    if isinstance(flist, CacheEntry):
         return [flist.path]
     elif (isinstance(flist, string_types) and
           flist.endswith(('.cache', '.lcf'))):

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -160,6 +160,18 @@ class TimeSeriesTestMixin(object):
     def test_frame_read_framecpp(self):
         return self._test_frame_read_format('framecpp')
 
+    def test_frame_read_cache(self):
+        try:
+            a = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel)
+        except Exception as e:  # don't care why this fails for this test
+            self.skipTest(str(e))
+        c = Cache.from_urls([TEST_GWF_FILE])
+        with tempfile.NamedTemporaryFile(suffix='.lcf', delete=False) as f:
+            c.tofile(f)
+            f.delete = True
+            b = self.TEST_CLASS.read(f.name, self.channel)
+            self.assertArraysEqual(a, b)
+
     def frame_write(self, format=None):
         try:
             ts = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -171,6 +171,8 @@ class TimeSeriesTestMixin(object):
             f.delete = True
             b = self.TEST_CLASS.read(f.name, self.channel)
             self.assertArraysEqual(a, b)
+            b = self.TEST_CLASS.read(f, self.channel)
+            self.assertArraysEqual(a, b)
 
     def frame_write(self, format=None):
         try:


### PR DESCRIPTION
This PR fixes bugs in the handling of cache files underneath `TimeSeries.read`. Astropy insists on opening the cache file, then passing it through the identifiers, so we need to handle open cache files (including temporary files) before passing on to the GWF reader.