### PR TITLE
Improved error handling in datafind.find_frametype

### DIFF
--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -551,7 +551,7 @@ class Channel(object):
 
     def find_frametype(self, gpstime=None, frametype_match=None,
                        host=None, port=None, return_all=False,
-                       exclude_tape=False):
+                       allow_tape=True):
         """Find the containing frametype(s) for this `Channel`
 
         Parameters
@@ -568,8 +568,8 @@ class Channel(object):
         return_all: `bool`, default: `False`
             return all matched frame types, otherwise only the first match is
             returned
-        exclude_tape : `bool`, default: `False`
-            do not search frame files that appear to be on magnetic tape
+        allow_tape : `bool`, default: `True`
+            include frame files on (slow) magnetic tape in the search
 
         Returns
         -------
@@ -580,7 +580,7 @@ class Channel(object):
         return datafind.find_frametype(
             self, gpstime=gpstime, frametype_match=frametype_match,
             host=host, port=port, return_all=return_all,
-            exclude_tape=exclude_tape)
+            allow_tape=allow_tape)
 
     def copy(self):
         return type(self)(self.name, unit=self.unit,

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -169,7 +169,11 @@ def num_channels(framefile):
     -----
     This method requires LALFrame
     """
-    frfile = lalframe.FrameUFrFileOpen(framefile, "r")
+    try:
+        frfile = lalframe.FrameUFrFileOpen(framefile, "r")
+    except RuntimeError as e:
+        e.args = ('Failed to read %r: %s' % (framefile, str(e)),)
+        raise
     frtoc = lalframe.FrameUFrTOCRead(frfile)
     return sum(
         getattr(lalframe, 'FrameUFrTOCQuery%sN' % type_.title())(frtoc) for

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -91,6 +91,9 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     from ..detector import Channel
     channel = Channel(channel)
     name = channel.name
+    if not channel.ifo:
+        raise ValueError("Cannot parse interferometer prefix from channel "
+                         "name %r, cannot proceed with find()" % name)
     if gpstime is not None:
         gpstime = to_gps(gpstime).seconds
     connection = connect(host, port)

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -139,14 +139,13 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
             return ft
         elif inframe:
             found.append(ft)
-    if exclude_tape:
-        msg = "Cannot locate %r in any known frametype that isn't on tape"
-    else:
-        msg = "Cannot locate %r in any known frametype"
+    msg = "Cannot locate %r in any known frametype" % name
     if gpstime:
         msg += " at GPS=%d" % gpstime
+    if exclude_tape:
+        msg += " [those on tape have not been checked]"
     if len(found) == 0:
-        raise ValueError(msg % name)
+        raise ValueError(msg)
     else:
         return found
 

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -61,7 +61,7 @@ def connect(host=None, port=None):
 
 
 def find_frametype(channel, gpstime=None, frametype_match=None,
-                   host=None, port=None, return_all=False, exclude_tape=False):
+                   host=None, port=None, return_all=False, allow_tape=False):
     """Find the frametype(s) that hold data for a given channel
 
     Parameters
@@ -77,7 +77,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
         port on datafind host to use
     return_all : `bool`, optional, default: `False`
         return all found types, default is to return to 'best' match
-    exclude_tape : `bool`, optional, default: `False`
+    allow_tape : `bool`, optional, default: `False`
         do not test types whose frame files are stored on tape (not on
         spinning disk)
 
@@ -113,7 +113,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
             continue
         else:
             if os.access(frame.path, os.R_OK) and (
-                    not exclude_tape or not on_tape(frame)):
+                    allow_tape or not on_tape(frame)):
                 frames.append((ft, frame.path))
     # sort frames by allocated block size and regular size
     # (to put frames on tape at the bottom of the list)
@@ -145,8 +145,9 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     msg = "Cannot locate %r in any known frametype" % name
     if gpstime:
         msg += " at GPS=%d" % gpstime
-    if exclude_tape:
-        msg += " [those files on tape have not been checked]"
+    if not allow_tape:
+        msg += (" [those files on tape have not been checked, use "
+                "allow_tape=True to perform a complete search]")
     if len(found) == 0:
         raise ValueError(msg)
     else:
@@ -255,7 +256,7 @@ def find_best_frametype(channel, start, end, urltype='file',
     start = to_gps(start).seconds
     end = to_gps(end).seconds
     frametype = find_frametype(channel, gpstime=start, host=host, port=port,
-                               exclude_tape=not allow_tape)
+                               allow_tape=allow_tape)
     connection = connect(host=host, port=port)
     try:
         cache = connection.find_frame_urls(channel[0], frametype,
@@ -265,7 +266,7 @@ def find_best_frametype(channel, start, end, urltype='file',
             raise RuntimeError()
     except RuntimeError:
         alltypes = find_frametype(channel, gpstime=start, host=host, port=port,
-                                  return_all=True, exclude_tape=not allow_tape)
+                                  return_all=True, allow_tape=allow_tape)
         cache = [(ft, connection.find_frame_urls(
             channel[0], ft, start, end, urltype=urltype,
             on_gaps='ignore')) for ft in alltypes]

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -146,7 +146,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     if gpstime:
         msg += " at GPS=%d" % gpstime
     if exclude_tape:
-        msg += " [those on tape have not been checked]"
+        msg += " [those files on tape have not been checked]"
     if len(found) == 0:
         raise ValueError(msg)
     else:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -348,6 +348,9 @@ class TimeSeriesBase(Series):
             numeric data type for returned data, e.g. `numpy.float`, or
             `dict` of (`channel`, `dtype`) pairs
 
+        allow_tape : `bool`, optional, default: `True`
+            allow reading from frame files on (slow) magnetic tape
+
         verbose : `bool`, optional
             print verbose output about NDS progress.
 
@@ -391,10 +394,17 @@ class TimeSeriesBase(Series):
             number of parallel processes to use, serial process by
             default.
 
+        allow_tape : `bool`, optional, default: `False`
+            allow the use of frames that are held on tape, default is `False`
+            to attempt to allow the `TimeSeries.fetch` method to
+            intelligently select a server that doesn't use tapes for
+            data storage (doesn't always work)
+
         verbose : `bool`, optional
             print verbose output about NDS progress.
 
-        **kwargs            other keyword arguments to pass to either
+        **kwargs
+            other keyword arguments to pass to either
             :meth:`.find` (for direct GWF file access) or
             :meth:`.fetch` for remote NDS2 access
 
@@ -1009,11 +1019,11 @@ class TimeSeriesBaseDict(OrderedDict):
             number of parallel processes to use, serial process by
             default.
 
+        allow_tape : `bool`, optional, default: `True`
+            allow reading from frame files on (slow) magnetic tape
+
         verbose : `bool`, optional
             print verbose output about NDS progress.
-
-        allow_tape : `bool`, optional, default: `True`
-            allow reading from frames on tape
 
         **readargs
             any other keyword arguments to be passed to `.read()`
@@ -1109,14 +1119,14 @@ class TimeSeriesBaseDict(OrderedDict):
             number of parallel processes to use, serial process by
             default.
 
-        verbose : `bool`, optional
-            print verbose output about NDS progress.
-
         allow_tape : `bool`, optional, default: `False`
             allow the use of frames that are held on tape, default is `False`
             to attempt to allow the `TimeSeries.fetch` method to
             intelligently select a server that doesn't use tapes for
             data storage (doesn't always work)
+
+        verbose : `bool`, optional
+            print verbose output about NDS progress.
 
         **kwargs
             other keyword arguments to pass to either


### PR DESCRIPTION
This PR improves the error handling in the `gwpy.io.datafind.find_frametype` method -- fixes #296  with a better error message. The main user-level change is that the `exclude_tape` keyword argument was renamed `allow_tape` to bring it inline with the `TimeSeries.find` arguments.

The new error for a channel not found is:

```
ValueError: Cannot locate 'L1:Test' in any known frametype at GPS=1158710417 [those files on tape have not been checked, use allow_tape=True to perform a complete search]
```

EDIT: fixes #288 by improving documentation of the `allow_tape` kwarg in the `TimeSeries` object.