### PR TITLE
Added dynamic subplot params based on figure dimensions

### DIFF
--- a/gwpy/plotter/__init__.py
+++ b/gwpy/plotter/__init__.py
@@ -23,7 +23,10 @@ all be easily visualised using the relevant plotting objects, with
 many configurable parameters both interactive, and in saving to disk.
 """
 
-from matplotlib import (rcParams, pyplot, __version__ as mpl_version)
+from matplotlib import (rcParams, rc_params, pyplot,
+                        __version__ as mpl_version)
+
+DEFAULT_RCPARAMS = rc_params()
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -47,10 +50,6 @@ GWPY_PLOT_PARAMS = {
     "axes.formatter.limits": (-3, 4),
     "axes.labelsize": 22,
     'axes.titlesize': 22,
-    'figure.subplot.bottom': 0.13,
-    'figure.subplot.left': 0.15,
-    'figure.subplot.right': 0.88,
-    'figure.subplot.top': 0.88,
     "image.aspect": 'auto',
     "image.interpolation": 'nearest',
     "image.origin": 'lower',

--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     from mpl_toolkits.axes_grid import make_axes_locatable
 
-from . import (axes, utils, rcParams)
+from . import (axes, utils, rcParams, DEFAULT_RCPARAMS)
 from .axes import Axes
 from .log import CombinedLogFormatterMathtext
 from .decorators import (auto_refresh, axes_method)
@@ -66,8 +66,16 @@ class Plot(figure.Figure):
         auto_refresh = kwargs.pop('auto_refresh', False)
 
         # dynamically set the subplot positions based on the figure size
+        # -- only if the user hasn't customised the subplot params
         figsize = kwargs.get('figsize', rcParams['figure.figsize'])
-        kwargs.setdefault('subplotpars', utils.get_subplot_params(figsize))
+        subplotpars = utils.get_subplot_params(figsize)
+        use_subplotpars = 'subplotpars' not in kwargs and all([
+            rcParams['figure.subplot.%s' % pos] ==
+                DEFAULT_RCPARAMS['figure.subplot.%s' % pos] for
+            pos in ('left', 'bottom', 'right', 'top')])
+        print(use_subplotpars)
+        if use_subplotpars:
+            kwargs['subplotpars'] = subplotpars
 
         # generated figure, with associated interactivity from pyplot
         super(Plot, self).__init__(*args, **kwargs)

--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     from mpl_toolkits.axes_grid import make_axes_locatable
 
-from . import (axes, utils)
+from . import (axes, utils, rcParams)
 from .axes import Axes
 from .log import CombinedLogFormatterMathtext
 from .decorators import (auto_refresh, axes_method)
@@ -64,6 +64,10 @@ class Plot(figure.Figure):
     def __init__(self, *args, **kwargs):
         # pull non-standard keyword arguments
         auto_refresh = kwargs.pop('auto_refresh', False)
+
+        # dynamically set the subplot positions based on the figure size
+        figsize = kwargs.get('figsize', rcParams['figure.figsize'])
+        kwargs.setdefault('subplotpars', utils.get_subplot_params(figsize))
 
         # generated figure, with associated interactivity from pyplot
         super(Plot, self).__init__(*args, **kwargs)

--- a/gwpy/plotter/utils.py
+++ b/gwpy/plotter/utils.py
@@ -22,6 +22,8 @@
 import itertools
 import re
 
+from matplotlib.figure import SubplotParams
+
 from . import rcParams
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -88,3 +90,19 @@ def marker_cycle(markers=None):
         return itertools.cycle(markers)
     else:
         return itertools.cycle(('o', 'x', '+', '^', 'D', 'H', '1'))
+
+
+# -- dynamic subplot positioning -----------------------------------------------
+
+SUBPLOT_POSITIONS = {
+    (12, 4): (.12, .2, .88, .85),
+    (12, 6): (.12, .15, .88, .88),
+    (12, 8): (.12, .1, .88, .92),
+}
+
+def get_subplot_params(figsize):
+    try:
+        l, b, r, t = SUBPLOT_POSITIONS[tuple(figsize)]
+    except KeyError:
+        l = b = r = t = None
+    return SubplotParams(**{'left': l, 'bottom': b, 'right': r, 'top': t})

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -50,6 +50,7 @@ from gwpy.plotter import (figure, rcParams, Plot, Axes,
                           HistogramPlot, HistogramAxes,
                           SegmentPlot, SegmentAxes,
                           SpectrogramPlot, BodePlot)
+from gwpy.plotter import utils
 from gwpy.plotter.gps import (GPSTransform, InvertedGPSTransform)
 from gwpy.plotter.html import map_data
 from gwpy.plotter.tex import (float_to_latex, label_to_latex,
@@ -73,12 +74,12 @@ class Mixin(object):
     FIGURE_CLASS = Plot
     AXES_CLASS = Axes
 
-    def new(self):
+    def new(self, **figkwargs):
         """Create a new `Figure` with some `Axes`
 
         Returns (fig, ax)
         """
-        fig = self.FIGURE_CLASS()
+        fig = self.FIGURE_CLASS(**figkwargs)
         return fig, fig.gca()
 
     @property
@@ -120,6 +121,12 @@ class PlotTestCase(Mixin, unittest.TestCase):
         fig = self.FIGURE_CLASS(auto_refresh=True)
         self.assertTrue(fig.get_auto_refresh())
         self.save_and_close(fig)
+
+    def test_subplotpars(self):
+        fig, ax = self.new(figsize=(12, 4))
+        sbp = fig.subplotpars
+        self.assertTupleEqual(utils.SUBPLOT_POSITIONS[(12, 4)],
+                              (sbp.left, sbp.bottom, sbp.right, sbp.top))
 
     # -- test axes_method decorators
     def test_axes_methods(self):

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -28,7 +28,7 @@ from numpy import testing as nptest
 
 from scipy import signal
 
-from matplotlib import use
+from matplotlib import (use, rc_context)
 use('agg')
 from matplotlib.legend import Legend
 from matplotlib.colors import LogNorm
@@ -123,10 +123,18 @@ class PlotTestCase(Mixin, unittest.TestCase):
         self.save_and_close(fig)
 
     def test_subplotpars(self):
+        # check that dynamic subplotpars gets applied
         fig, ax = self.new(figsize=(12, 4))
+        target = utils.SUBPLOT_POSITIONS[(12, 4)]
         sbp = fig.subplotpars
-        self.assertTupleEqual(utils.SUBPLOT_POSITIONS[(12, 4)],
+        self.assertTupleEqual(target,
                               (sbp.left, sbp.bottom, sbp.right, sbp.top))
+        # check that dynamic subplotpars doesn't get applied if the user
+        # overrides any of the settings
+        with rc_context(rc={'figure.subplot.left': target[0]*.1}):
+            fig, ax = self.new(figsize=(12, 4))
+            sbp = fig.subplotpars
+            self.assertEqual(sbp.left, target[0]*.1)
 
     # -- test axes_method decorators
     def test_axes_methods(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,6 @@ versionfile_build = gwpy/_version.py
 tag_prefix = v
 parentdir_prefix = gwpy-
 
-[pytest]
+[tool:pytest]
 ; print name of each test, fail after first error, print skip reasons
 addopts = --verbose --exitfirst -r s


### PR DESCRIPTION
This PR improves the default styling for figures by dynamically setting the subplot parameters using a lookup table for the figure dimensions.

This _only_ happens if the user has not changed the subplot params in `rcParams` compared to the defaults read from the `matplotlibrc` file - so there's still a hole if the user really wants the defaults - but if they specify `subplotpars` as a keyword in their `Plot` call everything is fine.