### PR TITLE
Fixed bug in default plot for FrequencySeries

### DIFF
--- a/gwpy/plotter/frequencyseries.py
+++ b/gwpy/plotter/frequencyseries.py
@@ -301,17 +301,15 @@ class FrequencySeriesPlot(Plot):
             # format axes
             for key, val in axargs.items():
                 getattr(ax, 'set_%s' % key)(val)
-            # fix log frequency scale with f0 = DC
-            if xscale in ['log']:
+            # set axis scales
+            ax.set_xscale(xscale)
+            ax.set_yscale(yscale)
+            # format log scales
+            if ax.get_xscale() in ['log']:
                 xlim = list(ax.get_xlim())
                 if not xlim[0]:
                     xlim[0] = x0[i]
                 ax.set_xlim(*xlim)
-            # set axis scales
-            ax.set_xscale(xscale)
-            ax.set_yscale(yscale)
-            # set grid
-            if xscale == 'log':
                 ax.grid(True, axis='x', which='both')
-            if yscale == 'log':
+            if ax.get_yscale() in ['log']:
                 ax.grid(True, axis='y', which='both')

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -59,6 +59,8 @@ class FrequencySeriesTestCase(SeriesTestCase):
         array = self.create()
         plot = array.plot()
         self.assertIsInstance(plot, FrequencySeriesPlot)
+        with tempfile.NamedTemporaryFile(suffix='.png') as f:
+            plot.save(f.name)
 
     def test_filter(self):
         array = self.create()
@@ -138,6 +140,8 @@ class SpectralVarianceTestCase(Array2DTestCase):
     def test_plot(self):
         plot = self.create().plot()
         self.assertIsInstance(plot, FrequencySeriesPlot)
+        with tempfile.NamedTemporaryFile(suffix='.png') as f:
+            plot.save(f.name)
 
     def test_value_at(self):
         ts1 = self.create(dx=.5, unit='m')

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -406,7 +406,7 @@ class TimeSeriesAxesTestCase(TimeSeriesMixin, AxesTestCase):
         self.save_and_close(fig)
 
 
-# -- FrequencySeries plotters --------------------------------------------------------
+# -- FrequencySeries plotters -------------------------------------------------
 
 class FrequencySeriesMixin(object):
     FIGURE_CLASS = FrequencySeriesPlot

--- a/gwpy/tests/test_spectrogram.py
+++ b/gwpy/tests/test_spectrogram.py
@@ -19,6 +19,8 @@
 """Unit test for spectrogram module
 """
 
+import tempfile
+
 import pytest
 
 import numpy
@@ -96,6 +98,11 @@ class SpectrogramTestCase(Array2DTestCase):
             array.crop_frequencies(array.yspan[0]-1, array.yspan[1])
         with pytest.warns(UserWarning):
             array.crop_frequencies(array.yspan[0], array.yspan[1]+1)
+
+    def test_plot(self):
+        plot = self.TEST_ARRAY.plot()
+        with tempfile.NamedTemporaryFile(suffix='.png') as f:
+            plot.save(f.name)
 
 
 if __name__ == '__main__':

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -428,6 +428,8 @@ class TimeSeriesTestMixin(object):
         ts = self.create()
         plot = ts.plot()
         self.assertIsInstance(plot, TimeSeriesPlot)
+        with tempfile.NamedTemporaryFile(suffix='.png') as f:
+            plot.save(f.name)
         return plot
 
 
@@ -794,6 +796,8 @@ class TimeSeriesDictTestCase(unittest.TestCase):
         plot = tsd.plot()
         self.assertIsInstance(plot, TimeSeriesPlot)
         self.assertEqual(len(plot.gca().lines), 2)
+        with tempfile.NamedTemporaryFile(suffix='.png') as f:
+            plot.save(f.name)
 
     def test_resample(self):
         tsd = self.read()
@@ -833,6 +837,8 @@ class StateVectorDictTestCase(TimeSeriesDictTestCase):
         tsd = self.read()
         plot = tsd.plot()
         self.assertIsInstance(plot, TimeSeriesPlot)
+        with tempfile.NamedTemporaryFile(suffix='.png') as f:
+            plot.save(f.name)
 
 
 # -- TimeSeriesList tests -----------------------------------------------------


### PR DESCRIPTION
This PR fixes #412 by improving the default formatting of log axes on a `FrequencySeriesPlot`. The trick is to set the x-axis scale (`ax.set_xscale`) before setting the limits.

This PR also modifies the `test_plot` method for all of the class tests to include a `plot.save` operation to make sure that the default figure actually renders (which would have caught #412).