### PR TITLE
Fixed bug in reading Tables directly from h5py objects

### DIFF
--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -42,7 +42,10 @@ def with_nproc(reader, flatten):
         if isinstance(source, list):
             files = source
         else:
-            files = file_list(source)
+            try:  # try and map to a list of file-like objects
+                files = file_list(source)
+            except ValueError:  # otherwise treat as single
+                files = [source]
 
         # determine input format
         if kwargs.get('format', None) is None:

--- a/gwpy/io/registry.py
+++ b/gwpy/io/registry.py
@@ -51,8 +51,6 @@ def identify_with_list(identifier):
                 else:
                     if len(files):
                         path = files[0]
-            else:
-                raise
         except IndexError:
             pass
         return identifier(origin, path, fileobj, *args, **kwargs)

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -22,6 +22,15 @@
 import re
 from os.path import basename
 
+from six import string_types
+
+try:
+    import h5py
+except ImportError:
+    HAS_H5PY = False
+else:
+    HAS_H5PY = True
+
 from glue.lal import CacheEntry
 
 from astropy.table import vstack as vstack_tables
@@ -186,7 +195,9 @@ def empty_hdf5_file(fp, ifo=None):
 def identify_pycbc_live(origin, path, fileobj, *args, **kwargs):
     """Identify a PyCBC Live file from its basename
     """
-    if path is not None and PYCBC_FILENAME.match(basename(path)):
+    if HAS_H5PY and isinstance(path, h5py.HLObject):
+        path = path.file.name
+    if isinstance(path, string_types) and PYCBC_FILENAME.match(basename(path)):
         return True
     return False
 

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -22,7 +22,7 @@
 import os.path
 import tempfile
 
-from numpy import (may_share_memory, testing as nptest)
+from numpy import (may_share_memory, testing as nptest, random)
 
 from astropy import units
 
@@ -121,3 +121,19 @@ class EventTableTests(TableTests):
         table = self.TABLE_CLASS.read(TEST_OMEGA_FILE, format='ascii.omega')
         nptest.assert_array_equal(table.get_column('normalizedEnergy'),
                                   table['normalizedEnergy'])
+
+    def test_read_hdf5_mp(self):
+        try:
+            import h5py
+        except ImportError as e:
+            self.skipTest(str(e))
+        t = self.TABLE_CLASS(random.random((10, 10)))
+        fp = tempfile.mktemp(suffix='.hdf')
+        try:
+            t.write(fp, format='hdf5', path='/test')
+            h5file = h5py.File(fp, 'r')
+            h5dset = h5file['/test']
+            t2 = self.TABLE_CLASS.read(h5dset, format='hdf5')
+        finally:
+            if os.path.exists(fp):
+                os.remove(fp)


### PR DESCRIPTION
This PR fixes a bug introduced by #378 whereby reading directly from h5py objects would raise a `ValueError`. This includes a unittest to guard against regression.