### PR TITLE
Added filtfilt support in TimeSeries.filter

### DIFF
--- a/gwpy/signal/__init__.py
+++ b/gwpy/signal/__init__.py
@@ -22,3 +22,5 @@ applications.
 """
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+from .filter_design import *

--- a/gwpy/signal/__init__.py
+++ b/gwpy/signal/__init__.py
@@ -24,3 +24,4 @@ applications.
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 from .filter_design import *
+from .filter import *

--- a/gwpy/signal/filter.py
+++ b/gwpy/signal/filter.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2016)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extensions to `scipy.signal.signaltools`.
+"""
+
+from numpy import (asarray, reshape)
+
+from scipy.signal.signaltools import (sosfilt, sosfilt_zi)
+from scipy.signal._arraytools import (axis_slice, axis_reverse, odd_ext,
+                                      even_ext, const_ext)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def sosfiltfilt(sos, x, axis=-1, padtype='odd', padlen=0):
+    x = asarray(x)
+
+    # `method` is "pad"
+    if padtype not in ['even', 'odd', 'constant', None]:
+        raise ValueError(("Unknown value '%s' given to padtype.  padtype "
+                          "must be 'even', 'odd', 'constant', or None.") %
+                         padtype)
+
+    if padtype is None:
+        padlen = 0
+    if padlen is None:
+        edge = sos.shape[0] * 6
+    else:
+        edge = padlen
+
+    # x's 'axis' dimension must be bigger than edge.
+    if x.shape[axis] <= edge:
+        raise ValueError("The length of the input vector x must be at least "
+                         "padlen, which is %d." % edge)
+
+    if padtype is not None and edge > 0:
+        # Make an extension of length `edge` at each
+        # end of the input array.
+        if padtype == 'even':
+            ext = even_ext(x, edge, axis=axis)
+        elif padtype == 'odd':
+            ext = odd_ext(x, edge, axis=axis)
+        else:
+            ext = const_ext(x, edge, axis=axis)
+    else:
+        ext = x
+
+    # Get the steady state of the filter's step response.
+    zi = sosfilt_zi(sos)
+
+    # Reshape zi and create x0 so that zi*x0 broadcasts
+    # to the correct value for the 'zi' keyword argument
+    # to lfilter.
+    zi_shape = [1] * x.ndim
+    zi_shape[axis] = zi.size
+    zi = reshape(zi, zi_shape)
+    x0 = axis_slice(ext, stop=1, axis=axis)
+    zix0 = reshape(zi * x0, (sos.shape[0], 2))
+
+    # Forward filter
+    (y, zf) = sosfilt(sos, ext, axis=axis, zi=zix0)
+
+    # Backward filter
+    # Create y0 so zi*y0 broadcasts appropriately.
+    y0 = axis_slice(y, start=-1, axis=axis)
+    ziy0 = reshape(zi * y0, (sos.shape[0], 2))
+
+    (y, zf) = sosfilt(sos, axis_reverse(y, axis=axis), axis=axis, zi=ziy0)
+
+    # Reverse y
+    y = axis_reverse(y, axis=axis)
+
+    if edge > 0:
+        # Slice the actual signal from the extended signal.
+        y = axis_slice(y, start=edge, stop=-edge, axis=axis)
+
+    return y

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -28,7 +28,7 @@ from astropy.units import Quantity
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 
-def create_notch(frequency, sample_rate, type='iir', **kwargs):
+def notch(frequency, sample_rate, type='iir', **kwargs):
     """Design a ZPK notch filter for the given frequency and sampling rate
 
     Parameters

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit test for signal module
+"""
+
+from compat import unittest
+
+import numpy
+from numpy import testing as nptest
+
+from scipy import signal
+
+from gwpy import signal as gwpy_signal
+
+# filtering test outputs
+NOTCH_60HZ = (
+    numpy.asarray([ 0.99973536+0.02300468j,  0.99973536-0.02300468j]),
+    numpy.asarray([ 0.99954635-0.02299956j,  0.99954635+0.02299956j]),
+    0.99981094420429639,
+)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+# -----------------------------------------------------------------------------
+
+class FilterDesignTestCase(unittest.TestCase):
+    """`~unittest.TestCase` for the `gwpy.signal.filter_design` module
+    """
+    def test_notch_design(self):
+        # test simple notch
+        notch = gwpy_signal.notch(60, 16384)
+        for a, b in zip(notch, NOTCH_60HZ):
+            nptest.assert_array_almost_equal(a, b)
+        # test Quantities
+        notch2 = create_notch(60 * ONE_HZ, 16384 * ONE_HZ)
+        for a, b in zip(notch, notch2):
+            nptest.assert_array_almost_equal(a, b)

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -26,9 +26,12 @@ from numpy import testing as nptest
 
 from scipy import signal
 
+from astropy import units
+
 from gwpy import signal as gwpy_signal
 
-# filtering test outputs
+ONE_HZ = units.Quantity(1, 'Hz')
+
 NOTCH_60HZ = (
     numpy.asarray([ 0.99973536+0.02300468j,  0.99973536-0.02300468j]),
     numpy.asarray([ 0.99954635-0.02299956j,  0.99954635+0.02299956j]),
@@ -45,10 +48,10 @@ class FilterDesignTestCase(unittest.TestCase):
     """
     def test_notch_design(self):
         # test simple notch
-        notch = gwpy_signal.notch(60, 16384)
-        for a, b in zip(notch, NOTCH_60HZ):
+        zpk = gwpy_signal.notch(60, 16384)
+        for a, b in zip(zpk, NOTCH_60HZ):
             nptest.assert_array_almost_equal(a, b)
         # test Quantities
-        notch2 = create_notch(60 * ONE_HZ, 16384 * ONE_HZ)
-        for a, b in zip(notch, notch2):
+        zpk2 = gwpy_signal.notch(60 * ONE_HZ, 16384 * ONE_HZ)
+        for a, b in zip(zpk, zpk2):
             nptest.assert_array_almost_equal(a, b)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -92,13 +92,6 @@ LOSC_DQ_BITS = [
 ]
 LOSC_GW150914 = 1126259462
 
-# filtering test outputs
-NOTCH_60HZ = (
-    numpy.asarray([ 0.99973536+0.02300468j,  0.99973536-0.02300468j]),
-    numpy.asarray([ 0.99954635-0.02299956j,  0.99954635+0.02299956j]),
-    0.99981094420429639,
-)
-
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
@@ -568,17 +561,6 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         # test method not 'welch' raises warning
         with pytest.warns(UserWarning):
            ts.csd_spectrogram(ts, 0.5, method='median-mean')
-
-    def test_notch_design(self):
-        # test simple notch
-        from gwpy.timeseries.filter import create_notch
-        notch = create_notch(60, 16384)
-        for a, b in zip(notch, NOTCH_60HZ):
-            nptest.assert_array_almost_equal(a, b)
-        # test Quantities
-        notch2 = create_notch(60 * ONE_HZ, 16384 * ONE_HZ)
-        for a, b in zip(notch, notch2):
-            nptest.assert_array_almost_equal(a, b)
 
     def test_notch(self):
         # test notch runs end-to-end

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -269,8 +269,9 @@ class TimeSeriesTestMixin(object):
         """Test the `TimeSeries.resample` method
         """
         ts1 = self.create(sample_rate=100)
-        ts2 = ts1.resample(10)
+        ts2 = ts1.resample(10, ftype='iir')
         self.assertEquals(ts2.sample_rate, ONE_HZ*10)
+        ts1.resample(10, ftype='fir', n=10)
 
     def test_to_from_lal(self):
         ts = self.create()

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -642,6 +642,11 @@ class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):
         self.assertIsInstance(b, Array2D)
         self.assertTupleEqual(b.shape, (data.size, len(data.bits)))
 
+    def test_resample(self):
+        ts1 = self.create(sample_rate=100)
+        ts2 = ts1.resample(10)
+        self.assertEquals(ts2.sample_rate, ONE_HZ*10)
+
 
 # -- TimeSeriesDict tests ------------------------------------------------------
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1030,11 +1030,12 @@ class TimeSeries(TimeSeriesBase):
             rate to which to resample this `Series`
         window : array_like, callable, string, float, or tuple, optional
             specifies the window applied to the signal in the Fourier
-            domain.
-        numtaps : `int`, default: ``61``
-            length of the filter (number of coefficients, i.e. the filter
-            order + 1). This option is only valid for an integer-scale
-            downsampling.
+            domain, only used for `ftype='fir'` or irregular downsampling
+        ftype : `str`, optional
+            type of filter, either 'fir' or 'iir', defaults to 'fir'
+        n : `int`, optional
+            if `ftype='fir'` the number of taps in the filter, otherwise
+            the order of the Chebyshev type I IIR filter
 
         Returns
         -------

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -33,12 +33,12 @@ from astropy import units
 
 from ..io import (reader, writer)
 from ..segments import Segment
+from ..signal import notch
 from ..utils import with_import
 from ..utils.docstring import interpolate_docstring
 from ..utils.compat import OrderedDict
 from .core import (TimeSeriesBase, TimeSeriesBaseDict, TimeSeriesBaseList,
                    as_series_dict_class)
-from .filter import create_notch
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -1524,8 +1524,7 @@ class TimeSeries(TimeSeriesBase):
         scipy.signal.iirdesign
             for details on the IIR filter design method
         """
-        zpk = create_notch(frequency, self.sample_rate.value,
-                           type=type, **kwargs)
+        zpk = notch(frequency, self.sample_rate.value, type=type, **kwargs)
         return self.filter(*zpk)
 
     def q_transform(self, qrange=(4, 64), frange=(0, numpy.inf),


### PR DESCRIPTION
This PR addes a `filtfilt` kwarg to the `TimeSeries.filter` method, whilst also shuffling a few things in `gwpy.signal`.

This includes a quick `sosfiltfilt` implementation that can be removed whenever such a function becomes available.