### PR TITLE
Added --style command-line option to gwpy-plot

### DIFF
--- a/bin/gwpy-plot
+++ b/bin/gwpy-plot
@@ -127,6 +127,8 @@ if __name__ == '__main__':
     # If they requested interactive mode and run from ipython
     # this makes it easier
     if prod.is_interactive:
+        # import pyplot so that user has access to it
+        from matplotlib import pyplot as plt  # pylint: disable=unused-import
         plot = prod.plot
         # pull raw data and plotted results from product for their use
         timeseries = prod.timeseries

--- a/bin/gwpy-plot
+++ b/bin/gwpy-plot
@@ -115,11 +115,18 @@ if __name__ == '__main__':
                            "Please try again with --help.")
     prod = actions[args.func]
     prod.log(2, ('%s called' % args.func))
+
+    # apply custom styling
+    if args.style:
+        from matplotlib import pyplot
+        pyplot.style.use(args.style)
+
+    # generate the plot
     result_code = prod.makePlot(args)
+
     # If they requested interactive mode and run from ipython
     # this makes it easier
     if prod.is_interactive:
-        from matplotlib import pyplot as plt
         plot = prod.plot
         # pull raw data and plotted results from product for their use
         timeseries = prod.timeseries

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -242,9 +242,10 @@ class CliProduct(object):
                             help='do not display grid lines')
         # allow custom styling with a style file
         parser.add_argument(
-           '--style', help='path to custom matplotlib style sheet, see '
-                           'http://matplotlib.org/users/style_sheets.html'
-                           '#style-sheets for details of how to write one')
+           '--style', metavar='FILE',
+           help='path to custom matplotlib style sheet, see '
+                'http://matplotlib.org/users/style_sheets.html#style-sheets '
+                'for details of how to write one')
 
         return
 

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -240,6 +240,11 @@ class CliProduct(object):
                             help='do not display legend')
         parser.add_argument('--nogrid', action='store_true',
                             help='do not display grid lines')
+        # allow custom styling with a style file
+        parser.add_argument(
+           '--style', help='path to custom matplotlib style sheet, see '
+                           'http://matplotlib.org/users/style_sheets.html'
+                           '#style-sheets for details of how to write one')
 
         return
 
@@ -468,18 +473,6 @@ class CliProduct(object):
     def config_plot(self, arg_list):
         """Configure global plot parameters"""
         from matplotlib import rcParams
-
-        # set rcParams
-        rcParams.update({
-            'figure.dpi': 100.,
-            'font.family': 'sans-serif',
-            'font.size': 16.,
-            'font.weight': 'book',
-            'legend.loc': 'best',
-            'lines.linewidth': 1.5,
-            'text.usetex': 'true',
-            'agg.path.chunksize': 10000,
-        })
 
         # determine image dimensions (geometry)
         self.width = 1600


### PR DESCRIPTION
This PR adds a `--style` option for `gwpy-plot` documented as

```
  --style FILE          path to custom matplotlib style sheet, see
                        http://matplotlib.org/users/style_sheets.html#style-
                        sheets for details of how to write one
```

The argument is a path to a matplotlib style sheet, as documented [here](http://matplotlib.org/users/style_sheets.html#style-sheets). This will allow users to customise their plots ad nauseam without manually editing python code.

In line with this I have removed the custom `rcParams` settings in `gwpy.cli.cliproduct`. These can be reinstated (e.g. on LDVW) with the following style file

```
figure.dpi: 100
font.family: sans-serif
font.size: 16
font.weight: book
legend.loc: best
lines.linewidth: 1.5
text.usetex: True
agg.path.chunksize: 10000
```