### PR TITLE
Configured auto-deployment to pypi from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,18 @@ script:
 after_success:
   - coveralls
 
+deploy:
+  - provider: pypi
+    user: duncanmmacleod
+    password:
+      secure: AWHqZruQMW9uHIhXLlKwgdfWBHZIgwLtvkP7D+al4zYG/wSOvZDTT7ZsxOhFogYxIXWzwcBIPYgUGplkMOlb+N0Wl45OPL6U2tN5EtUEtWnTd/OxrDzA/DJJbgdfy4VqFSj0fY7FTBNJCeCciZ+TmtBrcWSFbHorrLyF5oOW7VQ=
+    on:
+      branch: master
+      tags: true
+      distributions: sdist bdist_wheel
+      python: '2.7'
+      repo: gwpy/gwpy
+
 notifications:
   slack:
     secure: jQdoSpwNbUnq0Eo7o6Ko7vuhu58LQdfy8jFKxLUnUjv/GLezK/PPAQCU9SgmyDPh1yD8sb5Xa8UtbNfGtpYdwBAGwZxPHz3oQQAflivFwcF6UP7/NlAB9muSOOnL0QfQyX1I4sIKOkX+gkl+TBciX4v58B8NUU02dDkwDqTLUqQ=


### PR DESCRIPTION
This PR adds auto-deployment from travis to pypi.python.org for all tags from the master branch. Currently this is configured only for python 2.7, but we should enable python 3.x when the builds run successfully. 