### PR TITLE
Improved TimeSeries documentation

### DIFF
--- a/docs/references.txt
+++ b/docs/references.txt
@@ -6,3 +6,12 @@
 
 .. |glue.ligolw| replace:: `glue.ligolw`
 .. _glue.ligolw: http://software.ligo.org/docs/glue/glue.ligolw-module.html
+
+.. |LDAStools.frameCPP| replace:: `LDAStools.frameCPP`
+.. _LDAStools.frameCPP: https://ldas-jobs.ligo.caltech.edu/~emaros/share/doc/ldas-tools/framecpp/html/
+
+.. |lalframe| replace:: `lalframe`
+.. _lalframe: https://software.ligo.org/docs/lalsuite/lalframe/
+
+.. |nds2| replace:: `nds2`
+.. _nds2: https://www.lsc-group.phys.uwm.edu/daswg/projects/nds-client/doc/manual/

--- a/docs/timeseries/index.rst
+++ b/docs/timeseries/index.rst
@@ -2,188 +2,80 @@
 
 .. currentmodule:: gwpy.timeseries
 
-#############################
-Accessing interferometer data
-#############################
+################
+Time-domain data
+################
+
+================
+The `TimeSeries`
+================
 
 Gravitational-wave detectors are time-domain instruments, attempting to record gravitational-wave amplitude as a differential change in the lengths of each of the interferometer arms.
 The primary output of these detectors is a single time-stream of gravitational-wave strain.
 
-Alongside these data, thousands of auxiliary instrumental control and error signals and environmental monitors are recorded in real-time and recorded to disk and archived for off-line study.
-The data are archived in ``.gwf`` files, a custom binary format that efficiently stores the time streams and all necessary metadata, for more details about this particular data format, take a look at the specification document `LIGO-T970130 <https://dcc.ligo.org/LIGO-T970130/public>`_.
+Alongside these data, thousands of auxiliary instrumental control and error signals and environmental monitors are recorded in real-time and archived for off-line study.
+
+GWpy provides the `TimeSeries` object as a way of representing these and similar time-domain data.
+The `TimeSeries` is built from the :class:`numpy.ndarray`, and so many of the methods and applications of this object should be familiar to :mod:`numpy` users.
+
+For example, to create a simple `TimeSeries` filled with :mod:`~numpy.random` data::
+
+   >>> from numpy.random import random
+   >>> from gwpy.timeseries import TimeSeries
+   >>> t = TimeSeries(random(1000))
+   >>> print(t)
+   TimeSeries([ 0.59442285, 0.61979421, 0.62968915,...,  0.98309223,
+                0.94513298, 0.1826175 ]
+              unit: Unit(dimensionless),
+              t0: 0.0 s,
+              dt: 1.0 s,
+              name: None,
+              channel: None)
+
+Here we see the random data we have created, as well as the associated metadata common to any time-domain data:
+
+.. autosummary::
+
+   ~TimeSeries.unit
+   ~TimeSeries.t0
+   ~TimeSeries.dt
+   ~TimeSeries.name
+   ~TimeSeries.channel
 
 ==================
-Remote data access
+Associated classes
 ==================
 
-GWpy provides ways to download these data, one for authorised collaborators, and another for public data releases:
+Alongside the `TimeSeries` class, `gwpy.timeseries` module provides a small set of related classes for handling bit-vector data, and collections of data:
 
-==================================  ===========  =========================
-Method                              Restricted?  Description
-==================================  ===========  =========================
-:meth:`TimeSeries.get`              LIGO.ORG     Fetch data via NDS2 or
-                                                 `gw_data_find`
-:meth:`TimeSeries.fetch_open_data`  public       Fetch data from LIGO Open
-                                                 Science Center (LOSC)
-==================================  ===========  =========================
+.. autosummary::
+   :nosignatures:
+   :toctree: ../api/
 
-Public
-------
+   TimeSeries
+   StateVector
+   TimeSeriesDict
+   StateVectorDict
 
-For example, to fetch 32 seconds of strain data around event `GW150914 <http://dx.doi.org/10.1103/PhysRevLett.116.061102>`_
+================================
+Reading/writing time-domain data
+================================
 
-.. plot::
-   :context: reset
-   :include-source:
+.. toctree::
+   :maxdepth: 2
 
-   from gwpy.timeseries import TimeSeries
-   data = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
+   remote-access
+   ldg
+   io
 
-Here the ``'L1'`` refers to the `LIGO Livingston Observatory <https://www.ligo.caltech.edu/LA>`_ (``'H1'`` would be the `LIGO Hanford Observatory <https://www.ligo.caltech.edu/WA>`_), and the two 10-digit numbers are GPS times (for more details on GPS timing, see :ref:`time`). You could just as easily use a more readable format::
+=========================
+Plotting time-domain data
+=========================
 
-    data = TimeSeries.fetch_open_data('L1', 'Sep 14 2015 09:50:29', 'Sep 14 2015 09:51:01')
+.. toctree::
+   :maxdepth: 2
 
-Now that you have the data, making a plot is as easy as calling the :meth:`~TimeSeries.Plot` method:
-
-.. plot::
-   :context:
-
-   plot = data.plot()
-   plot.show()
-
-.. note::
-
-   These data are part of small snippet of LIGO data provided by the `LIGO Open Science Center <https://losc.ligo.org>`_, and are freely available to the public, see the LOSC website for full details on which data are available.
-
-LIGO.ORG
---------
-
-If you have LIGO.ORG credentials, meaning you're a member of the LIGO Scientific Collaboration or the Virgo Collaboration, you need to specify the exact name of the :ref:`channel <channel>` you want.
-For Advanced LIGO the calibrated strain channel is called ``GDS-CALIB_STRAIN``, so to fetch H1 strain data for the same period as above::
-
-    data = TimeSeries.get('H1:GDS-CALIB_STRAIN', 1126259446, 1126259478)
-
-With authenticated access, you also have access to the thousands of auxiliary channels mentioned above, if you run.::
-
-    gnd = TimeSeries.get('L1:ISI-GND_STS_ITMY_Z_DQ', 'Jan 1 2016', 'Jan 1 2016 01:00')
-
-you'll get back one hour of data from the vertical-ground-motion seismometer located near the ITMY vacuum enclosure at LIGO Livingston.
-
-The :meth:`TimeSeries.get` method tries direct file access (using :mod:`glue.datafind` for file discovery) first, then falls back to using the Network Data Server (NDS2) for remote access. If you want to manually use NDS2 for remote access you can instead use the :meth:`TimeSeries.fetch` method.
-
-=================
-Local data access
-=================
-
-If you have direct access to one or more files of data, either on the LIGO Data Grid (where the observatory data are stored) or you have some files of your own, you can use the `TimeSeries.read` method:
-
-This method is an example of the unified input/output system provided by `astropy <https://astropy.org>`_, so should respond in the same way whether you give it a ``gwf`` file, or an `''hdf5''` file, or a simple `''txt''` file.::
-
-    data = TimeSeries.read('mydata.gwf', 'L1:GDS-CALIB_STRAIN')
-
-.. note::
-
-   The input options to `TimeSeries.read` depend on what format the source data are in, but the first argument will always be the path of the file to read. Please refer to the function documentation for details and examples
-
-If you are on the LIGO Data Grid, but you don't know where the files are, you can use the :meth:`TimeSeries.find` method to automatically locate and read data for a given channel::
-
-    data = TimeSeries.find('L1:ISI-GND_STS_ITMY_Z_DQ', 'Jan 1 2016', 'Jan 1 2016 01:00')
-
-This method will search through all available data to find the correct files to read, so this may take a while. If you know the frametype - the tag associated with files containing your data, you can pass that to significantly speed up the search::
-
-    data = TimeSeries.find('L1:ISI-GND_STS_ITMY_Z_DQ', 'Jan 1 2016', 'Jan 1 2016 01:00', frametype='L1_R')
-
-Passing ``frametype`` will help most for accessing auxiliary data, rather than calibrated strain.
-
-----------
-Frametypes
-----------
-
-Data recorded by LIGO are identified by a frametype tag, which identifies which data are contained in a given ``gwf`` file.
-The following table is an incomplete, but probably OK, reference to which frametype you want to use for auxiliary data access:
-
-===============  =============================================================================
-Frametype        Description
-===============  =============================================================================
-``H1_R``         All auxiliary channels, stored at the native sampling rate
-``H1_T``         Second trends of all channels, including ``.mean``, ``.min``, and ``.max``
-``H1_M``         Minute trends of all channels, including ``.mean``, ``.min``, and ``.max``
-``H1_HOFT_C00``  Strain *h(t)* and metadata generated using the real-time calibration pipeline
-===============  =============================================================================
-
-The above frametypes refer to the ``H1`` (LIGO-Hanford) instrument, the same are available for LIGO-Livingston by substituting the ``L1`` prefix.
-
-============================================
-Accessing data for multiple channels at once
-============================================
-
-Because typically each ``gwf`` file contains data for a large number of channels, it is inefficient to ask for data for each channel in turn, since that would meaning opening, decoding, and closing each file every time.
-Instead you can read all of the data you want in a single step, using the `TimeSeriesDict` object:
-
-.. plot::
-   :context: reset
-   :include-source:
-   :nofigs:
-
-   from gwpy.timeseries import TimeSeriesDict
-   alldata = TimeSeriesDict.get(['H1:PSL-PWR_PMC_TRANS_OUT16','H1:IMC-PWR_IN_OUT16'], 'Feb 1 00:00', 'Feb 1 02:00')
-
-[These two channels represent the power generated by the Pre-Stabilized Laser at the input to interferometer, and the power actually entering the Input Mode Cleaner.]
-
-=================================
-Reading/writing `TimeSeries` data
-=================================
-
-The documentation above describes how to access interferometer data stored in GWF-format files.
-However, GWpy allows you to read and write `TimeSeries` data in any of a number of file formats using the
-:meth:`TimeSeries.read` and :meth:`TimeSeries.write` methods.
-
-.. note::
-
-   The method documentation for :meth:`TimeSeries.read` and :meth:`TimeSeries.write` includes a list of built-in file formats for storage of `TimeSeries` data.
-
-For example, you can load data from the LOSC and store it in a local HDF5 file as follows:
-
-.. code-block:: python
-
-   from gwpy.timeseries import TimeSeries
-   data = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-   data.write('l1-losc-data.hdf5')
-
-The ``l1-losc-data.hdf5`` file will then be written with a single dataset at the bottom level called ``strain``, which can then be re-read using
-
-.. code-block:: python
-
-   TimeSeries.read('l1-losc-data.hdf5')
-
-Similarly these data can be written to a GWF file, simply by naming the output file with the `.gwf` extension:
-
-.. code-block:: python
-
-   data.write('l1-losc-data.gwf')
-
-Reading/writing with HDF5 files requires the `h5py <http://www.h5py.org/>`_ package, and reading/writing with GWF files requires one of the frame libraries to be installed, either `lalframe <https://wiki.ligo.org/DASWG/LALSuite>`_ or `FrameCPP <https://ldas-jobs.ligo.caltech.edu/~emaros/share/doc/ldas-tools/framecpp/html/index.html>`_.
-
-=======================
-Plotting a `TimeSeries`
-=======================
-
-As we have seem above, the `TimeSeries` object comes with its own :meth:`~TimeSeries.plot` method, which will quickly construct a `~gwpy.plotter.TimeSeriesPlot`.
-The same is true of the `TimeSeriesDict`, so we can extend the above snippet to plot multiple channels:
-
-.. plot::
-   :context:
-   :include-source:
-
-   plot = alldata.plot()
-   ax = plot.gca()
-   ax.set_ylabel('Power [W]')
-   ax.set_title('Available vs requested input power for H1')
-   plot.show()
-
-.. rubric:: What's next
-
-The next documentation topic is :ref:`signal-processing`.
+   plot
 
 =============
 Reference/API
@@ -198,3 +90,6 @@ The above documentation references the following objects:
    TimeSeries
    TimeSeriesDict
    TimeSeriesList
+   StateVector
+   StateVectorDict
+   StateTimeSeries

--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -1,0 +1,150 @@
+.. _timeseries-io:
+.. currentmodule:: gwpy.timeseries
+.. include:: ../references.txt
+
+####################################
+Reading and writing time-domain data
+####################################
+
+The `TimeSeries` object includes :meth:`~TimeSeries.read` and :meth:`~TimeSeries.write` methods to enable reading from and writing to files respectively.
+For example, to read from an ASCII file containing time and amplitude columns::
+
+   >>> data = TimeSeries.read('my-data.txt')
+
+The ``format`` keyword argument can be used to manually identify the input file-format, but is not required where the file extension is sufficiently well understood.
+
+The :meth:`~TimeSeries.read` and :meth:`~TimeSeries.write` methods take different arguments and keywords based on the input/output file format, see the following sections for details on reading/writing for each of the built-in formats.
+Those formats are:
+
+- :ref:`timeseries-io-ascii`
+- :ref:`timeseries-io-gwf`
+- :ref:`timeseries-io-hdf5`
+
+.. _timeseries-io-ascii:
+
+=====
+ASCII
+=====
+
+GWpy supports writing `TimeSeries` (and `~gwpy.frequencyseries.FrequencySeries`) data to ASCII in a two-column ``time`` and ``amplitude`` format.
+
+Reading
+-------
+
+To read a `TimeSeries` from ASCII::
+
+   >>> t = TimeSeries.read('data.txt')
+
+See :func:`numpy.loadtxt` for keyword argument options.
+
+Writing
+-------
+
+To write a `TimeSeries` to ASCII::
+
+   >>> t.write('data.txt')
+
+See :func:`numpy.savetxt` for keyword argument options.
+
+.. _timeseries-io-gwf:
+
+===============================
+Gravitational-wave frames (GWF)
+===============================
+
+**Additional dependencies:**  |LDAStools.frameCPP|_ or |lalframe|_
+
+The raw observatory data are archived in ``.gwf`` files, a custom binary format that efficiently stores the time streams and all necessary metadata, for more details about this particular data format, take a look at the specification document `LIGO-T970130 <https://dcc.ligo.org/LIGO-T970130/public>`_.
+
+Reading
+-------
+
+To read data from a GWF file, pass the input file path (or paths) and the name of the data channel to read::
+
+    >>> data = TimeSeries.read('HLV-GW100916-968654552-1.gwf', 'L1:LDAS-STRAIN')
+
+.. note::
+
+   The ``HLV-GW100916-968654552-1.gwf`` file is included with the GWpy source under `/gwpy/tests/data/ <https://github.com/gwpy/gwpy/tree/master/gwpy/tests/data>`_.
+
+Reading a `StateVector` uses the same syntax::
+
+    >>> data = StateVector.read('my-state-data.gwf', 'L1:GWO-STATE_VECTOR')
+
+Multiple files can be read by passing a list of files::
+
+   >>> data = TimeSeries.read([file1, file2], 'L1:LDAS-STRAIN')
+
+When reading multiple files, the ``nproc`` keyword argument can be used to distribute the reading over multiple CPUs, which should make it faster::
+
+   >>> data = TimeSeries.read([file1, file2, file3, file4], 'L1:LDAS-STRAIN', nproc=2)
+
+The above command will separate the input list of 4 file paths into two sets of 2 files, combining the results into a single `TimeSeries` before returning.
+
+Additionally, the following keyword arguments can be passed to manipulate the data on-the-fly when reading:
+
+============  =======  ==========================================
+Keyword       Type     Usage
+============  =======  ==========================================
+``resample``  `float`  resample the data to a different number of
+                       samples per second
+``dtype``     `type`   cast the input data to a different data type
+============  =======  ==========================================
+
+For example::
+
+   >>> data = TimeSeries.read('HLV-GW100916-968654552-1.gwf', 'L1:LDAS-STRAIN', resample=2048)
+
+Reading multiple channels
+-------------------------
+
+To read multiple channels from one or more GWF files (rather than opening and closing the files multiple times), use the `TimeSeriesDict` or `StateVectorDict` classes, and pass a list of data channel names::
+
+    >>> data = TimeSeriesDict.read('HLV-GW100916-968654552-1.gwf', ['H1:LDAS-STRAIN', 'L1:LDAS-STRAIN'])
+
+In this case the ``resample`` and ``dtype`` keywords can be given as a single value used for all data channels, or a `dict` mapping an argument for each data channel name::
+
+    >>> data = TimeSeriesDict.read('HLV-GW100916-968654552-1.gwf', ['H1:LDAS-STRAIN', 'L1:LDAS-STRAIN'], resample={'H1:LDAS-STRAIN': 2048})
+
+The above example will resample only the ``'H1:LDAS-STRAIN'`` `TimeSeries` and will not modify that for ``'L1:LDAS-STRAIN'``.
+
+.. note::
+
+   A mix of `TimeSeries` and `StateVector` objects can be read by using only `TimeSeriesDict` class, and casting the returned data to a `StateVector` using :meth:`~TimeSeries.view`.
+
+Writing
+-------
+
+To write data held in any of the :mod:`gwpy.timeseries` classes to a GWF file, simply use::
+
+    >>> data.write('output.gwf')
+
+**If the output file already exists it will be overwritten.**
+
+.. _timeseries-io-hdf5:
+
+====
+HDF5
+====
+
+**Additional dependencies:** |h5py|_
+
+GWpy allows storing data in HDF5 format files, using a custom specification for storage of metadata.
+
+.. warning::
+
+   Reading/writing multiple datasets with the `TimeSeriesDict` and `StateVectorDict` classes is not supported at this time.
+
+Reading
+-------
+
+To read `TimeSeries` or `StateVector` data held in HDF5 files pass the filename (or filenames) or the source, and the path of the data inside the HDF5 file::
+
+   >>> data = TimeSeries.read('HLV-GW100916-968654552-1.hdf', 'L1:LDAS-STRAIN')
+
+Writing
+-------
+
+Data held in a `TimeSeries` or `StateVector` can be written to an HDF5 file via::
+
+   >>> data.write('output.hdf')

--- a/docs/timeseries/ldg.rst
+++ b/docs/timeseries/ldg.rst
@@ -1,0 +1,50 @@
+.. currentmodule:: gwpy.timeseries
+
+.. _timeseries-datafind:
+
+####################################
+Data-discovery on the LIGO Data Grid
+####################################
+
+.. _timeseries-datafind-discovery:
+
+Data discovery
+--------------
+
+The LIGO Data Grid consists of a trio of large-scale high-throughput computing (HTC) facilities operated by the LIGO Laboratory, and serves as the primary host of the data recorded from the observatories.
+
+The observatories record ~30 MBytes/second of 'raw' data that are continuously written to GWF-format files (see :ref:`timeseries-io-gwf` for more details on the GWF format), as well as the processed strain data produced in real-time for low-latency gravitational-wave searches.
+A data discovery service named `datafind` is available allowing any authenticated user to query for the locations of GWF files by specifying the observatory, the frame type, and a time interval.
+
+The `TimeSeries.find` method leverages that discovery service to enable users to automatically locate and read data from these files in a convenient manner.
+For example::
+
+    >>> data = TimeSeries.find('L1:ISI-GND_STS_ITMY_Z_DQ', 'Jan 1 2016', 'Jan 1 2016 01:00')
+
+This method will search through all available data to find the correct files to read, so this may take a while. If you know the frametype - the tag associated with files containing your data - you can pass that via the ``frametype`` keyword argument to significantly speed up the search::
+
+    >>> data = TimeSeries.find('L1:ISI-GND_STS_ITMY_Z_DQ', 'Jan 1 2016', 'Jan 1 2016 01:00', frametype='L1_R')
+
+.. _timeseries-datafind-frametypes:
+
+Frametypes
+----------
+
+All data recorded by LIGO are identified by a frametype tag, which identifies which data are contained in a given ``gwf`` file.
+The following table is an incomplete, but probably OK, reference to which frametype you want to use for auxiliary data access:
+
+===============  ==========================================================
+Frametype        Description
+===============  ==========================================================
+``H1_R``         All auxiliary channels, stored at the native sampling rate
+``H1_T``         Second trends of all channels, including ``.mean``,
+                 ``.min``, and ``.max``
+``H1_M``         Minute trends of all channels, including ``.mean``,
+                 ``.min``, and ``.max``
+``H1_HOFT_C00``  Strain *h(t)* and metadata generated using the real-time
+                 calibration pipeline
+``H1_HOFT_CXY``  Strain *h(t)* and metadata generated using the off-line
+                 calibration pipeline at version ``XY``
+===============  ==========================================================
+
+The above frametypes refer to the ``H1`` (LIGO-Hanford) instrument, the same are available for LIGO-Livingston by substituting the ``L1`` prefix.

--- a/docs/timeseries/plot.rst
+++ b/docs/timeseries/plot.rst
@@ -1,0 +1,120 @@
+.. currentmodule:: gwpy.timeseries
+
+.. plot::
+   :include-source: False
+   :context: reset
+   :nofigs:
+
+   >>> from gwpy.timeseries import (TimeSeries, TimeSeriesDict, StateVector, StateVectorDict)
+
+.. _timeseries-plot:
+
+#########################
+Plotting time-domain data
+#########################
+
+=========================
+Plotting one `TimeSeries`
+=========================
+
+The `TimeSeries` class includes a :meth:`~TimeSeries.plot` method to trivialise visualisation of the contained data.
+Reproducing the example from :ref:`timeseries-remote-access`:
+
+.. plot::
+   :include-source:
+   :context:
+
+   >>> l1hoft = TimeSeries.fetch_open_data('L1', 'Sep 14 2015 09:50:29', 'Sep 14 2015 09:51:01')
+   >>> plot = l1hoft.plot()
+   >>> plot.show()
+
+The returned object `plot` is a :class:`~gwpy.plotter.TimeSeriesPlot`, a sub-class of :class:`matplotlib.figure.Figure` adapted for GPS time-stamped data.
+Customisations of the figure or the underlying :class:`~gwpy.plotter.TimeSeriesAxes` can be done using standard :mod:`matplotlib` methods.
+For example:
+
+.. plot::
+   :include-source:
+   :context:
+
+   >>> ax = plot.gca()
+   >>> ax.set_ylabel('Gravitational-wave amplitude [strain]')
+   >>> ax.set_epoch(1126259462)
+   >>> ax.set_title('LIGO-Livingston strain data around GW150914')
+   >>> ax.axvline(1126259462, color='orange', linestyle='--')
+   >>> plot.refresh()
+
+Here the :meth:`~gwpy.plotter.TimeSeriesAxes.set_epoch` method is used to reset the reference time for the x-axis.
+
+=======================================
+Plotting multiple `TimeSeries` together
+=======================================
+
+Multiple `TimeSeries` classes can be combined on a figure in a number of different ways, the most obvious is to :meth:`~TimeSeries.plot` the first, then add the second on the same axes.
+Reusing the same ``plot`` from above:
+
+.. plot::
+   :include-source:
+   :context:
+
+   >>> h1hoft = TimeSeries.fetch_open_data('H1', 'Sep 14 2015 09:50:29', 'Sep 14 2015 09:51:01')
+   >>> ax = plot.gca()
+   >>> ax.plot(h1hoft)
+   >>> plot.refresh()
+
+Alternatively, the two `TimeSeries` could be combined into a `TimeSeriesDict` to use the :meth:`~TimeSeriesDict.plot` method from that class:
+
+.. plot::
+   :include-source:
+   :context: close-figs
+
+   >>> combined = TimeSeriesDict()
+   >>> combined['L1'] = l1hoft
+   >>> combined['H1'] = h1hoft
+   >>> plot = combined.plot()
+   >>> plot.gca().legend()
+   >>> plot.show()
+
+The third method of achieving the same result is by importing and accessing the `~gwpy.plotter.TimeSeriesPlot` object directly:
+
+.. plot::
+   :include-source:
+   :context: close-figs
+
+   >>> from gwpy.plotter import TimeSeriesPlot
+   >>> plot = TimeSeriesPlot(l1hoft, h1hoft)
+   >>> plot.show()
+
+Using the `~gwpy.plotter.TimeSeriesPlot` directly allows for greater customisation.
+The ``sep=True`` keyword argument can be used to plot each `TimeSeries` on its own axes:
+
+.. plot::
+   :include-source:
+   :context: close-figs
+
+   >>> plot = TimeSeriesPlot(l1hoft, h1hoft, sep=True)
+   >>> plot.show()
+
+========================
+Plotting a `StateVector`
+========================
+
+A `StateVector` can be trivially plotted in two ways, specified by the ``format`` keyword argument of the :meth:`~StateVector.plot` method:
+
+================  =============================================================
+Format            Description
+================  =============================================================
+``'segments'``    A bit-wise representation of each bit in the vector (default)
+``'timeseries'``  A standard time-series representation
+================  =============================================================
+
+.. plot::
+   :include-source:
+   :context: close-figs
+
+   >>> h1state = StateVector.fetch_open_data('H1', 'Sep 14 2015 09:50:29', 'Sep 14 2015 09:51:01')
+   >>> plot = h1state.plot(insetlabels=True)
+   >>> plot.show()
+
+For a ``format='segments'`` display the :attr:`~StateVector.bits` attribute of the `StateVector` is used to identify and label each of the binary bits in the vector.
+Also, the ``insetlabels=True`` keyword was given to display the bit labels inside the axes (otherwise they would be cut off the side of the figure).
+That each of the segment bars is green for the full 32-second duration indicates that each of the statements (e.g. '*passes cbc CAT1 test*') is true throughout this time interval.

--- a/docs/timeseries/remote-access.rst
+++ b/docs/timeseries/remote-access.rst
@@ -1,0 +1,91 @@
+.. currentmodule:: gwpy.timeseries
+.. include:: ../references.txt
+
+.. _timeseries-remote-access:
+
+##################
+Remote data access
+##################
+
+The LIGO Laboratory archives instrumental data in GWF files hosted on the LIGO Data Grid (see :ref:`timeseries-datafind` for more details), however, remote access tools have been developed to simplify loading data.
+GWpy provides two methods for remote data access, one for public data releases, and another for authenticated access to the complete data archive:
+
+==================================  ===========  =========================
+Method                              Restricted?  Description
+==================================  ===========  =========================
+:meth:`TimeSeries.fetch_open_data`  public       Fetch data from LIGO Open
+                                                 Science Center (LOSC)
+:meth:`TimeSeries.get`              LIGO.ORG     Fetch data via local disk
+                                                 or NDS2
+==================================  ===========  =========================
+
+.. _timeseries-remote-public:
+
+==================
+Open data releases
+==================
+
+**Additional dependencies:** |h5py|_
+
+The `LIGO Open Science Center <https://losc.ligo.org/>`_ hosts a large quantity of open (meaning publicly-available) data from LIGO science runs, including the full strain record for the sixth LIGO science run (S6, 2009-2010) and short extracts of the strain record surrounding published GW observations from Advanced LIGO.
+
+To fetch 32 seconds of strain data around event `GW150914 <http://dx.doi.org/10.1103/PhysRevLett.116.061102>`_, you need to give the prefix of the relevant observatory (``'H1'`` for the LIGO Hanford Observatory, ``'L1'`` for LIGO Livingston), and the start and end times of your query:
+
+.. plot::
+   :context: reset
+   :include-source:
+   :nofigs:
+
+   >>> from gwpy.timeseries import TimeSeries
+   >>> data = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
+
+Above the times are given in GPS format, but you could just as easily use a more readable format::
+
+    >>> data = TimeSeries.fetch_open_data('L1', 'Sep 14 2015 09:50:29', 'Sep 14 2015 09:51:01')
+
+You can then trivially plot these data:
+
+.. plot::
+   :include-source:
+   :context:
+
+   >>> plot = data.plot()
+   >>> plot.show()
+
+For more details on plotting a `TimeSeries`, see :ref:`timeseries-plot`.
+
+.. _timeseries-remote-nds2:
+
+=============================
+Restricted full data archives
+=============================
+
+**Additional dependencies:** |nds2|_
+
+Members of the LIGO Scientific Collaboration or the Virgo Collaboration can access the full raw and processed data archived via an authenticated remote protocol called NDS2.
+In this case, the :meth:`TimeSeries.get` method can be used to download data for any one of thousands of archived data channels.
+
+.. note::
+
+   Access to data using the `nds2` client requires a `Kerberos <https://web.mit.edu/kerberos/>`_ authentication ticket.
+   This can be generated from the command-line using ``kinit``:
+
+   .. code-block:: bash
+
+      $ kinit albert.einstein@LIGO.ORG
+
+   where ``albert.einstein`` should be replaced with your own LIGO.ORG identity.
+   If you don't have an active kerberos credential at the time you run `TimeSeries.get`, GWpy will prompt you to create one.
+
+For Advanced LIGO the calibrated strain data channel is called ``GDS-CALIB_STRAIN``, so to fetch H1 strain data for the same period as above::
+
+    >>> data = TimeSeries.get('H1:GDS-CALIB_STRAIN', 1126259446, 1126259478)
+
+Authenticated collaborators also have access to the thousands of auxiliary channels mentioned above, for example running::
+
+    >>> gnd = TimeSeries.get('L1:ISI-GND_STS_ITMY_Z_DQ', 'Jan 1 2016', 'Jan 1 2016 01:00')
+
+will return one hour of data from the vertical-ground-motion seismometer located near the ITMY vacuum enclosure at LIGO Livingston.
+
+The `TimeSeries.get` method tries direct file access (using :mod:`glue.datafind` for file discovery) first, then falls back to using the Network Data Server (NDS2) for remote access.
+If you want to manually use NDS2 for remote access you can instead use the `TimeSeries.fetch` method.

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -130,7 +130,7 @@ class TimeSeriesBase(Series):
         allow passing of sub-classes by the array generator
     """
     _default_xunit = units.second
-    _print_slots = ['sample_rate', 'epoch', 'name', 'channel', '_times']
+    _print_slots = ['t0', 'dt', 'name', 'channel']
     DictClass = None
 
     def __new__(cls, data, unit=None, t0=None, dt=None, sample_rate=None,


### PR DESCRIPTION
This PR improves the sphinx documentation for the `TimeSeries` and associated objects, mainly to improve the I/O components, spelling out what you can do for each filetype, similar to what is done in the Astropy documentation.