### PR TITLE
Fixed metadata bugs in Array2D.__getitem__

### DIFF
--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -22,6 +22,7 @@
 import os.path
 import tempfile
 import StringIO
+from ssl import SSLError
 
 from six import PY3
 from six.moves.urllib.request import urlopen
@@ -126,7 +127,7 @@ class TestCaseWithQueryMixin(object):
         try:
             return cm(*args, **kwargs)
         except (ImportError, UnboundLocalError, LDBDClientException,
-                SystemExit) as e:
+                SystemExit, SSLError) as e:
             self.skipTest(str(e))
         except URLError as e:
             if e.code in [401, 500]:

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -150,22 +150,27 @@ class Array2D(Series):
         else:
             new = new.view(type(self))
             #new.__dict__ = self.copy_metadata()
-        # update metadata
-        if isinstance(x, slice):
-            if x.start:
-                new.x0 = new.x0 + x.start * new.dx
-            if x.step:
-                new.dx = new.dx + x.step
-        if len(new.shape) == 1 and isinstance(y, slice):
-            if y.start:
-                new.x0 = new.x0 + y.start * new.dx
-            if y.step:
-                new.dx = new.dx * y.step
-        elif isinstance(y, slice):
-            if y.start:
-                new.y0 = new.y0 + y.start * new.dy
-            if y.step:
-                new.dy = new.dy * y.step
+        # update metadata (Series.__getitem__ has already done x slice)
+        if len(new.shape) == 1 and isinstance(y, slice):  # FrequencySeries
+            try:
+                self._xindex
+            except AttributeError:
+                if y.start:
+                    new.x0 = self.x0 + y.start * self.dx
+                if y.step:
+                    new.dx = self.dx * y.step
+            else:
+                new.xindex = self.xindex[y]
+        elif isinstance(y, slice):  # slice Array2D y-axis
+            try:
+                self._yindex
+            except AttributeError:
+                if y.start:
+                    new.y0 = new.y0 + y.start * new.dy
+                if y.step:
+                    new.dy = new.dy * y.step
+            else:
+                new.yindex = self.yindex[y]
         return new
 
     def __array_finalize__(self, obj):


### PR DESCRIPTION
This PR fixes a bug in `Array2D.__getitem__` whereby changes to the x-axis metadata were being down twice, once in `Series.__getitem__` and once in `Array2D.__getitem__`.