### PR TITLE
Use pytest-xdist to multiprocess tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install:
   - travis_retry pip install -q ${PRE} --install-option="--no-cython-compile" Cython
 
   # install testing dependencies
-  - pip install -q ${PRE} coveralls "pytest>=2.8" unittest2
+  - pip install -q ${PRE} coveralls "pytest>=2.8" pytest-xdist unittest2
 
   # need to install astropy 1.1 specifically for py26
   - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi

--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -7,4 +7,4 @@ else
     _strict=""
 fi
 
-coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*,gwpy/utils/sphinx/*" -m py.test -v -r s ${_strict} gwpy/
+coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*,gwpy/utils/sphinx/*" -m py.test -n 2 -v -r s ${_strict} gwpy/


### PR DESCRIPTION
This PR modifies the travis tests to use [`pytest-xdist`](http://pytest.org/dev/xdist.html) to multiprocess the tests with 2 CPUs, allowing (naively) a 50% speed up. This will be most useful on personal/LDG systems where a lot of tests hang on data access.