### PR TITLE
Force query times to int when calling to dqsegdb

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -507,13 +507,13 @@ class DataQualityFlag(object):
             if out.version is None:
                 data, versions, _ = apicalls.dqsegdbCascadedQuery(
                     protocol, server, out.ifo, out.tag, request,
-                    start, end)
+                    int(start), int(end))
                 data['metadata'] = versions[-1]['metadata']
             else:
                 try:
                     data, _ = apicalls.dqsegdbQueryTimes(
                         protocol, server, out.ifo, out.tag, out.version,
-                        request, start, end)
+                        request, int(start), int(end))
                 except URLError as e:
                     e.args = ('Error querying for %s: %s' % (flag, e),)
                     raise


### PR DESCRIPTION
This PR works around problems serialising LIGOTimeGPS with JSON when querying for segments from `dqsegdb`.

This may have to be changed/updated if/when dqsegdb allows non-integer segments.