### PR TITLE
Updated build dependencies to reference lscsoft-glue and dqegdb on pypi

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+# include core requirements
 -r requirements.txt
 
 # dependencies for glue
@@ -9,7 +10,7 @@ pyRXP
 # extras
 h5py>=1.3
 MySQL-python
-http://software.ligo.org/lscsoft/source/dqsegdb-1.4.0.tar.gz
+dqsegdb
 https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
 
 # docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ numpy>=1.10
 scipy>=0.16
 astropy>=1.2
 matplotlib>=1.4.1
-http://software.ligo.org/lscsoft/source/glue-1.53.0.tar.gz
+lscsoft-glue>=1.55.2

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ install_requires = [
     'matplotlib>=1.4.1',
     'astropy>=1.2',
     'six>=1.5',
+    'lscsoft-glue>=1.55.2',
 ]
 extras_require = {
     'nds': ['nds2-client'],


### PR DESCRIPTION
This PR updates the setup/requirements dependencies to reference [`lscsoft-glue`](https://pypi.python.org/pypi/lscsoft-glue/) and [`dqsegdb`](https://pypi.python.org/pypi/dqsegdb/) from pypi. This should simplify the build.