### PR TITLE
Updated lal/lalframe port references in installation docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,7 +29,7 @@ You can also run the following to install a number of optional dependencies - pa
 
 .. code-block:: bash
 
-   sudo port install py27-ipython nds2-client kerberos5 py27-pykerberos py27-h5py lal lalframe
+   sudo port install py27-ipython nds2-client kerberos5 py27-pykerberos py27-h5py py27-lal py27-lalframe
 
 Once you have at least the required dependencies installed, you can :ref:`install GWpy using pip <install-pip>`.
 


### PR DESCRIPTION
This PR fixes #332 by updating the macports references for `lal` and `lalframe`.