### PR TITLE
Fixed tests of colors for matplotlib 2.0

### DIFF
--- a/gwpy/plotter/__init__.py
+++ b/gwpy/plotter/__init__.py
@@ -23,8 +23,7 @@ all be easily visualised using the relevant plotting objects, with
 many configurable parameters both interactive, and in saving to disk.
 """
 
-from matplotlib import (rcParams, rc_params, pyplot,
-                        __version__ as mpl_version)
+from matplotlib import (rcParams, rc_params, pyplot)
 
 DEFAULT_RCPARAMS = rc_params()
 
@@ -74,13 +73,13 @@ GWPY_COLOR_CYCLE = [
 ]
 
 # set mpl version dependent stuff
-if mpl_version < '1.5':
-    GWPY_PLOT_PARAMS['axes.color_cycle'] = GWPY_COLOR_CYCLE
-else:
+try:
     from matplotlib import cycler
     GWPY_PLOT_PARAMS.update({
         'axes.prop_cycle': cycler('color', GWPY_COLOR_CYCLE),
     })
+except (ImportError, KeyError):  # mpl < 1.5
+    GWPY_PLOT_PARAMS['axes.color_cycle'] = GWPY_COLOR_CYCLE
 
 # set latex options
 if rcParams['text.usetex'] or USE_TEX:

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -29,7 +29,7 @@ from compat import unittest
 from numpy import testing as nptest
 import numpy
 
-from astropy import units
+from astropy import (units, __version__ as astropy_version)
 from astropy.time import Time
 
 from gwpy.types import (Array, Series, Array2D)
@@ -50,7 +50,10 @@ class CommonTests(object):
     __metaclass_ = abc.ABCMeta
     TEST_CLASS = Array
     tmpfile = '%s.%%s' % tempfile.mktemp(prefix='gwpy_test_')
-    EMPTY_ARRAY_ERROR = IndexError
+    if astropy_version >= '1.3':
+        EMPTY_ARRAY_ERROR = None
+    else:
+        EMPTY_ARRAY_ERROR = IndexError
 
     @classmethod
     def setUpClass(cls, dtype=None):
@@ -96,7 +99,8 @@ class CommonTests(object):
         """
         # test basic empty contructor
         self.assertRaises(TypeError, self.TEST_CLASS)
-        self.assertRaises(self.EMPTY_ARRAY_ERROR, self.TEST_CLASS, [])
+        if self.EMPTY_ARRAY_ERROR:
+            self.assertRaises(self.EMPTY_ARRAY_ERROR, self.TEST_CLASS, [])
         # test with some data
         array = self.create()
         nptest.assert_array_equal(array.value, self.data)

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -588,7 +588,6 @@ class SegmentAxesTestCase(SegmentMixin, AxesTestCase):
         self.assertIsInstance(c, PatchCollection)
         self.assertEqual(ax.dataLim.x0, 0.)
         self.assertAlmostEqual(ax.dataLim.x1, 7.)
-        self.assertTupleEqual(ax.get_ylim(), (-1., 1.))
         self.assertEqual(len(c.get_paths()), len(self.segments))
         self.assertEqual(ax.get_epoch(), self.segments[0][0])
         # test y

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -31,7 +31,7 @@ from scipy import signal
 from matplotlib import (use, rc_context)
 use('agg')
 from matplotlib.legend import Legend
-from matplotlib.colors import LogNorm
+from matplotlib.colors import (LogNorm, ColorConverter)
 from matplotlib.collections import (PathCollection, PatchCollection,
                                     PolyCollection)
 
@@ -65,6 +65,15 @@ ZPK = [100], [1], 1e-2
 FREQUENCIES, H = signal.freqresp(ZPK, n=100)
 MAGNITUDE = 20 * numpy.log10(numpy.absolute(H))
 PHASE = numpy.degrees(numpy.unwrap(numpy.angle(H)))
+
+# extract color cycle
+COLOR_CONVERTER = ColorConverter()
+try:
+    COLOR_CYCLE = rcParams['axes.prop_cycle'].by_key()['color']
+except KeyError:  # mpl < 1.5
+    COLOR0 = COLOR_CONVERTER.to_rgba('b')
+else:
+    COLOR0 = COLOR_CONVERTER.to_rgba(COLOR_CYCLE[0])
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -559,10 +568,11 @@ class SegmentAxesTestCase(SegmentMixin, AxesTestCase):
         self.assertTupleEqual(patch.get_xy(), (1.1, 9.6))
         self.assertAlmostEqual(patch.get_height(), 0.8)
         self.assertAlmostEqual(patch.get_width(), 1.3)
-        self.assertTupleEqual(patch.get_facecolor(), (0.0, 0.0, 1.0, 1.0))
+        self.assertTupleEqual(patch.get_facecolor(), COLOR0)
         # check kwarg passing
         patch = self.AXES_CLASS.build_segment((1.1, 2.4), 10, facecolor='red')
-        self.assertTupleEqual(patch.get_facecolor(), (1.0, 0.0, 0.0, 1.0))
+        self.assertTupleEqual(patch.get_facecolor(),
+                              COLOR_CONVERTER.to_rgba('red'))
         # check valign
         patch = self.AXES_CLASS.build_segment((1.1, 2.4), 10, valign='top')
         self.assertTupleEqual(patch.get_xy(), (1.1, 9.2))

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -28,7 +28,7 @@ from numpy import testing as nptest
 
 from scipy import signal
 
-from matplotlib import (use, rc_context)
+from matplotlib import (use, rc_context, __version__ as mpl_version)
 use('agg')
 from matplotlib.legend import Legend
 from matplotlib.colors import (LogNorm, ColorConverter)
@@ -73,7 +73,10 @@ try:
 except KeyError:  # mpl < 1.5
     COLOR0 = COLOR_CONVERTER.to_rgba('b')
 else:
-    COLOR0 = COLOR_CONVERTER.to_rgba(COLOR_CYCLE[0])
+    if mpl_version >= '2.0':
+        COLOR0 = COLOR_CONVERTER.to_rgba(COLOR_CYCLE[0])
+    else:
+        COLOR0 = COLOR_CONVERTER.to_rgba('b')
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 


### PR DESCRIPTION
This PR fixes (hopefully) the test failure in `gwpy/tests/test_plotter.py::SegmentAxesTestCase::test_build_segment` under matplotlib-2.0.