### PR TITLE
Fixed missing channel parameters in TimeSeries.read(format='framecpp')

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -105,16 +105,16 @@ class TimeSeriesTestMixin(object):
     def test_creation_with_metadata(self):
         self.ts = self.create()
         repr(self.ts)
-        self.assertTrue(self.ts.epoch == GPS_EPOCH)
-        self.assertTrue(self.ts.sample_rate == ONE_HZ)
-        self.assertTrue(self.ts.dt == ONE_SECOND)
+        self.assertEqual(self.ts.epoch, GPS_EPOCH)
+        self.assertEqual(self.ts.sample_rate, ONE_HZ)
+        self.assertEqual(self.ts.dt, ONE_SECOND)
 
     def frame_read(self, format=None):
         ts = self.TEST_CLASS.read(
             TEST_GWF_FILE, self.channel, format=format)
-        self.assertTrue(ts.epoch == Time(968654552, format='gps', scale='utc'))
-        self.assertTrue(ts.sample_rate == units.Quantity(16384, 'Hz'))
-        self.assertTrue(ts.unit == units.Unit('strain'))
+        self.assertEqual(ts.epoch, Time(968654552, format='gps', scale='utc'))
+        self.assertEqual(ts.sample_rate, units.Quantity(16384, 'Hz'))
+        self.assertEqual(ts.unit, units.Unit('strain'))
         # check that channel carries the correct parameters
         self.assertEqual(ts.channel.sample_rate, ts.sample_rate)
         self.assertEqual(ts.channel.unit, ts.unit)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -115,6 +115,9 @@ class TimeSeriesTestMixin(object):
         self.assertTrue(ts.epoch == Time(968654552, format='gps', scale='utc'))
         self.assertTrue(ts.sample_rate == units.Quantity(16384, 'Hz'))
         self.assertTrue(ts.unit == units.Unit('strain'))
+        # check that channel carries the correct parameters
+        self.assertEqual(ts.channel.sample_rate, ts.sample_rate)
+        self.assertEqual(ts.channel.unit, ts.unit)
         return ts
 
     def test_epoch(self):

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -179,6 +179,8 @@ def read_timeseriesdict(source, channels, start=None, end=None, type=None,
                % (verbose, len(channels), N, N))
     # finalise
     for channel, ts in out.iteritems():
+        ts.channel.sample_rate = ts.sample_rate
+        ts.channel.unit = ts.unit
         ts.channel.frametype = frametype
         # resample data
         if resample is not None and channel in resample:

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -181,7 +181,7 @@ def from_lal_unit(lunit):
         lunit = lal.Unit(lunit)
     except RuntimeError:
         raise TypeError("Cannot convert %r to lal.Unit" % lunit)
-    aunit = None
+    aunit = units.Unit("")
     for power, lalbase in zip(lunit.unitNumerator, LAL_UNIT_INDEX):
         # if not used, continue
         if not power:
@@ -192,10 +192,7 @@ def from_lal_unit(lunit):
         except ValueError:
             raise ValueError("Astropy has no unit corresponding to %r"
                              % lalbase)
-        if aunit is None:
-            aunit = u ** power
-        else:
-            aunit *= u ** power
+        aunit *= u ** power
     return aunit
 
 


### PR DESCRIPTION
This PR fixes a bug in reading frames using frameCPP where channel parameters in the output `TimeSeries` were not set properly.