### PR TITLE
Expand use of numpy.recarray for tabular data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,9 @@ before_install:
   # install testing dependencies
   - pip install -q ${PRE} coveralls "pytest>=2.8" unittest2
 
+  # need to install astropy 1.1 specifically for py26
+  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
+
 install:
   - pip install ${PRE} -r requirements.txt
   - python setup.py build

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -26,6 +26,9 @@ from six import string_types
 import tempfile
 import warnings
 
+from numpy import recarray
+from numpy.lib import recfunctions
+
 from glue.lal import (Cache, CacheEntry)
 from glue.ligolw.table import Table
 
@@ -194,6 +197,8 @@ def read_cache(cache, target, nproc, post, *args, **kwargs):
     queue = ProcessQueue(nproc)
     proclist = []
     for i, subcache in enumerate(subcaches):
+        if len(subcache) == 0:
+            continue
         process = Process(target=_read, args=(queue, subcache, i))
         process.daemon = True
         proclist.append(process)
@@ -211,15 +216,19 @@ def read_cache(cache, target, nproc, post, *args, **kwargs):
 
     # combine and return
     data = zip(*sorted(pout, key=lambda out: out[0]))[1]
-    try:
-        if issubclass(target, Table):
+    if issubclass(target, recarray):
+        out = recfunctions.stack_arrays(data, asrecarray=True,
+                                        usemask=False).view(target)
+    else:
+        try:
+            if issubclass(target, Table):
+                out = data[0]
+            else:
+                out = data[0].copy()
+        except AttributeError:
             out = data[0]
-        else:
-            out = data[0].copy()
-    except AttributeError:
-        out = data[0]
-    for datum in data[1:]:
-        out += datum
+        for datum in data[1:]:
+            out += datum
 
     if post:
         return post(out)

--- a/gwpy/table/__init__.py
+++ b/gwpy/table/__init__.py
@@ -45,9 +45,11 @@ warnings.filterwarnings('ignore', 'column name', UserWarning)
 from glue.ligolw.ligolw import (Column, Document)
 from glue.ligolw.table import Table
 
+# import custom recarray
+from .rec import GWRecArray
+
 # import all tables
 from . import lsctables
-
 
 # attach unified I/O
 from .io import *
@@ -57,4 +59,4 @@ from .rate import (event_rate, binned_event_rates)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Kipp Cannon <kipp.cannon@ligo.org>'
-__all__ = ['Column', 'Document', 'Table', 'lsctables']
+__all__ = ['Column', 'Document', 'Table', 'lsctables', 'GWRecArray']

--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -37,3 +37,6 @@ from .omega import *
 
 # import cWB I/O
 from .cwb import *
+
+# import PyCBC live I/O
+from .pycbc import *

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2013-2016)
 #
 # This file is part of GWpy.
 #
@@ -19,11 +19,15 @@
 """Read LIGO_LW documents into glue.ligolw.table.Table objects.
 """
 
+import warnings
+
 from glue.ligolw.table import StripTableName as strip
 from glue.ligolw.lsctables import TableByName
 
 from ...io import registry
+from ...io.cache import (read_cache, file_list)
 from ...io.ligolw import (table_from_file, identify_ligolw)
+from .. import GWRecArray
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __all__ = []
@@ -32,15 +36,38 @@ __all__ = []
 def read_table_factory(table_):
     """Define a custom function to read this table from a LIGO_LW file.
     """
-    def _read(f, *args, **kwargs):
+    def _read_ligolw(f, *args, **kwargs):
         return table_from_file(f, table_.tableName, *args, **kwargs)
-    return _read
+
+    def _read_recarray(f, *args, **kwargs):
+        # set up keyword arguments
+        reckwargs = {
+            'on_attributeerror': 'raise',
+            'get_as_columns': False
+        }
+        for key in reckwargs:
+            if key in kwargs:
+                reckwargs[key] = kwargs.pop(key)
+        # handle multiprocessing
+        nproc = kwargs.pop('nproc', 1)
+        if nproc > 1:
+            kwargs['format'] = strip(table_.tableName)
+            return read_cache(file_list(f), GWRecArray, nproc, None,
+                              *args, **kwargs)
+
+        return table_from_file(f, table_.tableName,
+                               *args, **kwargs).to_recarray(**reckwargs)
+
+    return _read_ligolw, _read_recarray
+
 
 # register reader and auto-id for LIGO_LW
 for table in TableByName.itervalues():
     tablename = strip(table.tableName)
-    func = read_table_factory(table)
-    # register generic reader and table-specific reader
-    registry.register_reader('ligolw', table, func)
-    registry.register_reader(tablename, table, func)
+    llwfunc, recfunc = read_table_factory(table)
+    # register generic reader and table-specific reader for LIGO_LW
+    registry.register_reader('ligolw', table, llwfunc)
+    registry.register_reader(tablename, table, llwfunc)
     registry.register_identifier('ligolw', table, identify_ligolw)
+    # register table-specific reader for GWRecArray
+    registry.register_reader(tablename, GWRecArray, recfunc)

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read events from the PyCBC live online GW search
+"""
+
+import re
+from os.path import basename
+
+import numpy
+from numpy import rec
+from numpy.lib import recfunctions
+
+from glue.lal import CacheEntry
+
+from ...utils.deps import with_import
+from ...io.cache import file_list
+from ...io.registry import (register_reader, register_identifier)
+from ..rec import GWRecArray
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+INVALID_COLUMNS = ['psd']
+PYCBC_FILENAME = re.compile('([A-Z][0-9])+-Live-[0-9.]+-[0-9.]+.hdf')
+
+
+@with_import('h5py')
+def recarray_from_file(source, ifo=None, columns=None):
+    """Read a `GWRecArray` from a PyCBC live HDF5 file
+    """
+    # read HDF5 file
+    if isinstance(source, CacheEntry):
+        source = source.path
+    if isinstance(source, str):
+        source = h5py.File(source, 'r')
+    # find group
+    if isinstance(source, h5py.File):
+        if ifo is None:
+            try:
+                ifo, = list(source)
+            except ValueError as e:
+                e.args = ("PyCBC live HDF5 file contains multiple IFO groups, "
+                          "please select ifo manually",)
+                raise
+        try:
+            source = source[ifo]
+        except KeyError as e:
+            e.args = ("No group for ifo %r in PyCBC live HDF5 file" % ifo,)
+            raise
+    # at this stage, 'source' should be an HDF5 group in the pycbc live format
+    if columns is None:
+        columns = [c for c in source if c not in INVALID_COLUMNS]
+    names, data = zip(*[(k, source[k][:]) for k in source if k in columns])
+    names = list(map(str, names))
+    data = list(data)
+    # calculate new_snr on-the-fly
+    if 'new_snr' in columns and 'new_snr' not in source:
+        # get columns needed for newsnr
+        snr = data[names.index('snr')]
+        rchisq = data[names.index('chisq')]  # chisq is already reduced
+        # calculate and append to column list
+        data.append(get_new_snr(snr, rchisq))
+        names.append('new_snr')
+    # calculate mchirp
+    if 'mchirp' in columns and 'mchirp' not in source:
+        mass1 = data[names.index('mass1')]
+        mass2 = data[names.index('mass2')]
+        data.append(get_mchirp(mass1, mass2))
+        names.append('mchirp')
+    # read columns into numpy recarray
+    out = rec.fromarrays(data, names=map(str, names)).view(GWRecArray)
+    if 'end_time' in columns:
+        out.sort(order='end_time')
+    return out
+
+
+def recarray_from_pycbc_live(source, ifo=None, columns=None, nproc=1):
+    """Read a `GWRecArray` from one or more PyCBC live files
+    """
+    source = file_list(source)
+    if nproc > 1:
+        from ...io.cache import read_cache
+        return read_cache(source, GWRecArray, nproc, None,
+                          ifo=ifo, columns=columns, format='pycbc_live')
+
+    source = filter_empty_files(source, ifo=ifo)
+    arrays = [recarray_from_file(x, ifo=ifo, columns=columns) for x in source]
+    return recfunctions.stack_arrays(arrays, asrecarray=True, usemask=False,
+                                     autoconvert=True).view(GWRecArray)
+
+
+def filter_empty_files(files, ifo=None):
+    return [f for f in files if not empty_hdf5_file(f, ifo=ifo)]
+
+
+@with_import('h5py')
+def empty_hdf5_file(fp, ifo=None):
+    if isinstance(fp, CacheEntry):
+        fp = fp.path
+    if isinstance(fp, str):
+        h5f = h5py.File(fp, 'r')
+    elif isinstance(fp, h5py.File):
+        h5f = fp
+    else:
+        return  # default to something that will evaluate as false
+    if list(h5f) == []:
+        return True
+    if ifo is not None and list(h5f[ifo]) == ['psd']:
+        return True
+    return False
+
+
+def identify_pycbc_live(origin, path, fileobj, *args, **kwargs):
+    """Identify a PyCBC Live file from its basename
+    """
+    if path is not None and PYCBC_FILENAME.match(basename(path)):
+        return True
+    return False
+
+
+def get_new_snr(snr, reduced_x2, q=6., n=2.):
+    newsnr = snr.copy()
+    # map arrays
+    if isinstance(newsnr, numpy.ndarray) and newsnr.shape:
+        idx = numpy.where(reduced_x2 > 1.)[0]
+        newsnr[idx] *= _new_snr_scale(newsnr[idx], reduced_x2[idx], q=q, n=n)
+    # map single value if reduced_x2 > 1
+    elif reduced_x2 > 1.:
+        return newsnr * _new_snr_scale(newsnr, reduced_x2, q=q, n=n)
+    return newsnr
+
+
+def _new_snr_scale(snr, redx2, q=6., n=2.):
+    return (.5 * (1. + redx2 ** (q/n))) ** (-1./q)
+
+
+def get_mchirp(mass1, mass2):
+    return (mass1 * mass2) ** (3/5.) / (mass1 + mass2) ** (1/5.)
+
+
+# register for unified I/O
+register_identifier('pycbc_live', GWRecArray, identify_pycbc_live)
+register_reader('pycbc_live', GWRecArray, recarray_from_pycbc_live)

--- a/gwpy/table/rec.py
+++ b/gwpy/table/rec.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Custom `numpy.recarray` for reading tabular data
+"""
+
+from numpy import recarray
+
+from ..io import (reader, writer)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+class GWRecArray(recarray):
+    """`~numpy.recarray` to store tabular data from GW analyses
+
+    See Also
+    --------
+    numpy.recarray
+        for documentation of how to create a new `GWRecArray`
+    """
+    read = classmethod(reader(doc="""
+        Read data into a `GWRecArray`
+
+        Parameters
+        ----------
+        source : `str`, `list`, :class:`~glue.lal.Cache`
+            source of files, normally a filename or list of filenames,
+            or a structured cache of file descriptions
+
+        columns : `list`, optional
+            list of column names to read, default reads all available data
+
+        Notes
+        -----"""))
+
+    write = writer()
+
+    # -- ligolw compatibility -------------------
+
+    def get_column(self, column):
+        """Return a column of this array
+
+        This method is provided for compatibility with the
+        :class:`glue.ligolw.table.Table`
+
+        Parameters
+        ----------
+        column : `str`
+            name of column (field) to return
+
+        Returns
+        -------
+        array : `~numpy.ndarray`
+            the array for this column
+        """
+        return self[column]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ M2Crypto
 pykerberos
 python-cjson
 pyRXP
-http://software.ligo.org/lscsoft/source/glue-1.49.1.tar.gz
+http://software.ligo.org/lscsoft/source/glue-1.50.0.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.2.2.tar.gz


### PR DESCRIPTION
This PR expands support for using the `numpy.recarray` to store tabular data normally stored in `LIGO_LW` format (using `glue.ligolw`). Changes include

- new `GWRecArray` object with `.read()` method tied to all `LIGO_LW` table formats
- new parser for `pycbc_live` files