### PR TITLE
Axes.legend: inherit frame linewidth from rcparams

### DIFF
--- a/gwpy/plotter/axes.py
+++ b/gwpy/plotter/axes.py
@@ -219,6 +219,7 @@ class Axes(_Axes):
         if legend is not None:
             lframe = legend.get_frame()
             lframe.set_alpha(alpha)
+            lframe.set_linewidth(rcParams['axes.linewidth'])
             [l.set_linewidth(linewidth) for l in legend.get_lines()]
         return legend
     legend.__doc__ = _Axes.legend.__doc__

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -264,7 +264,9 @@ class AxesTestCase(Mixin, unittest.TestCase):
         ax = fig.add_subplot(111, projection=self.AXES_CLASS.name)
         ax.plot([1, 2, 3, 4], label='Plot')
         leg = ax.legend()
-        self.assertEqual(leg.get_frame().get_alpha(), 0.8)
+        legframe = leg.get_frame()
+        self.assertEqual(legframe.get_alpha(), 0.8)
+        self.assertEqual(legframe.get_linewidth(), rcParams['axes.linewidth'])
         for l in leg.get_lines():
             self.assertEqual(l.get_linewidth(), 8)
         self.save_and_close(fig)


### PR DESCRIPTION
This PR modifies the `Axes.legend` method to force the legend frame to inherit the linewidth from the `axes.linewidth` setting. By default this means that a figure's axes and legends will have the same frame width, which is nice.