### PR TITLE
Don't copy all vectors on reading with lalframe

### DIFF
--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -26,6 +26,8 @@ import warnings
 from math import ceil
 from multiprocessing import (Process, Queue as ProcessQueue)
 
+import numpy
+
 from glue.lal import Cache
 
 from ...io.cache import (cache_segments, open_cache)
@@ -148,6 +150,11 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
                              target=cls, **kwargs)
             if out is None:
                 out = new
+                if issubclass(cls, dict):
+                    for key in out:
+                        out[key] = numpy.require(out[key], requirements=['O'])
+                else:
+                    out = numpy.require(out, requirements=['O'])
             else:
                 # if we get here, we know user chose to pad gaps
                 out.append(new, gap='pad', pad=pad)

--- a/gwpy/timeseries/io/lalframe.py
+++ b/gwpy/timeseries/io/lalframe.py
@@ -210,7 +210,8 @@ def read_timeseriesdict(source, channels, start=None, end=None, dtype=None,
     for src in source:
         stream = open_data_source(src)
         out.append(read_stream(stream, channels, start=start, end=end,
-                               series_class=series_class), gap=gap, pad=pad)
+                               series_class=series_class),
+                   gap=gap, pad=pad, copy=False)
     for name in out:
         if (resample.get(name) and
                 resample[name] != out[name].sample_rate.value):

--- a/gwpy/timeseries/io/lalframe.py
+++ b/gwpy/timeseries/io/lalframe.py
@@ -36,7 +36,7 @@ except ImportError:
 
 from ...io.registry import (register_reader, register_writer,
                             register_identifier)
-from ...io.cache import (find_contiguous)
+from ...io.cache import (FILE_LIKE, open_cache, find_contiguous)
 from ...io.utils import identify_factory
 from ...utils import import_method_dependency
 from .. import (TimeSeries, TimeSeriesDict, StateVector, StateVectorDict)
@@ -195,8 +195,10 @@ def read_timeseriesdict(source, channels, start=None, end=None, dtype=None,
 
     # read cache file up-front
     if (isinstance(source, string_types) and
-        source.endswith(('.lcf', '.cache'))):
-        source = read_cache(source)
+            source.endswith(('.lcf', '.cache'))) or (
+            isinstance(source, FILE_LIKE) and
+            source.name.endswith(('.lcf', '.cache'))):
+        source = open_cache(source)
     # separate cache into contiguous segments
     if isinstance(source, GlueCache):
         source = list(find_contiguous(source))

--- a/gwpy/timeseries/io/lalframe.py
+++ b/gwpy/timeseries/io/lalframe.py
@@ -210,13 +210,13 @@ def read_timeseriesdict(source, channels, start=None, end=None, dtype=None,
     # now read the data
     out = series_class.DictClass()
     for i, src in enumerate(source):
+        if i == 1:  # force data into fresh memory so that append works
+            for name in out:
+                out[name] = numpy.require(out[name], requirements=['O'])
         stream = open_data_source(src)
         out.append(read_stream(stream, channels, start=start, end=end,
                                series_class=series_class),
                    gap=gap, pad=pad, copy=False)
-        if i == 0:  # force data into fresh memory if needed
-            for name in out:
-                out[name] = numpy.require(out[name], requirements=['O'])
     for name in out:
         if (resample.get(name) and
                 resample[name] != out[name].sample_rate.value):

--- a/gwpy/timeseries/io/lalframe.py
+++ b/gwpy/timeseries/io/lalframe.py
@@ -209,11 +209,14 @@ def read_timeseriesdict(source, channels, start=None, end=None, dtype=None,
 
     # now read the data
     out = series_class.DictClass()
-    for src in source:
+    for i, src in enumerate(source):
         stream = open_data_source(src)
         out.append(read_stream(stream, channels, start=start, end=end,
                                series_class=series_class),
                    gap=gap, pad=pad, copy=False)
+        if i == 0:  # force data into fresh memory if needed
+            for name in out:
+                out[name] = numpy.require(out[name], requirements=['O'])
     for name in out:
         if (resample.get(name) and
                 resample[name] != out[name].sample_rate.value):


### PR DESCRIPTION
This PR optimises `gwpy.timeseries.io.lalframe` by removing an array copy when appending to a `TimeSeriesDict`.

I also include a tiny addition to parse a `glue.lal.Cache` from an open file object. 