### PR TITLE
Use gzip module for GzipFile

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -25,6 +25,7 @@ from multiprocessing import (cpu_count, Process, Queue as ProcessQueue)
 from six import string_types
 import tempfile
 import warnings
+from gzip import GzipFile
 
 from numpy import recarray
 from numpy.lib import recfunctions
@@ -33,8 +34,6 @@ from glue.lal import (Cache, CacheEntry)
 from glue.ligolw.table import Table
 
 from astropy.io.registry import _get_valid_format
-
-from .utils import GzipFile
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -19,9 +19,9 @@
 """Utilities for unified input/output
 """
 
-from six import string_types
+import gzip
 
-from astropy.utils.compat.gzip import GzipFile
+from six import string_types
 
 from glue.lal import CacheEntry
 
@@ -51,6 +51,6 @@ def gopen(name, *args, **kwargs):
         `gzip.open` for files with a `name` ending in `.gz`
     """
     if name.endswith('.gz'):
-        return GzipFile(name, *args, **kwargs)
+        return gzip.open(name, *args, **kwargs)
     else:
         return open(name, *args, **kwargs)

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -31,9 +31,8 @@ from glue.ligolw.utils.ligolw_add import ligolw_add
 from astropy.time import Time
 
 from ...io import registry
-from ...io.utils import FILE_LIKE
 from ...io.ligolw import (identify_ligolw, GWpyContentHandler)
-from ...io.cache import file_list
+from ...io.cache import (file_list, FILE_LIKE)
 from ...segments import (Segment, DataQualityFlag, DataQualityDict)
 from ...table import lsctables
 

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -31,7 +31,7 @@ from glue.ligolw.utils.ligolw_add import ligolw_add
 from astropy.time import Time
 
 from ...io import registry
-from ...io.utils import GzipFile
+from ...io.utils import FILE_LIKE
 from ...io.ligolw import (identify_ligolw, GWpyContentHandler)
 from ...io.cache import file_list
 from ...segments import (Segment, DataQualityFlag, DataQualityDict)
@@ -67,8 +67,8 @@ def read_flag_dict(f, flags=None, gpstype=LIGOTimeGPS, coalesce=False,
 
     # generate Document and populate
     xmldoc = Document()
-    files = [fp.name if isinstance(fp, (file, GzipFile))
-             else fp for fp in file_list(f)]
+    files = [fp.name if isinstance(fp, FILE_LIKE) else fp
+             for fp in file_list(f)]
     ligolw_add(xmldoc, files, non_lsc_tables_ok=True,
                contenthandler=contenthandler)
 

--- a/gwpy/table/io/cwb.py
+++ b/gwpy/table/io/cwb.py
@@ -29,7 +29,7 @@ from .ascii import return_reassign_ids
 from ..lsctables import SnglBurstTable
 from ...io.registry import (register_reader, register_identifier)
 from ...io.cache import (file_list, read_cache)
-from ...io.utils import (gopen, GzipFile)
+from ...io.utils import gopen
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 


### PR DESCRIPTION
This PR resolves the `DeprecationWarning` currently displayed from `astropy.utils.compat.gzip` by using the builtin `gzip` module.

Fixes #293.