### PR TITLE
Removed unnecessary log10 call in plotting

### DIFF
--- a/gwpy/plotter/log.py
+++ b/gwpy/plotter/log.py
@@ -53,7 +53,7 @@ class GWpyLogFormatterMathtext(LogFormatterMathtext):
                 return '$%s$' % x
             else:
                 return '$\mathdefault{%s}$' % x
-        elif usetex and abs(log10(x)) > 2:
+        elif usetex and abs(x) > 100:
             return '$%s$' % float_to_latex(x, '%.2e')
         elif usetex:
             return '$%s$' % float_to_latex(x, '%.2g')


### PR DESCRIPTION
This PR removes an unnecessary call to `math.log10` thereby removing a potential `ValueError` when zeros creep into a log scale.