### PR TITLE
Speed up travis-ci by not running ./configure for src builds every time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ cache:
     - ./python-${TRAVIS_PYTHON_VERSION}-lalframe/
     - ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/
 before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log
   - rm -f ./python-${TRAVIS_PYTHON_VERSION}-lal/config.log
   - rm -f ./python-${TRAVIS_PYTHON_VERSION}-lalframe/config.log
   - rm -f ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/config.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ addons:
       - bc
       - libfftw3-dev
       - libframe-dev
-      # framecpp dependencies
-      - ldas-tools-al-dev
       # nds2 dependencies
       - libsasl2-2
       # misc python dependencies
@@ -95,6 +93,5 @@ cache:
   ccache: true
   directories:
     - ./python-${TRAVIS_PYTHON_VERSION}-lal/
-    - ./python-${TRAVIS_PYTHON_VERSION}-framecpp/
     - ./python-${TRAVIS_PYTHON_VERSION}-lalframe/
     - ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,3 +95,7 @@ cache:
     - ./python-${TRAVIS_PYTHON_VERSION}-lal/
     - ./python-${TRAVIS_PYTHON_VERSION}-lalframe/
     - ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/
+before_cache:
+  - rm -f ./python-${TRAVIS_PYTHON_VERSION}-lal/config.log
+  - rm -f ./python-${TRAVIS_PYTHON_VERSION}-lalframe/config.log
+  - rm -f ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/config.log

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -39,6 +39,11 @@ else
     ./configure --enable-silent-rules --prefix=$target $@
 fi
 
+# configure if the makefile still doesn't exist
+if [ ! -f $builddir/Makefile ]; then
+    ./configure --enable-silent-rules --prefix=$target $@
+fi
+
 # make and install
 make --silent
 make install --silent

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -20,6 +20,7 @@ echo "Building into $builddir"
 # check for existing file
 if [ -f $builddir/.travis-src-file ] && [ `cat $builddir/.travis-src-file` == "$tarball" ]; then
     echo "Cached build directory found, skippping to make..."
+    cd $builddir
 else
     # download tarball
     echo "New build requested, downloading tarball..."
@@ -40,7 +41,7 @@ else
 fi
 
 # configure if the makefile still doesn't exist
-if [ ! -f $builddir/Makefile ]; then
+if [ ! -f ./Makefile ]; then
     ./configure --enable-silent-rules --prefix=$target $@
 fi
 

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -19,26 +19,31 @@ echo "Building into $builddir"
 
 # check for existing file
 if [ -f $builddir/.travis-src-file ] && [ `cat $builddir/.travis-src-file` == "$tarball" ]; then
-    echo "Cached build directory found, not downloading tarball"
+    echo "Cached build directory found, skippping to make..."
 else
+    # download tarball
     echo "New build requested, downloading tarball..."
     rm -rf $builddir/
     mkdir -p $builddir
     wget $tarball -O `basename $tarball`
     tar -xf `basename $tarball` -C $builddir --strip-components=1
     echo $tarball > $builddir/.travis-src-file
+
+    # boot and configure
+    cd $builddir
+    if [ -f ./00boot ]; then
+        ./00boot
+    elif [ -f ./autogen.sh ]; then
+        ./autogen.sh
+    fi
+    ./configure --enable-silent-rules --prefix=$target $@
 fi
 
-# always install and return
-cd $builddir
-if [ -f ./00boot ]; then
-    ./00boot
-elif [ -f ./autogen.sh ]; then
-    ./autogen.sh
-fi
-./configure --enable-silent-rules --prefix=$target $@
-make -j 2 --silent || make --silent
+# make and install
+make --silent
 make install --silent
+
+# finish
 cd -
 echo "----------------------------------------------------------------------"
 echo "Successfully installed `basename ${tarball}`"


### PR DESCRIPTION
This PR should speed up the continuous integration build by only running `./configure` for fresh builds.