### PR TITLE
Fixed bugs in reading data from multi-frame GWF with framecpp

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -210,6 +210,12 @@ class TimeSeriesTestMixin(object):
         t = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel, format='gwf',
                                  start=start, end=end)
         self.assertTupleEqual(t.span, (start, end))
+        t = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel, format='gwf',
+                                 start=start)
+        self.assertTupleEqual(t.span, (start, TEST_SEGMENT[1]))
+        t = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel, format='gwf',
+                                 end=end)
+        self.assertTupleEqual(t.span, (TEST_SEGMENT[0], end))
 
     def read_write_gwf_api(self, api):
         fmt = 'gwf.%s' % api

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -216,6 +216,13 @@ class TimeSeriesTestMixin(object):
         t = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel, format='gwf',
                                  end=end)
         self.assertTupleEqual(t.span, (TEST_SEGMENT[0], end))
+        # check errors
+        self.assertRaises((ValueError, RuntimeError), self.TEST_CLASS.read,
+                          TEST_GWF_FILE, self.channel, format='gwf',
+                          start=TEST_SEGMENT[1])
+        self.assertRaises((ValueError, RuntimeError), self.TEST_CLASS.read,
+                          TEST_GWF_FILE, self.channel, format='gwf',
+                          end=TEST_SEGMENT[0])
 
     def read_write_gwf_api(self, api):
         fmt = 'gwf.%s' % api

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -163,7 +163,7 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
             if end and datastart >= end and nframe == 1:
                 raise ValueError("Cannot read %s from FrVect in %s "
                                  "ending at %s" % (name, fp, end))
-            elif end and datastart >= end: # don't need this frame
+            elif end and datastart >= end:  # don't need this frame
                 continue
             try:
                 dataend = datastart + data.GetTRange()


### PR DESCRIPTION
This PR fixes a bug when reading data from a frame file that contains multiple frames (as in the aggregated LIGO h(t) frame files), when not reading the full data (i.e. `start` or `end` is given).