### PR TITLE
Updated reference to deleted glue.ligolw object

### DIFF
--- a/gwpy/table/io/ascii.py
+++ b/gwpy/table/io/ascii.py
@@ -35,7 +35,7 @@ from six import string_types
 
 from numpy import loadtxt
 
-from glue.ligolw.table import (reassign_ids, StripTableName)
+from glue.ligolw.table import reassign_ids
 
 from ..lsctables import (New, TableByName)
 from ..utils import TIME_COLUMN
@@ -189,7 +189,7 @@ def row_from_ascii_factory(table, delimiter):
         ------
         AttributeError
             if any column is not recognised
-        """.format(RowType.__name__, StripTableName(name))
+        """.format(RowType.__name__, table.TableName(table.tableName))
         row = table.RowType()
         if isinstance(line, str):
             line = line.rstrip('\n').split(delimiter)


### PR DESCRIPTION
This PR fixes another reference to `StripTableNames` which was removed in the latest release of `glue`.