### PR TITLE
Set unit after array.view(cls) operations

### DIFF
--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -37,7 +37,7 @@ class SpectralVariance(Array2D):
     """A 2-dimensional array containing the variance histogram of a
     frequency-series `FrequencySeries`
     """
-    _metadata_slots = FrequencySeries._metadata_slots + ['bins']
+    _metadata_slots = FrequencySeries._metadata_slots + ('bins',)
     _default_xunit = FrequencySeries._default_xunit
     _rowclass = FrequencySeries
 

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -106,7 +106,7 @@ class Spectrogram(Array2D):
        ~Spectrogram.plot
        ~Spectrogram.zpk
     """
-    _metadata_slots = Series._metadata_slots + ['y0', 'dy', 'yindex']
+    _metadata_slots = Series._metadata_slots + ('y0', 'dy', 'yindex')
     _default_xunit = TimeSeries._default_xunit
     _default_yunit = FrequencySeries._default_xunit
     _rowclass = TimeSeries

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -295,6 +295,7 @@ class TimeSeriesTestMixin(object):
         ts1 = self.create(sample_rate=100)
         ts2 = ts1.resample(10, ftype='iir')
         self.assertEquals(ts2.sample_rate, ONE_HZ*10)
+        self.assertEqual(ts1.unit, ts2.unit)
         ts1.resample(10, ftype='fir', n=10)
 
     def test_to_from_lal(self):
@@ -671,7 +672,8 @@ class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):
     def test_resample(self):
         ts1 = self.create(sample_rate=100)
         ts2 = ts1.resample(10)
-        self.assertEquals(ts2.sample_rate, ONE_HZ*10)
+        self.assertEqual(ts2.sample_rate, ONE_HZ*10)
+        self.assertEqual(ts1.unit, ts2.unit)
 
 
 # -- TimeSeriesDict tests ------------------------------------------------------

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -821,6 +821,7 @@ class StateVector(TimeSeriesBase):
                                     for bit in bits], dtype=self.dtype)
             new = StateVector(it.operands[1], dtype=dtype)
             new.__metadata_finalize__(self)
+            new._unit = self.unit
             new.sample_rate = rate2
             return new
         # error for non-integer resampling factors

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -346,7 +346,7 @@ class StateVector(TimeSeriesBase):
         ~StateVector.plot
 
     """
-    _metadata_slots = TimeSeriesBase._metadata_slots + ['bits']
+    _metadata_slots = TimeSeriesBase._metadata_slots + ('bits',)
 
     def __new__(cls, data, bits=None, t0=None, dt=None, sample_rate=None,
                 times=None, channel=None, name=None, **kwargs):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1103,6 +1103,7 @@ class TimeSeries(TimeSeriesBase):
             new = signal.resample(self.value, nsamp,
                                   window=window).view(self.__class__)
             new.__metadata_finalize__(self)
+            new._unit = self.unit
             new.sample_rate = rate
             return new
 
@@ -1288,6 +1289,7 @@ class TimeSeries(TimeSeriesBase):
             else:
                 new = signal.lfilter(b, a, self, axis=0, **kwargs).view(cls)
         new.__metadata_finalize__(self)
+        new._unit = self.unit
         return new
 
     def coherence(self, other, fftlength=None, overlap=None,
@@ -1543,6 +1545,7 @@ class TimeSeries(TimeSeriesBase):
         nsteps = 1 + int((self.size - nfft) / nstride)
         out = numpy.zeros(nsteps * nstride + noverlap).view(type(self))
         out.__metadata_finalize__(self)
+        out._unit = self.unit
         del out.times
         # loop over ffts and whiten each one
         for i in range(nsteps):
@@ -1576,6 +1579,7 @@ class TimeSeries(TimeSeriesBase):
         """
         data = signal.detrend(self.value, type=detrend).view(type(self))
         data.__metadata_finalize__(self)
+        data._unit = self.unit
         return data
 
     def plot(self, **kwargs):

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -100,7 +100,7 @@ class Array(Quantity):
     #
     # this is used in __array_finalize__ to create new instances of this
     # object [http://docs.scipy.org/doc/numpy/user/basics.subclassing.html]
-    _metadata_slots = ['name', 'epoch', 'channel']
+    _metadata_slots = ('name', 'epoch', 'channel')
 
     def __new__(cls, value, unit=None,  # Quantity attrs
                 name=None, epoch=None, channel=None,  # new attrs

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -94,7 +94,7 @@ class Array2D(Series):
     array : `Array`
         a new array, with a view of the data, and all associated metadata
     """
-    _metadata_slots = Series._metadata_slots + ['y0', 'dy', 'yindex']
+    _metadata_slots = Series._metadata_slots + ('y0', 'dy', 'yindex')
     _default_xunit = Unit('')
     _default_yunit = Unit('')
     _rowclass = Series

--- a/gwpy/types/io/hdf5.py
+++ b/gwpy/types/io/hdf5.py
@@ -143,7 +143,7 @@ def array_to_hdf5(array, output, name=None, group=None, compression='gzip',
             raise
 
         # store metadata
-        for attr in ['unit'] + array._metadata_slots:
+        for attr in ('unit',) + array._metadata_slots:
             # get private attribute
             mdval = getattr(array, '_%s' % attr, None)
             if mdval is None:

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -797,6 +797,7 @@ class Series(Array):
         new = numpy.pad(self, pad_width, **kwargs).view(type(self))
         # numpy.pad has stripped all metadata, so copy it over
         new.__metadata_finalize__(self)
+        new._unit = self.unit
         # finally move the starting index based on the amount of left-padding
         new.x0 -= self.dx * pad_width[0]
         return new

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -104,7 +104,7 @@ class Series(Array):
            dx: 2.0 W,
            xindex: [  0.   2.   4.   6.   8.  10.] W)
     """
-    _metadata_slots = Array._metadata_slots + ['x0', 'dx', 'xindex']
+    _metadata_slots = Array._metadata_slots + ('x0', 'dx', 'xindex')
     _default_xunit = Unit('')
     _ndim = 1
 


### PR DESCRIPTION
This PR improves a number of `Array` manipulation methods that rely on `numpy.ndarray.view` to cast to the output type. This operation loses all metadata, so we need to reset the unit explicitly because astropy doesn't do it for us.