### PR TITLE
Allow DataQualityDict.populate to skip failed downloads

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1229,7 +1229,7 @@ class DataQualityDict(OrderedDict):
     write = writer()
 
     def populate(self, source='https://segments.ligo.org',
-                 segments=None, pad=True, **kwargs):
+                 segments=None, pad=True, on_error='raise', **kwargs):
         """Query the segment database for each flag's active segments.
 
         This method assumes all of the metadata for each flag have been
@@ -1259,6 +1259,13 @@ class DataQualityDict(OrderedDict):
             apply the `~DataQualityFlag.padding` associated with each
             flag, default: `True`.
 
+        on_error : `str`
+            how to handle an error querying for one flag, one of
+
+            - `'raise'` (default): raise the Exception
+            - `'warn'`: print a warning
+            - `'ignore'`: move onto the next flag as if nothing happened
+
         **kwargs
             any other keyword arguments to be passed to
             :meth:`DataQualityFlag.query` or :meth:`DataQualityFlag.read`.
@@ -1268,19 +1275,33 @@ class DataQualityDict(OrderedDict):
         self : `DataQualityDict`
             a reference to the modified DataQualityDict
         """
+        # check on_error flag
+        if on_error not in ['raise', 'warn', 'ignore']:
+            raise ValueError("on_error must be one of 'raise', 'warn', "
+                             "or 'ignore'")
         # format source
         source = urlparse(source)
         # perform query for all segments
         if source.netloc and segments is not None:
             segments = SegmentList(map(Segment, segments))
-            tmp = type(self).query(self.keys(), segments,
-                                   url=source.geturl(), **kwargs)
+            tmp = type(self).query(self.keys(), segments, url=source.geturl(),
+                                   on_error=on_error, **kwargs)
         elif not source.netloc:
             tmp = type(self).read(source.geturl(), self.name, **kwargs)
         # apply padding and wrap to given known segments
         for key in self:
             if segments is None and source.netloc:
-                tmp = {key: self[key].query(self[key].name, self[key].known)}
+                try:
+                    tmp = {key: self[key].query(
+                        self[key].name, self[key].known, **kwargs)}
+                except URLError as e:
+                    if on_error == 'ignore':
+                        pass
+                    elif on_error == 'warn':
+                        warnings.warn('Error querying for %s: %s' % (key, e))
+                    else:
+                        raise
+                    continue
             self[key].known &= tmp[key].known
             self[key].active = tmp[key].active
             if pad:

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -37,6 +37,7 @@ from threading import Thread
 from Queue import Queue
 
 from six.moves.urllib import request
+from six.moves.urllib.error import URLError
 
 from numpy import inf
 
@@ -499,9 +500,13 @@ class DataQualityFlag(object):
                     start, end)
                 metadata = versions[-1]['metadata']
             else:
-                data, _ = apicalls.dqsegdbQueryTimes(
-                    protocol, server, out.ifo, out.tag, out.version, request,
-                    start, end)
+                try:
+                    data, _ = apicalls.dqsegdbQueryTimes(
+                        protocol, server, out.ifo, out.tag, out.version,
+                        request, start, end)
+                except URLError as e:
+                    e.args = ('Error querying for %s: %s' % (flag, e),)
+                    raise
                 metadata = data['metadata']
             new = cls(name=flag)
             for s2 in data['active']:

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -22,8 +22,10 @@
 import os.path
 import tempfile
 import StringIO
+
 from six import PY3
-from urllib2 import (urlopen, URLError)
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.error import URLError
 
 import pytest
 
@@ -125,8 +127,14 @@ class TestCaseWithQueryMixin(object):
     def _query(self, cm, *args, **kwargs):
         try:
             return cm(*args, **kwargs)
-        except (ImportError, URLError, LDBDClientException) as e:
+        except (ImportError, UnboundLocalError, LDBDClientException,
+                SystemExit) as e:
             self.skipTest(str(e))
+        except URLError as e:
+            if e.code == 401:
+                self.skipTest(str(e))
+            else:
+                raise
         except AttributeError as e:
             if 'PKCS5_SALT_LEN' in str(e):
                 self.skipTest(str(e))

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -489,21 +489,36 @@ class DataQualityDictTests(unittest.TestCase, TestCaseWithQueryMixin):
         common.test_io_identify(DataQualityDict, ['xml', 'xml.gz'])
 
     def test_populate(self):
+        # read veto definer
         start, end = VETO_DEFINER_TEST_SEGMENTS[0]
         vdf = DataQualityDict.from_veto_definer_file(
             VETO_DEFINER_FILE, ifo='H1', start=start, end=end)
-        vdf.pop("H1:FAKE_CAT5:1", None)
+        # test query that should fail with 404
         try:
             vdf.populate(url='https://segments.ligo.org')
-        except ImportError as e:
+        except (ImportError, UnboundLocalError) as e:
             self.skipTest(str(e))
+        except URLError as e:
+            if e.code == 401:  # 401 is uninformative
+                self.skipTest(str(e))
+            elif e.code == 404:
+                pass
+            else:
+                raise
         else:
-            self.assertEqual(
-                len(vdf['H1:HVT-ER7_A_RND17:1'].active), 36)
-            vdf = DataQualityDict.from_veto_definer_file(
-                VETO_DEFINER_FILE, ifo='H1')
-            vdf.pop("H1:FAKE_CAT5:1", None)
-            vdf.populate(segments=VETO_DEFINER_TEST_SEGMENTS)
+            raise AssertionError("URLError not raised")
+        # check reduction to warning
+        vdf = DataQualityDict.from_veto_definer_file(
+            VETO_DEFINER_FILE, ifo='H1', start=start, end=end)
+        with pytest.warns(UserWarning):
+            vdf.populate(url='https://segments.ligo.org', on_error='warn')
+        # check results
+        self.assertEqual(
+            len(vdf['H1:HVT-ER7_A_RND17:1'].active), 36)
+        # check use of specific segments
+        vdf = DataQualityDict.from_veto_definer_file(
+            VETO_DEFINER_FILE, ifo='H1')
+        vdf.populate(segments=VETO_DEFINER_TEST_SEGMENTS, on_error='ignore')
 
     def test_query(self):
         result = self._query(DataQualityDict.query,


### PR DESCRIPTION
This PR introduces an explicit `on_error` kwarg for `DataQualityDict.populate` to skip over failed flag queries. Also included are improvements of the tests for this method, and of segment tests in general.