### PR TITLE
Replaced deprecated Spectrum references

### DIFF
--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -149,7 +149,7 @@ class Coherence(CliProduct):
                                 if not cohs:
                                     self.plot = coh.plot()
                                 else:
-                                    self.plot.add_spectrum(coh)
+                                    self.plot.add_frequencyseries(coh)
 
                                 cohs.append(coh)
 

--- a/gwpy/frequencyseries/core.py
+++ b/gwpy/frequencyseries/core.py
@@ -103,7 +103,7 @@ class FrequencySeries(Series):
         if frequencies is not None:
             kwargs['xindex'] = frequencies
 
-        # generate Spectrum
+        # generate FrequencySeries
         return super(FrequencySeries, cls).__new__(
             cls, data, unit=unit, name=name, channel=channel,
             epoch=epoch, **kwargs)
@@ -145,7 +145,7 @@ class FrequencySeries(Series):
 
     def ifft(self):
         """Compute the one-dimensional discrete inverse Fourier
-        transform of this `Spectrum`.
+        transform of this `FrequencySeries`.
 
         Returns
         -------

--- a/gwpy/frequencyseries/lal_.py
+++ b/gwpy/frequencyseries/lal_.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Spectrum generation methods using LAL.
+"""FrequencySeries generation methods using LAL.
 """
 
 import re

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -212,7 +212,7 @@ class QPlane(QBase):
 
         Parameters
         ----------
-        fseries : `~gwpy.spectrum.Spectrum`
+        fseries : `~gwpy.frequencyseries.FrequencySeries`
             the complex FFT of a time-series data set
         normalized : `bool`, optional
             normalize the energy of the output, if `False` the output
@@ -315,7 +315,7 @@ class QTile(QBase):
 
         Parameters
         ----------
-        fseries : `~gwpy.spectrum.Spectrum`
+        fseries : `~gwpy.frequencyseries.FrequencySeries`
             the complex FFT of a time-series data set
         normalized : `bool`, optional
             normalize the energy of the output, if `False` the output


### PR DESCRIPTION
This PR fixes #300 by removing a few lingering references to the `Spectrum`