### PR TITLE
Use apt/sourceline to install more stuff for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ addons:
       - libhdf5-serial-dev
 
 python:
-  - '2.6'
   - '2.7'
   - '3.5'
+  - 'nightly'
 
 env:
   # minimal build, normal tests
@@ -47,18 +47,11 @@ env:
   - PIP_FLAGS="--quiet --pre" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
 
 matrix:
-  exclude:
-    - python: '2.6'
-      env: PIP_FLAGS="--quiet" MINIMAL=false PYTEST_FLAGS="-v -r s"
-    - python: '2.6'
-      env: PIP_FLAGS="--quiet" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
-    - python: '2.6'
-      env: PIP_FLAGS="--quiet --pre" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
   allow_failures:
-    - python: '2.6'
-    - python: '3.5'
     - python: '2.7'
       env: PIP_FLAGS="--quiet --pre" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
+    - python: '3.5'
+    - python: 'nightly'
   fast_finish: true
 
 before_install:
@@ -76,9 +69,6 @@ before_install:
 
   # install testing dependencies
   - pip install ${PIP_FLAGS} coveralls "pytest>=2.8" unittest2
-
-  # need to install astropy 1.1 specifically for py26
-  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
 
 install:
   # install dependencies (using version-dependent requirements if needed)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: python
 
 addons:
   apt:
+    sources:
+      - sourceline: deb http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
+      - sourceline: deb-src http://software.ligo.org/lscsoft/debian wheezy contrib
+        key_url: http://software.ligo.org/keys/deb/lscsoft.key
     packages:
       # generic packages
       - gcc
@@ -14,6 +19,10 @@ addons:
       - libgsl0-dev
       - swig
       - bc
+      - libfftw3-dev
+      - libframe-dev
+      # framecpp dependencies
+      - ldas-tools-al-dev
       # nds2 dependencies
       - libsasl2-2
       # misc python dependencies
@@ -22,63 +31,51 @@ addons:
       - dvipng
       - libhdf5-serial-dev
 
+python:
+  - '2.6'
+  - '2.7'
+  - '3.5'
+
 env:
-  global:
-    - SWIG_VERSION="3.0.8"
-    - FFTW_VERSION="3.3.4"
-    - LAL_VERSION="6.15.0"
-    - LALFRAME_VERSION="1.3.0"
-    - LIBFRAME_VERSION="8.20"
-    - LDAS_TOOLS_AL_VERSION="2.5.5""
-    - FRAMECPP_VERSION="2.5.4"
-    - NDS2_CLIENT_VERSION="0.10.4"
-    # tarballs
-    - SWIG_="https://github.com/swig/swig/archive/rel-${SWIG_VERSION}.tar.gz"
-    - FFTW="http://www.fftw.org/fftw-${FFTW_VERSION}.tar.gz"
-    - LDAS_TOOLS_AL="http://software.ligo.org/lscsoft/source/ldas-tools-al-${LDAS_TOOLS_AL_VERSION}.tar.gz"
-    - FRAMECPP="http://software.ligo.org/lscsoft/source/ldas-tools-framecpp-${FRAMECPP_VERSION}.tar.gz"
-    - LIBFRAME="http://software.ligo.org/lscsoft/source/libframe-${LIBFRAME_VERSION}.tar.gz"
-    - LAL="http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.gz"
-    - LALFRAME="http://software.ligo.org/lscsoft/source/lalsuite/lalframe-${LALFRAME_VERSION}.tar.gz"
-    - NDS2_CLIENT="http://software.ligo.org/lscsoft/source/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz"
+  # minimal build, normal tests
+  - PIP_FLAGS="--quiet" MINIMAL=true PYTEST_FLAGS="-v -r s"
+  # normal build, normal tests
+  - PIP_FLAGS="--quiet" MINIMAL=false PYTEST_FLAGS="-v -r s"
+  # normal build, pedantic tests
+  - PIP_FLAGS="--quiet" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
+  # pre-release build, pedantic tests
+  - PIP_FLAGS="--quiet --pre" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
 
 matrix:
-  include:
-    - python: 2.6
-    - python: 2.7
-      env: STRICT=false
-    - python: 2.7  # test latest release of upstream packages
-      env: STRICT=true PRE="--pre"
-    - python: 2.7  # python-only build
-      env: MINIMAL=true
-    - python: 3.5
-    - python: 3.5  # python-only build
-      env: MINIMAL=true
+  exclude:
+    - python: '2.6'
+      env: PIP_FLAGS="--quiet" MINIMAL=false PYTEST_FLAGS="-v -r s"
+    - python: '2.6'
+      env: PIP_FLAGS="--quiet" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
+    - python: '2.6'
+      env: PIP_FLAGS="--quiet --pre" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
   allow_failures:
-    - python: 2.6
-    - python: 2.7
-      env: STRICT=true PRE="--pre"
-    - python: 3.5
-    - python: 3.5
-      env: MINIMAL=true
+    - python: '2.6'
+    - python: '3.5'
+    - python: '2.7'
+      env: PIP_FLAGS="--quiet --pre" MINIMAL=false PYTEST_FLAGS="-v -r s --strict"
   fast_finish: true
 
 before_install:
   # update pip
-  - pip install -q ${PRE} --upgrade pip
+  - pip install ${PIP_FLAGS} --upgrade pip
 
   # build and install numpy first
-  - pip install -q ${PRE} "numpy>=1.7"
+  - pip install ${PIP_FLAGS} "numpy>=1.7"
 
   # build src packages and set 'latest' package versions (if required)
-  - source .travis/find-latest-releases.sh
   - source .travis/build-src-dependencies.sh
 
   # install cython to speed up scipy build
-  - travis_retry pip install -q ${PRE} --install-option="--no-cython-compile" Cython
+  - travis_retry pip install ${PIP_FLAGS} --install-option="--no-cython-compile" Cython
 
   # install testing dependencies
-  - pip install -q ${PRE} coveralls "pytest>=2.8" unittest2
+  - pip install ${PIP_FLAGS} coveralls "pytest>=2.8" unittest2
 
   # need to install astropy 1.1 specifically for py26
   - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
@@ -87,7 +84,7 @@ install:
   # install dependencies (using version-dependent requirements if needed)
   - . .travis/install-requirements.sh
   # add extra dependencies for testing
-  - pip install ${PRE} -r requirements-extra.txt
+  - pip install ${PIP_FLAGS} -r requirements-extra.txt
   # build
   - python setup.py build
 
@@ -107,13 +104,7 @@ cache:
   pip: true
   ccache: true
   directories:
-    # cache src builds
-    - ./swig-${SWIG_VERSION}
-    - ./fftw-${FFTW_VERSION}
-    - ./fftw-${FFTW_VERSION}-float
-    - ./ldas-tools-al-${LDAS_TOOLS_AL_VERSION}
-    - ./framecpp-${FRAMECPP_VERSION}
-    - ./libframe-${LIBFRAME_VERSION}
-    - ./lal-${LAL_VERSION}
-    - ./lalframe-${LALFRAME_VERSION}
-    - ./nds2-client-${NDS2_CLIENT_VERSION}
+    - ./python-${TRAVIS_PYTHON_VERSION}-lal/
+    - ./python-${TRAVIS_PYTHON_VERSION}-framecpp/
+    - ./python-${TRAVIS_PYTHON_VERSION}-lalframe/
+    - ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -17,14 +17,16 @@ target=`python -c "import sys; print(sys.prefix)"`
 echo "Will install into ${target}"
 echo "Building into $builddir"
 
-# dont rebuild from scratch if not required
-if [ -f $builddir/configure ]; then
+# check for existing file
+if [ -f $builddir/.travis-src-file ] && [ `cat $builddir/.travis-src-file` == "$tarball" ]; then
     echo "Cached build directory found, not downloading tarball"
 else
     echo "New build requested, downloading tarball..."
+    rm -rf $builddir/
     mkdir -p $builddir
     wget $tarball -O `basename $tarball`
-    tar -zxf `basename $tarball` -C $builddir --strip-components=1
+    tar -xf `basename $tarball` -C $builddir --strip-components=1
+    echo $tarball > $builddir/.travis-src-file
 fi
 
 # always install and return

--- a/.travis/find-latest-releases.sh
+++ b/.travis/find-latest-releases.sh
@@ -2,13 +2,11 @@
 #
 # Set environment for src builds for the GWpy travis-ci runner
 
-if [[ "${PRE}" == "--pre" ]]; then  # open conditional
-
 # -- utilities
 
 pip install --quiet bs4 six
 find_latest_version() {
-    python .travis/find-latest-release.py -o version $@
+    python .travis/find-latest-release.py $@
 }
 
 get_requirements_version() {
@@ -32,34 +30,28 @@ LALSUITE_URL="${LSCSOFT_URL}/lalsuite"
 
 # -- non-pure-python packages
 
-LIBFRAME_VERSION=`find_latest_version ${LSCSOFT_URL} libframe`
-LIBFRAME="${LSCSOFT_URL}/libframe-${LIBFRAME_VERSION}.tar.gz"
+echo "Querying for latest versions of LSCSoft packages:"
 
-NDS2_CLIENT_VERSION=`find_latest_version ${LSCSOFT_URL} nds2-client`
-NDS2_CLIENT="${LSCSOFT_URL}/nds2-client-${NDS2_CLIENT_VERSION}.tar.gz"
+read NDS2_CLIENT_VERSION NDS2_CLIENT < <(python .travis/find-latest-release.py ${LSCSOFT_URL} nds2-client)
+echo "   nds2-client: ${NDS2_CLIENT_VERSION}"
 
-LDAS_TOOLS_VERSION=`find_latest_version ${LSCSOFT_URL} ldas-tools`
-LDAS_TOOLS="${LSCSOFT_URL}/ldas-tools-${LDAS_TOOLS_VERSION}.tar.gz"
+read FRAMECPP_VERSION FRAMECPP < <(python .travis/find-latest-release.py ${LSCSOFT_URL} ldas-tools-framecpp)
+echo "   frameCPP:    ${FRAMECPP_VERSION}"
 
-LAL_VERSION=`find_latest_version ${LALSUITE_URL} lal`
-LAL="${LALSUITE_URL}/lal-${LAL_VERSION}.tar.gz"
+read LAL_VERSION LAL < <(python .travis/find-latest-release.py ${LALSUITE_URL} lal)
+echo "   lal:         ${LAL_VERSION}"
 
-LALFRAME_VERSION=`find_latest_version ${LALSUITE_URL} lalframe`
-LALFRAME="${LALSUITE_URL}/lalframe-${LALFRAME_VERSION}.tar.gz"
+read LALFRAME_VERSION LALFRAME < <(python .travis/find-latest-release.py ${LALSUITE_URL} lalframe)
+echo "   lalframe:    ${LALFRAME_VERSION}"
 
 # -- python packages
 
 OLD_GLUE_VERSION=`get_requirements_version glue`
-GLUE="${LSCSOFT_URL}/glue-${GLUE_VERSION}.tar.gz"
-GLUE_VERSION=`find_latest_version ${LSCSOFT_URL} glue`
+read GLUE_VERSION GLUE < <(python .travis/find-latest-release.py ${LSCSOFT_URL} glue)
+echo "   glue:        ${GLUE_VERSION}"
 sedx 's/glue-'${OLD_GLUE_VERSION}'/glue-'${GLUE_VERSION}'/g' requirements.txt
 
 OLD_DQSEGDB_VERSION=`get_requirements_version dqsegdb`
-DQSEGDB="${LSCSOFT_URL}/dqsegdb-${DQSEGDB_VERSION}.tar.gz"
-DQSEGDB_VERSION=`find_latest_version ${LSCSOFT_URL} dqsegdb`
+read DQSEGDB_VERSION DQSEGDB < <(python .travis/find-latest-release.py ${LSCSOFT_URL} dqsegdb)
+echo "   dqsegdb:     ${DQSEGDB_VERSION}"
 sedx 's/dqsegdb-'${OLD_DQSEGDB_VERSION}'/dqsegdb-'${DQSEGDB_VERSION}'/g' requirements.txt
-
-# -- clean up
-
-fi  # close conditional
-

--- a/.travis/install-requirements.sh
+++ b/.travis/install-requirements.sh
@@ -9,4 +9,4 @@ else
 fi
 
 # execute the install
-pip install ${PRE} -r ${_reqfile}
+pip install ${PIP_FLAGS} -r ${_reqfile}

--- a/bin/gwpy-plot
+++ b/bin/gwpy-plot
@@ -31,8 +31,8 @@ __email__ = 'joseph.areeda@ligo.org'
 
 VERBOSE = 3     # 0 = errors only, 1 = Warnings, 2 = INFO, >2 DEBUG >=5 ALL
 
-if sys.version < '2.6':
-    raise ImportError("Python versions older than 2.6 are not supported.")
+if sys.version < '2.7':
+    raise ImportError("Python versions older than 2.7 are not supported.")
 
 
 # ---needed to generate help messages---

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -717,14 +717,6 @@ class StateVector(TimeSeriesBase):
             new.bits = bits
         return new
 
-    def to_lal(self, *args, **kwargs):
-        """Bogus function inherited from superclass, do not use.
-        """
-        raise NotImplementedError("The to_lal method, inherited from the "
-                                  "TimeSeries, cannot be used with the "
-                                  "StateTimeSeries because LAL has no "
-                                  "BooleanTimeSeries structure")
-
     def plot(self, format='segments', bits=None, **kwargs):
         """Plot the data for this `StateVector`
 

--- a/requirements-2.6.txt
+++ b/requirements-2.6.txt
@@ -1,4 +1,0 @@
--r requirements.txt
-importlib
-ordereddict>=1.1
-argparse

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@
 """
 
 import sys
-if sys.version < '2.6':
-    raise ImportError("Python versions older than 2.6 are not supported.")
+if sys.version < '2.7':
+    raise ImportError("Python versions older than 2.7 are not supported.")
 
 import glob
 import hashlib


### PR DESCRIPTION
This PR modifies the travis-ci configuration to include the LSCSoft apt sources for non-python dependency installation.