### PR TITLE
Updated gwpy to python3-compatible syntax

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -39,7 +39,7 @@ import re
 
 from argparse import ArgumentError
 
-from gwpy.timeseries import TimeSeries
+from ..timeseries import TimeSeries
 
 
 class CliProduct(object):

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -784,7 +784,7 @@ class CliProduct(object):
 
         if self.verbose > 2:
             print('Arguments:')
-            for key, value in args.__dict__.iteritems():
+            for key, value in args.__dict__.items():
                 print('%s = %s' % (key, value))
 
         self.getTimeSeries(args)

--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -21,7 +21,7 @@
 
 """ Coherence plots
 """
-from cliproduct import CliProduct
+from .cliproduct import CliProduct
 
 
 class Coherence(CliProduct):

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -21,7 +21,7 @@
 
 """ Coherence plots
 """
-from cliproduct import CliProduct
+from .cliproduct import CliProduct
 
 
 class Spectrogram(CliProduct):

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -21,7 +21,7 @@
 
 """ Spectrum plots
 """
-from cliproduct import CliProduct
+from .cliproduct import CliProduct
 
 
 class Spectrum(CliProduct):

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -21,7 +21,7 @@
 
 """ Time Series plots
 """
-from cliproduct import CliProduct
+from .cliproduct import CliProduct
 
 
 class TimeSeries(CliProduct):

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -45,7 +45,7 @@ except ImportError:
          128: 'rds',
     }
     NDS2_CHANNEL_TYPE = dict((val, key) for (key, val) in
-                             NDS2_CHANNEL_TYPESTR.iteritems())
+                             NDS2_CHANNEL_TYPESTR.items())
 
 from ..io import datafind
 from ..time import to_gps
@@ -123,7 +123,7 @@ class Channel(object):
             self.name = str(name)
         else:
             self.name = str(name).split(',')[0]
-            for key, val in parts.iteritems():
+            for key, val in parts.items():
                 try:
                     setattr(self, key, val)
                 except AttributeError:
@@ -662,7 +662,7 @@ class ChannelList(list):
             namestr = namestr.strip('\' \n')
             if ',' not in namestr:
                 break
-            for nds2type in NDS2_CHANNEL_TYPE.keys() + ['']:
+            for nds2type in list(NDS2_CHANNEL_TYPE.keys()) + ['']:
                 if nds2type and ',%s' % nds2type in namestr:
                     try:
                         channel, ctype, namestr = namestr.split(',', 2)
@@ -748,7 +748,7 @@ class ChannelList(list):
             c = [entry for entry in c if
                  sample_range[0] <= entry.sample_rate.value <=
                  sample_range[1]]
-        for attr, val in others.iteritems():
+        for attr, val in others.items():
             if val is not None:
                 c = [entry for entry in c if
                      (hasattr(entry, attr) and getattr(entry, attr) == val)]

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -28,6 +28,8 @@ import subprocess
 import sys
 from math import log
 
+from six import string_types
+
 from astropy import units
 from astropy.io import registry as io_registry
 
@@ -828,7 +830,7 @@ class ChannelList(list):
             names = [names]
         for name in names:
             # format channel query
-            if (type and (isinstance(type, (unicode, str)) or
+            if (type and (isinstance(type, string_types) or
                           (isinstance(type, int) and
                            log(type, 2).is_integer()))):
                 channel = Channel(name, type=type)

--- a/gwpy/detector/io/cis.py
+++ b/gwpy/detector/io/cis.py
@@ -20,9 +20,10 @@
 """
 
 import json
-import numpy
 
-from urllib2 import HTTPError
+from six.moves.urllib.error import HTTPError
+
+import numpy
 
 from ...utils import auth
 from .. import (Channel, ChannelList)

--- a/gwpy/detector/io/cis.py
+++ b/gwpy/detector/io/cis.py
@@ -68,13 +68,25 @@ def query(name, debug=False, timeout=None):
 def _get(url, debug=False, timeout=None):
     """Perform a GET query against the CIS
     """
+    # perform query
     try:
         response = auth.request(url, debug=debug, timeout=timeout)
     except HTTPError:
         raise ValueError("Channel not found at URL %s "
                          "Information System. Please double check the "
                          "name and try again." % url)
-    return json.loads(response.read())
+
+    # decode response
+    data = response.read()
+    if isinstance(data, bytes):
+        data = data.decode('utf-8')
+
+    # check for HTML data (authentication failure)
+    if data.startswith('<!DOCTYPE'):
+        raise RuntimeError("CIS query redirected to login prompt, "
+                           "authentication failed")
+
+    return json.loads(data)
 
 
 def parse_json(data):

--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -147,7 +147,7 @@ def write_channel_list_file(channels, fobj):
         group = channel.group
         if not out.has_section(group):
             out.add_section(group)
-        for param, value in channel.params.iteritems():
+        for param, value in channel.params.items():
             out.set(group, param, value)
         if channel.sample_rate:
             entry = '%s %s' % (str(channel),

--- a/gwpy/detector/io/omega.py
+++ b/gwpy/detector/io/omega.py
@@ -186,7 +186,7 @@ def print_omega_channel(channel, file=sys.stdout):
     for key in ['channelName', 'frameType']:
         if key not in params:
             raise KeyError("No %r defined for %s" % (key, str(channel)))
-    for key, value in params.iteritems():
+    for key, value in params.items():
         key = '%s:' % str(key)
         if isinstance(value, tuple):
             value = '[%s]' % ' '.join(map(str, value))

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -50,7 +50,10 @@ def parse_unit(name, parse_strict='warn'):
     """
     if name is None or isinstance(name, units.UnitBase):
         return name
-    name = str(name)
+    if isinstance(name, bytes):
+        name = name.decode('utf-8')
+    else:
+        name = str(name)
     # try simple parse
     try:
         return units.Unit(name)

--- a/gwpy/frequencyseries/registry.py
+++ b/gwpy/frequencyseries/registry.py
@@ -54,7 +54,10 @@ def register_method(func, name=None, force=False, scaling='density'):
             suffix = lines.pop(-1)
         else:
             suffix = ''
-        obj.__func__.__doc__ = '\n'.join(lines + [newdoc, suffix])
+        try:
+            obj.__doc__ = '\n'.join(lines + [newdoc, suffix])
+        except AttributeError:  # python 2.x
+            obj.__func__.__doc__ = '\n'.join(lines + [newdoc, suffix])
 
     # determine spectrum method type, and append doc
     if scaling == 'density':

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -37,10 +37,16 @@ from glue.lal import (Cache, CacheEntry)
 from astropy.table import (Table, vstack as vstack_tables)
 from astropy.io.registry import _get_valid_format
 
+from ..time import LIGOTimeGPS
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 # build list of file-like types
-FILE_LIKE = [file, GzipFile]
+try:  # python2.x
+    FILE_LIKE = [file, GzipFile]
+except NameError:  # python3.x
+    from io import IOBase
+    FILE_LIKE = [IOBase, GzipFile]
 try:  # protect against private member being removed
     FILE_LIKE.append(tempfile._TemporaryFileWrapper)
 except AttributeError:

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -27,6 +27,8 @@ import tempfile
 import warnings
 from gzip import GzipFile
 
+from six import string_types
+
 from numpy import recarray
 from numpy.lib import recfunctions
 
@@ -153,7 +155,7 @@ def read_cache(cache, target, nproc, post, *args, **kwargs):
        of this feature.
     """
     # read the cache
-    if isinstance(cache, (file, unicode, str)):
+    if isinstance(cache, FILE_LIKE + string_types):
         cache = open_cache(cache)
     if isinstance(cache, Cache):
         cache.sort(key=lambda ce: ce.segment[0])

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -54,15 +54,15 @@ except AttributeError:
 FILE_LIKE = tuple(FILE_LIKE)
 
 
-def open_cache(lcf):
+def open_cache(lcf, coltype=LIGOTimeGPS):
     """Read a LAL-format cache file into memory as a
     :class:`glue.lal.Cache`.
     """
-    if isinstance(lcf, file):
-        return Cache.fromfile(lcf)
+    if isinstance(lcf, FILE_LIKE):
+        return Cache.fromfile(lcf, coltype=coltype)
     else:
         with open(lcf, 'r') as f:
-            return Cache.fromfile(f)
+            return Cache.fromfile(f, coltype=coltype)
 
 
 def file_list(flist):

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -104,7 +104,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
         raise ValueError("Cannot parse interferometer prefix from channel "
                          "name %r, cannot proceed with find()" % name)
     if gpstime is not None:
-        gpstime = to_gps(gpstime).seconds
+        gpstime = to_gps(gpstime).gpsSeconds
     connection = connect(host, port)
     types = connection.find_types(channel.ifo[0], match=frametype_match)
     # get reference frame for all types
@@ -167,8 +167,8 @@ def find_best_frametype(channel, start, end, urltype='file',
                         host=None, port=None, allow_tape=True):
     """Intelligently select the best frametype from which to read this channel
     """
-    start = to_gps(start).seconds
-    end = to_gps(end).seconds
+    start = to_gps(start).gpsSeconds
+    end = to_gps(end).gpsSeconds
     frametype = find_frametype(channel, gpstime=start, host=host, port=port,
                                allow_tape=allow_tape)
     connection = connect(host=host, port=port)

--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -145,7 +145,7 @@ def iter_channel_names(framefile):
                 i += 1
     else:
         for line in iter(out.splitlines()):
-            yield line.split(' ', 1)[0]
+            yield line.split(b' ', 1)[0].decode('utf-8')
 
 
 def get_channel_names(framefile):

--- a/gwpy/io/hdf5.py
+++ b/gwpy/io/hdf5.py
@@ -36,7 +36,7 @@ def open_hdf5(filename, mode='r'):
     import h5py
     if isinstance(filename, (h5py.Group, h5py.Dataset)):
         return filename
-    elif isinstance(filename, file):
+    elif isinstance(filename, FILE_LIKE):
         return h5py.File(filename.name, mode)
     else:
         return h5py.File(filename, mode)

--- a/gwpy/io/hdf5.py
+++ b/gwpy/io/hdf5.py
@@ -92,7 +92,7 @@ def find_dataset(h5o, path=None):
     if isinstance(h5o, h5py.Dataset):
         return h5o
     elif path is None and len(h5o) == 1:
-        path = h5o.keys()[0]
+        path = list(h5o.keys())[0]
     elif path is None:
         raise ValueError("Please specify the HDF5 path via the "
                          "``path=`` keyword argument")

--- a/gwpy/io/nds.py
+++ b/gwpy/io/nds.py
@@ -55,7 +55,7 @@ for ctype in (nds2.channel.CHANNEL_TYPE_RAW,
     NDS2_CHANNEL_TYPESTR[ctype] = nds2.channel_channel_type_to_string(ctype)
 NDS2_CHANNEL_TYPESTR[max(NDS2_CHANNEL_TYPESTR.keys()) * 2] = 'rds'
 NDS2_CHANNEL_TYPE = dict((val, key) for (key, val) in
-                         NDS2_CHANNEL_TYPESTR.iteritems())
+                         NDS2_CHANNEL_TYPESTR.items())
 # manually add RDS
 
 

--- a/gwpy/plotter/frequencyseries.py
+++ b/gwpy/plotter/frequencyseries.py
@@ -299,7 +299,7 @@ class FrequencySeriesPlot(Plot):
 
         for i, ax in enumerate(self.axes):
             # format axes
-            for key, val in axargs.iteritems():
+            for key, val in axargs.items():
                 getattr(ax, 'set_%s' % key)(val)
             # fix log frequency scale with f0 = DC
             if xscale in ['log']:

--- a/gwpy/plotter/html.py
+++ b/gwpy/plotter/html.py
@@ -19,7 +19,7 @@
 """Construct HTML maps on top of images.
 """
 
-from itertools import izip
+from six.moves import zip
 
 import numpy
 
@@ -238,7 +238,7 @@ def _map(data, axes, filename, href='#', mapname='points', popup=None,
     # build map
     areas = []
     for i, (datum, pixel, href) in enumerate(
-            izip(data[::-1], pixels[::-1], hrefs[::-1])):
+            zip(data[::-1], pixels[::-1], hrefs[::-1])):
         if callable(popup):
             alt = popup(*datum)
         elif popup is None:

--- a/gwpy/plotter/html.py
+++ b/gwpy/plotter/html.py
@@ -93,7 +93,7 @@ def html_area(x, y, href='#', alt=None, shape='circle', **kwargs):
         alt = '(%s, %s)' % (x, y)
     out = ('<area shape="{shape}" coords="{x:d},{y:d},5" href="{href}" '
            'alt="{alt}" '.format(shape=shape, x=x, y=y, href=href, alt=alt))
-    for attr, value in kwargs.iteritems():
+    for attr, value in kwargs.items():
         out += '%s="%s" ' % (attr, value)
     out += '/>'
     return out

--- a/gwpy/plotter/segments.py
+++ b/gwpy/plotter/segments.py
@@ -166,7 +166,7 @@ class SegmentAxes(TimeSeriesAxes):
             list of `~matplotlib.patches.Rectangle` patches
         """
         out = []
-        for lab, flag in flags.iteritems():
+        for lab, flag in flags.items():
             if label.lower() == 'name':
                 lab = flag.name
             elif label.lower() != 'key':
@@ -335,7 +335,7 @@ class SegmentAxes(TimeSeriesAxes):
         if y is None:
             y = self.get_next_y()
         collections = []
-        for name, segmentlist in segmentlistdict.iteritems():
+        for name, segmentlist in segmentlistdict.items():
             collections.append(self.plot_segmentlist(segmentlist, y=y,
                                                      label=name, **kwargs))
             y += dy

--- a/gwpy/plotter/segments.py
+++ b/gwpy/plotter/segments.py
@@ -22,6 +22,7 @@
 import operator
 
 from six import string_types
+from six.moves import reduce
 
 from matplotlib.artist import allow_rasterization
 from matplotlib.ticker import (Formatter, MultipleLocator, NullLocator)

--- a/gwpy/plotter/segments.py
+++ b/gwpy/plotter/segments.py
@@ -21,6 +21,8 @@
 
 import operator
 
+from six import string_types
+
 from matplotlib.artist import allow_rasterization
 from matplotlib.ticker import (Formatter, MultipleLocator, NullLocator)
 from matplotlib.projections import register_projection
@@ -558,7 +560,7 @@ class SegmentPlot(TimeSeriesPlot):
         # format mask as a binary string and work out how many bits to set
         if isinstance(mask, int):
             mask = bin(mask)
-        elif isinstance(mask, (unicode, str)) and 'x' in mask:
+        elif isinstance(mask, string_types) and 'x' in mask:
             mask = bin(int(mask, 16))
         maskint = int(mask, 2)
         if topdown:

--- a/gwpy/plotter/table.py
+++ b/gwpy/plotter/table.py
@@ -122,21 +122,21 @@ class EventTableAxes(TimeSeriesAxes):
         if sizecol:
             sdata = table[sizecol]
         if color and sizecol:
-            zipped = zip(xdata, ydata, cdata, sdata)
+            zipped = list(zip(xdata, ydata, cdata, sdata))
             zipped.sort(key=lambda row: row[2])
             try:
                 xdata, ydata, cdata, sdata = map(numpy.asarray, zip(*zipped))
             except ValueError:
                 pass
         elif sizecol:
-            zipped = zip(xdata, ydata, sdata)
+            zipped = list(zip(xdata, ydata, sdata))
             zipped.sort(key=lambda row: row[-1])
             try:
                 xdata, ydata, sdata = map(numpy.asarray, zip(*zipped))
             except ValueError:
                 pass
         elif color:
-            zipped = zip(xdata, ydata, cdata)
+            zipped = list(zip(xdata, ydata, cdata))
             zipped.sort(key=lambda row: row[-1])
             try:
                 xdata, ydata, cdata = map(numpy.asarray, zip(*zipped))
@@ -185,7 +185,7 @@ class EventTableAxes(TimeSeriesAxes):
         # get color and sort
         if color:
             cdata = table[color]
-            zipped = zip(xdata, ydata, wdata, hdata, cdata)
+            zipped = list(zip(xdata, ydata, wdata, hdata, cdata))
             zipped.sort(key=lambda row: row[-1])
             try:
                 xdata, ydata, wdata, hdata, cdata = map(numpy.asarray,
@@ -270,21 +270,21 @@ class EventTableAxes(TimeSeriesAxes):
         if sizecol:
             sdata = get_table_column(table, sizecol)
         if color and sizecol:
-            zipped = zip(xdata, ydata, cdata, sdata)
+            zipped = list(zip(xdata, ydata, cdata, sdata))
             zipped.sort(key=lambda row: row[2])
             try:
                 xdata, ydata, cdata, sdata = map(numpy.asarray, zip(*zipped))
             except ValueError:
                 pass
         elif sizecol:
-            zipped = zip(xdata, ydata, sdata)
+            zipped = list(zip(xdata, ydata, sdata))
             zipped.sort(key=lambda row: row[-1])
             try:
                 xdata, ydata, sdata = map(numpy.asarray, zip(*zipped))
             except ValueError:
                 pass
         elif color:
-            zipped = zip(xdata, ydata, cdata)
+            zipped = list(zip(xdata, ydata, cdata))
             zipped.sort(key=lambda row: row[-1])
             try:
                 xdata, ydata, cdata = map(numpy.asarray, zip(*zipped))
@@ -334,7 +334,7 @@ class EventTableAxes(TimeSeriesAxes):
         # get color and sort
         if color:
             cdata = get_table_column(table, color)
-            zipped = zip(xdata, ydata, wdata, hdata, cdata)
+            zipped = list(zip(xdata, ydata, wdata, hdata, cdata))
             zipped.sort(key=lambda row: row[-1])
             try:
                 xdata, ydata, wdata, hdata, cdata = map(numpy.asarray,

--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -367,7 +367,7 @@ class TimeSeriesPlot(Plot):
             flatdata = [ts for data in axesdata for ts in data]
             span = SegmentList([ts.span for ts in flatdata]).extent()
             for ax in self.axes:
-                for key, val in axargs.iteritems():
+                for key, val in axargs.items():
                     getattr(ax, 'set_%s' % key)(val)
                 if epoch is not None:
                     ax.set_epoch(epoch)

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -33,7 +33,7 @@ import operator
 import re
 import warnings
 import tempfile
-from io import BytesIO
+from io import StringIO
 from urlparse import urlparse
 from copy import (copy as shallowcopy, deepcopy)
 from math import (floor, ceil)
@@ -519,7 +519,14 @@ class DataQualityFlag(object):
                     e.args = ('Error querying for %s: %s' % (flag, e),)
                     raise
             # read from json buffer
-            new = cls.read(BytesIO(json.dumps(data)), format='json')
+            try:
+                new = cls.read(StringIO(json.dumps(data)), format='json')
+            except TypeError as e:
+                if 'initial_value must be unicode' in str(e):  # python2
+                    new = cls.read(StringIO(json.dumps(data).decode('utf-8')),
+                                   format='json')
+                else:
+                    raise
             # restrict to query segments
             segl = SegmentList([Segment(start, end)])
             new.known &= segl

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1123,8 +1123,8 @@ class DataQualityDict(OrderedDict):
         inq.join()
         outq.join()
         new = cls()
-        results = zip(*sorted([outq.get() for i in range(len(flags))],
-                              key=lambda x: x[0]))[1]
+        results = list(zip(*sorted([outq.get() for i in range(len(flags))],
+                                   key=lambda x: x[0])))[1]
         for result, flag in zip(results, flags):
             if isinstance(result, Exception):
                 new[flag] = cls._EntryClass(name=flag)

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -40,6 +40,7 @@ from math import (floor, ceil)
 from threading import Thread
 from Queue import Queue
 
+from six import string_types
 from six.moves.urllib import request
 from six.moves.urllib.error import URLError
 
@@ -1015,7 +1016,7 @@ class DataQualityDict(OrderedDict):
             raise TypeError("DataQualityDict.query_segdb has no keyword "
                             "argument '%s'" % list(kwargs.keys()[0]))
         # parse flags
-        if isinstance(flags, (str, unicode)):
+        if isinstance(flags, string_types):
             flags = flags.split(',')
         else:
             flags = flags

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -716,7 +716,7 @@ class DataQualityFlag(object):
             new = self.copy()
         if kwargs:
             raise TypeError("unexpected keyword argument %r"
-                            % kwargs.keys()[0])
+                            % list(kwargs.keys())[0])
         new.known = [(s[0]+start, s[1]+end) for s in self.known]
         new.active = [(s[0]+start, s[1]+end) for s in self.active]
         return new
@@ -1013,7 +1013,7 @@ class DataQualityDict(OrderedDict):
                           "on_error keyword argument")
         if kwargs.keys():
             raise TypeError("DataQualityDict.query_segdb has no keyword "
-                            "argument '%s'" % kwargs.keys()[0])
+                            "argument '%s'" % list(kwargs.keys()[0]))
         # parse flags
         if isinstance(flags, (str, unicode)):
             flags = flags.split(',')
@@ -1336,7 +1336,7 @@ class DataQualityDict(OrderedDict):
         return self
 
     def __iand__(self, other):
-        for key, value in other.iteritems():
+        for key, value in other.items():
             if key in self:
                 self[key] &= value
             else:
@@ -1350,7 +1350,7 @@ class DataQualityDict(OrderedDict):
         return other.copy().__iand__(self)
 
     def __ior__(self, other):
-        for key, value in other.iteritems():
+        for key, value in other.items():
             if key in self:
                 self[key] |= value
             else:
@@ -1367,7 +1367,7 @@ class DataQualityDict(OrderedDict):
     __add__ = __or__
 
     def __isub__(self, other):
-        for key, value in other.iteritems():
+        for key, value in other.items():
             if key in self:
                 self[key] -= value
         return self
@@ -1376,7 +1376,7 @@ class DataQualityDict(OrderedDict):
         return self.copy().__isub__(other)
 
     def __ixor__(self, other):
-        for key, value in other.iteritems():
+        for key, value in other.items():
             if key in self:
                 self[key] ^= value
             else:
@@ -1404,8 +1404,8 @@ class DataQualityDict(OrderedDict):
             a new `DataQualityFlag` who's active and known segments
             are the union of those of the values of this dict
         """
-        usegs = reduce(operator.or_, self.itervalues())
-        usegs.name = ' | '.join(self.iterkeys())
+        usegs = reduce(operator.or_, self.values())
+        usegs.name = ' | '.join(self.keys())
         return usegs
 
     def intersection(self):
@@ -1417,8 +1417,8 @@ class DataQualityDict(OrderedDict):
             a new `DataQualityFlag` who's active and known segments
             are the intersection of those of the values of this dict
         """
-        isegs = reduce(operator.and_, self.itervalues())
-        isegs.name = ' & '.join(self.iterkeys())
+        isegs = reduce(operator.and_, self.values())
+        isegs.name = ' & '.join(self.keys())
         return isegs
 
     def plot(self, label='key', **kwargs):

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -34,15 +34,16 @@ import re
 import warnings
 import tempfile
 from io import StringIO
-from urlparse import urlparse
 from copy import (copy as shallowcopy, deepcopy)
 from math import (floor, ceil)
 from threading import Thread
-from Queue import Queue
 
 from six import string_types
+from six.moves import reduce
 from six.moves.urllib import request
 from six.moves.urllib.error import URLError
+from six.moves.urllib.parse import urlparse
+from six.moves.queue import Queue
 
 from numpy import inf
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -429,9 +429,10 @@ class DataQualityFlag(object):
         if len(args) == 1 and isinstance(args[0], SegmentList):
             qsegs = args[0]
         elif len(args) == 1 and len(args[0]) == 2:
-            qsegs = SegmentList(Segment(map(to_gps, args[0])))
+            qsegs = SegmentList(Segment(to_gps(args[0][0]),
+                                        to_gps(args[0][1])))
         elif len(args) == 2:
-            qsegs = SegmentList([Segment(map(to_gps, args))])
+            qsegs = SegmentList([Segment(to_gps(args[0]), to_gps(args[1]))])
         else:
             raise ValueError("DataQualityFlag.query must be called with a "
                              "flag name, and either GPS start and stop times, "
@@ -482,9 +483,10 @@ class DataQualityFlag(object):
         if len(args) == 1 and isinstance(args[0], SegmentList):
             qsegs = args[0]
         elif len(args) == 1 and len(args[0]) == 2:
-            qsegs = SegmentList(Segment(map(to_gps, args[0])))
+            qsegs = SegmentList(Segment(to_gps(args[0][0]),
+                                        to_gps(args[0][1])))
         elif len(args) == 2:
-            qsegs = SegmentList([Segment(map(to_gps, args))])
+            qsegs = SegmentList([Segment(to_gps(args[0]), to_gps(args[1]))])
         else:
             raise ValueError("DataQualityFlag.query must be called with a "
                              "flag name, and either GPS start and stop times, "
@@ -1009,9 +1011,10 @@ class DataQualityDict(OrderedDict):
         if len(args) == 1 and isinstance(args[0], SegmentList):
             qsegs = args[0]
         elif len(args) == 1 and len(args[0]) == 2:
-            qsegs = SegmentList(Segment(map(to_gps, args[0])))
+            qsegs = SegmentList(Segment(to_gps(args[0][0]),
+                                        to_gps(args[0][1])))
         elif len(args) == 2:
-            qsegs = SegmentList([Segment(map(to_gps, args))])
+            qsegs = SegmentList([Segment(to_gps(args[0]), to_gps(args[1]))])
         else:
             raise ValueError("DataQualityDict.query_segdb must be called with "
                              "a list of flag names, and either GPS start and "

--- a/gwpy/segments/io/hdf5.py
+++ b/gwpy/segments/io/hdf5.py
@@ -108,10 +108,15 @@ def read_hdf5_segmentlist(f, path=None, gpstype=LIGOTimeGPS, **kwargs):
     dataset = io_hdf5.find_dataset(f, path=path)
 
     segtable = Table.read(dataset, format='hdf5')
-    return SegmentList([Segment(
-        LIGOTimeGPS(row['start_time'], row['start_time_ns']),
-        LIGOTimeGPS(row['end_time'], row['end_time_ns']))
-        for row in segtable])
+    out = SegmentList()
+    for row in segtable:
+        start = LIGOTimeGPS(int(row['start_time']), int(row['start_time_ns']))
+        end = LIGOTimeGPS(int(row['end_time']), int(row['end_time_ns']))
+        if gpstype is LIGOTimeGPS:
+            out.append(Segment(start, end))
+        else:
+            out.append(Segment(gpstype(start), gpstype(end)))
+    return out
 
 
 @io_hdf5.with_read_hdf5

--- a/gwpy/segments/io/json.py
+++ b/gwpy/segments/io/json.py
@@ -41,7 +41,10 @@ def read_json_flag(f):
         f = open(f, 'r')
 
     with f:
-        data = json.load(f)
+        txt = f.read()
+        if isinstance(txt, bytes):
+            txt = txt.decode('utf-8')
+        data = json.loads(txt)
     name = '{ifo}:{name}:{version}'.format(**data)
     out = DataQualityFlag(name, active=data['active'],
                           known=data['known'])

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -21,6 +21,8 @@
 
 import datetime
 
+from six import string_types
+
 from ...time import (LIGOTimeGPS, to_gps)
 from ...io import registry
 from ...io.ligolw import (identify_ligolw, write_tables)
@@ -77,7 +79,7 @@ def read_ligolw_dict(f, flags=None, gpstype=LIGOTimeGPS, coalesce=False,
     seg_def_table = lsctables.SegmentDefTable.get_table(xmldoc)
 
     # find flags
-    if isinstance(flags, (unicode, str)):
+    if isinstance(flags, string_types):
         flags = flags.split(',')
     out = DataQualityDict()
     id_ = dict()

--- a/gwpy/segments/io/segwizard.py
+++ b/gwpy/segments/io/segwizard.py
@@ -48,8 +48,6 @@ def from_segwizard(f, coalesce=True, gpstype=LIGOTimeGPS, strict=True,
     files = file_list(f)
     segs = SegmentList()
     for fp in files:
-        if isinstance(fp, file):
-            fp = fp.name
         with open(fp, 'r') as fobj:
             segs += SegmentList(map(Segment, segmentsUtils.fromsegwizard(
                 fobj, coltype=gpstype, strict=strict)))

--- a/gwpy/table/io/ascii.py
+++ b/gwpy/table/io/ascii.py
@@ -209,7 +209,7 @@ def row_from_ascii_factory(table, delimiter):
     return row_from_ascii
 
 # register generic ASCII parsing for all tables
-for table in TableByName.itervalues():
+for table in TableByName.values():
     # register whitespace-delimited ASCII
     register_reader(
         'ascii', table, table_from_ascii_factory(

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -246,7 +246,7 @@ def ligolw_io_factory(table_):
 # -- register -----------------------------------------------------------------
 
 # register reader and auto-id for LIGO_LW
-for table in TableByName.itervalues():
+for table in TableByName.values():
     name = 'ligolw.%s' % table.TableName(table.tableName)
 
     # build readers for this table

--- a/gwpy/table/lsctables.py
+++ b/gwpy/table/lsctables.py
@@ -310,7 +310,7 @@ def _fetch_factory(table):
     return classmethod(fetch)
 
 # annotate lsctables with new methods
-for table in TableByName.itervalues():
+for table in TableByName.values():
 
     def read(cls, source, *args, **kwargs):
         """Read data into a :class:`~glue.ligolw.lsctables.{0}`

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -22,6 +22,8 @@
 import operator as _operator
 from math import ceil
 
+from six import string_types
+
 import numpy
 
 from astropy.table import (Table, Column, vstack)
@@ -292,7 +294,7 @@ class EventTable(Table):
             for i, bin_ in enumerate(bins[:-1]):
                 bins2.append((bin_, bins[i+1]))
             bins = bins2
-        elif isinstance(operator, (unicode, str)):
+        elif isinstance(operator, string_types):
             op = OPERATORS[operator]
         else:
             op = operator

--- a/gwpy/tests/common.py
+++ b/gwpy/tests/common.py
@@ -55,10 +55,13 @@ def skip_missing_import(module):
     def decorate_method(func):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
-            try:
+            try:  # python3.x
+                func.__globals__[modname] = import_method_dependency(
+                    module, stacklevel=2)
+            except AttributeError:  # python2.x
                 func.func_globals[modname] = import_method_dependency(
                     module, stacklevel=2)
-            except ImportError as e:
+            except ImportError as e:  # will strike before attributeerror
                 self.skipTest(str(e))
             return func(self, *args, **kwargs)
         return wrapper

--- a/gwpy/tests/common.py
+++ b/gwpy/tests/common.py
@@ -32,7 +32,7 @@ def test_io_identify(cls, extensions, modes=['read', 'write']):
     for mode in modes:
         for ext in extensions:
             p = 'X-TEST_CACHE_ENTRY-0-1.%s' % ext
-            c = Cache([CacheEntry.from_T050017(p)])
+            c = Cache([CacheEntry.from_T050017(p, coltype=int)])
             for path in [p, [p], c[0], c]:
                 formats = identify_format(
                     mode, cls, path, None, [], {})

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -22,6 +22,7 @@
 import abc
 import os
 import tempfile
+import pickle
 
 import pytest
 from compat import unittest
@@ -219,10 +220,9 @@ class CommonTests(object):
     def test_pickle(self):
         """Check pickle-unpickle yields unchanged data
         """
-        import cPickle
         ts = self.create()
-        pickle = ts.dumps()
-        ts2 = cPickle.loads(pickle)
+        pkl = ts.dumps()
+        ts2 = pickle.loads(pkl)
         self.assertArraysEqual(ts, ts2)
 
     # -- test I/O -------------------------------

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -19,7 +19,7 @@
 """Unit test for detector module
 """
 
-from urllib2 import URLError
+from six.moves.urllib.error import URLError
 
 import pytest
 

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -136,6 +136,10 @@ class ChannelTests(unittest.TestCase):
             if 'No JSON object could be decoded' in str(e):
                 self.skipTest(str(e))
             raise
+        except RuntimeError as e:
+            if 'redirected' in str(e):
+                self.skipTest(str(e))
+            raise
         except Exception as e:
             try:
                 import kerberos

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -248,7 +248,7 @@ class ChannelListTestCase(unittest.TestCase):
 
     def test_from_names(self):
         cl = ChannelList.from_names(*self.NAMES)
-        self.assertListEqual(cl, map(Channel, self.NAMES))
+        self.assertListEqual(cl, list(map(Channel, self.NAMES)))
         cl2 = ChannelList.from_names(','.join(self.NAMES))
         self.assertListEqual(cl, cl2)
 

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -131,7 +131,7 @@ class CacheIoTestCase(unittest.TestCase):
         for seg in [(0, 1), (1, 2), (4, 5)]:
             d = seg[1] - seg[0]
             f = 'A-B-%d-%d.tmp' % (seg[0], d)
-            cache.append(CacheEntry.from_T050017(f))
+            cache.append(CacheEntry.from_T050017(f, coltype=int))
             segs.append(Segment(*seg))
         return cache, segs
 
@@ -217,7 +217,7 @@ class DataFindIoTestCase(unittest.TestCase):
     def test_on_tape(self):
         self.assertFalse(datafind.on_tape(TEST_GWF_FILE))
         self.assertFalse(datafind.on_tape(
-            CacheEntry.from_T050017(TEST_GWF_FILE)))
+            CacheEntry.from_T050017(TEST_GWF_FILE, coltype=int)))
 
     def test_connect(self):
         with mock.patch('glue.datafind.GWDataFindHTTPConnection',

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -28,6 +28,9 @@ from six.moves.urllib.error import URLError
 
 import pytest
 
+from matplotlib import use
+use('agg')
+
 from glue.segments import PosInfinity
 from glue.LDBDWClient import LDBDClientException
 

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -240,7 +240,7 @@ class DataQualityFlagTests(unittest.TestCase, SegmentClassTestsMixin):
     """Unit tests for the `DataQualityFlag` class
     """
     TEST_CLASS = DataQualityFlag
-    TEST_DATA = QUERY_RESULT.values()[0]
+    TEST_DATA = list(QUERY_RESULT.values())[0]
     tmpfile = '%s.%%s' % tempfile.mktemp(prefix='gwpy_test_dqflag')
 
     def test_properties(self):
@@ -544,7 +544,7 @@ class DataQualityDictTests(unittest.TestCase, SegmentClassTestsMixin):
         result = self._mock_query(
             self.TEST_CLASS.query, QUERY_RESULT,
             QUERY_FLAGS, QUERY_START, QUERY_END, url=QUERY_URL)
-        self.assertListEqual(result.keys(), QUERY_FLAGS)
+        self.assertListEqual(list(result.keys()), QUERY_FLAGS)
         for flag in result:
             self.assertEqual(result[flag].known, QUERY_RESULT[flag].known)
             self.assertEqual(result[flag].active, QUERY_RESULT[flag].active)
@@ -553,7 +553,7 @@ class DataQualityDictTests(unittest.TestCase, SegmentClassTestsMixin):
         result = self._mock_query(
             self.TEST_CLASS.query_dqsegdb, QUERY_RESULT,
             QUERY_FLAGS, QUERY_START, QUERY_END, url=QUERY_URL)
-        self.assertListEqual(result.keys(), QUERY_FLAGS)
+        self.assertListEqual(list(result.keys()), QUERY_FLAGS)
         for flag in result:
             self.assertEqual(result[flag].known, QUERY_RESULT[flag].known)
             self.assertEqual(result[flag].active, QUERY_RESULT[flag].active)
@@ -564,7 +564,7 @@ class DataQualityDictTests(unittest.TestCase, SegmentClassTestsMixin):
                 QUERY_FLAGS, QUERY_START, QUERY_END, url=QUERY_URL_SEGDB)
         except (SystemExit, LDBDClientException) as e:
             self.skipTest(str(e))
-        self.assertListEqual(result.keys(), QUERY_FLAGS)
+        self.assertListEqual(list(result.keys()), QUERY_FLAGS)
         for flag in result:
             self.assertEqual(result[flag].known, QUERY_RESULT[flag].known)
             self.assertEqual(result[flag].active, QUERY_RESULT[flag].active)

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -465,7 +465,10 @@ class DataQualityDictTests(unittest.TestCase, SegmentClassTestsMixin):
         # download veto definer
         vdffile = urlopen(VETO_DEFINER_FILE)
         with open(self.VETO_DEFINER, 'w') as f:
-            f.write(vdffile.read())
+            try:
+                f.write(vdffile.read().decode('utf-8'))
+            except AttributeError:
+                f.write(vdffile.read())
 
     def tearDown(self):
         if os.path.isfile(self.VETO_DEFINER):

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -123,8 +123,8 @@ class TableTests(unittest.TestCase):
 
     def test_read_write_root(self):
         table = self.TABLE_CLASS.read(
-           TEST_XML_FILE, format='ligolw.sngl_burst',
-           columns=['peak_time', 'peak_time_ns', 'snr', 'peak_frequency'])
+            TEST_XML_FILE, format='ligolw.sngl_burst',
+            columns=['peak_time', 'peak_time_ns', 'snr', 'peak_frequency'])
         tempdir = tempfile.mkdtemp()
         try:
             fp = tempfile.mktemp(suffix='.root', dir=tempdir)

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -25,6 +25,9 @@ import tempfile
 
 from numpy import (may_share_memory, testing as nptest, random)
 
+from matplotlib import use
+use('agg')
+
 from astropy import units
 
 from gwpy.table import (Table, EventTable)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -395,7 +395,7 @@ class TimeSeriesTestMixin(object):
         _, tmpfile = tempfile.mkstemp(prefix='GWPY-TEST_LOSC_', suffix='.hdf')
         try:
             response = urlopen(LOSC_HDF_FILE)
-            with open(tmpfile, 'w') as f:
+            with open(tmpfile, 'wb') as f:
                 f.write(response.read())
             self._test_losc_inner(tmpfile)  # actually run test here
         except (URLError, ImportError) as e:
@@ -590,9 +590,9 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         self.assertAlmostEqual(tmax.value, -glitchtime)
 
     def test_detrend(self):
-        self.assertNotAlmostEqual(self.random.mean(), 0.0)
+        self.assertNotAlmostEqual(self.random.value.mean(), 0.0)
         detrended = self.random.detrend()
-        self.assertAlmostEqual(detrended.mean(), 0.0)
+        self.assertAlmostEqual(detrended.value.mean(), 0.0)
 
     def test_csd_spectrogram(self):
         ts = self._read()

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -151,7 +151,7 @@ class TimeSeriesTestMixin(object):
             a.write(f1.name)
 
         # test reading it from the cache
-        cache = Cache.from_urls([f1.name])
+        cache = Cache.from_urls([f1.name], coltype=int)
         b = self.TEST_CLASS.read(cache, a.name)
         self.assertArraysEqual(a, b, exclude=exclude)
 

--- a/gwpy/tests/test_utils.py
+++ b/gwpy/tests/test_utils.py
@@ -54,5 +54,5 @@ class UtilsTestCase(unittest.TestCase):
         except Exception as e:
             self.skipTest(str(e))
         else:
-            result = result.rstrip('\n')
+            result = result.decode('utf-8').rstrip('\n')
         self.assertEqual(shell.which('true'), result)

--- a/gwpy/time/__init__.py
+++ b/gwpy/time/__init__.py
@@ -28,10 +28,7 @@ object.
 
 from astropy.time import Time
 
-try:
-    from pylal.xlal.datatypes.ligotimegps import LIGOTimeGPS
-except ImportError:
-    from glue.lal import LIGOTimeGPS
+from lal import LIGOTimeGPS
 
 from ._tconvert import *
 

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -99,9 +99,9 @@ def to_gps(t, *args, **kwargs):
     # allow Time conversion to override type-checking
     if args or kwargs:
         return Time(t, *args, **kwargs).utc.gps
-    # if lal.LIGOTimeGPS
-    if hasattr(t, 'gpsSeconds'):
-        return LIGOTimeGPS(t.gpsSeconds, t.gpsNanoSeconds)
+    # if lal.LIGOTimeGPS, just return it
+    if isinstance(t, LIGOTimeGPS):
+        return t
     # or convert numeric string to float (e.g. '123.456')
     try:
         t = float(t)
@@ -154,11 +154,11 @@ def from_gps(gps):
     try:
         from lal import GPSToUTC
     except ImportError:
-        dt = Time(gps.seconds, gps.nanoseconds * 1e-9,
+        dt = Time(gps.gpsSeconds, gps.gpsNanoSeconds * 1e-9,
                   format='gps', scale='utc').datetime
     else:
-        dt = datetime.datetime(*GPSToUTC(gps.seconds)[:6])
-        dt += datetime.timedelta(seconds=gps.nanoseconds * 1e-9)
+        dt = datetime.datetime(*GPSToUTC(gps.gpsSeconds)[:6])
+        dt += datetime.timedelta(seconds=gps.gpsNanoSeconds * 1e-9)
     if float(gps).is_integer():
         return dt.replace(microsecond=0)
     else:

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -57,7 +57,7 @@ def tconvert(gpsordate='now'):
     # convert from GPS into datetime
     try:
         gps = LIGOTimeGPS(gpsordate)
-    except (ValueError, TypeError):
+    except (TypeError, RuntimeError):
         if hasattr(gpsordate, 'gpsSeconds'):
             return from_gps(gpsordate)
         else:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -750,7 +750,7 @@ class TimeSeriesBaseDict(OrderedDict):
         # parse times
         start = to_gps(start)
         end = to_gps(end)
-        istart = start.seconds
+        istart = start.gpsSeconds
         iend = ceil(end)
 
         # test S6 h(t) channel so that it gets ,rds appends

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -621,12 +621,12 @@ class TimeSeriesBaseDict(OrderedDict):
 
     def copy(self):
         new = self.__class__()
-        for key, val in self.iteritems():
+        for key, val in self.items():
             new[key] = val.copy()
         return new
 
     def append(self, other, copy=True, **kwargs):
-        for key, ts in other.iteritems():
+        for key, ts in other.items():
             if key in self:
                 self[key].append(ts, **kwargs)
             elif copy:
@@ -636,7 +636,7 @@ class TimeSeriesBaseDict(OrderedDict):
         return self
 
     def prepend(self, other, **kwargs):
-        for key, ts in other.iteritems():
+        for key, ts in other.items():
             if key in self:
                 self[key].prepend(ts, **kwargs)
             else:
@@ -664,7 +664,7 @@ class TimeSeriesBaseDict(OrderedDict):
         TimeSeries.crop
             for more details
         """
-        for key, val in self.iteritems():
+        for key, val in self.items():
             self[key] = val.crop(start=start, end=end, copy=copy)
         return self
 
@@ -685,7 +685,7 @@ class TimeSeriesBaseDict(OrderedDict):
         """
         if not isinstance(rate, dict):
             rate = dict((c, rate) for c in self)
-        for key, resamp in rate.iteritems():
+        for key, resamp in rate.items():
             self[key] = self[key].resample(resamp, **kwargs)
         return self
 
@@ -1014,12 +1014,12 @@ class TimeSeriesBaseDict(OrderedDict):
                 gprint("Determined %d frametypes to read" % len(frametypes))
             elif verbose:
                 gprint("Determined best frametype as %r"
-                       % frametypes.keys()[0])
+                       % list(frametypes.keys()[0]))
         else:
             frametypes = {frametype: channels}
         # -- read data
         out = cls()
-        for ft, clist in frametypes.iteritems():
+        for ft, clist in frametypes.items():
             if verbose:
                 gprint("Reading data from %s frames..." % ft, end=' ')
             # parse as a ChannelList
@@ -1171,7 +1171,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 figargs[key] = kwargs.pop(key)
         plot_ = TimeSeriesPlot(**figargs)
         ax = plot_.gca()
-        for lab, ts in self.iteritems():
+        for lab, ts in self.items():
             if label.lower() == 'name':
                 lab = ts.name
             elif label.lower() != 'key':

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1296,4 +1296,3 @@ class TimeSeriesBaseList(list):
 
     def __getslice__(self, i, j):
         return type(self)(*super(TimeSeriesBaseList, self).__getslice__(i, j))
-    __getslice__.__doc__ = list.__getslice__.__doc__

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -26,11 +26,13 @@ import warnings
 from math import ceil
 from multiprocessing import (Process, Queue as ProcessQueue)
 
+from six import string_types
+
 import numpy
 
 from glue.lal import Cache
 
-from ...io.cache import (cache_segments, open_cache)
+from ...io.cache import (FILE_LIKE, cache_segments, open_cache)
 from .. import (TimeSeries, TimeSeriesList, TimeSeriesDict,
                 StateVector, StateVectorList, StateVectorDict)
 
@@ -90,7 +92,7 @@ def read_cache(cache, channel, start=None, end=None, resample=None,
 
     cls = kwargs.pop('target', TimeSeries)
     # open cache from file if given
-    if isinstance(cache, (unicode, str, file)):
+    if isinstance(cache, FILE_LIKE + string_types):
         cache = open_cache(cache)
 
     # force single-process for empty cache (since its a null-op anyway)

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -275,7 +275,7 @@ def register_gwf_api(library):
         kwargs.setdefault('series_class', StateVector)
         svd = StateVectorDict(
             read_timeseriesdict(source, channels, *args, **kwargs))
-        for (channel, bits) in bitss.iteritems():
+        for (channel, bits) in bitss.items():
             svd[channel].bits = bits
         return svd
 

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -110,7 +110,7 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
     # as required by the file-naming convention
     epochs = None
     try:
-        ce = CacheEntry.from_T050017(fp)
+        ce = CacheEntry.from_T050017(fp, coltype=LIGOTimeGPS)
     except ValueError:
         pass
     else:

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -162,9 +162,9 @@ def write(tsdict, outfile, start=None, end=None,
     """Write data to a GWF file using the LALFrame API
     """
     if not start:
-        start = tsdict.values()[0].xspan[0]
+        start = list(tsdict.values())[0].xspan[0]
     if not end:
-        end = tsdict.values()[0].xspan[1]
+        end = list(tsdict.values())[0].xspan[1]
     duration = end - start
 
     # get ifos list

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -57,8 +57,11 @@ def _fetch_losc_json(url):
                   % (url, str(e)),)
         raise
     # parse the JSON
+    data = response.read()
+    if isinstance(data, bytes):
+        data = data.decode('utf-8')
     try:
-        return json.loads(response.read())
+        return json.loads(data)
     except ValueError as e:
         e.args = ("Failed to parse LOSC JSON from %r: %s"
                   % (url, str(e)),)

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -310,7 +310,7 @@ def read_losc_state(filename, channel, group=None, start=None, end=None,
     maskset = _find_dataset(h5file, '%s/DQDescriptions' % channel)
     # read data
     nddata = dataset.value
-    bits = list(maskset.value)
+    bits = list(map(lambda b: bytes.decode(bytes(b), 'utf-8'), maskset.value))
     # read metadata
     try:
         epoch = dataset.attrs['Xstart']

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -40,7 +40,7 @@ from ...io.cache import (file_list, cache_segments)
 from ...io.hdf5 import open_hdf5
 from ...detector.units import parse_unit
 from ...segments import (Segment, SegmentList)
-from ...time import to_gps
+from ...time import (to_gps, LIGOTimeGPS)
 
 # default URL
 LOSC_URL = 'https://losc.ligo.org'
@@ -81,7 +81,7 @@ def _losc_json_cache(metadata, detector, sample_rate=4096,
                 fmd['duration'] != duration):
             continue
         urls.append(fmd['url'])
-    return Cache.from_urls(urls)
+    return Cache.from_urls(urls, coltype=LIGOTimeGPS)
 
 
 def fetch_losc_url_cache(detector, start, end, host=LOSC_URL,
@@ -316,7 +316,7 @@ def read_losc_state(filename, channel, group=None, start=None, end=None,
         epoch = dataset.attrs['Xstart']
     except KeyError:
         try:
-            ce = CacheEntry.from_T050017(h5file.filename)
+            ce = CacheEntry.from_T050017(h5file.filename, coltype=LIGOTimeGPS)
         except ValueError:
             epoch = None
         else:

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -80,7 +80,7 @@ def _losc_json_cache(metadata, detector, sample_rate=4096,
                 fmd['format'] != format or
                 fmd['duration'] != duration):
             continue
-        urls.append(fmd['url'])
+        urls.append(str(fmd['url']))
     return Cache.from_urls(urls, coltype=LIGOTimeGPS)
 
 

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -578,7 +578,7 @@ class StateVector(TimeSeriesBase):
         from ..segments import DataQualityDict
         out = DataQualityDict()
         bitseries = self.get_bit_series(bits=bits)
-        for bit, sts in bitseries.iteritems():
+        for bit, sts in bitseries.items():
             out[bit] = sts.to_dqflag(name=bit, minlen=minlen, round=round,
                                      dtype=dtype,
                                      description=self.bits.description[bit])

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -25,6 +25,8 @@ from warnings import warn
 from math import (ceil, pi)
 from multiprocessing import (Process, Queue as ProcessQueue)
 
+from six.moves import range
+
 import numpy
 from numpy import fft as npfft
 from scipy import signal
@@ -689,7 +691,7 @@ class TimeSeries(TimeSeriesBase):
             window = signal.get_window(window, nfft)
 
         # calculate overlapping periodograms
-        for i in xrange(nsteps):
+        for i in range(nsteps):
             idx = i * nstride
             # don't proceed past end of data, causes artefacts
             if idx+nfft > self.size:
@@ -701,7 +703,7 @@ class TimeSeries(TimeSeriesBase):
         # normalize for over-dense grid
         density = nfft//nstride
         weights = signal.triang(density)
-        for i in xrange(nsteps):
+        for i in range(nsteps):
             # get indices of overlapping columns
             x0 = max(0, i+1-density)
             x1 = min(i+1, nsteps-density+1)

--- a/gwpy/utils/deps.py
+++ b/gwpy/utils/deps.py
@@ -75,8 +75,12 @@ def with_import(module):
     def decorate_method(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            func.func_globals[modname] = import_method_dependency(module,
-                                                                  stacklevel=2)
+            try:  # python3.x
+                func.__globals__[modname] = import_method_dependency(
+                    module, stacklevel=2)
+            except AttributeError:  # python2.x
+                func.func_globals[modname] = import_method_dependency(
+                    module, stacklevel=2)
             return func(*args, **kwargs)
         return wrapper
     return decorate_method

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -59,7 +59,7 @@ except AttributeError:
                     lal.C_TYPE_CODE: 'COMPLEX8',
                     lal.Z_TYPE_CODE: 'COMPLEX16'}
 
-LAL_TYPE_FROM_STR = dict((v, k) for k, v in LAL_TYPE_STR.iteritems())
+LAL_TYPE_FROM_STR = dict((v, k) for k, v in LAL_TYPE_STR.items())
 
 # map numpy dtypes to LAL type codes
 try:
@@ -86,7 +86,7 @@ except AttributeError:
                            numpy.complex128: lal.Z_TYPE_CODE}
 
 LAL_TYPE_STR_FROM_NUMPY = dict((key, LAL_TYPE_STR[value]) for (key, value) in
-                               LAL_TYPE_FROM_NUMPY.iteritems())
+                               LAL_TYPE_FROM_NUMPY.items())
 
 try:
     LAL_UNIT_INDEX = [lal.lalMeterUnit,

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -20,6 +20,7 @@
 """
 
 from __future__ import absolute_import
+import warnings
 
 from collections import OrderedDict
 from six import string_types
@@ -210,8 +211,10 @@ def to_lal_ligotimegps(gps):
     ligotimegps : `lal.LIGOTimeGPS`
         a SWIG-LAL `~lal.LIGOTimeGPS` representation of the given GPS time
     """
-    gps = to_gps(gps)
-    return lal.LIGOTimeGPS(gps.seconds, gps.nanoseconds)
+    warnings.warn("to_lal_ligotimegps has been deprecated in favour of "
+                  "gwpy.time.to_gps, which returns a `lal.LIGOTimeGPS` object",
+                  DeprecationWarning)
+    return to_gps(gps)
 
 
 # -- detectors ----------------------------------------------------------------


### PR DESCRIPTION
This PR makes numerous changes to achieve (or get closer to) python3 compatibility, including (but not limited to):

- `dict.iteritems()` -> `dict.items()` and similar
- use `six.string_types` instead of `(unicode, str)`
- handle `bytes` from HTTP requests
- update imports for renamed modules (mainly using `six.moves`)
- use `lal.LIGOTimeGPS` as standard, `glue.lal.LIGOTimeGPS` isn't python3-compatible

For full details, just read the diff.