### PR TITLE
Moved rcParams customisation to new gwpy.plotter.rc module

### DIFF
--- a/gwpy/plotter/__init__.py
+++ b/gwpy/plotter/__init__.py
@@ -23,15 +23,14 @@ all be easily visualised using the relevant plotting objects, with
 many configurable parameters both interactive, and in saving to disk.
 """
 
-from matplotlib import (rcParams, rc_params, pyplot)
+from matplotlib import pyplot
 
-# record matplotlib's original rcParams
-DEFAULT_RCPARAMS = rc_params()
-
-from .tex import (USE_TEX, MACROS)
+# utilities
+from .rc import GWPY_PLOT_PARAMS
 from .gps import *
 from .log import *
 
+# figure and axes extensions
 from .core import *
 from .timeseries import *
 from .spectrogram import *
@@ -43,63 +42,8 @@ from .histogram import *
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
-# set default params
-GWPY_PLOT_PARAMS = {
-    "axes.grid": True,
-    "axes.axisbelow": False,
-    "axes.formatter.limits": (-3, 4),
-    "axes.labelsize": 22,
-    "axes.titlesize": 26,
-    "grid.color": 'gray',
-    "image.aspect": 'auto',
-    "image.interpolation": 'nearest',
-    "image.origin": 'lower',
-    "xtick.labelsize": 20,
-    "ytick.labelsize": 20,
-}
 
-# construct new default color cycle
-GWPY_COLOR_CYCLE = [
-    (0.0, 0.4, 1.0),  # blue
-    'r',              # red
-    (0.2, 0.8, 0.2),  # green
-    (1.0, 0.7, 0.0),  # yellow(ish)
-    (0.5, 0., 0.75),  # magenta
-    'gray',
-    (0.3, 0.7, 1.0),  # light blue
-    'pink',
-    (0.13671875, 0.171875, 0.0859375),  # dark green
-    (1.0, 0.4, 0.0),  # orange
-    'saddlebrown',
-    'navy',
-]
-
-# set mpl version dependent stuff
-try:
-    from matplotlib import cycler
-    GWPY_PLOT_PARAMS.update({
-        'axes.prop_cycle': cycler('color', GWPY_COLOR_CYCLE),
-    })
-except (ImportError, KeyError):  # mpl < 1.5
-    GWPY_PLOT_PARAMS['axes.color_cycle'] = GWPY_COLOR_CYCLE
-
-# set latex options
-if rcParams['text.usetex'] or USE_TEX:
-    GWPY_PLOT_PARAMS.update({
-        "text.usetex": True,
-        "font.family": "serif",
-        "font.serif": ["Computer Modern"],
-        "text.latex.preamble": MACROS,
-    })
-
-# update matplotlib rcParams with new settings
-rcParams.update(GWPY_PLOT_PARAMS)
-
-# fix matplotlib issue #3470
-if rcParams['font.family'] == 'serif':
-    rcParams['font.family'] = u'serif'
-
-
+# pyplot.figure replacement
 def figure(*args, **kwargs):
     kwargs.setdefault('FigureClass', Plot)
     return pyplot.figure(*args, **kwargs)

--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     from mpl_toolkits.axes_grid import make_axes_locatable
 
-from . import (axes, utils)
+from . import utils
 from .rc import (rcParams, DEFAULT_RCPARAMS)
 from .axes import Axes
 from .log import CombinedLogFormatterMathtext
@@ -176,7 +176,7 @@ class Plot(figure.Figure):
     @auto_refresh
     def add_colorbar(self, mappable=None, ax=None, location='right',
                      width=0.2, pad=0.1, log=None, label="", clim=None,
-                     cmap=None, clip=None, visible=True, axes_class=axes.Axes,
+                     cmap=None, clip=None, visible=True, axes_class=Axes,
                      **kwargs):
         """Add a colorbar to the current `Axes`
 
@@ -781,13 +781,13 @@ class Plot(figure.Figure):
     @axes_method
     def get_xlim(self):
         pass
-    get_xlim.__doc__ = axes.Axes.get_xlim.__doc__
+    get_xlim.__doc__ = Axes.get_xlim.__doc__
 
     @auto_refresh
     @axes_method
     def set_xlim(self, *args, **kwargs):
         pass
-    set_xlim.__doc__ = axes.Axes.set_xlim.__doc__
+    set_xlim.__doc__ = Axes.set_xlim.__doc__
 
     xlim = property(fget=get_xlim, fset=set_xlim,
                     doc='x-axis limits for the current axes')
@@ -795,13 +795,13 @@ class Plot(figure.Figure):
     @axes_method
     def get_ylim(self):
         pass
-    get_ylim.__doc__ = axes.Axes.get_ylim.__doc__
+    get_ylim.__doc__ = Axes.get_ylim.__doc__
 
     @auto_refresh
     @axes_method
     def set_ylim(self, *args, **kwargs):
         pass
-    set_ylim.__doc__ = axes.Axes.set_ylim.__doc__
+    set_ylim.__doc__ = Axes.set_ylim.__doc__
 
     ylim = property(fget=get_ylim, fset=set_ylim,
                     doc='y-axis limits for the current axes')
@@ -809,13 +809,13 @@ class Plot(figure.Figure):
     @axes_method
     def get_xlabel(self):
         pass
-    get_xlabel.__doc__ = axes.Axes.get_xlabel.__doc__
+    get_xlabel.__doc__ = Axes.get_xlabel.__doc__
 
     @axes_method
     @auto_refresh
     def set_xlabel(self, *args, **kwargs):
         pass
-    set_xlabel.__doc__ = axes.Axes.set_xlabel.__doc__
+    set_xlabel.__doc__ = Axes.set_xlabel.__doc__
 
     xlabel = property(fget=get_xlabel, fset=set_xlabel,
                       doc='x-axis label for the current axes')
@@ -823,13 +823,13 @@ class Plot(figure.Figure):
     @axes_method
     def get_ylabel(self):
         pass
-    get_ylabel.__doc__ = axes.Axes.get_ylabel.__doc__
+    get_ylabel.__doc__ = Axes.get_ylabel.__doc__
 
     @auto_refresh
     @axes_method
     def set_ylabel(self, *args, **kwargs):
         pass
-    set_ylabel.__doc__ = axes.Axes.set_ylabel.__doc__
+    set_ylabel.__doc__ = Axes.set_ylabel.__doc__
 
     ylabel = property(fget=get_ylabel, fset=set_ylabel,
                       doc='y-axis label for the current axes')
@@ -837,13 +837,13 @@ class Plot(figure.Figure):
     @axes_method
     def get_title(self):
         pass
-    get_title.__doc__ = axes.Axes.get_title.__doc__
+    get_title.__doc__ = Axes.get_title.__doc__
 
     @auto_refresh
     @axes_method
     def set_title(self, *args, **kwargs):
         pass
-    set_title.__doc__ = axes.Axes.set_title.__doc__
+    set_title.__doc__ = Axes.set_title.__doc__
 
     title = property(fget=get_title, fset=set_title,
                      doc='title for the current axes')
@@ -851,13 +851,13 @@ class Plot(figure.Figure):
     @axes_method
     def get_xscale(self):
         pass
-    get_xscale.__doc__ = axes.Axes.get_xscale.__doc__
+    get_xscale.__doc__ = Axes.get_xscale.__doc__
 
     @auto_refresh
     @axes_method
     def set_xscale(self, *args, **kwargs):
         pass
-    set_xscale.__doc__ = axes.Axes.set_xscale.__doc__
+    set_xscale.__doc__ = Axes.set_xscale.__doc__
 
     @property
     def logx(self):
@@ -876,13 +876,13 @@ class Plot(figure.Figure):
     @axes_method
     def get_yscale(self):
         pass
-    get_yscale.__doc__ = axes.Axes.get_yscale.__doc__
+    get_yscale.__doc__ = Axes.get_yscale.__doc__
 
     @auto_refresh
     @axes_method
     def set_yscale(self, *args, **kwargs):
         pass
-    set_yscale.__doc__ = axes.Axes.set_yscale.__doc__
+    set_yscale.__doc__ = Axes.set_yscale.__doc__
 
     @property
     def logy(self):
@@ -901,7 +901,7 @@ class Plot(figure.Figure):
     @axes_method
     def html_map(self, filename, data=None, **kwargs):
         pass
-    html_map.__doc__ = axes.Axes.html_map.__doc__
+    html_map.__doc__ = Axes.html_map.__doc__
 
     # -----------------------------------------------
     # utilies

--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -33,7 +33,8 @@ try:
 except ImportError:
     from mpl_toolkits.axes_grid import make_axes_locatable
 
-from . import (axes, utils, rcParams, DEFAULT_RCPARAMS)
+from . import (axes, utils)
+from .rc import (rcParams, DEFAULT_RCPARAMS)
 from .axes import Axes
 from .log import CombinedLogFormatterMathtext
 from .decorators import (auto_refresh, axes_method)

--- a/gwpy/plotter/rc.py
+++ b/gwpy/plotter/rc.py
@@ -67,11 +67,12 @@ GWPY_COLOR_CYCLE = [
 # set mpl version dependent stuff
 try:
     from matplotlib import cycler
+except (ImportError, KeyError):  # mpl < 1.5
+    GWPY_PLOT_PARAMS['axes.color_cycle'] = GWPY_COLOR_CYCLE
+else:
     GWPY_PLOT_PARAMS.update({
         'axes.prop_cycle': cycler('color', GWPY_COLOR_CYCLE),
     })
-except (ImportError, KeyError):  # mpl < 1.5
-    GWPY_PLOT_PARAMS['axes.color_cycle'] = GWPY_COLOR_CYCLE
 
 # set latex options
 if rcParams['text.usetex'] or USE_TEX:

--- a/gwpy/plotter/rc.py
+++ b/gwpy/plotter/rc.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides plotting utilities for visualising GW data
+
+The standard data types (`TimeSeries`, `Table`, `DataQualityFlag`, ...) can
+all be easily visualised using the relevant plotting objects, with
+many configurable parameters both interactive, and in saving to disk.
+"""
+
+from matplotlib import (rcParams, rc_params)
+
+from .tex import (USE_TEX, MACROS as TEX_MACROS)
+
+# record matplotlib's original rcParams
+DEFAULT_RCPARAMS = rc_params()
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+# set default params
+GWPY_PLOT_PARAMS = {
+    'axes.grid': True,
+    'axes.axisbelow': False,
+    'axes.formatter.limits': (-3, 4),
+    'axes.labelsize': 22,
+    'axes.titlesize': 26,
+    'grid.linestyle': ':',
+    'grid.linewidth': .5,
+    'image.aspect': 'auto',
+    'image.interpolation': 'nearest',
+    'image.origin': 'lower',
+    'xtick.labelsize': 20,
+    'ytick.labelsize': 20,
+}
+
+# construct new default color cycle
+GWPY_COLOR_CYCLE = [
+    (0.0, 0.4, 1.0),  # blue
+    'r',              # red
+    (0.2, 0.8, 0.2),  # green
+    (1.0, 0.7, 0.0),  # yellow(ish)
+    (0.5, 0., 0.75),  # magenta
+    'gray',
+    (0.3, 0.7, 1.0),  # light blue
+    'pink',
+    (0.13671875, 0.171875, 0.0859375),  # dark green
+    (1.0, 0.4, 0.0),  # orange
+    'saddlebrown',
+    'navy',
+]
+
+# set mpl version dependent stuff
+try:
+    from matplotlib import cycler
+    GWPY_PLOT_PARAMS.update({
+        'axes.prop_cycle': cycler('color', GWPY_COLOR_CYCLE),
+    })
+except (ImportError, KeyError):  # mpl < 1.5
+    GWPY_PLOT_PARAMS['axes.color_cycle'] = GWPY_COLOR_CYCLE
+
+# set latex options
+if rcParams['text.usetex'] or USE_TEX:
+    GWPY_PLOT_PARAMS.update({
+        "text.usetex": True,
+        "font.family": "serif",
+        "font.serif": ["Computer Modern"],
+        "text.latex.preamble": TEX_MACROS,
+    })
+
+# update matplotlib rcParams with new settings
+rcParams.update(GWPY_PLOT_PARAMS)
+
+# fix matplotlib issue #3470
+if rcParams['font.family'] == 'serif':
+    rcParams['font.family'] = u'serif'


### PR DESCRIPTION
This PR moves the `GWPY_PLOT_PARAMS` dict, and related customisations of `matplotlib.rcParams` to a new `gwpy.plotter.rc` module.

This cleans up the code a wee bit, whilst retaining backwards compatibility.