### PR TITLE
Use LOSC JSON API to discover public data

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -256,20 +256,13 @@ def read_cache_factory(target):
     return _read
 
 
-def cache_segments(*caches, **kwargs):
+def cache_segments(*caches):
     """Build a `SegmentList` of data availability for these `Caches`
 
     Parameters
     ----------
     *cache : `~glue.lal.Cache`
         one of more frame file caches describing files on disk
-    on_missing : `str`
-        what to do if files in a `Cache` are not found on disk, one of
-
-        - "warn": print a warning message saying how many files
-                  are missing out of the total checked [DEFAULT].
-        - "error": raise an exception if any are missing
-        - "ignore": do nothing
 
     Returns
     -------
@@ -277,12 +270,7 @@ def cache_segments(*caches, **kwargs):
         a list of segments for when data should be available
     """
     from ..segments import SegmentList
-    on_missing = kwargs.pop('on_missing', 'warn')
-    if kwargs:
-        raise TypeError("%r is an invalid keyword for cache_segments"
-                        % kwargs.keys()[0])
     out = SegmentList()
     for cache in caches:
-        found, _ = cache.checkfilesexist(on_missing=on_missing)
-        out.extend(e.segment for e in found)
+        out.extend(e.segment for e in cache)
     return out.coalesce()

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -280,7 +280,8 @@ class TimeSeriesBase(Series):
 
     @classmethod
     def fetch_open_data(cls, ifo, start, end, name='strain/Strain',
-                        sample_rate=4096, host='https://losc.ligo.org'):
+                        sample_rate=4096, host='https://losc.ligo.org',
+                        verbose=False):
         """Fetch open-access data from the LIGO Open Science Center
 
         Parameters
@@ -307,12 +308,16 @@ class TimeSeriesBase(Series):
             by LOSC at 4096 Hz, however there may be event-related
             data releases with a 16384 Hz rate
 
+        verbose : `bool`, optional, default: `False`
+            print verbose output while fetching data
+
         host : `str`, optional
             HTTP host name of LOSC server to access
         """
         from .io.losc import fetch_losc_data
         return fetch_losc_data(ifo, start, end, channel=name, cls=cls,
-                               sample_rate=sample_rate, host=host)
+                               sample_rate=sample_rate, host=host,
+                               verbose=verbose)
 
     @classmethod
     def find(cls, channel, start, end, frametype=None,

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -115,7 +115,7 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
         gap = 'pad'
     elif gap is None:
         gap = 'raise'
-    segs = cache_segments(cache, on_missing='ignore') & SegmentList([span])
+    segs = cache_segments(cache) & SegmentList([span])
     if len(segs) != 1 and gap.lower() == 'ignore' or gap.lower() == 'pad':
         pass
     elif len(segs) != 1:

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -632,7 +632,7 @@ class StateVector(TimeSeriesBase):
 
     @classmethod
     def fetch_open_data(cls, ifo, start, end, name='quality/simple',
-                        host='https://losc.ligo.org'):
+                        host='https://losc.ligo.org', verbose=False):
         """Fetch open-access data from the LIGO Open Science Center
 
         Parameters
@@ -656,10 +656,14 @@ class StateVector(TimeSeriesBase):
 
         host : `str`, optional
             HTTP host name of LOSC server to access
+
+        verbose : `bool`, optional, default: `False`
+            print verbose output while fetching data
+
         """
         from .io.losc import fetch_losc_data
         return fetch_losc_data(ifo, start, end, channel=name, cls=cls,
-                               host=host)
+                               host=host, verbose=verbose)
 
     @classmethod
     def get(cls, channel, start, end, bits=None, **kwargs):


### PR DESCRIPTION
This PR updates the `gwpy.timeseries.io.losc` module to use the JSON API for discovering public data hosted by https://losc.ligo.org.