### PR TITLE
Update travis build to use separate ldas-tools-framecpp package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,14 @@ env:
     - LAL_VERSION="6.15.0"
     - LALFRAME_VERSION="1.3.0"
     - LIBFRAME_VERSION="8.20"
-    - LDAS_TOOLS_VERSION="2.4.1"
+    - LDAS_TOOLS_AL_VERSION="2.5.5""
+    - FRAMECPP_VERSION="2.5.4"
     - NDS2_CLIENT_VERSION="0.10.4"
     # tarballs
     - SWIG_="https://github.com/swig/swig/archive/rel-${SWIG_VERSION}.tar.gz"
     - FFTW="http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz"
-    - LDAS_TOOLS="http://software.ligo.org/lscsoft/source/ldas-tools-${LDAS_TOOLS_VERSION}.tar.gz"
+    - LDAS_TOOLS_AL="http://software.ligo.org/lscsoft/source/ldas-tools-al-${LDAS_TOOLS_AL_VERSION}.tar.gz"
+    - FRAMECPP="http://software.ligo.org/lscsoft/source/ldas-tools-framecpp-${FRAMECPP_VERSION}.tar.gz"
     - LIBFRAME="http://software.ligo.org/lscsoft/source/libframe-${LIBFRAME_VERSION}.tar.gz"
     - LAL="http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz"
     - LALFRAME="http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz"
@@ -109,7 +111,8 @@ cache:
     - ./swig-${SWIG_VERSION}
     - ./fftw-${FFTW_VERSION}
     - ./fftw-${FFTW_VERSION}-float
-    - ./ldas-tools-${LDAS_TOOLS_VERSION}
+    - ./ldas-tools-al-${LDAS_TOOLS_AL_VERSION}
+    - ./framecpp-${FRAMECPP_VERSION}
     - ./libframe-${LIBFRAME_VERSION}
     - ./lal-${LAL_VERSION}
     - ./lalframe-${LALFRAME_VERSION}

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -13,8 +13,11 @@ export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:${VIRTUAL_ENV}/lib/pkgconfig
 
 FAILURES=""
 
-# build frame libraries
-bash .travis/build-with-autotools.sh ldas-tools-${LDAS_TOOLS_VERSION}/${TRAVIS_PYTHON_VERSION} ${LDAS_TOOLS} || FAILURES="$FAILURES ldas-tools"
+# frameCPP
+bash .travis/build-with-autotools.sh ldas-tools-al-${LDAS_TOOLS_AL_VERSION}/${TRAVIS_PYTHON_VERSION} ${LDAS_TOOLS_AL} || FAILURES="$FAILURES ldas-tools-al"
+bash .travis/build-with-autotools.sh framecpp-${FRAMECPP_VERSION}/${TRAVIS_PYTHON_VERSION} ${FRAMECPP} --enable-python || FAILURES="$FAILURES framecpp"
+
+# libframe
 bash .travis/build-with-autotools.sh libframe-${LIBFRAME_VERSION}/${TRAVIS_PYTHON_VERSION} ${LIBFRAME} || FAILURES="$FAILURES libframe"
 
 # LALFrame


### PR DESCRIPTION
This PR modifies the build script to use the separated ldas-tools-framecpp package, rather than the monolithic (deprecated) ldas-tools build.