### PR TITLE
Renamed one more ghost of Spectrum

### DIFF
--- a/gwpy/plotter/frequencyseries.py
+++ b/gwpy/plotter/frequencyseries.py
@@ -20,6 +20,8 @@
 `~gwpy.frequencyseries`
 """
 
+import warnings
+
 import numpy
 
 from matplotlib.projections import register_projection
@@ -65,14 +67,14 @@ class FrequencySeriesAxes(Axes):
             for a full description of acceptable ``*args` and ``**kwargs``
         """
         if len(args) == 1 and isinstance(args[0], FrequencySeries):
-            return self.plot_spectrum(*args, **kwargs)
+            return self.plot_frequencyseries(*args, **kwargs)
         elif len(args) == 1 and isinstance(args[0], SpectralVariance):
             return self.plot_variance(*args, **kwargs)
         else:
             return super(FrequencySeriesAxes, self).plot(*args, **kwargs)
 
     @auto_refresh
-    def plot_spectrum(self, spectrum, **kwargs):
+    def plot_frequencyseries(self, spectrum, **kwargs):
         """Plot a :class:`~gwpy.frequencyseries.FrequencySeries` onto these axes
 
         Parameters
@@ -110,7 +112,15 @@ class FrequencySeriesAxes(Axes):
         return line
 
     @auto_refresh
-    def plot_spectrum_mmm(self, mean_, min_=None, max_=None, alpha=0.1,
+    def plot_spectrum(self, *args, **kwargs):
+        warnings.warn("{0}.plot_spectrum was renamed "
+                      "{0}.plot_frequencyseries, "
+                      "and will be removed in an upcoming release".format(
+                      type(self).__name__))
+        return self.plot_frequencyseries(*args, **kwargs)
+
+    @auto_refresh
+    def plot_frequencyseries_mmm(self, mean_, min_=None, max_=None, alpha=0.1,
                           **kwargs):
         """Plot a `FrequencySeries` onto these axes, with (min, max) shaded
         regions
@@ -147,7 +157,7 @@ class FrequencySeriesAxes(Axes):
             for a full description of acceptable ``*args` and ``**kwargs``
         """
         # plot mean
-        line1 = self.plot_spectrum(mean_, **kwargs)[0]
+        line1 = self.plot_frequencyseries(mean_, **kwargs)[0]
         # plot min and max
         kwargs.pop('label', None)
         color = kwargs.pop('color', line1.get_color())
@@ -175,6 +185,14 @@ class FrequencySeriesAxes(Axes):
         else:
             c = d = None
         return line1, a, b, c, d
+
+    @auto_refresh
+    def plot_spectrum_mmm(self, *args, **kwargs):
+        warnings.warn("{0}.plot_spectrum_mmm was renamed "
+                      "{0}.plot_frequencyseries_mmm, "
+                      "and will be removed in an upcoming release".format(
+                      type(self).__name__))
+        return self.plot_frequencyseries(*args, **kwargs)
 
     @auto_refresh
     def plot_variance(self, specvar, norm='log', **kwargs):

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -402,24 +402,24 @@ class FrequencySeriesPlotTestCase(FrequencySeriesMixin, PlotTestCase):
 
 
 class FrequencySeriesAxesTestCase(FrequencySeriesMixin, AxesTestCase):
-    def test_plot_spectrum(self):
+    def test_plot_frequencyseries(self):
         fig, ax = self.new()
-        l = ax.plot_spectrum(self.asd)[0]
+        l = ax.plot_frequencyseries(self.asd)[0]
         nptest.assert_array_equal(l.get_xdata(), self.asd.frequencies.value)
         nptest.assert_array_equal(l.get_ydata(), self.asd.value)
         self.save_and_close(fig)
 
-    def test_plot_spectrum_mmm(self):
+    def test_plot_frequencyseries_mmm(self):
         fig, ax = self.new()
         # test defaults
-        artists = ax.plot_spectrum_mmm(*self.mmm)
+        artists = ax.plot_frequencyseries_mmm(*self.mmm)
         self.assertEqual(len(artists), 5)
         self.assertEqual(len(ax.lines), 3)
         self.assertEqual(len(ax.collections), 2)
         self.save_and_close(fig)
         # test min only
         fig, ax = self.new()
-        artists = ax.plot_spectrum_mmm(self.mmm[0], min_=self.mmm[1])
+        artists = ax.plot_frequencyseries_mmm(self.mmm[0], min_=self.mmm[1])
         self.assertEqual(len(artists), 5)
         self.assertIsNone(artists[3])
         self.assertIsNone(artists[4])
@@ -428,7 +428,7 @@ class FrequencySeriesAxesTestCase(FrequencySeriesMixin, AxesTestCase):
         self.save_and_close(fig)
         # test max only
         fig, ax = self.new()
-        artists = ax.plot_spectrum_mmm(self.mmm[0], max_=self.mmm[2])
+        artists = ax.plot_frequencyseries_mmm(self.mmm[0], max_=self.mmm[2])
         self.assertEqual(len(artists), 5)
         self.assertIsNone(artists[1])
         self.assertIsNone(artists[2])


### PR DESCRIPTION
This PR renames the `FrequencySeriesAxes.plot_spectrum` method to `FrequencySeriesAxes.plot_frequencyseries` and provides a `DeprecationWarning`ed wrapper for legacy calls. Most users probably just use `plot()` anyway, so this might not hit many people.