### PR TITLE
Added --nds2-server argument to gwpy-plot

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -163,6 +163,9 @@ class CliProduct(object):
         parser.add_argument('-c', '--framecache',
                             help='use .gwf files in cache not NDS2,' +
                                  ' default use NDS2')
+        parser.add_argument('-n', '--nds2-server', metavar='HOSTNAME',
+                            help='name of nds2 server to use, default is to '
+                                 'try all of them')
         parser.add_argument('--highpass',
                             help='frequency for high pass butterworth,' +
                                  ' default no filter')
@@ -416,7 +419,8 @@ class CliProduct(object):
                                            end=start+self.dur)
                 else:
                     data = TimeSeries.fetch(chan, start, start+self.dur,
-                                            verbose=verb)
+                                            verbose=verb,
+                                            host=arg_list.nds2_server)
 
                 if highpass > 0:
                     data = data.highpass(highpass)


### PR DESCRIPTION
This PR fixes #352 by allowing the user to manually select the nds2 host for `TimeSeries.fetch`.