### PR TITLE
Remove python-cjson from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ h5py>=1.3
 jinja2
 M2Crypto
 pykerberos
-python-cjson
 pyRXP
 http://software.ligo.org/lscsoft/source/glue-1.53.0.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.4.0.tar.gz


### PR DESCRIPTION
This PR removes the `python-cjson` package from `requirements.txt` since it doesn't support python3. It's only an optional dependency for glue anyway, and will hopefully be patched out.