### PR TITLE
Don't install cjson/M2Crypto from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,7 @@ matplotlib>=1.4.1
 gitpython
 h5py>=1.3
 jinja2
-M2Crypto
 pykerberos
-python-cjson
 pyRXP
 http://software.ligo.org/lscsoft/source/glue-1.53.0.tar.gz
 http://software.ligo.org/lscsoft/source/dqsegdb-1.4.0.tar.gz


### PR DESCRIPTION
This PR removes `python-cjson` and `M2Crypto` from the `requirements.txt` file. These are dependencies for `glue`, but aren't available for python3.