### PR TITLE
Added unified nproc option to gwpy.io.reader

### DIFF
--- a/gwpy/io/__init__.py
+++ b/gwpy/io/__init__.py
@@ -22,11 +22,12 @@
 from types import FunctionType
 
 from .registry import (read, write)
+from .mp import with_nproc
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 
-def reader(name=None, doc=None):
+def reader(name=None, doc=None, mp_flattener=False):
     """Construct a new unified input/output reader.
 
     This method is required to create a new copy of the
@@ -35,14 +36,24 @@ def reader(name=None, doc=None):
     Returns
     -------
     read : `function`
-        A copy of the :func:`astropy.io.registry.read` function
+        a copy of the :func:`astropy.io.registry.read` function
+
+    doc : `str`
+        custom docstring for this reader
+
+    mp_flattener : `function`
+        the function to flatten multiple instances of the parent object,
+        enabling multiprocessed reading via the `nproc` argument
     """
     func = FunctionType(read.func_code, read.func_globals,
                         name or read.func_name, read.func_defaults,
                         read.func_closure)
     if doc is not None:
         func.__doc__ = doc.strip('\n ')
-    return func
+    if mp_flattener:
+        return with_nproc(func, mp_flattener)
+    else:
+        return func
 
 
 def writer(doc=None):

--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (division, absolute_import)
+
+from functools import wraps
+from math import ceil
+from multiprocessing import (Process, Queue as ProcessQueue)
+
+from .cache import file_list
+
+from astropy.table import vstack
+from astropy.io.registry import _get_valid_format as get_format
+
+
+def with_nproc(reader, flatten):
+    """Decorate a Class.read `classmethod` with multiprocessing
+
+    This method adds the `nproc` keyword argument to the `reader` method
+    which enables splitting an input list of files into chunks and
+    reading each chunk in parallel, using `flatten` to combine the
+    chunked data into a single object of the correct type
+    """
+    @wraps(reader)
+    def _read(cls, source, *args, **kwargs):
+        # parse input as a list of files
+        if isinstance(source, list):
+            files = source
+        else:
+            files = file_list(source)
+
+        # determine input format
+        if kwargs.get('format', None) is None:
+            kwargs['format'] = get_format(
+                'read', cls, files[0], source, args, kwargs)
+
+        # calculate maximum number of processes
+        nproc = kwargs.pop('nproc', 1)
+        num = len(files)
+        nproc = min(nproc, num)
+
+        # read single file or single process
+        if num == 1:
+            return reader(cls, files[0], *args, **kwargs)
+        if nproc == 1:
+            return reader(cls, source, *args, **kwargs)
+
+        # define multiprocessing method
+        def _read_chunk(q, chunk, index):
+            if len(chunk) == 1:
+                chunk = chunk[0]
+            try:
+                if cls:
+                    q.put((index, reader(cls, chunk, *args, **kwargs)))
+                else:
+                    q.put((index, reader(chunk, *args, **kwargs)))
+            except Exception as e:
+                q.put(e)
+
+        # split source into parts
+        numperproc = int(ceil(num / nproc))
+        chunks = [type(files)(files[i:i+numperproc]) for i in
+                  range(0, num, numperproc)]
+
+        # process
+        queue = ProcessQueue(nproc)
+        processes = []
+        for i, chunk in enumerate(chunks):
+            if len(chunk) == 0:
+                continue
+            process = Process(target=_read_chunk, args=(queue, chunk, i))
+            process.daemon = True
+            process.start()
+            processes.append(process)
+
+        # get data and block
+        output = []
+        for i in range(len(processes)):
+            result = queue.get()
+            if isinstance(result, Exception):
+                raise result
+            output.append(result)
+        for process in processes:
+            process.join()
+
+        # return chunks sorted into input order
+        return flatten(zip(*sorted(output, key=lambda out: out[0]))[1])
+    return _read

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -28,7 +28,6 @@ import glue.segments
 from glue.ligolw.lsctables import (TableByName, LIGOTimeGPS)
 
 from ...io import registry
-from ...io.cache import (read_cache, file_list)
 from ...io.ligolw import (table_from_file, identify_ligolw)
 from .. import (Table, EventTable)
 from ..lsctables import EVENT_TABLES
@@ -156,12 +155,6 @@ def read_table_factory(table_):
 
     def _read_table(f, *args, **kwargs):
         tablename = table_.TableName(table_.tableName)
-        # handle multiprocessing
-        nproc = kwargs.pop('nproc', 1)
-        if nproc > 1:
-            kwargs['format'] = 'ligolw.%s' % tablename
-            return read_cache(file_list(f), Table, nproc, None,
-                              *args, **kwargs)
 
         # set up keyword arguments
         llwcolumns = kwargs.pop('ligolw_columns', kwargs.get('columns', None))

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -117,16 +117,10 @@ def _table_from_file(source, ifo=None, columns=None, loudest=False):
     return EventTable(data, meta=meta)
 
 
-def table_from_pycbc_live(source, ifo=None, columns=None, nproc=1, **kwargs):
+def table_from_pycbc_live(source, ifo=None, columns=None, **kwargs):
     """Read a `GWRecArray` from one or more PyCBC live files
     """
     source = file_list(source)
-    if nproc > 1:
-        from ...io.cache import read_cache
-        return read_cache(source, EventTable, nproc, None,
-                          ifo=ifo, columns=columns, format=PYCBC_LIVE_FORMAT,
-                          **kwargs)
-
     source = filter_empty_files(source, ifo=ifo)
     return vstack_tables(
         [_table_from_file(x, ifo=ifo, columns=columns, **kwargs)

--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -29,13 +29,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
 @with_import('root_numpy')
-def table_from_root(f, tree, columns=None, nproc=1, **kwargs):
-    # allow multiprocessing
-    if nproc != 1:
-        return read_cache(f, Table, nproc, columns=columns,
-                          format='omicron')
-
-    # read single file
+def table_from_root(f, tree, columns=None, **kwargs):
     return Table(root_numpy.root2array(file_list(f), tree,
                                             branches=columns, **kwargs))
 

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -24,7 +24,7 @@ from math import ceil
 
 import numpy
 
-from astropy.table import (Table, Column)
+from astropy.table import (Table, Column, vstack)
 
 from ..io import (reader, writer)
 
@@ -92,8 +92,7 @@ class EventTable(Table):
 
     # -- i/o ------------------------------------
 
-    read = classmethod(reader(doc="""
-        read data into an `eventtable`
+    read = classmethod(reader(doc="""Read data into an `EventTable`
 
         Parameters
         ----------
@@ -107,6 +106,9 @@ class EventTable(Table):
         columns : `list` of `str`, optional
             list of column names ro read; should represent a sub-set of
             all available columns
+
+        nproc : `int`, optional, default: 1
+            number of CPUs to use for parallel file reading
 
         .. note::
 
@@ -123,7 +125,7 @@ class EventTable(Table):
             if the `format` cannot be automatically identified
 
         Notes
-        -----"""))
+        -----""", mp_flattener=vstack))
 
     write = writer(doc="""
         write this table to a file

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -86,7 +86,20 @@ class EventColumn(Column):
 
 
 class EventTable(Table):
-    """Container for a table of events
+    """A container for a table of events
+
+    This differs from the basic `~astropy.table.Table` in two ways
+
+    - GW-specific file formats are registered to use with
+      `EventTable.read` and `EventTable.write`
+    - columns of this table are of the `EventColumn` type, which provides
+      methods for filtering based on a `~gwpy.segments.SegmentList` (not
+      specifically time segments)
+
+    See also
+    --------
+    astropy.table.Table
+        for details on parameters for creating an `EventTable`
     """
     Column = EventColumn
 
@@ -127,8 +140,7 @@ class EventTable(Table):
         Notes
         -----""", mp_flattener=vstack))
 
-    write = writer(doc="""
-        write this table to a file
+    write = writer(doc="""Write this table to a file
 
         parameters
         ----------

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -65,10 +65,6 @@ class TableTests(unittest.TestCase):
                                        format='ligolw.sngl_burst')
         self.assertEqual(len(table2), 4104)
         self.assertEqual(table2[0]['snr'], table2[2052]['snr'])
-        # try with nproc
-        table3 = self.TABLE_CLASS.read([TEST_XML_FILE, TEST_XML_FILE],
-                                       nproc=2, format='ligolw.sngl_burst')
-        self.assertTableEqual(table2, table3)
         # try with columns
         table4 = self.TABLE_CLASS.read(
             TEST_XML_FILE, format='ligolw.sngl_burst',
@@ -82,6 +78,15 @@ class TableTests(unittest.TestCase):
 
 class EventTableTests(TableTests):
     TABLE_CLASS = EventTable
+
+    def test_read_ligolw(self):
+        table = super(EventTableTests, self).test_read_ligolw()
+        # try with nproc
+        table = self.TABLE_CLASS.read([TEST_XML_FILE, TEST_XML_FILE],
+                                      format='ligolw.sngl_burst')
+        table2 = self.TABLE_CLASS.read([TEST_XML_FILE, TEST_XML_FILE],
+                                       nproc=2, format='ligolw.sngl_burst')
+        self.assertTableEqual(table, table2)
 
     def test_read_omega(self):
         table = self.TABLE_CLASS.read(TEST_OMEGA_FILE, format='ascii.omega')


### PR DESCRIPTION
This PR cleans up the application of the `nproc` keyword argument to `Class.read` methods. The unified `gwpy.io.reader` factor method now takes a `mp_flattener` keyword argument that defines how to flatten a list of objects into a single object, as would be needed to coalesce the results of a multi-processed read operation.

This PR applies it first to the `EventTable.read` method, cleaning up the `nproc` references in `gwpy.table.io`.