### PR TITLE
Re-write of gwpy.table to inherit from astropy.table

### DIFF
--- a/.travis/run-tests.sh
+++ b/.travis/run-tests.sh
@@ -7,4 +7,4 @@ else
     _strict=""
 fi
 
-coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*,gwpy/utils/sphinx/*" -m py.test -v -r s ${_strict} gwpy/
+coverage run --source=gwpy --omit="gwpy/tests/*,gwpy/*version*,gwpy/utils/sphinx/*,gwpy/table/rate.py,gwpy/table/utils.py,gwpy/table/rec.py,gwpy/table/io/ascii.py" -m py.test -v -r s ${_strict} gwpy/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,14 @@ Working with data
    spectrum/index
    spectrogram/index
 
+**Working with tabular data and events**
+
+.. toctree::
+   :maxdepth: 2
+
+   table/index
+
+
 **Visualising data**
 
 .. toctree::

--- a/docs/table/H1-LDAS_STRAIN-968654552-10.xml.gz
+++ b/docs/table/H1-LDAS_STRAIN-968654552-10.xml.gz
@@ -1,0 +1,1 @@
+../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz

--- a/docs/table/histogram.rst
+++ b/docs/table/histogram.rst
@@ -1,14 +1,27 @@
+.. currentmodule:: gwpy.table
+
 #####################
 Data table histograms
 #####################
 
-One can easily generate a histogram of a tabular data using the :meth`hist` instance method.
-For example, as defined for the `SnglBurstTable`:
+The `EventTable` object comes with a :meth:`~EventTable.hist` method, allowing
+trivial generation of histograms using any column as the counter:
 
-.. automethod:: SnglBurstTable.hist
+.. automethod:: EventTable.hist
 
-Following the worked example on :doc:`plotting an event table histogram <../examples/table/histogram>` we can study the cumulative distribution of event signal-to-noise ratio:
+Using the above method we can generate a histogram as follows
 
-.. plot:: ../examples/table/histogram.py
+.. plot::
+   :include-source:
 
-|
+   >>> from gwpy.table import EventTable
+   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst', columns=['snr'])
+   >>> plot = events.hist('snr', weights=1/10., logbins=True, bins=50, histtype='stepfilled')
+   >>> ax = plot.gca()
+   >>> ax.set_xlabel('Signal-to-noise ratio (SNR)')
+   >>> ax.set_ylabel('Rate [Hz]')
+   >>> ax.set_title('LHO event triggers for GW100916')
+   >>> ax.autoscale(axis='x', tight=True)
+   >>> plot.show()
+
+This is a snippet from the example :ref:`example-table-histogram`.

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -4,14 +4,61 @@
 Tabular data
 ############
 
-Alongside the `timeseries <../timeseries>`_ data produced continuously at the
-laboratories, the gravitational-wave community produces a number of different
-sets of tabular data, including segments of time indicating interferometer
-state, and transient event triggers.
+Alongside the :ref:`timeseries <timeseries>` data produced continuously at the
+laboratories, a number of different sets of tabular data are generated, typically
+recording significant noise transients (glitches) or gravitational-wave events found
+in the data.
 
-==========================
-The ``LIGO_LW`` XML format
-==========================
+========================
+`Table` and `EventTable`
+========================
+
+GWpy provides two classes for handling tabular data.
+
+.. autosummary::
+
+   gwpy.table.Table
+   gwpy.table.EventTable
+
+.. note::
+
+   The `Table` object is just an import of the
+   :mod:`astropy.table.Table <astropy.table>` object, provided for import convenience,
+   see the Astropy documentation for full details on that (excellent) object).
+
+e.g.::
+
+    >>> from gwpy.table import EventTable
+
+The `EventTable` object extends the functionality of the regular
+`~astropy.table.Table` with utilities for processing and plotting tables of
+events that contain GPS timestamps. The methods given include
+
+.. autosummary::
+
+   EventTable.plot
+   EventTable.hist
+   EventTable.event_rate
+   EventTable.binned_event_rates
+
+====================
+Reading tabular data
+====================
+
+Astropy provides an excellent unified input/output system for the
+`~astropy.table.Table` object, and GWpy extends upon that to include common
+gravitational-wave file types, as well as providing event-specific
+input/output registrations for event data.
+In the most general case you can read a table of ASCII data as follows::
+
+    >>> from gwpy.table import Table
+    >>> table = Table.read('mydata.txt')
+
+See the Astropy documentation page on :mod:`astropy.table` for more details.
+
+----------------------
+Reading LIGO_LW tables
+----------------------
 
 The LIGO Scientific Collaboration uses a custom scheme of XML in which to
 store tabular data, called the ``LIGO_LW`` scheme.
@@ -19,73 +66,134 @@ Complementing the scheme is a python library - :mod:`glue.ligolw` - which
 allows users to read and write all of the different types of tabular data
 produced by gravitational-wave searches.
 
-The remainder of this document outlines the small number of extensions that
-GWpy provides for the table classes provided by :mod:`glue.ligolw`.
+In GWpy you can read ``LIGO_LW``-format XML files into a `Table` or
+`EventTable` by using the relevant `read()` method, while specifying the
+table name that you want to read via the ``format`` keyword argument::
 
-.. note::
+   >>> from gwpy.table import Table
+   >>> proc = Table.read('mydata.xml', format='ligolw.process')
 
-   All users should review the original documentation for :mod:`glue.ligolw`
-   to get any full sense of how to use these objects.
+This will return the ``process`` table from the given ``mydata.xml`` file.
 
-=========================
-Reading ``LIGO_LW`` files
-=========================
+For event tables it is recommended that you read data into an `EventTable`
+so that you get access to specialist methods for timestamped events that
+aren't available for regular data tables, e.g.
 
-GWpy annotates all of the :class:`~glue.ligolw.table.Table` subclasses defined
-in :mod:`glue.ligolw.lsctables` to make reading those tables from ``LIGO_LW``
-XML files a bit easier.
+.. code-block:: python
 
-These annotations hook into the unified input/output scheme used for all of
-the other core data classes.
-For example, you can read a table of single-interferometer burst events as
-follows:
+   >>> from gwpy.table import EventTable
+   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst')
 
-.. literalinclude:: ../../examples/table/scatter.py
-   :lines: 35,38
+By default, this will read all columns available in the file, so you end up with
+something like this
 
-For full details, check out the :meth:`~SnglBurstTable.read` documentation.
+.. code-block:: python
 
-=======================
+   >>> print(events)
+   ifo peak_time peak_time_ns start_time ... confidence chisq chisq_dof bandwidth
+   --- --------- ------------ ---------- ... ---------- ----- --------- ---------
+    H1 968654557    783203126  968654557 ...  16.811825   0.0     512.0     256.0
+    H1 968654557    781250001  968654557 ...  16.816761   0.0     512.0     256.0
+    H1 968654557    779296876  968654557 ...  16.696106   0.0     512.0     256.0
+    H1 968654557    777343751  968654557 ...  16.739489   0.0     512.0     256.0
+    H1 968654557    775390626  968654557 ...  16.802326   0.0     512.0     256.0
+    H1 968654557    773437501  968654557 ...   16.30731   0.0     512.0     256.0
+    H1 968654557    771484376  968654557 ...  16.307253   0.0     512.0     256.0
+    H1 968654557    769531251  968654557 ...   16.35647   0.0     512.0     256.0
+    H1 968654557    767578126  968654557 ...  16.561176   0.0     512.0     256.0
+    H1 968654557    765625001  968654557 ...  16.393112   0.0     512.0     256.0
+    H1 968654557    763671876  968654557 ...  16.404041   0.0     512.0     256.0
+    H1 968654557    761718751  968654557 ...  16.405825   0.0     512.0     256.0
+    H1 968654557    759765626  968654557 ...  16.715092   0.0     512.0     256.0
+    H1 968654557    757812501  968654557 ...  17.512749   0.0     512.0     256.0
+    H1 968654557    755859376  968654557 ...  17.347675   0.0     512.0     256.0
+    H1 968654557    753906251  968654557 ...  17.077478   0.0     512.0     256.0
+    H1 968654557    751953126  968654557 ...  16.742907   0.0     512.0     256.0
+   ...       ...          ...        ... ...        ...   ...       ...       ...
+    H1 968654560    342773438  968654559 ...  11.029792   0.0      16.0       8.0
+    H1 968654559    280273438  968654558 ...  12.363036   0.0      16.0       8.0
+    H1 968654559    217773438  968654558 ...  13.985101   0.0      16.0       8.0
+    H1 968654559    155273438  968654558 ...  14.662391   0.0      16.0       8.0
+    H1 968654559     92773438  968654558 ...  15.864924   0.0      16.0       8.0
+    H1 968654559     30273438  968654558 ...  16.321821   0.0      16.0       8.0
+    H1 968654558    967773438  968654558 ...  16.975931   0.0      16.0       8.0
+    H1 968654558    905273438  968654558 ...  19.160393   0.0      16.0       8.0
+    H1 968654560    811523438  968654560 ...  11.270205   0.0       8.0       4.0
+    H1 968654560    686523438  968654560 ...  15.839205   0.0       8.0       4.0
+    H1 968654560    561523438  968654560 ...  15.944695   0.0       8.0       4.0
+    H1 968654560    436523438  968654559 ...  14.384432   0.0       8.0       4.0
+    H1 968654560    311523438  968654559 ...  14.465309   0.0       8.0       4.0
+    H1 968654560    186523438  968654559 ...  13.045853   0.0       8.0       4.0
+    H1 968654560    561523438  968654560 ...  11.636543   0.0       4.0       4.0
+    H1 968654560    436523438  968654560 ...  15.344837   0.0       4.0       4.0
+    H1 968654560    311523438  968654560 ...  11.367717   0.0       4.0       4.0
+   Length = 2052 rows
+
+-----------------------
+Registered file formats
+-----------------------
+
+The full list of registered file formats can be seen by reading the docstring
+for the `Table.read` method:
+
+.. automethod:: Table.read
+
+and similarly for the `EventTable`
+
+.. automethod:: EventTable.read
+
+
+=====================
+Plotting tabular data
+=====================
+
+-----------------------
 Plotting event triggers
-=======================
+-----------------------
 
-The other annotation GWpy defines provides a simple plotting method for a
-number of classes.
+The `EventTable` class provides a convenience instance method to
+:meth:`~EventTable.plot` events by specifying the columns to use for the
+x-axis, y-axis, and optionally colouring:
 
-We can extend the above example to include plotting:
+.. plot::
+   :context: reset
+   :include-source:
 
-.. literalinclude:: ../../examples/table/scatter.py
-   :append: plot.show()
-   :lines: 41-46
+   >>> from gwpy.table import EventTable
+   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst', columns=['time', 'central_freq', 'snr'])
+   >>> plot = events.plot('time', 'central_freq', color='snr')
+   >>> ax = plot.gca()
+   >>> ax.set_epoch(968654552)
+   >>> ax.set_yscale('log')
+   >>> ax.set_ylabel('Frequency [Hz]')
+   >>> plot.add_colorbar(clim=[1, 10], cmap='YlGnBu', log=True, label='Signal-to-noise ratio (SNR)')
 
-.. plot:: ../examples/table/scatter.py
-
-|
-
-These code snippets are part of the GWpy example on
-:doc:`plotting event triggers <../examples/table/scatter>`.
-
-====================
+--------------------
 Plotting event tiles
-====================
+--------------------
 
 Many types of event triggers define a 2-dimensional tile, for example in time and frequency.
 These tiles can be plotted in a similar manner to simple triggers.
 
-.. literalinclude:: ../../examples/table/tiles.py
-   :append: plot.show()
-   :lines: 42-47
+.. plot::
+   :context:
+   :include-source:
 
-.. plot:: ../examples/table/tiles.py
+   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst', columns=['time', 'central_freq', 'snr', 'duration', 'bandwidth'])
+   >>> plot = events.plot('time', 'central_freq', 'duration', 'bandwidth', color='snr')
+   >>> ax = plot.gca()
+   >>> ax.set_epoch(968654552)
+   >>> ax.set_yscale('log')
+   >>> ax.set_ylabel('Frequency [Hz]')
+   >>> plot.add_colorbar(clim=[1, 10], cmap='YlGnBu', log=True, label='Signal-to-noise ratio (SNR)')
 
-|
 
 These code snippets are part of the GWpy example on
 :doc:`plotting events as 2-d tiles <../examples/table/tiles>`.
 
-==================
-Table applications
-==================
+=========================
+`EventTable` applications
+=========================
 
 .. toctree::
    :titlesonly:
@@ -97,11 +205,7 @@ Table applications
 Class reference
 ===============
 
-.. currentmodule:: gwpy.table.lsctables
-
-.. note::
-
-   All of the below classes are based on :class:`glue.ligolw.table.Table`.
+.. currentmodule:: gwpy.table
 
 This reference includes the following `class` entries:
 
@@ -109,34 +213,5 @@ This reference includes the following `class` entries:
    :toctree: ../api/
    :nosignatures:
 
-   CoincDefTable
-   CoincTable
-   CoincInspiralTable
-   CoincRingdownTable
-   ExperimentMapTable
-   ExperimentSummaryTable
-   ExperimentTable
-   FilterTable
-   GDSTriggerTable
-   MultiBurstTable
-   MultiInspiralTable
-   ProcessTable
-   ProcessParamsTable
-   SearchSummaryTable
-   SearchSummVarsTable
-   SimBurstTable
-   SimInspiralTable
-   SimRingdownTable
-   SnglBurstTable
-   SnglInspiralTable
-   SnglRingdownTable
-   StochasticTable
-   StochSummTable
-   SummValueTable
-   SegmentTable
-   SegmentSumTable
-   SegmentDefTable
-   SummMimeTable
-   TimeSlideSegmentMapTable
-   TimeSlideTable
-   VetoDefTable
+   Table
+   EventTable

--- a/docs/table/rate.rst
+++ b/docs/table/rate.rst
@@ -1,4 +1,4 @@
-.. currentmodule:: gwpy.table.lsctables
+.. currentmodule:: gwpy.table
 
 ##############################
 Calculating event trigger rate
@@ -8,41 +8,54 @@ Calculating event trigger rate
 Simple event rate
 =================
 
-For discrete data in the form of event triggers, it is often very illuminating to analyse the rate at which these events occur in time - usually a high event rate is indicative of a higher noise level.
-One can calculate the event rate of any of the annotated tables using its :meth:`event_rate` method.
-For example, as defined for the `SnglBurstTable`:
+For discrete data in the form of event triggers, it is often very
+illuminating to analyse the rate at which these events occur in time -
+usually a high event rate is indicative of a higher noise level.
+One can calculate the event rate of an `EventTable` via the 
+:meth:`event_rate` method:.
 
-.. automethod:: SnglBurstTable.event_rate
+.. automethod:: EventTable.event_rate
    :noindex:
 
-We can use the same data as for the example on :doc:`plotting event triggers <../examples/table/scatter>` to demonstrate how to calculate and display the rate versus time of some event triggers:
+For example, using the same data as before we can calculate and plot the
+event rate on a 1-second stride:
 
-.. literalinclude:: ../../examples/table/rate.py
-   :lines: 36,39,40,43,46-50
+.. plot::
+   :context:
+   :include-source:
 
-.. plot:: ../examples/table/rate.py
+   >>> rate = events.event_rate(1, start=968654552, end=968654562)
+   >>> plot = rate.plot()
+   >>> ax = plot.gca()
+   >>> ax.set_ylabel('Event rate [Hz]')
+   >>> ax.set_title('LIGO Hanford Observatory event rate for GW100916')
+   >>> plot.show()
 
-|
-
-This code is a snippet of the example on :doc:`plotting event rate <../examples/table/rate>`.
+This code is a snippet of the example :ref:`example-table-rate`.
 
 =================
 Binned event rate
 =================
 
-Following from a simple rate versus time calculation, it is often useful to calculate the event rate for multiple conditions on the same table.
-The :meth:`binned_event_rates` method is attached to each :class:`~glue.ligolw.table.Table` subclass for convenience.
+Following from a simple rate versus time calculation, it is often useful
+to calculate the event rate for multiple conditions on the same table.
+For this, we can use the :meth:`~EventTable.binned_event_rates` method:
 
-.. automethod:: SnglBurstTable.binned_event_rates
+.. automethod:: EventTable.binned_event_rates
    :noindex:
 
-For example, in the following example, we calculate the rate of events with signal-to-noise ratio (SNR) above some threshold, for the same table as above.
+For example, in the following example, we calculate the rate of events with
+signal-to-noise ratio (SNR) above some threshold, for the same table as above.
 
-.. literalinclude:: ../../examples/table/rate_binned.py
-   :lines: 41-42,48-53
+.. plot::
+   :context:
+   :include-source:
 
-.. plot:: ../examples/table/rate_binned.py
+   >>> rates = events.binned_event_rates(1, 'snr', [2, 3, 5, 8], operator='>=', start=968654552, end=968654562)
+   >>> plot = rates.plot()
+   >>> ax = plot.gca()
+   >>> ax.set_ylabel('Event rate [Hz]')
+   >>> ax.set_title('LIGO Hanford Observatory event rate for GW100916')
+   >>> plot.show()
 
-|
-
-This code is a snippet of the example on :doc:`plotting event rate <../examples/table/rate_binned>`.
+This code is a snippet of the example on :ref:`example-table-rate_binned`.

--- a/examples/table/H1-LDAS_STRAIN-968654552-10.xml.gz
+++ b/examples/table/H1-LDAS_STRAIN-968654552-10.xml.gz
@@ -1,0 +1,1 @@
+../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz

--- a/examples/table/histogram.py
+++ b/examples/table/histogram.py
@@ -30,17 +30,30 @@ detection of future, real signals.
 """
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-__currentmodule__ = 'gwpy.table.lsctables'
+__currentmodule__ = 'gwpy.table'
 
-# First, we import the `SnglBurstTable`, an XML-based data holder for single-detector ('Sngl') gravitational-wave burst-like events:
-from gwpy.table.lsctables import SnglBurstTable
+# First, we import the `EventTable` object and read in a set of events from
+# a LIGO_LW-format XML file containing a
+# :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
+from gwpy.table import EventTable
+events = EventTable.read(
+    '../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz',
+    format='ligolw.sngl_burst', columns=['time', 'snr'])
 
-# We can read a set of events using the :meth:`~SnglBurstTable.read` method:
-events = SnglBurstTable.read('../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz')
+# .. note::
+#
+#    Here we manually specify the `columns` to read in order to optimise
+#    the `read()` operation to parse only the data we actually need.
 
-# and can generate a new `~gwpy.plotter.HistogramPlot` using the :meth:`~SnglBurstTable.hist` instance method
-plot = events.hist('snr', weights=1/10., log=True, logbins=True, histtype='stepfilled', cumulative=-1)
-plot.set_xlabel('Signal-to-noise ratio (SNR)')
-plot.set_ylabel('Rate [Hz]')
-plot.set_title('LHO event triggers for GW100916')
+# and can generate a new `~gwpy.plotter.HistogramPlot` using the
+# :meth:`~EventTable.hist` instance method using `weights=1/10.`
+#  to convert the counts from the histogram into a rate in Hertz
+
+plot = events.hist('snr', weights=1/10., logbins=True,
+                   bins=50, histtype='stepfilled')
+ax = plot.gca()
+ax.set_xlabel('Signal-to-noise ratio (SNR)')
+ax.set_ylabel('Rate [Hz]')
+ax.set_title('LHO event triggers for GW100916')
+ax.autoscale(axis='x', tight=True)
 plot.show()

--- a/examples/table/index.rst
+++ b/examples/table/index.rst
@@ -1,7 +1,7 @@
-.. currentmodule:: gwpy.table.lsctables
+.. currentmodule:: gwpy.table
 
 #####################
-LIGO_LW data examples
+Tabular data examples
 #####################
 
 .. toctree::

--- a/examples/table/rate.py
+++ b/examples/table/rate.py
@@ -30,19 +30,27 @@ future, real signals.
 """
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-__currentmodule__ = 'gwpy.table.lsctables'
+__currentmodule__ = 'gwpy.table'
 
-# First, import the `SnglBurstTable`:
-from gwpy.table.lsctables import SnglBurstTable
+# First, we import the `EventTable` object and read in a set of events from
+# a LIGO_LW-format XML file containing a
+# :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
+from gwpy.table import EventTable
+events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz',
+                         format='ligolw.sngl_burst', columns=['time', 'snr'])
 
-# and read a table of (simulated) events:
-events = SnglBurstTable.read('../../gwpy/tests/data/'
-                             'H1-LDAS_STRAIN-968654552-10.xml.gz')
+# .. note::
+#
+#    Here we manually specify the `columns` to read in order to optimise
+#    the `read()` operation to parse only the data we actually need.
 
-# We can calculate the rate of events (in Hertz) using the :meth:`~SnglBurstTable.event_rate` method:
+# We can calculate the rate of events (in Hertz) using the
+# :meth:`~EventTable.event_rate` method:
 rate = events.event_rate(1, start=968654552, end=968654562)
 
-# The :meth:`~SnglBurstTable.event_rate` method has returned a :class:`~gwpy.timeseries.TimeSeries`, so we can display this using the :meth:`~gwpy.timeseries.TimeSeries.plot` method of that object:
+# The :meth:`~EventTable.event_rate` method has returned a
+# `~gwpy.timeseries.TimeSeries`, so we can display this using the
+# :meth:`~gwpy.timeseries.TimeSeries.plot` method of that object:
 plot = rate.plot()
 plot.set_xlim(968654552, 968654562)
 plot.set_ylabel('Event rate [Hz]')

--- a/examples/table/rate_binned.py
+++ b/examples/table/rate_binned.py
@@ -30,14 +30,23 @@ future, real signals.
 """
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-__currentmodule__ = 'gwpy.table.lsctables'
+__currentmodule__ = 'gwpy.table'
 
+# First, we import the `EventTable` object and read in a set of events from
+# a LIGO_LW-format XML file containing a
+# :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
+from gwpy.table import EventTable
+events = EventTable.read(
+    '../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz',
+    format='ligolw.sngl_burst', columns=['time', 'snr'])
 
-# First, we import the `SnglBurstTable` and read the events
-from gwpy.table.lsctables import SnglBurstTable
-events = SnglBurstTable.read('../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz')
+# .. note::
+#
+#    Here we manually specify the `columns` to read in order to optimise
+#    the `read()` operation to parse only the data we actually need.
 
-# Now we can use the :math:`~SnglBurstTable.binned_event_rates` method to calculated the event rate in a number of bins of SNR.
+# Now we can use the :meth:`~EventTable.binned_event_rates` method to
+# calculate the event rate in a number of bins of SNR.
 rates = events.binned_event_rates(1, 'snr', [2, 3, 5, 8], operator='>=',
                                   start=968654552, end=968654562)
 # .. note::

--- a/examples/table/scatter.py
+++ b/examples/table/scatter.py
@@ -29,19 +29,35 @@ future, real signals.
 """
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-__currentmodule__ = 'gwpy.table.lsctables'
+__currentmodule__ = 'gwpy.table'
 
-# First, we import the `SnglBurstTable`
-from gwpy.table.lsctables import SnglBurstTable
+# First, we import the `EventTable` object and read in a set of events from
+# a LIGO_LW-format XML file containing a
+# :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
+from gwpy.table import EventTable
+events = EventTable.read(
+    'H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst',
+    columns=['time', 'central_freq', 'snr'])
 
-# and read a set of events
-events = SnglBurstTable.read('../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz')
+# .. note::
+#
+#    Here we manually specify the `columns` to read in order to optimise
+#    the `read()` operation to parse only the data we actually need.
 
-# We can now make a scatter plot by specifying the x- and y-axis columns, and (optionally) the colour:
-plot = events.plot('time', 'central_freq', color='snr', edgecolor='none', epoch=968654552)
-plot.set_xlim(968654552, 968654552+10)
-plot.set_ylabel('Frequency [Hz]')
-plot.set_yscale('log')
-plot.set_title('LIGO Hanford Observatory event triggers for GW100916')
-plot.add_colorbar(clim=[1, 5], label='Signal-to-noise ratio', cmap='hot_r')
+# We can now make a scatter plot by specifying the x- and y-axis columns,
+# and (optionally) the colour:
+plot = events.plot('time', 'central_freq', color='snr')
+ax = plot.gca()
+ax.set_yscale('log')
+ax.set_ylabel('Frequency [Hz]')
+ax.set_epoch(968654552)
+ax.set_xlim(968654552, 968654552+10)
+ax.set_title('LIGO-Hanford event triggers for HW100916')
+plot.add_colorbar(clim=[1, 10], cmap='YlGnBu',
+                  label='Signal-to-noise ratio (SNR)')
 plot.show()
+
+# This shows the central time and frequency of each event trigger (row
+# in the ``events`` table). Alternatively we can visualise each trigger
+# as a two-dimensional tile on the time-frequency plane - for more details
+# see the example :ref:`example-table-tiles`.

--- a/examples/table/tiles.py
+++ b/examples/table/tiles.py
@@ -29,20 +29,31 @@ future, real signals.
 """
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-__currentmodule__ = 'gwpy.table.lsctables'
+__currentmodule__ = 'gwpy.table'
 
-# First, we import the `SnglBurstTable` class
-from gwpy.table.lsctables import SnglBurstTable
+# First, we import the `EventTable` object and read in a set of events from
+# a LIGO_LW-format XML file containing a
+# :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
+from gwpy.table import EventTable
+events = EventTable.read(
+    'H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst',
+    columns=['time', 'central_freq', 'bandwidth', 'duration', 'snr'])
 
-# and read the table of events:
-events = SnglBurstTable.read('../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz')
+# .. note::
+#
+#    Here we manually specify the `columns` to read in order to optimise
+#    the `read()` operation to parse only the data we actually need.
 
 # We can make a plot of these events as 2-dimensional tiles by specifying
 # the x- and y-axis columns, and the widths in those directions:
-plot = events.plot('time', 'central_freq', 'duration', 'bandwidth', color='snr', epoch=968654552)
-plot.set_xlim(968654552, 968654552+10)
-plot.set_ylabel('Frequency [Hz]')
-plot.set_yscale('log')
-plot.set_title('LIGO Hanford Observatory event triggers for GW100916')
-plot.add_colorbar(clim=[1, 5], label='Signal-to-noise ratio', cmap='hot_r')
+plot = events.plot('time', 'central_freq', 'duration', 'bandwidth',
+                   color='snr')
+ax = plot.gca()
+ax.set_yscale('log')
+ax.set_ylabel('Frequency [Hz]')
+ax.set_epoch(968654552)
+ax.set_xlim(968654552, 968654552+10)
+ax.set_title('LIGO-Hanford event tiles for HW100916')
+plot.add_colorbar(clim=[1, 8], cmap='YlGnBu',
+                  label='Signal-to-noise ratio (SNR)')
 plot.show()

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -111,6 +111,8 @@ def table_from_file(f, tablename, columns=None, filt=None,
                                contenthandler=contenthandler,
                                nproc=nproc, format='cache')
 
+    lsctables.use_in(contenthandler)
+
     # set columns to read
     if columns is not None:
         _oldcols = tableclass.loadcolumns

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -22,10 +22,11 @@
 import datetime
 from six import string_types
 
+from glue.lal import LIGOTimeGPS
+from glue.ligolw import lsctables
 from glue.ligolw.ligolw import (Document, LIGO_LW)
 from glue.ligolw.utils import (write_filename, write_fileobj)
 from glue.ligolw.utils.ligolw_add import ligolw_add
-
 
 from astropy.time import Time
 
@@ -33,8 +34,6 @@ from ...io import registry
 from ...io.ligolw import (identify_ligolw, GWpyContentHandler)
 from ...io.cache import (file_list, FILE_LIKE)
 from ...segments import (Segment, DataQualityFlag, DataQualityDict)
-from ...table import lsctables
-from ...time import LIGOTimeGPS
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -63,6 +62,8 @@ def read_flag_dict(f, flags=None, gpstype=LIGOTimeGPS, coalesce=False,
                                     gpstype=gpstype,
                                     contenthandler=contenthandler,
                                     format='cache', nproc=nproc)
+
+    lsctables.use_in(contenthandler)
 
     # generate Document and populate
     xmldoc = Document()

--- a/gwpy/table/__init__.py
+++ b/gwpy/table/__init__.py
@@ -16,47 +16,34 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""This module extends the functionality of the :mod:`glue.ligolw`
-library for reading/writing/manipulating LIGO_LW format XML tables.
+"""This module extends the functionality of the :mod:`astropy.table`
+library for reading/writing/manipulating hetergeneous data tables.
 
-The :mod:`glue.ligolw.lsctables` library defines a number of specific
-tables used in GW data analysis; this module extends their functionality
-with the unified input/output system (the .read() method).
+Importing the `~astropy.table.Table` object from here via
 
-Additionally, for event tables (burst, inspiral, and ringdown), methods
-to calculate event rate are also attached.
+    >>> from gwpy.table import Table
 
-Users can make the extensions available by either importing the
-:mod:`~glue.ligolw.lsctables` module from gwpy as follows::
+loads extra input/output definitions available for
+:meth:`~astropy.table.Table.read` and :meth:`~astropy.table.Table.write`.
 
-    >>> from gwpy.table import lsctables
-
-or simply importing the :mod:`gwpy.table` module at any point before
-using the lsctables module (even after importing it from glue)::
-
-    >>> from glue.ligolw import lsctables
-    >>> import gwpy.table
-
+Additionally, the `EventTable` object is provided to simplify working with
+tables of time-stamped GW (or other) events.
 """
 
-import warnings
-warnings.filterwarnings('ignore', 'column name', UserWarning)
-
-from glue.ligolw.ligolw import (Column, Document)
-from glue.ligolw.table import Table
-
-# import custom recarray
-from .rec import GWRecArray
-
-# import all tables
-from . import lsctables
+# load tables
+from astropy.table import (Column, Table)
+from .table import (EventColumn, EventTable)
 
 # attach unified I/O
-from .io import *
-
-# attach rate methods
-from .rate import (event_rate, binned_event_rates)
+from . import io
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-__credits__ = 'Kipp Cannon <kipp.cannon@ligo.org>'
-__all__ = ['Column', 'Document', 'Table', 'lsctables', 'GWRecArray']
+
+
+# -----------------------------------------------------------------------------
+#
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+#
+# -----------------------------------------------------------------------------
+
+from .rec import GWRecArray

--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -19,27 +19,14 @@
 """Input/output methods for tabular data.
 """
 
-from glue.ligolw.ligolw import LIGOLWContentHandler
-
-from .. import lsctables
-lsctables.use_in(LIGOLWContentHandler)
+from . import (  # pylint: disable=unused-import
+    ligolw,  # glue.ligolw XML format
+    root,  # generic ROOT stuff
+    omicron,  # Omicron ROOT format
+    omega,  # Omega ASCII format
+    cwb,  # cWB ROOT and ASCII formats
+    pycbc,  # PyCBC (Live) HDF5
+    hacr,  # Hierarchichal Algorithm for Curves and Ridges
+)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-
-# import LIGO_LW I/O
-from .ligolw import *
-
-# try importing ROOT-based I/O
-from .omicron import *
-
-# import omega I/O
-from .omega import *
-
-# import cWB I/O
-from .cwb import *
-
-# import PyCBC live I/O
-from .pycbc import *
-
-# import HACR db reader
-from .hacr import *

--- a/gwpy/table/io/ascii.py
+++ b/gwpy/table/io/ascii.py
@@ -25,6 +25,12 @@ Each specific ASCII table format should define their own line parser
 (that generates each row of the table) and pass it to the factory method.
 """
 
+# -----------------------------------------------------------------------------
+#
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+#
+# -----------------------------------------------------------------------------
+
 from six import string_types
 
 from numpy import loadtxt

--- a/gwpy/table/io/cwb.py
+++ b/gwpy/table/io/cwb.py
@@ -16,8 +16,101 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Read events from an Omega-format ASCII file.
+"""Read events from Coherent Wave-Burst (cWB)-format ROOT files.
 """
+
+from astropy.io.ascii import core
+
+from ...io import registry
+from .. import (Table, EventTable)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+# -- ROOT ---------------------------------------------------------------------
+
+def table_from_cwb(f, **kwargs):
+    return EventTable.read(f, 'waveburst', *args, format='root', **kwargs)
+
+registry.register_reader('root.cwb', EventTable, table_from_cwb)
+
+
+# -- ASCII --------------------------------------------------------------------
+
+class CwbHeader(core.BaseHeader):
+    """Read a multi-line column-definition header
+    """
+
+    def get_cols(self, lines):
+        """Initialize Column objects from a multi-line ASCII header
+
+        Parameters
+        ----------
+        lines : `list`
+            List of table lines
+        """
+        re_name_def = re.compile(
+            "^\s*#\s+"  # whitespace and comment marker
+            "(?P<colnumber>[0-9]+)\s+-\s+"  # number of column
+            "(?P<colname>(.*))"
+            )
+        self.names = []
+        for line in lines:
+            if not line.startswith('# '):
+                break  # End of header lines
+            elif line.startswith('# -/+'):
+                include_cuts = True
+            else:
+                match = re_name_def.search(line)
+                if match:
+                    self.names.append(match.group('colname').rstrip())
+
+        if not self.names:
+            raise core.InconsistentTableError(
+                'No column names found in cWB header')
+
+        if include_cuts:
+            self.cols = [
+                core.Column(name='selection cut 1'),
+                core.Column(name='selection cut 2'),
+            ]
+        else:
+            self.cols = []
+        for n in self.names:
+            col = core.Column(name=n)
+            self.cols.append(col)
+
+    def write(self, lines):
+        if 'selection cut 1' in self.colnames:
+            lines.append('# -/+ - not passed/passed final selection cuts')
+        for i, name in enumerate(self.colnames[2:]):
+            lines.append('# %.2d - %s' % (i+1, name))
+
+
+class CwbData(core.BaseData):
+    comment = '#'
+
+
+class Cwb(core.BaseReader):
+    """Read an Cwb file
+    """
+    _format_name = 'cwb'
+    _io_registry_can_write = True
+    _description = 'cWB EVENTS format table'
+
+    header_class = CwbHeader
+    data_class = CwbData
+
+# register ascii.cwb for EventTable
+registry.register_reader(
+    'ascii.cwb', EventTable, registry.get_reader('ascii.cwb', Table))
+
+
+# -----------------------------------------------------------------------------
+#
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+#
+# -----------------------------------------------------------------------------
 
 import os.path
 import re

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -19,16 +19,134 @@
 """Read LIGO_LW documents into glue.ligolw.table.Table objects.
 """
 
+import inspect
+import warnings
+
+import numpy
+
+import glue.segments
 from glue.ligolw.table import StripTableName as strip
-from glue.ligolw.lsctables import TableByName
+from glue.ligolw.lsctables import (TableByName, LIGOTimeGPS)
 
 from ...io import registry
 from ...io.cache import (read_cache, file_list)
 from ...io.ligolw import (table_from_file, identify_ligolw)
-from .. import GWRecArray
+from .. import (Table, EventTable)
+from ..lsctables import EVENT_TABLES
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __all__ = []
+
+INVALID_REC_TYPES = [glue.segments.segment]
+
+
+# -- read ---------------------------------------------------------------------
+
+def _table_from_ligolw(llwtable, target, copy, columns=None,
+                      on_attributeerror='raise', get_as_columns=False,
+                      rename={}):
+    """Convert this `~glue.ligolw.table.Table` to an `~astropy.tableTable`
+
+        Parameters
+        ----------
+        columns : `list` of `str`, optional
+            the columns to populate, if not given, all columns present in the
+            table are mapped
+
+        on_attributeerror : `str`, optional, default: `'raise'`
+            how to handle `AttributeError` when accessing rows, one of
+
+            - 'raise' : raise normal exception
+            - 'ignore' : silently ignore this column
+            - 'warn' : verbosely ignore this column
+
+            .. note::
+
+               this option is ignored if a `columns` list is given
+
+        get_as_columns : `bool`, optional
+            convert all `get_xxx()` methods into fields in the
+            `~numpy.recarray`; the default is to _not_ do this.
+
+        rename : `dict`, optional
+            dict of ('old name', 'new name') pairs to rename columns
+            from the original LIGO_LW table
+
+        Returns
+        -------
+        table : `EventTable`
+            a view of the original data
+    """
+    if rename is None:
+        rename = {}
+    # create table
+    names = []
+    data = []
+
+    # and fill it
+    for column in llwtable.columnnames:
+        if columns and column not in columns:  # skip if not wanted
+            continue
+        orig_type = llwtable.validcolumns[column]
+        try:
+            if orig_type == 'ilwd:char':  # numpy tries long() which breaks
+                arr = map(int, llwtable.getColumnByName(column))
+            else:
+                arr = llwtable.getColumnByName(column)
+        except AttributeError as e:
+            if not columns and on_attributeerror == 'ignore':
+                pass
+            elif not columns and on_attributeerror == 'warn':
+                warnings.warn('Caught %s: %s' % (type(e).__name__, str(e)))
+            else:
+                raise
+        else:
+            names.append(column)
+            try:
+                data.append(target.Column(name=rename[column], data=arr))
+            except KeyError:
+                data.append(target.Column(name=column, data=arr))
+
+    # fill out get_xxx columns
+    if get_as_columns:
+        getters = filter(
+            lambda x: x[0].startswith('get_'),
+            inspect.getmembers(llwtable, predicate=inspect.ismethod))
+        for name, meth in getters:
+            column = name.split('_', 1)[1]
+            if column in names:  # don't overwrite existing columns
+                continue
+            if columns and column not in columns:  # skip if not wanted
+                continue
+            arr = meth()
+            try:
+                dtype = arr.dtype
+            except AttributeError:
+                try:
+                    dtype = type(arr[0])
+                except (TypeError, KeyError):
+                    continue
+                except IndexError:
+                    dtype = None
+            if dtype == LIGOTimeGPS:
+                dtype = numpy.float64
+            elif dtype in INVALID_REC_TYPES:
+                raise TypeError("Cannot store data of type %s in %s"
+                                % (dtype, target.__name__))
+            names.append(column)
+            try:
+                data.append(target.Column(name=rename[column], data=arr,
+                                       dtype=dtype))
+            except KeyError:
+                data.append(target.Column(name=column, data=arr, dtype=dtype))
+
+    # sort data columns into user-specified order
+    if columns:
+        names = [rename[n] if n in rename else n for n in columns]
+        data.sort(key=lambda col: names.index(col.name))
+    # build table and return
+    return target(data, copy=copy,
+                  meta={'type': 'ligolw.%s' % str(llwtable.Name)})
 
 
 def read_table_factory(table_):
@@ -37,38 +155,85 @@ def read_table_factory(table_):
     def _read_ligolw(f, *args, **kwargs):
         return table_from_file(f, table_.tableName, *args, **kwargs)
 
-    def _read_recarray(f, *args, **kwargs):
+    def _read_table(f, *args, **kwargs):
+        tablename = strip(table_.tableName)
         # handle multiprocessing
         nproc = kwargs.pop('nproc', 1)
         if nproc > 1:
-            kwargs['format'] = strip(table_.tableName)
-            return read_cache(file_list(f), GWRecArray, nproc, None,
+            kwargs['format'] = 'ligolw.%s' % tablename
+            return read_cache(file_list(f), Table, nproc, None,
                               *args, **kwargs)
 
         # set up keyword arguments
+        llwcolumns = kwargs.pop('ligolw_columns', kwargs.get('columns', None))
         reckwargs = {
             'on_attributeerror': 'raise',
-            'get_as_columns': False
+            'get_as_columns': False,
+            'rename': {},
         }
         for key in reckwargs:
             if key in kwargs:
                 reckwargs[key] = kwargs.pop(key)
-        reckwargs['columns'] = kwargs.get('columns', None)
+        reckwargs['columns'] = kwargs.pop('columns', llwcolumns)
+        kwargs['columns'] = llwcolumns
+        if reckwargs['rename'] is None:
+            reckwargs['rename'] = {}
+
+        # handle requests for 'time' as a special case
+        needtime = (reckwargs['columns'] is not None and
+                    'time' in reckwargs['columns'] and
+                    not 'time' in table_.validcolumns)
+        if needtime:
+            if tablename.endswith('_burst'):
+                tname = 'peak'
+            elif tablename.endswith('_inspiral'):
+                tname = 'end'
+            elif tablename.endswith('_ringdown'):
+                tname = 'start'
+            else:
+                raise ValueError("'time' column requested from a table that "
+                                 "doesn't supply it or have a good proxy "
+                                 "(e.g. 'peak_time')")
+            # replace 'time' with get_xxx method name
+            idx = reckwargs['columns'].index('time')
+            reckwargs['columns'].insert(idx, tname)
+            reckwargs['columns'].pop(idx+1)
+            reckwargs['rename'][tname] = 'time'
+            reckwargs['get_as_columns'] = True
+            # add required LIGO_LW columns to read kwargs
+            kwargs['columns'] = list(set(
+                kwargs['columns'] + ['%s_time' % tname, '%s_time_ns' % tname]))
 
         # read from LIGO_LW
-        return table_from_file(f, table_.tableName,
-                               *args, **kwargs).to_recarray(**reckwargs)
+        llw = table_from_file(f, table_.tableName, *args, **kwargs)
+        return Table(llw, **reckwargs)
 
-    return _read_ligolw, _read_recarray
+    return _read_ligolw, _read_table
 
+# -- write --------------------------------------------------------------------
+
+# work in progress
+
+
+# -- register -----------------------------------------------------------------
 
 # register reader and auto-id for LIGO_LW
 for table in TableByName.itervalues():
-    tablename = strip(table.tableName)
+    name = 'ligolw.%s' % strip(table.tableName)
+
+    # build readers for this table
     llwfunc, recfunc = read_table_factory(table)
+
     # register generic reader and table-specific reader for LIGO_LW
+    registry.register_reader(name, table, llwfunc)
     registry.register_reader('ligolw', table, llwfunc)
-    registry.register_reader(tablename, table, llwfunc)
     registry.register_identifier('ligolw', table, identify_ligolw)
-    # register table-specific reader for GWRecArray
-    registry.register_reader(tablename, GWRecArray, recfunc)
+
+    # register conversion from LIGO_LW to astropy Table
+    table.__astropy_table__ = _table_from_ligolw
+    # register table-specific reader for Table and EventTable
+    registry.register_reader(name, Table, recfunc)
+    if table in EVENT_TABLES:
+        # this is done explicitly so that the docstring for table.read()
+        # shows the reader
+        registry.register_reader(name, EventTable, recfunc)

--- a/gwpy/table/io/omicron.py
+++ b/gwpy/table/io/omicron.py
@@ -19,6 +19,25 @@
 """Read events from an Omicron-format ROOT file.
 """
 
+from ...io import registry
+from .. import EventTable
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def table_from_omicron(f, **kwargs):
+    return EventTable.read(f, 'triggers', *args, format='root', **kwargs)
+
+
+registry.register_reader('root.omicron', EventTable, table_from_omicron)
+
+
+# -----------------------------------------------------------------------------
+#
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+#
+# -----------------------------------------------------------------------------
+
 import sys
 
 if sys.version_info[0] < 3:
@@ -27,12 +46,9 @@ if sys.version_info[0] < 3:
 from glue.lal import (Cache, CacheEntry)
 
 from .. import lsctables
-from ...io import registry
 from ...io.cache import open_cache
 from ...time import LIGOTimeGPS
 from ...utils import with_import
-
-__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 OMICRON_COLUMNS = ['search', 'peak_time', 'peak_time_ns',
                    'start_time', 'start_time_ns',
@@ -105,7 +121,7 @@ def sngl_burst_from_root(tchain, columns=OMICRON_COLUMNS):
 
 
 @with_import('ROOT')
-def table_from_root(f, columns=OMICRON_COLUMNS, filt=None, nproc=1):
+def sngl_burst_table_from_root(f, columns=OMICRON_COLUMNS, filt=None, nproc=1):
     """Build a `SnglBurstTable` from events in an Omicron ROOT file.
 
     Parameters
@@ -178,6 +194,9 @@ def identify_omicron(origin, path, fileobj, *args, **kwargs):
         return False
 
 
-registry.register_reader('omicron', lsctables.SnglBurstTable, table_from_root)
+registry.register_reader('omicron', lsctables.SnglBurstTable,
+                         sngl_burst_table_from_root)
 registry.register_identifier('omicron', lsctables.SnglBurstTable,
                              identify_omicron)
+
+

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -22,6 +22,180 @@
 import re
 from os.path import basename
 
+from glue.lal import CacheEntry
+
+from astropy.table import vstack as vstack_tables
+
+from ...utils.deps import with_import
+from ...io.cache import file_list
+from ...io.registry import (register_reader, register_identifier)
+from .. import EventTable
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Alex Nitz <alex.nitz@ligo.org>'
+
+INVALID_COLUMNS = ['psd', 'loudest']
+PYCBC_FILENAME = re.compile('([A-Z][0-9])+-Live-[0-9.]+-[0-9.]+.hdf')
+
+
+@with_import('h5py')
+def _table_from_file(source, ifo=None, columns=None, loudest=False):
+    """Read a `Table` from a single PyCBC live HDF5 file
+
+    This method is for internal use only.
+    """
+    # read HDF5 file
+    if isinstance(source, CacheEntry):
+        source = source.path
+    if isinstance(source, str):
+        source = h5py.File(source, 'r')
+    # find group
+    if isinstance(source, h5py.File):
+        if ifo is None:
+            try:
+                ifo, = [key for key in list(source) if key != 'background']
+            except ValueError as e:
+                e.args = ("PyCBC live HDF5 file contains multiple IFO groups, "
+                          "please select ifo manually",)
+                raise
+        try:
+            source = source[ifo]
+        except KeyError as e:
+            e.args = ("No group for ifo %r in PyCBC live HDF5 file" % ifo,)
+            raise
+    # at this stage, 'source' should be an HDF5 group in the pycbc live format
+    if columns is None:
+        columns = [c for c in source if c not in INVALID_COLUMNS]
+
+    # set up meta dict
+    meta = {'ifo': ifo}
+
+    # record loudest in meta
+    try:
+        meta['loudest'] = source['loudest'][:]
+    except KeyError:
+        if loudest:
+            raise
+
+    # record PSD in meta
+    try:
+        psd = source['psd']
+    except KeyError:
+        pass
+    else:
+        from gwpy.frequencyseries import FrequencySeries
+        df = psd.attrs['delta_f']
+        meta['psd'] = FrequencySeries(
+            psd[:], f0=0, df=df, name='pycbc_live')
+
+    # map data to columns
+    data = []
+    get_ = []
+    for c in columns:
+        # convert hdf5 dataset into Column
+        try:
+            arr = source[c][:]
+        except KeyError:
+            if c in GET_COLUMN:
+                arr = GET_COLUMN[c](source)
+            else:
+                raise
+        if loudest:
+            arr = arr[meta['loudest']]
+        data.append(EventTable.Column(arr, name=c))
+
+    return EventTable(data, meta=meta)
+
+
+def table_from_pycbc_live(source, ifo=None, columns=None, nproc=1, **kwargs):
+    """Read a `GWRecArray` from one or more PyCBC live files
+    """
+    source = file_list(source)
+    if nproc > 1:
+        from ...io.cache import read_cache
+        return read_cache(source, GWRecArray, nproc, None,
+                          ifo=ifo, columns=columns, format='pycbc_live',
+                          **kwargs)
+
+    source = filter_empty_files(source, ifo=ifo)
+    return vstack_tables(
+        [_table_from_file(x, ifo=ifo, columns=columns, **kwargs)
+         for x in source])
+
+
+def filter_empty_files(files, ifo=None):
+    """Remove empty PyCBC-HDF5 files from a list
+    """
+    return [f for f in files if not empty_hdf5_file(f, ifo=ifo)]
+
+
+@with_import('h5py')
+def empty_hdf5_file(fp, ifo=None):
+    """Determine whether PyCBC-HDF5 file is empty
+    """
+    if isinstance(fp, CacheEntry):
+        fp = fp.path
+    if isinstance(fp, str):
+        h5f = h5py.File(fp, 'r')
+    elif isinstance(fp, h5py.File):
+        h5f = fp
+    else:
+        return  # default to something that will evaluate as false
+    if list(h5f) == []:
+        return True
+    if ifo is not None and list(h5f[ifo]) == ['psd']:
+        return True
+    return False
+
+
+def identify_pycbc_live(origin, path, fileobj, *args, **kwargs):
+    """Identify a PyCBC Live file from its basename
+    """
+    if path is not None and PYCBC_FILENAME.match(basename(path)):
+        return True
+    return False
+
+# register for unified I/O
+register_identifier('hdf5.pycbc_live', EventTable, identify_pycbc_live)
+register_reader('hdf5.pycbc_live', EventTable, table_from_pycbc_live)
+
+# -- processed columns --------------------------------------------------------
+#
+# Here we define methods required to build commonly desired columns that
+# are just a combination of the basic columns.
+#
+# Each method should take in an `~h5py.Group` and return a `numpy.ndarray`
+
+GET_COLUMN = {}
+
+
+def get_new_snr(h5group, q=6., n=2.):
+    newsnr = h5group['snr'][:].copy()
+    rchisq = h5group['chisq'][:]
+    idx = numpy.where(rchisq > 1.)[0]
+    newsnr[idx] *= _new_snr_scale(newsnr[idx], rchisq[idx], q=q, n=n)
+    return newsnr
+
+GET_COLUMN['new_snr'] = get_new_snr
+
+
+def get_mchirp(h5group):
+    mass1 = h5group['mass1'][:]
+    mass2 = h5group['mass2'][:]
+    return (mass1 * mass2) ** (3/5.) / (mass1 + mass2) ** (1/5.)
+
+GET_COLUMN['mchirp'] = get_mchirp
+
+
+# -----------------------------------------------------------------------------
+#
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+#
+# -----------------------------------------------------------------------------
+
+import re
+from os.path import basename
+
 import numpy
 from numpy import rec
 from numpy.lib import recfunctions

--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read events from ROOT trees into Tables
+"""
+
+from ...io import registry
+from ...io.utils import identify_factory
+from ...io.cache import (file_list, read_cache)
+from ...utils import with_import
+from .. import Table
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+@with_import('root_numpy')
+def table_from_root(f, tree, columns=None, nproc=1, **kwargs):
+    # allow multiprocessing
+    if nproc != 1:
+        return read_cache(f, Table, nproc, columns=columns,
+                          format='omicron')
+
+    # read single file
+    return Table(root_numpy.root2array(file_list(f), tree,
+                                            branches=columns, **kwargs))
+
+
+@with_import('root_numpy')
+def table_to_root(table, filename, **kwargs):
+    root_numpy.array2root(table.as_array(), filename, **kwargs)
+
+
+# register I/O
+registry.register_reader('root', Table, table_from_root)
+registry.register_writer('root', Table, table_to_root)
+registry.register_identifier('root', Table, identify_factory('.root'))

--- a/gwpy/table/lsctables.py
+++ b/gwpy/table/lsctables.py
@@ -16,8 +16,92 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Drop in of :mod:`glue.ligolw.lsctables` to annotate Table classes.
+"""Drop in of :mod:`glue.ligolw.lsctables` to annotate
+:class:`~glue.ligolw.table.Table` objects.
 """
+
+from glue.ligolw.lsctables import *
+from glue.ligolw.table import StripTableName as strip_table_name
+
+from ..io import reader
+
+# sub-list of tables that hold events
+EVENT_TABLES = (
+    SnglBurstTable, MultiBurstTable,
+    SnglInspiralTable, MultiInspiralTable,
+    SnglRingdownTable,
+)
+
+# annotate lsctables with new methods
+for table in TableByName.values():
+    # define the read classmethod with docstring
+    table.read = classmethod(reader(doc="""
+        Read data into a :class:`~glue.ligolw.lsctables.{0}`.
+
+        Parameters
+        ----------
+        f : `file`, `str`, `~glue.lal.CacheEntry`, `list`, `~glue.lal.Cache`
+            object representing one or more files. One of
+
+                - an open `file`
+                - a `str` pointing to a file path on disk
+                - a formatted `~glue.lal.CacheEntry` representing one file
+                - a `list` of `str` file paths
+                - a formatted `~glue.lal.Cache` representing many files
+
+        columns : `list`, optional
+            list of column name strings to read, default all.
+
+        ifo : `str`, optional
+            prefix of IFO to read
+
+            .. warning::
+
+               the ``ifo`` keyword argument is only applicable (but is
+               required) when reading single-interferometer data from
+               a multi-interferometer file
+
+        filt : `function`, optional
+            function by which to `filter` events. The callable must
+            accept as input a row of the table event and return
+            `True`/`False`.
+
+        nproc : `int`, optional, default: ``1``
+            number of parallel processes with which to distribute file I/O,
+            default: serial process.
+
+            .. warning::
+
+               The ``nproc`` keyword argument is only applicable when
+               reading a `list` (or `~glue.lal.Cache`) of files.
+
+        contenthandler : `~glue.ligolw.ligolw.LIGOLWContentHandler`
+            SAX content handler for parsing ``LIGO_LW`` documents.
+
+            .. warning::
+
+               The ``contenthandler`` keyword argument is only applicable
+               when reading from ``LIGO_LW`` documents.
+
+        **loadtxtkwargs
+            when reading from ASCII, all other keyword arguments are passed
+            directly to `numpy.loadtxt`
+
+        Returns
+        -------
+        table : :class:`~glue.ligolw.lsctables.{0}`
+            `{0}` of data with given columns filled
+
+        Notes
+        -----
+        """.format(table.__name__)))
+
+
+# -----------------------------------------------------------------------------
+#
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+#
+# -----------------------------------------------------------------------------
 
 import inspect
 import warnings
@@ -36,8 +120,10 @@ from ..time import to_gps
 from ..utils.deps import with_import
 from .rec import GWRecArray
 
-__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-__all__ = TableByName.keys()
+import warnings
+warnings.filterwarnings('ignore', 'column name', UserWarning)
+
+__credits__ = 'Kipp Cannon <kipp.cannon@ligo.org>'
 
 NUMPY_TYPE['ilwd:char'] = numpy.dtype(int).name
 NUMPY_TYPE['lstring'] = 'a20'

--- a/gwpy/table/rate.py
+++ b/gwpy/table/rate.py
@@ -17,7 +17,24 @@
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """Methods to calculate a rate TimeSeries from a LIGO_LW Table.
+
+.. warning::
+
+   This module has been totally deprecated in favour of the
+    `EventTable` object and the methods provided with it.
+
+   This module will be removed before the 1.0 release.
 """
+
+import warnings
+warnings.warn('The gwpy.table.rate module has been deprecated and will be '
+              'removed prior to the 1.0 release.', DeprecationWarning)
+
+# -----------------------------------------------------------------------------
+#
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+#
+# -----------------------------------------------------------------------------
 
 import operator as _operator
 from math import ceil

--- a/gwpy/table/rec.py
+++ b/gwpy/table/rec.py
@@ -19,6 +19,11 @@
 """Custom `numpy.recarray` for reading tabular data
 """
 
+import warnings
+warnings.warn('The gwpy.table.rec module has been deprecated and will be '
+              'removed prior to the 1.0 release.', DeprecationWarning)
+
+
 from numpy import recarray
 
 from ..io import (reader, writer)
@@ -34,6 +39,13 @@ class GWRecArray(recarray):
     numpy.recarray
         for documentation of how to create a new `GWRecArray`
     """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn('The GWRecArray has been deprecated in favour of '
+                      'gwpy.table.EventTable, and will be removed prior '
+                      'to the 1.0 release', DeprecationWarning)
+        return super(GWRecArray, self).__init__(*args, **kwargs)
+
     read = classmethod(reader(doc="""
         Read data into a `GWRecArray`
 

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -1,0 +1,359 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extend :mod:`astropy.table` with the `EventTable`
+"""
+
+import operator as _operator
+from math import ceil
+
+import numpy
+
+from astropy.table import (Table, Column)
+
+from ..io import (reader, writer)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__all__ = ['EventColumn', 'EventTable']
+
+OPERATORS = {'<': _operator.lt, '<=': _operator.le, '=': _operator.eq,
+             '>=': _operator.ge, '>': _operator.gt, '==': _operator.is_,
+             '!=': _operator.is_not}
+
+
+class EventColumn(Column):
+    """Custom `Column` that allows filtering with segments
+    """
+    def in_segmentlist(self, segmentlist):
+        """Return the index of values lying inside the given segmentlist
+
+        A `~gwpy.segments.Segment` represents a semi-open interval,
+        so for any segment `[a, b)`, a value `x` is 'in' the segment if
+
+            a <= x < b
+
+        """
+        segmentlist = type(segmentlist)(segmentlist).coalesce()
+        idx = self.argsort()
+        contains = numpy.zeros(self.shape[0], dtype=bool)
+        j = 0
+        try:
+            a, b = segmentlist[j]
+        except IndexError:  # no segments, return all False
+            return contains
+        i = 0
+        while i < contains.shape[0]:
+            x = idx[i]
+            v = self[x]
+            # if before start, move to next value
+            if v < a:
+                i += 1
+                continue
+            # if after end, find the next segment and check value again
+            if v >= b:
+                j += 1
+                try:
+                    a, b = segmentlist[j]
+                    continue
+                except IndexError:
+                    break
+            # otherwise value must be in this segment
+            contains[x] = True
+            i += 1
+        return contains
+
+    def not_in_segmentlist(self, segmentlist):
+        """Return the index of values not lying inside the given segmentlist
+
+        See `~EventColumn.in_segmentlist` for more details
+        """
+        return self.in_segmentlist(~segmentlist)
+
+
+class EventTable(Table):
+    """Container for a table of events
+    """
+    Column = EventColumn
+
+    # -- i/o ------------------------------------
+
+    read = classmethod(reader(doc="""
+        read data into an `eventtable`
+
+        Parameters
+        ----------
+        source : `str`, `list`, :class:`~glue.lal.Cache`
+            file or list of files from which to read events
+
+        format : `str`, optional
+            the format of the given source files; if not given, an attempt
+            will be made to automatically identify the format
+
+        columns : `list` of `str`, optional
+            list of column names ro read; should represent a sub-set of
+            all available columns
+
+        .. note::
+
+           Keyword arguments other than those listed here may be required
+           depending on the `format`
+
+        Returns
+        -------
+        table : `EventTable`
+
+        Raises
+        ------
+        astropy.io.registry.IORegistryError
+            if the `format` cannot be automatically identified
+
+        Notes
+        -----"""))
+
+    write = writer(doc="""
+        write this table to a file
+
+        parameters
+        ----------
+        target: `str`
+            filename for output data file
+
+        format : `str`, optional
+            format for output data; if not given, an attempt will be made
+            to automatically identify the format based on the `target`
+            filename
+
+        **kwargs
+            other keyword arguments will be passed directly to the
+            underlying writer method for the given format
+
+        raises
+        ------
+        astropy.io.registry.ioregistryerror
+            if the `format` cannot be automatically identified
+
+        notes
+        -----""")
+
+    # -- ligolw compatibility -------------------
+
+    def get_column(self, name):
+        """Return the `Column` with the given name
+
+        This method is provided only for compatibility with the
+        :class:`glue.ligolw.table.Table`.
+
+        Parameters
+        ----------
+        name : `str`
+            the name of the column to return
+
+        Returns
+        -------
+        column : `astropy.table.Column`
+
+        Raises
+        ------
+        KeyError
+            if no column is found with the given name
+        """
+        return self[name]
+
+    # -- extensions -----------------------------
+
+    def event_rate(self, stride, start=None, end=None, timecolumn='time'):
+        """Calculate the rate `~gwpy.timeseries.TimeSeries` for this `Table`.
+
+        Parameters
+        ----------
+        stride : `float`
+            size (seconds) of each time bin
+        start : `float`, :class:`~gwpy.time.LIGOTimeGPS`, optional
+            GPS start epoch of rate :class:`~gwpy.timeseries.TimeSeries`
+        end : `float`, :class:`~gwpy.time.LIGOTimeGPS`, optional
+            GPS end time of rate :class:`~gwpy.timeseries.TimeSeries`.
+            This value will be rounded up to the nearest sample if needed.
+        timecolumn : `str`, optional, default: ``time``
+            name of time-column to use when binning events
+
+        Returns
+        -------
+        rate : :class:`~gwpy.timeseries.TimeSeries`
+            a `TimeSeries` of events per second (Hz)
+        """
+        from gwpy.timeseries import TimeSeries
+        times = self[timecolumn]
+        if not start:
+            start = times.min()
+        if not end:
+            end = times.max()
+        nsamp = int(ceil((end - start) / stride))
+        timebins = numpy.arange(nsamp + 1) * stride + start
+        # histogram data and return
+        out = TimeSeries(
+            numpy.histogram(times, bins=timebins)[0] / float(stride),
+            t0=start, dt=stride, unit='Hz', name='Event rate')
+        return out
+
+    def binned_event_rates(self, stride, column, bins, operator='>=',
+                           start=None, end=None, timecolumn='time'):
+        """Calculate an event rate `~gwpy.timeseries.TimeSeriesDict` over
+        a number of bins.
+
+        Parameters
+        ----------
+        stride : `float`
+            size (seconds) of each time bin
+
+        column : `str`
+            name of column by which to bin.
+
+        bins : `list`
+            a list of `tuples <tuple>` marking containing bins, or a list of
+            `floats <float>` defining bin edges against which an math operation
+            is performed for each event.
+
+        operator : `str`, `callable`
+            one of:
+
+            - ``'<'``, ``'<='``, ``'>'``, ``'>='``, ``'=='``, ``'!='``,
+              for a standard mathematical operation,
+            - ``'in'`` to use the list of bins as containing bin edges, or
+            - a callable function that takes compares an event value
+              against the bin value and returns a boolean.
+
+            .. note::
+
+               If ``bins`` is given as a list of tuples, this argument
+               is ignored.
+
+        start : `float`, :class:`~gwpy.time.LIGOTimeGPS`, optional
+            GPS start epoch of rate `~gwpy.timeseries.TimeSeries`.
+
+        end : `float`, `~gwpy.time.LIGOTimeGPS`, optional
+            GPS end time of rate `~gwpy.timeseries.TimeSeries`.
+            This value will be rounded up to the nearest sample if needed.
+
+        timecolumn : `str`, optional, default: ``time``
+            name of time-column to use when binning events
+
+        Returns
+        -------
+        rates : ~gwpy.timeseries.TimeSeriesDict`
+            a dict of (bin, `~gwpy.timeseries.TimeSeries`) pairs describing a
+            rate of events per second (Hz) for each of the bins.
+        """
+        from gwpy.timeseries import TimeSeriesDict
+
+        # work out time boundaries
+        times = self[timecolumn]
+        if not start:
+            start = times.min()
+        if not end:
+            end = times.max()
+
+        # generate column bins
+        if not bins:
+            bins = [(-numpy.inf, numpy.inf)]
+        if operator == 'in' and not isinstance(bins[0], tuple):
+            bins2 = []
+            for i, bin_ in enumerate(bins[:-1]):
+                bins2.append((bin_, bins[i+1]))
+            bins = bins2
+        elif isinstance(operator, (unicode, str)):
+            op = OPERATORS[operator]
+        else:
+            op = operator
+
+        coldata = self[column]
+
+        # generate one TimeSeries per bin
+        out = TimeSeriesDict()
+        for bin_ in bins:
+            if isinstance(bin_, tuple):
+                keep = (coldata >= bin_[0]) & (coldata < bin_[1])
+            else:
+                keep = op(coldata, bin_)
+            out[bin_] = self[keep].event_rate(stride, start=start, end=end,
+                                              timecolumn=timecolumn)
+            out[bin_].name = '%s $%s$ %s' % (column, operator, bin_)
+
+        return out
+
+    def plot(self, x, y, *args, **kwargs):
+        """Generate an `EventTablePlot` of this `Table`.
+
+        Parameters
+        ----------
+        x : `str`
+            name of column defining centre point on the X-axis
+
+        y : `str`
+            name of column defining centre point on the Y-axis
+
+        width : `str`, optional
+            name of column defining width of tile
+
+        height : `str`, optional
+            name of column defining height of tile
+
+            .. note::
+
+               The ``width`` and ``height`` positional arguments should
+               either both be omitted, in which case a scatter plot will
+               be drawn, or both given, in which case a collection of
+               rectangles will be drawn.
+
+        color : `str`, optional, default:`None`
+            name of column by which to color markers
+
+        **kwargs
+            any other arguments applicable to the `Plot` constructor, and
+            the `Table` plotter.
+
+        Returns
+        -------
+        plot : `~gwpy.plotter.EventTablePlot`
+            new plot for displaying tabular data.
+
+        See Also
+        --------
+        gwpy.plotter.EventTablePlot
+            for more details.
+        """
+        from gwpy.plotter import EventTablePlot
+        return EventTablePlot(self, x, y, *args, **kwargs)
+
+    def hist(self, column, **kwargs):
+        """Generate a `HistogramPlot` of this `Table`.
+
+        Parameters
+        ----------
+        column : `str`
+            name of the column over which to histogram data
+
+        **kwargs
+            any other arguments applicable to the `HistogramPlot`
+
+        Returns
+        -------
+        plot : `~gwpy.plotter.HistogramPlot`
+            new plot displaying a histogram of this `Table`.
+        """
+        from gwpy.plotter import HistogramPlot
+        return HistogramPlot(self, column, **kwargs)

--- a/gwpy/table/utils.py
+++ b/gwpy/table/utils.py
@@ -17,7 +17,24 @@
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """Utilities for LIGO_LW tables.
+
+.. warning::
+
+   This module has been totally deprecated in favour of the
+    `EventTable` object and the methods provided with it.
+
+   This module will be removed before the 1.0 release.
 """
+
+import warnings
+warnings.warn('The gwpy.table.utils module has been deprecated and will be '
+              'removed prior to the 1.0 release.', DeprecationWarning)
+
+# -----------------------------------------------------------------------------
+#
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+#
+# -----------------------------------------------------------------------------
 
 import re
 

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -43,6 +43,7 @@ from gwpy.segments import (DataQualityFlag,
                            Segment, SegmentList, SegmentListDict)
 from gwpy.frequencyseries import FrequencySeries
 from gwpy.timeseries import TimeSeries
+from gwpy.table import EventTable
 from gwpy.plotter import (figure, rcParams, Plot, Axes,
                           TimeSeriesPlot, TimeSeriesAxes,
                           FrequencySeriesPlot, FrequencySeriesAxes,
@@ -58,7 +59,7 @@ from gwpy.plotter.tex import (float_to_latex, label_to_latex,
 from gwpy.plotter.table import get_column_string
 
 from test_timeseries import TEST_HDF_FILE
-from test_table import SnglBurstTableTestCase
+from test_table import TEST_OMEGA_FILE
 
 # design ZPK for BodePlot test
 ZPK = [100], [1], 1e-2
@@ -469,60 +470,62 @@ class EventTableMixin(object):
     AXES_CLASS = EventTableAxes
 
     def setUp(self):
-        self.table = SnglBurstTableTestCase.TABLE_CLASS.read(
-            SnglBurstTableTestCase.TEST_XML_FILE)
+        self.table = EventTable.read(TEST_OMEGA_FILE, format='ascii.omega')
 
 
 class EventTablePlotTestCase(EventTableMixin, PlotTestCase):
     def test_init_with_table(self):
-        self.FIGURE_CLASS(self.table, 'time', 'central_freq').close()
+        self.FIGURE_CLASS(self.table, 'time', 'frequency').close()
         self.assertRaises(ValueError, self.FIGURE_CLASS, self.table)
-        self.FIGURE_CLASS(self.table, 'time', 'central_freq', 'snr').close()
-        self.FIGURE_CLASS(self.table, 'time', 'central_freq', 'snr').close()
+        self.FIGURE_CLASS(
+            self.table, 'time', 'frequency', 'normalizedEnergy').close()
+        self.FIGURE_CLASS(
+            self.table, 'time', 'frequency', 'normalizedEnergy').close()
 
 
 class EventTableAxesTestCase(EventTableMixin, AxesTestCase):
     def test_plot_table(self):
         fig, ax = self.new()
-        snrs = self.table.get_column('snr')
+        snrs = self.table.get_column('normalizedEnergy')
         snrs.sort()
         # test with color
-        c = ax.plot_table(self.table, 'time', 'central_freq', 'snr')
+        c = ax.plot_table(self.table, 'time', 'frequency', 'normalizedEnergy')
         shape = c.get_offsets().shape
         self.assertIsInstance(c, PathCollection)
         self.assertEqual(shape[0], len(self.table))
         nptest.assert_array_equal(c.get_array(), snrs)
         # test with size_by
-        c = ax.plot_table(self.table, 'time', 'central_freq', size_by='snr')
+        c = ax.plot_table(self.table, 'time', 'frequency',
+                          size_by='normalizedEnergy')
         # test with color and size_by
-        c = ax.plot_table(self.table, 'time', 'central_freq', 'snr',
-                          size_by='snr')
+        c = ax.plot_table(self.table, 'time', 'frequency', 'normalizedEnergy',
+                          size_by='normalizedEnergy')
         nptest.assert_array_equal(c.get_array(), snrs)
         # test add_loudest
         ax.set_title('title')
-        ax.add_loudest(self.table, 'snr', 'time', 'central_freq')
+        ax.add_loudest(self.table, 'normalizedEnergy', 'time', 'frequency')
 
     def test_plot_tiles(self):
         fig, ax = self.new()
-        snrs = self.table.get_column('snr')
+        snrs = self.table.get_column('normalizedEnergy')
         snrs.sort()
         # test with color
-        c = ax.plot_tiles(self.table, 'time', 'central_freq', 'duration',
-                          'bandwidth', 'snr')
+        c = ax.plot_tiles(self.table, 'time', 'frequency', 'duration',
+                          'bandwidth', 'normalizedEnergy')
         shape = c.get_offsets().shape
         self.assertIsInstance(c, PolyCollection)
         # test other anchors
-        c = ax.plot_tiles(self.table, 'time', 'central_freq', 'duration',
-                          'bandwidth', 'snr', anchor='ll')
-        c = ax.plot_tiles(self.table, 'time', 'central_freq', 'duration',
-                          'bandwidth', 'snr', anchor='lr')
-        c = ax.plot_tiles(self.table, 'time', 'central_freq', 'duration',
-                          'bandwidth', 'snr', anchor='ul')
-        c = ax.plot_tiles(self.table, 'time', 'central_freq', 'duration',
-                          'bandwidth', 'snr', anchor='ur')
+        c = ax.plot_tiles(self.table, 'time', 'frequency', 'duration',
+                          'bandwidth', 'normalizedEnergy', anchor='ll')
+        c = ax.plot_tiles(self.table, 'time', 'frequency', 'duration',
+                          'bandwidth', 'normalizedEnergy', anchor='lr')
+        c = ax.plot_tiles(self.table, 'time', 'frequency', 'duration',
+                          'bandwidth', 'normalizedEnergy', anchor='ul')
+        c = ax.plot_tiles(self.table, 'time', 'frequency', 'duration',
+                          'bandwidth', 'normalizedEnergy', anchor='ur')
         self.assertRaises(ValueError, ax.plot_tiles, self.table, 'time',
-                          'central_freq', 'duration', 'bandwidth', 'snr',
-                          anchor='other')
+                          'frequency', 'duration', 'bandwidth',
+                          'normalizedEnergy', anchor='other')
 
     def test_get_column_string(self):
         rcParams['text.usetex'] = True

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -389,7 +389,7 @@ class DataQualityFlagTests(unittest.TestCase, TestCaseWithQueryMixin):
         try:
             result = DataQualityFlag.query_segdb(flag, QUERY_START, QUERY_END,
                                                  url=QUERY_URL_SEGDB)
-        except SystemExit as e:
+        except (SystemExit, LDBDClientException) as e:
             self.skipTest(str(e))
         self.assertEqual(result.known, QUERY_RESULT[flag].known)
         self.assertEqual(result.active, QUERY_RESULT[flag].active)
@@ -562,7 +562,7 @@ class DataQualityDictTests(unittest.TestCase, TestCaseWithQueryMixin):
         try:
             result = DataQualityDict.query_segdb(
                 QUERY_FLAGS, QUERY_START, QUERY_END, url=QUERY_URL_SEGDB)
-        except SystemExit as e:
+        except (SystemExit, LDBDClientException) as e:
             self.skipTest(str(e))
         self.assertListEqual(result.keys(), QUERY_FLAGS)
         for flag in result:

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -16,23 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit test for table module
+"""Unit tests for `gwpy.table`
 """
 
 import os.path
 import tempfile
 
-import pytest
-
-import numpy
-from numpy import testing as nptest
+from numpy import (may_share_memory, testing as nptest)
 
 from astropy import units
 
-from gwpy.time import LIGOTimeGPS
-from gwpy.table import (lsctables, GWRecArray)
-from gwpy.table.io import omega
-from gwpy.table.utils import (get_table_column, get_row_value)
+from gwpy.table import (Table, EventTable)
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 
 import common
@@ -41,159 +35,75 @@ from compat import unittest
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 TEST_DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
+TEST_XML_FILE = os.path.join(
+    TEST_DATA_DIR, 'H1-LDAS_STRAIN-968654552-10.xml.gz')
+TEST_OMEGA_FILE = os.path.join(TEST_DATA_DIR, 'omega.txt')
 
 
-class TableTestMixin(object):
-    TABLE_CLASS = None
+class TableTests(unittest.TestCase):
+    TABLE_CLASS = Table
 
-    def test_has_gwpy_methods(self):
-        for method in ['read', 'plot']:
-            self.assertTrue(hasattr(self.TABLE_CLASS, method))
-
-    def test_recarray_read(self):
-        tablename = lsctables.strip_table_name(self.TABLE_CLASS.tableName)
-        # simple
-        table = GWRecArray.read(self.TEST_XML_FILE, format=tablename)
-        self.assertEquals(len(table), 2052)
-        # nproc
-        table = GWRecArray.read(self.TEST_XML_FILE, format=tablename, nproc=2)
-        # get_as_column
-        table = GWRecArray.read(self.TEST_XML_FILE, format=tablename,
-                                get_as_columns=True)
-
-
-class SnglBurstTableTestCase(TableTestMixin, unittest.TestCase):
-    """`TestCase` for `SnglBurstTable`
-    """
-    TABLE_CLASS = lsctables.SnglBurstTable
-    TEST_XML_FILE = os.path.join(
-        TEST_DATA_DIR, 'H1-LDAS_STRAIN-968654552-10.xml.gz')
-    TEST_OMEGA_FILE = os.path.join(TEST_DATA_DIR, 'omega.txt')
-    TEST_OMEGADQ_FILE = os.path.join(TEST_DATA_DIR, 'omegadq.txt')
+    def assertTableEqual(self, a, b, copy=None):
+        assert a.colnames == b.colnames
+        nptest.assert_array_equal(a.as_array(), b.as_array())
+        assert a.meta == b.meta
+        for col, col2 in zip(a.columns.values(), b.columns.values()):
+            if copy:
+                assert not may_share_memory(col, col2)
+            elif copy is False:
+                assert may_share_memory(col, col2)
 
     def test_read_ligolw(self):
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE)
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE, format='ligolw')
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE, format='sngl_burst')
-        self.assertEquals(len(table), 2052)
+        table = self.TABLE_CLASS.read(TEST_XML_FILE,
+                                      format='ligolw.sngl_burst')
+        self.assertIsInstance(table, self.TABLE_CLASS)
+        self.assertIsInstance(table['snr'], self.TABLE_CLASS.Column)
+        self.assertEqual(len(table), 2052)
+        self.assertAlmostEqual(table[0]['snr'], 0.69409615)
+        # try multiple files
+        table2 = self.TABLE_CLASS.read([TEST_XML_FILE, TEST_XML_FILE],
+                                       format='ligolw.sngl_burst')
+        self.assertEqual(len(table2), 4104)
+        self.assertEqual(table2[0]['snr'], table2[2052]['snr'])
+        # try with nproc
+        table3 = self.TABLE_CLASS.read([TEST_XML_FILE, TEST_XML_FILE],
+                                       nproc=2, format='ligolw.sngl_burst')
+        self.assertTableEqual(table2, table3)
 
-    def test_write_ligolw(self):
-        # read table
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE)
-        tmpxml = tempfile.mktemp(suffix='.xml.gz')
-        # write table
-        try:
-            table.write(open(tmpxml, 'w'))
-            table2 = self.TABLE_CLASS.read(tmpxml)
-        finally:
-            if os.path.isfile(tmpxml):
-                os.remove(tmpxml)
-        self.assertEquals(len(table), len(table2))
-        self.assertEquals(table[0].get_peak(), table2[0].get_peak())
-        self.assertEquals(table[0].snr, table2[0].snr)
 
-    def test_io_identify(self):
-        common.test_io_identify(self.TABLE_CLASS,
-                                ['xml', 'xml.gz', 'omicron.root'])
-
-    def test_read_ascii(self):
-        # read table
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE)
-        # write to ASCII
-        tmpascii = tempfile.mktemp(suffix='.txt')
-        numpy.savetxt(tmpascii, zip(table.get_peak(), table.get_column('snr'),
-                                    table.get_column('central_freq')),
-                      fmt=['%s', '%.18e', '%.18e'])
-        # read from ASCII
-        try:
-            table2 = self.TABLE_CLASS.read(
-                tmpascii, columns=['time', 'snr', 'central_freq'])
-        finally:
-            if os.path.isfile(tmpascii):
-                os.remove(tmpascii)
-        self.assertEquals(len(table), len(table2))
-        nptest.assert_array_equal(table.get_peak(), table2.get_peak())
-        nptest.assert_array_equal(table.get_column('snr'),
-                                  table2.get_column('snr'))
-        nptest.assert_array_equal(table.get_column('central_freq'),
-                                  table2.get_column('central_freq'))
+class EventTableTests(TableTests):
+    TABLE_CLASS = EventTable
 
     def test_read_omega(self):
-        self.assertRaises(TypeError, self.TABLE_CLASS.read,
-                          self.TEST_OMEGA_FILE)
-        table = self.TABLE_CLASS.read(self.TEST_OMEGA_FILE, format='omega')
-        self.assertEquals(len(table), 92)
-        self.assertEquals(table[0].snr, 147.66187483916312)
-        self.assertEquals(table[50].get_start(),
-                          LIGOTimeGPS(966211219, 530621317))
-        self.assertEquals(table.columnnames, omega.OMEGA_LIGOLW_COLUMNS)
+        table = self.TABLE_CLASS.read(TEST_OMEGA_FILE, format='ascii.omega')
+        self.assertIsInstance(table, self.TABLE_CLASS)
+        self.assertIsInstance(table['frequency'], self.TABLE_CLASS.Column)
+        self.assertEqual(len(table), 92)
+        self.assertAlmostEqual(table[0]['frequency'], 962.609375)
 
-    def test_read_omegadq(self):
-        self.assertRaises(TypeError, self.TABLE_CLASS.read,
-                          self.TEST_OMEGADQ_FILE)
-        table = self.TABLE_CLASS.read(self.TEST_OMEGADQ_FILE, format='omegadq')
-        self.assertEquals(len(table), 9)
-        self.assertEquals(table[0].snr, 5.304714883949938)
-        self.assertEquals(table[6].get_start(),
-                          LIGOTimeGPS(966211228,123722672))
-        self.assertEquals(table.columnnames, omega.OMEGADQ_LIGOLW_COLUMNS)
-
-    def test_rates(self):
+    def test_event_rates(self):
         # test event_rate
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE)
+        table = self.TABLE_CLASS.read(
+            TEST_XML_FILE, format='ligolw.sngl_burst',
+            columns=['time', 'snr'])
         rate = table.event_rate(1)
         self.assertIsInstance(rate, TimeSeries)
-        self.assertEquals(rate.sample_rate, 1 * units.Hz)
+        self.assertEqual(rate.sample_rate, 1 * units.Hz)
         # test binned_event_rates
         rates = table.binned_event_rates(1, 'snr', [2, 4, 6])
         self.assertIsInstance(rates, TimeSeriesDict)
         table.binned_event_rates(1, 'snr', [2, 4, 6], operator='in')
         table.binned_event_rates(1, 'snr', [(0, 2), (2, 4), (4, 6)])
 
-    def test_to_recarray(self):
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE)
-        arr = table.to_recarray()
-        self.assertListEqual(list(arr.dtype.names), table.columnnames)
-        nptest.assert_array_equal(table.get_column('snr'), arr['snr'])
-        nptest.assert_array_equal(
-            table.get_peak().astype(float),
-            arr['peak_time'] + arr['peak_time_ns'] * 1e-9)
-        # test with errors/warning
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE, columns=['snr'])
-        self.assertRaises(AttributeError, table.to_recarray)
-        with pytest.warns(UserWarning):
-            table.to_recarray(on_attributeerror='warn')
+    def test_plot(self):
+        table = self.TABLE_CLASS.read(TEST_OMEGA_FILE, format='ascii.omega')
+        plot = table.plot('time', 'frequency', color='normalizedEnergy')
 
-    def test_from_recarray(self):
-        table = self.TABLE_CLASS.read(self.TEST_XML_FILE)
-        arr = table.to_recarray()
-        table2 = self.TABLE_CLASS.from_recarray(arr)
-        for column in table.columnnames:
-            if column == 'process_id':  # broken
-                continue
-            if table.validcolumns[column] == 'ilwd:char':  # ID columns
-                nptest.assert_array_equal(table.getColumnByName(column),
-                                          table2.getColumnByName(column))
-            else:
-                nptest.assert_array_equal(
-                    table.getColumnByName(column).asarray(),
-                    table2.getColumnByName(column).asarray())
+    def test_hist(self):
+        table = self.TABLE_CLASS.read(TEST_OMEGA_FILE, format='ascii.omega')
+        table.hist('normalizedEnergy')
 
-
-class GWRecArrayTestCase(unittest.TestCase):
-    def test_get_table_row_methods(self):
-        testfile = SnglBurstTableTestCase.TEST_XML_FILE
-        table = GWRecArray.read(SnglBurstTableTestCase.TEST_XML_FILE,
-                                format='sngl_burst')
-        # test simple column
-        snr = get_table_column(table, 'snr')
-        nptest.assert_array_equal(snr, table['snr'])
-        # test 'time' special-case
-        time = get_table_column(table, 'time')
-        nptest.assert_array_equal(
-            time, table['peak_time'] + table['peak_time_ns'] * 1e-9)
-        # test row
-        row = table[0]
-        self.assertEqual(get_row_value(row, 'snr'), row['snr'])
-        self.assertEqual(get_row_value(row, 'time'),
-                         row['peak_time'] + row['peak_time_ns'] * 1e-9)
+    def test_get_column(self):
+        table = self.TABLE_CLASS.read(TEST_OMEGA_FILE, format='ascii.omega')
+        nptest.assert_array_equal(table.get_column('normalizedEnergy'),
+                                  table['normalizedEnergy'])


### PR DESCRIPTION
This PR completely rewrites the `gwpy.table` module, inheriting from `astropy.table` and deprecating most of the `glue.ligolw`-related functionality. None of the existing functionality has actually been removed, but deprecation warnings have been added to note a pending removal before v1.0.