### PR TITLE
Set default axes labels for TimeSeriesAxes and FrequencySeriesAxes

### DIFF
--- a/gwpy/plotter/frequencyseries.py
+++ b/gwpy/plotter/frequencyseries.py
@@ -107,6 +107,20 @@ class FrequencySeriesAxes(Axes):
                 pass
         if 'label' in kwargs:
             self.legend()
+        if not self.get_xlabel():
+            if tex.USE_TEX:
+                ustr = tex.unit_to_latex(spectrum.xunit)
+            else:
+                ustr = spectrum.xunit.to_string()
+            if ustr:
+                self.set_xlabel('Frequency [%s]' % ustr)
+        if not self.get_ylabel():
+            if tex.USE_TEX:
+                ustr = tex.unit_to_latex(spectrum.unit)
+            else:
+                ustr = spectrum.unit.to_string()
+            if ustr:
+                self.set_ylabel('[%s]' % ustr)
         return line
 
     @auto_refresh

--- a/gwpy/plotter/tex.py
+++ b/gwpy/plotter/tex.py
@@ -101,7 +101,10 @@ def unit_to_latex(unit):
             else:
                 positives = format_unit_list(positives)
                 s += positives
-    return r'$\mathrm{{{0}}}$'.format(s)
+    if s:
+        return r'$\mathrm{{{0}}}$'.format(s)
+    else:
+        return ''
 
 
 def format_unit_list(unitlist, negative=False):

--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -188,6 +188,13 @@ class TimeSeriesAxes(Axes):
         line = self.plot(timeseries.times.value, timeseries.value, **kwargs)
         if len(self.lines) == 1 and timeseries.size:
             self.set_xlim(*timeseries.xspan)
+        if not self.get_ylabel():
+            if tex.USE_TEX:
+                ustr = tex.unit_to_latex(timeseries.unit)
+            else:
+                ustr = timeseries.unit.to_string()
+            if ustr:
+                self.set_ylabel('[%s]' % ustr)
         return line
 
     @auto_refresh

--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -84,13 +84,16 @@ class TimeSeriesAxes(Axes):
     def auto_gps_label(self):
         scale = self.xaxis._scale
         epoch = scale.get_epoch()
+        if int(epoch) == epoch:
+            epoch = int(epoch)
         if epoch is None:
             self.set_xlabel('GPS Time')
         else:
             unit = scale.get_unit_name()
             utc = re.sub('\.0+', '',
                          Time(epoch, format='gps', scale='utc').iso)
-            self.set_xlabel('Time [%s] from %s UTC (%s)' % (unit, utc, epoch))
+            self.set_xlabel('Time [%s] from %s UTC (%s)'
+                            % (unit, utc, repr(epoch)))
 
     def auto_gps_scale(self):
         """Automagically set the GPS scale for the time-axis of this plot


### PR DESCRIPTION
This PR modifies the `TimeSeriesAxes.plot_timeseries` and `FrequencySeriesAxes.plot_spectrum` methods to set default axes labels.