### PR TITLE
Updated glue.ligolw calls to latest stable release

### DIFF
--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -24,7 +24,6 @@ an 'io' subdirectory of the containing directory for that class.
 
 from glue.ligolw.ligolw import (Document, LIGOLWContentHandler,
                                 PartialLIGOLWContentHandler)
-from glue.ligolw.table import CompareTableNames as compare_table_names
 from glue.ligolw.utils.ligolw_add import ligolw_add
 from glue.ligolw import (table, lsctables)
 
@@ -55,15 +54,12 @@ def get_partial_contenthandler(table):
         a subclass of `~glue.ligolw.ligolw.PartialLIGOLWContentHandler` to
         read only the given `table`
     """
-    def _filter_func(name, attrs):
-        if name == table.tagName and attrs.has_key('Name'):
-            return compare_table_names(attrs.get('Name'), table.tableName) == 0
-        else:
-            return False
+    def _element_filter(name, attrs):
+        return table.CheckProperties(name, attrs)
 
     class _ContentHandler(PartialLIGOLWContentHandler):
         def __init__(self, document):
-            super(_ContentHandler, self).__init__(document, _filter_func)
+            super(_ContentHandler, self).__init__(document, _element_filter)
 
     return _ContentHandler
 


### PR DESCRIPTION
The latest release of `glue` is backwards incompatible with previous, with a number of objects and methods being removed (`DeprecationWarning`s have been in place for a while). This PR updates any broken `glue.ligolw` calls in a backwards compatible manner.