### PR TITLE
Improved Channel.MATCH regex for GEO channel support

### DIFF
--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -91,9 +91,9 @@ class Channel(object):
         r'((?:(?P<ifo>[A-Z]\d))?|[\w-]+):'  # match IFO prefix
          '(?:(?P<system>[a-zA-Z0-9]+))?'  # match system
          '(?:[-_](?P<subsystem>[a-zA-Z0-9]+))?'  # match subsystem
-         '(?:_(?P<signal>[a-zA-Z0-9_]+))?'  # match signal
-         '(?:\.(?P<trend>[a-z]+))?'  # match trend type
-         '(?:,(?P<type>([a-z]-)?[a-z]+))?'  # match channel type
+         '(?:[-_](?P<signal>[a-zA-Z0-9_-]+?))?'  # match signal
+         '(?:[\.-](?P<trend>[a-z]+))?'  # match trend type
+         '(?:,(?P<type>([a-z]-)?[a-z]+))?$'  # match channel type
     )
 
     def __init__(self, name, sample_rate=None, unit=None, frequency_range=None,

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -85,6 +85,20 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(c.name, 'X1:TEST-CHANNEL_NAME_PARSING.rms')
         self.assertEqual(c.ndsname,
                          'X1:TEST-CHANNEL_NAME_PARSING.rms,m-trend')
+        # test parsing GEO channels
+        out = Channel.parse_channel_name("G1:PSL_SL_PWR-AMPL-OUTLP-av")
+        self.assertDictEqual(
+            out, {'ifo': 'G1', 'system': 'PSL', 'subsystem': 'SL',
+                  'signal': 'PWR-AMPL-OUTLP', 'trend': 'av', 'type': None})
+        # test virgo channels
+        out = Channel.parse_channel_name("V1:h_16384Hz")
+        self.assertDictEqual(
+            out, {'ifo': 'V1', 'system':'h', 'subsystem':'16384Hz',
+                  'signal': None, 'trend': None, 'type': None})
+        out = Channel.parse_channel_name("V1:Sa_PR_f0_zL_500Hz")
+        self.assertDictEqual(
+            out, {'ifo': 'V1', 'system':'Sa', 'subsystem':'PR',
+                  'signal': 'f0_zL_500Hz', 'trend': None, 'type': None})
 
     def test_property_frequency_range(self):
         new = Channel('test', frequency_range=(1, 40))


### PR DESCRIPTION
GEO and Virgo channels don't follow the same conventions as LIGO, but should be handled just the same. This PR modifies the `Channel.MATCH` regular expression specifically to allow dash-delimited channel-name components other than the first division, and to optional match a trailing `-[a-z]+` string as the trend type (GEO uses `-min` rather than `.min`, for example).

This might break if it turns out there are channels with a dash-delimited lowercase component that isn't the trend type, but I haven't come across an example of that to date.