### PR TITLE
Use ordered examples

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -149,33 +149,9 @@ doctest:
 .PHONY: examples
 examples: $(addprefix examples/,$(EXAMPLES:py=rst))
 
-../examples/%/index.rst:
-	@echo "##############################" > $@
-	@echo "$* examples" >> $@
-	@echo "##############################" >> $@
-	@echo >> $@
-	@echo ".. toctree::" >> $@
-	@echo "   :maxdepth: 1" >> $@
-	@echo >> $@
-
 examples/%/index.rst: ../examples/%/index.rst
 	@mkdir -p examples/$*
 	@cp ../examples/$*/index.rst $@
-
-examples/index.rst:
-	@mkdir -p examples/
-	@echo 'making top-level index.rst for examples'
-	@echo "#############" > $@
-	@echo "GWpy examples" >> $@
-	@echo "#############" >> $@
-	@echo >> $@
-	@echo ".. toctree::" >> $@
-	@echo "   :maxdepth: 2" >> $@
-	@echo >> $@
-	for EXD in $(EXAMPLEDIRS); do \
-		echo "   $${EXD}index" >> $@; \
-		echo >> $@; \
-	done
 
 examples/%.rst: export INDEX=$(addprefix examples/,$(dir $*))index.rst
 examples/%.rst: ex2rst.py ../examples/%.py examples/index.rst

--- a/examples/frequencyseries/index.rst
+++ b/examples/frequencyseries/index.rst
@@ -6,4 +6,10 @@
 
 .. toctree::
    :maxdepth: 1
+   :numbered:
 
+   hoff
+   variance
+   coherence
+   transfer_function
+   rayleigh

--- a/examples/signal/index.rst
+++ b/examples/signal/index.rst
@@ -6,4 +6,6 @@ Signal processing examples
 
 .. toctree::
    :maxdepth: 1
+   :numbered:
 
+   gw150914

--- a/examples/spectrogram/index.rst
+++ b/examples/spectrogram/index.rst
@@ -6,4 +6,10 @@
 
 .. toctree::
    :maxdepth: 1
+   :numbered:
 
+   plot
+   ratio
+   spectrogram2
+   coherence
+   rayleigh

--- a/examples/table/index.rst
+++ b/examples/table/index.rst
@@ -1,9 +1,15 @@
-.. currentmodule:: gwpy.table.lsctables
+.. currentmodule:: gwpy.table
 
 #####################
-LIGO_LW data examples
+Tabular data examples
 #####################
 
 .. toctree::
    :maxdepth: 1
+   :numbered:
 
+   scatter
+   histogram
+   tiles
+   rate
+   rate_binned

--- a/examples/timeseries/index.rst
+++ b/examples/timeseries/index.rst
@@ -6,4 +6,11 @@
 
 .. toctree::
    :maxdepth: 1
+   :numbered:
 
+   public
+   filter
+   whiten
+   blrms
+   statevector
+   qscan


### PR DESCRIPTION
This PR updates the examples in the documentation to use a manually ordered list. This should be a bit more pedagogical for walking through functionality.