### PR TITLE
Transition python26 support to 'best-effort'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ matrix:
       env: MINIMAL=true
     - python: 3.5
   allow_failures:
+    - python: 2.6
     - python: 2.7
       env: STRICT=true PRE="--pre"
     - python: 3.5


### PR DESCRIPTION
This PR moves the python26 build to the `allow_failures` section, now that python26 support will be best-effort.