### PR TITLE
Add minimal python-only build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,12 @@ env:
 matrix:
   include:
     - python: 2.6
-      env: STRICT=false
     - python: 2.7
-      env: STRICT=false
     - python: 3.5
-      env: STRICT=false
     - python: 2.7
       env: STRICT=true PRE="--pre"
+    - python: 2.7
+      env: MINIMAL=true
   allow_failures:
     - python: 2.7
       env: STRICT=true PRE="--pre"

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
   include:
     - python: 2.6
     - python: 2.7
-    - env: STRICT=false
+      env: STRICT=false
     - python: 2.7  # test latest release of upstream packages
       env: STRICT=true PRE="--pre"
     - python: 2.7  # python-only build

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,16 +44,16 @@ matrix:
   include:
     - python: 2.6
     - python: 2.7
-    - python: 3.5
-    - python: 2.7
+    - env: STRICT=false
+    - python: 2.7  # test latest release of upstream packages
       env: STRICT=true PRE="--pre"
-    - python: 2.7
+    - python: 2.7  # python-only build
       env: MINIMAL=true
+    - python: 3.5
   allow_failures:
     - python: 2.7
       env: STRICT=true PRE="--pre"
     - python: 3.5
-      env: STRICT=false
   fast_finish: true
 
 before_install:

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# don't install if doing a 'minimal' build
+[[ "$MINIMAL" = true ]] && return
+
 # set paths for PKG_CONFIG
 export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
 

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -233,7 +233,7 @@ def channel_in_frame(channel, framefile):
     name = str(channel)
     try:
         out = shell.call(['FrChannels', framefile])[0]
-    except shell.CalledProcessError:
+    except (OSError, shell.CalledProcessError):
         return get_channel_type(channel, framefile) is not False
     else:
         for line in out.splitlines():

--- a/gwpy/tests/test_cli.py
+++ b/gwpy/tests/test_cli.py
@@ -24,6 +24,8 @@ import tempfile
 import importlib
 import argparse
 
+from numpy import random
+
 from matplotlib import use
 use('agg')
 
@@ -80,12 +82,14 @@ class CliTestMixin(object):
         except (RuntimeError, ImportError):
             product.timeseries = []
             product.time_groups = []
+            product.start_list = []
             for s in args.start:
+                product.start_list.append(int(s))
                 product.time_groups.append([])
                 for c in args.chan:
                     product.timeseries.append(
-                        TimeSeries(range(1000), sample_rate=10, channel=c,
-                                   epoch=s))
+                        TimeSeries(random.random(1024 * 100), sample_rate=1024,
+                                   channel=c, epoch=s))
                     product.time_groups[-1].append(len(product.timeseries)-1)
         return product, args
 

--- a/gwpy/tests/test_cli.py
+++ b/gwpy/tests/test_cli.py
@@ -70,7 +70,13 @@ class CliTestMixin(object):
         product, parser = self.test_init_cli()
         args = parser.parse_args(self.TEST_ARGS + ['--out', TEMP_PLOT_FILE])
         try:
-            product.getTimeSeries(args)
+            try:
+                product.getTimeSeries(args)
+            except Exception as e:
+                if 'No reader' in str(e):
+                    raise RuntimeError(str(e))
+                else:
+                    raise
         except (RuntimeError, ImportError):
             product.timeseries = []
             product.time_groups = []

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -164,17 +164,27 @@ class CacheIoTestCase(unittest.TestCase):
 
 class DataFindIoTestCase(unittest.TestCase):
     def test_num_channels(self):
-        self.assertEqual(datafind.num_channels(TEST_GWF_FILE), 3)
+        try:
+            self.assertEqual(datafind.num_channels(TEST_GWF_FILE), 3)
+        except ImportError as e:
+            self.skipTest(str(e))
 
     def test_get_channel_type(self):
-        self.assertEqual(
-            datafind.get_channel_type('L1:LDAS-STRAIN', TEST_GWF_FILE), 'proc')
+        try:
+            self.assertEqual(datafind.get_channel_type(
+                'L1:LDAS-STRAIN', TEST_GWF_FILE), 'proc')
+        except ImportError as e:
+            self.skipTest(str(e))
 
     def test_channel_in_frame(self):
-        self.assertTrue(
-            datafind.channel_in_frame('L1:LDAS-STRAIN', TEST_GWF_FILE))
-        self.assertFalse(
-            datafind.channel_in_frame('X1:NOT-IN_FRAME', TEST_GWF_FILE))
+        try:
+            self.assertTrue(
+                datafind.channel_in_frame('L1:LDAS-STRAIN', TEST_GWF_FILE))
+        except ImportError as e:
+            self.skipTest(str(e))
+        else:
+            self.assertFalse(
+                datafind.channel_in_frame('X1:NOT-IN_FRAME', TEST_GWF_FILE))
 
     def test_on_tape(self):
         self.assertFalse(datafind.on_tape(TEST_GWF_FILE))

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -180,6 +180,11 @@ class TimeSeriesTestMixin(object):
     def frame_write(self, format=None):
         try:
             ts = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel)
+        except Exception as e:
+            if 'No reader' in str(e):
+                self.skipTest(str(e))
+            else:
+                raise
         except ImportError as e:
             self.skipTest(str(e))
         else:
@@ -598,11 +603,11 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         except (ImportError, RuntimeError) as e:
             self.skipTest(str(e))
         else:
-            qspecgram = ts.q_transform()
+            qspecgram = ts.q_transform(method='welch')
             self.assertIsInstance(qspecgram, Spectrogram)
             self.assertTupleEqual(qspecgram.shape, (32000, 2560))
             self.assertAlmostEqual(qspecgram.q, 11.31370849898476)
-            self.assertAlmostEqual(qspecgram.value.max(), 37.157012691452067)
+            self.assertAlmostEqual(qspecgram.value.max(), 37.035843858490509)
 
 
 class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):
@@ -668,6 +673,11 @@ class TimeSeriesDictTestCase(unittest.TestCase):
             try:
                 self._test_data = self.TEST_CLASS.read(
                     TEST_GWF_FILE, self.channels)
+            except Exception as e:
+                if 'No reader' in str(e):
+                    self.skipTest(str(e))
+                else:
+                    raise
             except ImportError as e:
                 self.skipTest(str(e))
             else:
@@ -677,11 +687,22 @@ class TimeSeriesDictTestCase(unittest.TestCase):
         tsd = self.TEST_CLASS()
 
     def test_frame_read(self):
-        return self.TEST_CLASS.read(TEST_GWF_FILE, self.channels)
+        try:
+            return self.TEST_CLASS.read(TEST_GWF_FILE, self.channels)
+        except Exception as e:
+            if 'No reader' in str(e):
+                self.skipTest(str(e))
+            else:
+                raise
 
     def test_frame_write(self):
         try:
             tsd = self.test_frame_read()
+        except Exception as e:
+            if 'No reader' in str(e):
+                self.skipTest(str(e))
+            else:
+                raise
         except ImportError as e:
             self.skipTest(str(e))
         else:


### PR DESCRIPTION
This PR adds another build to the travis-ci setup, skipping the src package builds in favour of testing only the pure python setup.

This is probably what most users outside of the LSC are going to be trying anyway.