### PR TITLE
Added row and column class refernences to Array2D

### DIFF
--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -274,7 +274,6 @@ class Array2D(Series):
         except IndexError as e:
             e.args = ("Value %r not found in array yindex",)
             raise
-        print(idx, idy)
         return self[idx, idy]
 
     # -------------------------------------------

--- a/gwpy/data/array2d.py
+++ b/gwpy/data/array2d.py
@@ -65,6 +65,8 @@ class Array2D(Series):
     _metadata_slots = Series._metadata_slots + ['y0', 'dy', 'yindex']
     _default_xunit = Unit('')
     _default_yunit = Unit('')
+    _rowclass = Series
+    _columnclass = Series
     _ndim = 2
 
     def __new__(cls, data, unit=None, xindex=None, yindex=None, x0=0,
@@ -101,10 +103,12 @@ class Array2D(Series):
             return Quantity(new, unit=self.unit)
         # unwrap a Series
         if len(new.shape) == 1:
-            new = new.view(Series)
             if isinstance(x, (float, int)):
+                new = new.view(self._columnclass)
                 new.dx = self.dy
                 new.x0 = self.y0
+            else:
+                new = new.view(self._rowclass)
         # unwrap a Spectrogram
         else:
             new = new.value.view(type(self))

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -40,6 +40,7 @@ class SpectralVariance(Array2D):
     """
     _metadata_slots = FrequencySeries._metadata_slots + ['bins']
     _default_xunit = FrequencySeries._default_xunit
+    _rowclass = FrequencySeries
 
     def __new__(cls, data, bins, name=None, channel=None, epoch=None, unit=None,
                 f0=0, df=1, **kwargs):

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -139,10 +139,21 @@ class SpectralVariance(Array2D):
     # SpectralVariance methods
 
     def __getitem__(self, item):
-        if isinstance(item, tuple) and len(item) == 2:
+        if isinstance(item, int):
+            out = self.value[item].view(self._columnclass)
+            out.unit = self.unit
+            try:
+                out.xindex = self.yindex
+            except AttributeError:
+                pass
+            return out
+        if isinstance(item, tuple) and item[0] == slice(None, None, None):
+            out = self.value.__getitem__(item).view(self._rowclass)
+            out.xindex = self.xindex
+            return out
+        if (isinstance(item, tuple) and len(item) == 2):
             return self[item[0]][item[1]]
-        else:
-            return super(SpectralVariance, self).__getitem__(item)
+        return super(SpectralVariance, self).__getitem__(item)
     __getitem__.__doc__ = Array2D.__getitem__.__doc__
 
     @classmethod

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -69,6 +69,8 @@ class Spectrogram(Array2D):
     _metadata_slots = ['name', 'channel', 'epoch', 'dt', 'f0', 'df']
     _default_xunit = TimeSeries._default_xunit
     _default_yunit = FrequencySeries._default_xunit
+    _rowclass = TimeSeries
+    _columnclass = FrequencySeries
 
     def __new__(cls, data, unit=None, name=None, channel=None, epoch=None,
                 dt=None, times=None, f0=None, df=None, frequencies=None,

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -387,10 +387,11 @@ class Array2DTestCase(CommonTests, unittest.TestCase):
         a = self.create()
         self.assertEqual(a[0, 0], a[0][0])
         nptest.assert_array_equal(a[0].value, a.value[0])
-        self.assertIsInstance(a[0], Series)
+        self.assertIsInstance(a[0], self.TEST_CLASS._columnclass)
         self.assertIsInstance(a[0][0], units.Quantity)
         self.assertEqual(a[0].unit, a.unit)
         self.assertEqual(a[0][0].unit, a.unit)
+        self.assertIsInstance(a[:,0], self.TEST_CLASS._rowclass)
 
     def test_value_at(self):
         ts1 = self.create(dx=.5, dy=.25, unit='m')


### PR DESCRIPTION
This PR introduces two new private class variables for the Array2D

- `_rowclass`
- `_columnclass`

which are used by `Array2D.__getitem__` to decide how to return items from the 2-d array.