### PR TITLE
Minor improvements to documentation styling

### DIFF
--- a/docs/_static/gwpy-sphinx.css
+++ b/docs/_static/gwpy-sphinx.css
@@ -20,6 +20,16 @@
  * This file contains sphinx-specific extensions to the core GWpy CSS
  */
 
+/* -- layout -------------------------------------------------------------- */
+
+body {
+		font-size: 15px;
+		font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
+.navbar + .container {
+		padding-top: 20px;
+}
 
 /* -- banner image -------------------------------------------------------- */
 
@@ -38,11 +48,14 @@ body {
 		margin-bottom: 140px;
 }
 
-footer {
+.footer {
 		position: absolute;
 		bottom: 0;
 		width: 100%;
 		height: 100px;
+		background-color: #eee;
+		padding-top: 20px;
+		padding-bottom: 20px;
 }
 
 /* -- side-bar formatting ------------------------------------------------- */
@@ -54,7 +67,37 @@ footer {
 		border-right: 1px solid #eee;
 }
 
-/* -- table links --------------------------------------------------------- */
+/* -- links --------------------------------------------------------------- */
+
+a.external,
+a.external:hover,
+a.external:focus {
+		color: #337ab7;
+}
+
+.alert a.external,
+.alert a.external:hover,
+.alert a.external:focus {
+		color: inherit;
+		text-decoration: underline;
+}
+
+/* -- tables -------------------------------------------------------------- */
+
+table > thead > tr > th,
+.table > thead > tr > th,
+table > tbody > tr > th,
+.table > tbody > tr > th,
+table > tfoot > tr > th,
+.table > tfoot > tr > th,
+table > thead > tr > td,
+.table > thead > tr > td,
+table > tbody > tr > td,
+.table > tbody > tr > td,
+table > tfoot > tr > td,
+.table > tfoot > tr > td {
+		border-top: 1px solid #ecf0f1;
+}
 
 table a {
 		text-decoration: none !important;

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,3 +1,3 @@
 {% extends "!layout.html" %}
 {% set script_files = ['_static/gwpy_https.js'] + script_files + ['_static/copybutton.js']%}
-{% set bootswatch_css_custom = ['//gwpy.github.io/css/gwpy.css', '_static/gwpy-sphinx.css']%}
+{% set bootswatch_css_custom = ['_static/gwpy-sphinx.css']%}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,6 +188,7 @@ html_theme_options = {
     'navbar_sidebarrel': True,
     'navbar_pagenav': False,
     'bootswatch_theme': 'flatly',
+    'bootstrap_version': '3',
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,12 +266,12 @@ htmlhelp_basename = 'GWpydoc'
 
 # Intersphinx
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
-    'matplotlib': ('http://matplotlib.sourceforge.net/', None),
+    'python': ('https://docs.python.org/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'matplotlib': ('http://matplotlib.org/', None),
     'astropy': ('http://docs.astropy.org/en/stable/', None),
-    'pycbc': ('http://ligo-cbc.github.io/pycbc/latest/html/', None),
+    'pycbc': ('https://ligo-cbc.github.io/pycbc/latest/html/', None),
 }
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ extensions = [
     'sphinx.ext.linkcode',
     'numpydoc',
     #'sphinxcontrib.epydoc',
-    'sphinxcontrib.doxylink',
+    #'sphinxcontrib.doxylink',
     'matplotlib.sphinxext.plot_directive',
     'gwpy.utils.sphinx.autoclassapi',
     'gwpy.utils.sphinx.directives',
@@ -87,12 +87,12 @@ autodoc_default_flags = ['show-inheritance', 'members', 'inherited-members']
 #    [r'glue(\.|$)'],
 #}
 
-# doxylink
-LALSUITE_DOCS = 'http://software.ligo.org/docs/lalsuite'
-doxylink = {
-    'lal': ('lal.tag', '%s/lal/' % LALSUITE_DOCS),
-    'lalframe': ('lalframe.tag', '%s/lalframe/' % LALSUITE_DOCS),
-}
+## doxylink
+#LALSUITE_DOCS = 'http://software.ligo.org/docs/lalsuite'
+#doxylink = {
+#    'lal': ('lal.tag', '%s/lal/' % LALSUITE_DOCS),
+#    'lalframe': ('lalframe.tag', '%s/lalframe/' % LALSUITE_DOCS),
+#}
 
 # matplotlib plot directive
 plot_rcparams = GWPY_PLOT_PARAMS

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.linkcode',
     'numpydoc',
-    'sphinxcontrib.epydoc',
+    #'sphinxcontrib.epydoc',
     'sphinxcontrib.doxylink',
     'matplotlib.sphinxext.plot_directive',
     'gwpy.utils.sphinx.autoclassapi',
@@ -80,12 +80,12 @@ extensions = [
 autoclass_content = 'class'
 autodoc_default_flags = ['show-inheritance', 'members', 'inherited-members']
 
-# Epydoc extension config for GLUE
-# Can de-comment when GLUE is actually referenced in the documentation
-epydoc_mapping = {
-    'https://www.lsc-group.phys.uwm.edu/daswg/projects/glue/doc/':
-    [r'glue(\.|$)'],
-}
+## Epydoc extension config for GLUE
+## Can de-comment when GLUE is actually referenced in the documentation
+#epydoc_mapping = {
+#    'https://www.lsc-group.phys.uwm.edu/daswg/projects/glue/doc/':
+#    [r'glue(\.|$)'],
+#}
 
 # doxylink
 LALSUITE_DOCS = 'http://software.ligo.org/docs/lalsuite'

--- a/docs/timeseries/index.rst
+++ b/docs/timeseries/index.rst
@@ -62,7 +62,7 @@ Local data access
 
 If you have direct access to one or more files of data, either on the LIGO Data Grid (where the ``gwf`` files are stored) or you have some files of your own, you can use the `TimeSeries.read` method:
 
-This method is an example of the unified input/output system provided by `astropy <https://astropy.org>`_, so should respond in the same way whether you give it a ``gwf`` file, or an `''hdf5''` file, or a simple `''txt''` file.:
+This method is an example of the unified input/output system provided by `astropy <https://astropy.org>`_, so should respond in the same way whether you give it a ``gwf`` file, or an `''hdf5''` file, or a simple `''txt''` file.::
 
     data = TimeSeries.read('mydata.gwf', 'L1:GDS-CALIB_STRAIN')
 


### PR DESCRIPTION
This PR updates the style of the GWpy documentation, mainly to not use Lato font.

This also removes a couple of sphinx extensions that seem to be dead (epydoc) or broken (doxylink).