### PR TITLE
Use print function for all calls (rather than print keyword)

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -147,7 +147,7 @@ class CliProduct(object):
     def log(self, level, msg):
         """print log message if verbosity is set high enough"""
         if self.verbose >= level:
-            print msg
+            print(msg)
         return
 
 
@@ -409,8 +409,8 @@ class CliProduct(object):
             time_group = []
             for chan in self.chan_list:
                 if verb:
-                    print 'Fetching %s %d, %d using %s' % \
-                          (chan, start, self.dur, source)
+                    print('Fetching %s %d, %d using %s'
+                          % (chan, start, self.dur, source))
                 if frame_cache:
                     data = TimeSeries.read(frame_cache, chan, start=start,
                                            end=start+self.dur)
@@ -761,9 +761,9 @@ class CliProduct(object):
         self.log(3, ('Verbosity level: %d' % self.verbose))
 
         if self.verbose > 2:
-            print 'Arguments:'
+            print('Arguments:')
             for key, value in args.__dict__.iteritems():
-                print '%s = %s' % (key, value)
+                print('%s = %s' % (key, value))
 
         self.getTimeSeries(args)
 

--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -112,21 +112,21 @@ class Coherence(CliProduct):
                 maxfs = max(maxfs, self.timeseries[ref_idx].sample_rate)
                 if numpy.min(self.timeseries[ref_idx]) == \
                         numpy.max(self.timeseries[ref_idx]):
-                    print 'Channel %s at %d has min=max,it cannot be used ' \
-                          'as a reference channel' \
-                          % self.timeseries[ref_idx].channel.name, \
-                        self.timeseries[ref_idx].epoch.gps
+                    print('Channel %s at %d has min=max,it cannot be used '
+                          'as a reference channel'
+                          % (self.timeseries[ref_idx].channel.name,
+                             self.timeseries[ref_idx].epoch.gps))
                 else:
                     for idxp in range(0, len(time_group)):
                         next_ts = time_group[idxp]
                         if next_ts != ref_idx:
                             if numpy.min(self.timeseries[next_ts]) == \
                                     numpy.max(self.timeseries[next_ts]):
-                                print 'Channel %s at %d has min=max, ' \
-                                      'coherence with this channel will not ' \
-                                      'be calculated' \
-                                      % self.timeseries[next_ts].channel.name,\
-                                    self.timeseries[next_ts].epoch.gps
+                                print('Channel %s at %d has min=max, '
+                                      'coherence with this channel will not '
+                                      'be calculated'
+                                      % (self.timeseries[next_ts].channel.name,
+                                         self.timeseries[next_ts].epoch.gps))
                             else:
                                 maxfs = max(maxfs,
                                             self.timeseries[next_ts].


### PR DESCRIPTION
This PR modifies the `gwpy.cli` module to use the python3-compatible `print()` function, rather than the outdated `python` keyword.

Fixes #351.