### PR TITLE
Use ints for slicing in TimeSeries.rms

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -676,6 +676,10 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
             comp.name,
             '%s >= 100.0 %s' % (self.TEST_ARRAY.name, self.TEST_ARRAY.unit))
 
+    def test_rms(self):
+        rms = self.TEST_ARRAY.rms(1.)
+        self.assertQuantityEqual(rms.sample_rate, 1 * units.Hertz)
+
 
 class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):
     """`~unittest.TestCase` for the `~gwpy.timeseries.StateVector` object

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1478,13 +1478,13 @@ class TimeSeries(TimeSeriesBase):
         rms : `TimeSeries`
             a new `TimeSeries` containing the RMS value with dt=stride
         """
-        stridesamp = stride * self.sample_rate.value
+        stridesamp = int(stride * self.sample_rate.value)
         nsteps = int(self.size // stridesamp)
         # stride through TimeSeries, recording RMS
         data = numpy.zeros(nsteps)
         for step in range(nsteps):
             # find step TimeSeries
-            idx = stridesamp * step
+            idx = int(stridesamp * step)
             idx_end = idx + stridesamp
             stepseries = self[idx:idx_end]
             rms_ = numpy.sqrt(numpy.mean(numpy.abs(stepseries.value)**2))


### PR DESCRIPTION
This PR fixes #393 by casting slice indices to `int` in `TimeSeries.rms`.