### PR TITLE
Added loudest kwarg for reading pycbc_live events with GWRecArray

### DIFF
--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -48,6 +48,8 @@ def read_table_factory(table_):
         for key in reckwargs:
             if key in kwargs:
                 reckwargs[key] = kwargs.pop(key)
+        reckwargs['columns'] = kwargs.get('columns', None)
+
         # handle multiprocessing
         nproc = kwargs.pop('nproc', 1)
         if nproc > 1:


### PR DESCRIPTION
This PR adds the `loudest=False` keyword argument for `GWRecArray.read(..., format='pycbc_live')`; if `loudest=True` then only the events indicated in the `loudest` dataset are returned, advertised as 50 events per file (16s).