### PR TITLE
Updated table.io ligolw calls to not use StripTableName

### DIFF
--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -95,7 +95,7 @@ def table_from_file(f, tablename, columns=None, filt=None,
         `Table` of data with given columns filled
     """
     # find table class
-    tableclass = lsctables.TableByName[table.StripTableName(tablename)]
+    tableclass = lsctables.TableByName[table.Table.TableName(tablename)]
 
     # get content handler
     if contenthandler is None:

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -25,7 +25,6 @@ import warnings
 import numpy
 
 import glue.segments
-from glue.ligolw.table import StripTableName as strip
 from glue.ligolw.lsctables import (TableByName, LIGOTimeGPS)
 
 from ...io import registry
@@ -156,7 +155,7 @@ def read_table_factory(table_):
         return table_from_file(f, table_.tableName, *args, **kwargs)
 
     def _read_table(f, *args, **kwargs):
-        tablename = strip(table_.tableName)
+        tablename = table_.TableName(table_.tableName)
         # handle multiprocessing
         nproc = kwargs.pop('nproc', 1)
         if nproc > 1:
@@ -219,7 +218,7 @@ def read_table_factory(table_):
 
 # register reader and auto-id for LIGO_LW
 for table in TableByName.itervalues():
-    name = 'ligolw.%s' % strip(table.tableName)
+    name = 'ligolw.%s' % table.TableName(table.tableName)
 
     # build readers for this table
     llwfunc, recfunc = read_table_factory(table)

--- a/gwpy/table/lsctables.py
+++ b/gwpy/table/lsctables.py
@@ -21,7 +21,6 @@
 """
 
 from glue.ligolw.lsctables import *
-from glue.ligolw.table import StripTableName as strip_table_name
 
 from ..io import reader
 
@@ -111,7 +110,6 @@ from numpy.lib import recfunctions
 
 import glue.segments
 from glue.ligolw.lsctables import *
-from glue.ligolw.table import StripTableName as strip_table_name
 from glue.ligolw.types import ToNumPyType as NUMPY_TYPE
 from glue.ligolw.ilwd import get_ilwdchar_class
 
@@ -233,7 +231,7 @@ def from_recarray(cls, array, columns=None):
     if columns is None:
         columns = list(array.dtype.names)
     out = New(cls, columns=columns)
-    tblname = strip_table_name(out.tableName)
+    tblname = out.TableName(out.tableName)
     ilwdchar = dict((col, get_ilwdchar_class(tblname, col))
                     for (col, llwtype) in zip(out.columnnames, out.columntypes)
                     if llwtype == 'ilwd:char')


### PR DESCRIPTION
This PR fixes a deprecation in the latest release of `glue`.