### PR TITLE
Use gwpy.time.LIGOTimeGPS import in segments.io

### DIFF
--- a/gwpy/segments/io/hdf5.py
+++ b/gwpy/segments/io/hdf5.py
@@ -29,11 +29,10 @@ from distutils.version import LooseVersion
 
 from astropy.units import (UnitBase, Quantity)
 
-from glue.lal import LIGOTimeGPS
-
 from ...io.hdf5 import (open_hdf5, identify_hdf5)
 from ...io.registry import (register_reader, register_writer,
                             register_identifier)
+from ...time import LIGOTimeGPS
 from ..flag import DataQualityFlag
 from ..segments import (SegmentList, Segment)
 

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -22,7 +22,6 @@
 import datetime
 from six import string_types
 
-from glue.lal import LIGOTimeGPS
 from glue.ligolw.ligolw import (Document, LIGO_LW)
 from glue.ligolw.utils import (write_filename, write_fileobj)
 from glue.ligolw.utils.ligolw_add import ligolw_add
@@ -35,6 +34,7 @@ from ...io.ligolw import (identify_ligolw, GWpyContentHandler)
 from ...io.cache import (file_list, FILE_LIKE)
 from ...segments import (Segment, DataQualityFlag, DataQualityDict)
 from ...table import lsctables
+from ...time import LIGOTimeGPS
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 


### PR DESCRIPTION
This PR modifies all imports of `LIGOTimeGPS` to the `gwpy.time` module. Only that module should import that object from outside, which should make removing the glue dependency a bit easier in the future.