### PR TITLE
Improved error reporting and tests for reading pycbc_live tables

### DIFF
--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -71,8 +71,10 @@ def _table_from_file(source, ifo=None, columns=None, loudest=False):
                 try:
                     ifo, = [key for key in list(source) if key != 'background']
                 except ValueError as e:
-                    e.args = ("PyCBC live HDF5 file contains multiple IFO "
-                              "groups, please select ifo manually",)
+                    e.args = ("PyCBC live HDF5 file contains dataset groups "
+                              "for multiple interferometers, please specify "
+                              "the prefix of the relevant interferometer via "
+                              "the `ifo` keyword argument, e.g: `ifo=G1`",)
                     raise
             try:
                 source = source[ifo]


### PR DESCRIPTION
This PR fixes #377 by improving the error message for multi-ifo files, and adds a test method for `EventTable.read(..., format='hdf5.pycbc_live')`.