### PR TITLE
Improved formatting/tests for timeseries comparisons

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -44,7 +44,7 @@ from astropy.io.registry import (get_reader, register_reader)
 from gwpy.detector import Channel
 from gwpy.time import (Time, LIGOTimeGPS)
 from gwpy.timeseries import (TimeSeries, StateVector, TimeSeriesDict,
-                             StateVectorDict, TimeSeriesList)
+                             StateVectorDict, TimeSeriesList, StateTimeSeries)
 from gwpy.segments import (Segment, DataQualityFlag, DataQualityDict)
 from gwpy.frequencyseries import (FrequencySeries, SpectralVariance)
 from gwpy.types import Array2D
@@ -667,6 +667,14 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
             self.assertTupleEqual(qspecgram.shape, (32000, 2560))
             self.assertAlmostEqual(qspecgram.q, 11.31370849898476)
             self.assertAlmostEqual(qspecgram.value.max(), 37.035843858490509)
+
+    def test_boolean_statetimeseries(self):
+        comp = self.TEST_ARRAY >= 100 * self.TEST_ARRAY.unit
+        self.assertIsInstance(comp, StateTimeSeries)
+        self.assertEqual(comp.unit, units.Unit(''))
+        self.assertEqual(
+            comp.name,
+            '%s >= 100.0 %s' % (self.TEST_ARRAY.name, self.TEST_ARRAY.unit))
 
 
 class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -552,9 +552,8 @@ class TimeSeriesBase(Series):
             except KeyError:
                 op_ = ufunc.__name__
             result = obj.view(StateTimeSeries)
+            result.override_unit('')
             result.name = '%s %s %s' % (obj.name, op_, value)
-            if hasattr(obj, 'unit') and str(obj.unit):
-                result.name += ' %s' % str(obj.unit)
         # otherwise, return a regular TimeSeries
         else:
             result = super(TimeSeriesBase, self).__array_wrap__(


### PR DESCRIPTION
This PR improves the formatting of the `StateTimeSeries` returned by comparison operations on a `TimeSeries`, e.g. TimeSeries(...) > 100.