### PR TITLE
Improved unit handling in TimeSeries.{to,from}_lal methods

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -336,14 +336,18 @@ class TimeSeriesTestMixin(object):
             lalts = ts.to_lal()
         except (NotImplementedError, ImportError) as e:
             self.skipTest(str(e))
+        import lal
         ts2 = type(ts).from_lal(lalts)
         self.assertEqual(ts, ts2)
         # test copy=False
         ts2 = type(ts).from_lal(lalts, copy=False)
         self.assertEqual(ts, ts2)
-        # test no unit
-        ts.override_unit(None)
-        ts2 = type(ts).from_lal(lalts, copy=False)
+        # test bad unit
+        ts.override_unit('undef')
+        with pytest.warns(UserWarning):
+            lalts = ts.to_lal()
+        self.assertEqual(lalts.sampleUnits, lal.DimensionlessUnit)
+        ts2 = self.TEST_CLASS.from_lal(lalts)
         self.assertIs(ts2.unit, units.dimensionless_unscaled)
 
     def test_io_identify(self):

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -474,7 +474,8 @@ class TimeSeriesBase(Series):
         from ..utils.lal import from_lal_unit
         try:
             unit = from_lal_unit(lalts.sampleUnits)
-        except TypeError:
+        except (TypeError, ValueError) as e:
+            warnings.warn("%s, defaulting to 'dimensionless'" % str(e))
             unit = None
         channel = Channel(lalts.name, sample_rate=1/lalts.deltaT, unit=unit,
                           dtype=lalts.data.data.dtype)
@@ -493,7 +494,8 @@ class TimeSeriesBase(Series):
         typestr = LAL_TYPE_STR_FROM_NUMPY[self.dtype.type]
         try:
             unit = to_lal_unit(self.unit)
-        except (TypeError, AttributeError):
+        except ValueError as e:
+            warnings.warn("%s, defaulting to lal.DimensionlessUnit" % str(e))
             try:
                 unit = lal.DimensionlessUnit
             except AttributeError:

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -166,7 +166,7 @@ def from_lal_unit(lunit):
 
     Parameters
     ----------
-    aunit : `LALUnit`
+    lunit : `lal.Unit`
         the input unit
 
     Returns
@@ -176,6 +176,8 @@ def from_lal_unit(lunit):
 
     Raises
     ------
+    TypeError
+        if ``lunit`` cannot be converted to `lal.Unit`
     ValueError
         if Astropy doesn't understand the base units for the input
     """


### PR DESCRIPTION
This PR fixes #406 by improving the unit handling in `TimeSeries.to_lal` and `TimeSeries.from_lal`