### PR TITLE
Improved handling of underscores in latex plotting

### DIFF
--- a/gwpy/plotter/segments.py
+++ b/gwpy/plotter/segments.py
@@ -209,7 +209,7 @@ class SegmentAxes(TimeSeriesAxes):
         if y is None:
             y = self.get_next_y()
         # get flag name
-        name = kwargs.pop('label', flag.texname)
+        name = kwargs.pop('label', flag.name)
 
         # get epoch
         try:

--- a/gwpy/plotter/utils.py
+++ b/gwpy/plotter/utils.py
@@ -27,7 +27,7 @@ from . import rcParams
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
-rUNDERSCORE = re.compile(r'(?<!\\)_')
+rUNDERSCORE = re.compile(r'(?<!\\)_(?!.*{)')
 
 # groups of input parameters (for passing to Plot() and subclasses)
 FIGURE_PARAMS = [


### PR DESCRIPTION
This PR improves the escaping of underscores when plotting with latex; those underscores followed by latex grouping brackets `{}` shouldn't be escaped - the assumption is that these are inside mathmode `$$`.