### PR TITLE
Updated references of glue.lal.CacheEntry to lal.utils.CacheEntry

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -32,7 +32,9 @@ from six import string_types
 from numpy import recarray
 from numpy.lib import recfunctions
 
-from glue.lal import (Cache, CacheEntry)
+from lal.utils import CacheEntry
+
+from glue.lal import Cache
 
 from astropy.table import (Table, vstack as vstack_tables)
 from astropy.io.registry import _get_valid_format
@@ -76,7 +78,7 @@ def file_list(flist):
 
         - `str` representing a single file path (or comma-separated collection)
         - open `file` or `~gzip.GzipFile` object
-        - `~glue.lal.CacheEntry`
+        - `~lal.utils.CacheEntry`
         - `~glue.lal.Cache` object or `str` with '.cache' or '.lcf extension
         - simple `list` or `tuple` of `str` paths
 

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -273,8 +273,8 @@ def cache_segments(*caches):
 
     Parameters
     ----------
-    *cache : `~glue.lal.Cache`
-        one of more frame file caches describing files on disk
+    *cache : `~glue.lal.Cache`, `list`
+        one of more `Cache` objects (or simple `list`)
 
     Returns
     -------

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -22,7 +22,7 @@
 import os.path
 import re
 
-from glue.lal import CacheEntry
+from lal.utils import CacheEntry
 
 from ..time import to_gps
 from ..utils import with_import
@@ -203,7 +203,7 @@ def on_tape(*files):
 
     Parameters
     ----------
-    *files : `str`, `~glue.lal.CacheEntry`
+    *files : `str`, `~lal.utils.CacheEntry`
         one or more paths to GWF files
 
     Returns

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -88,7 +88,7 @@ def table_from_file(f, tablename, columns=None, filt=None,
 
         - an open `file`
         - a `str` pointing to a file path on disk
-        - a formatted `~glue.lal.CacheEntry` representing one file
+        - a formatted `~lal.utils.CacheEntry` representing one file
         - a `list` of `str` file paths
         - a formatted `~glue.lal.Cache` representing many files
 

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -24,7 +24,7 @@ from os.path import basename
 
 from six import string_types
 
-from glue.lal import CacheEntry
+from lal.utils import CacheEntry
 
 from ...io.hdf5 import (identify_hdf5, with_read_hdf5)
 from ...io.registry import (register_reader, register_identifier)
@@ -215,7 +215,7 @@ import numpy
 from numpy import rec
 from numpy.lib import recfunctions
 
-from glue.lal import CacheEntry
+from lal.utils import CacheEntry
 
 from ...utils.deps import with_import
 from ...io.cache import file_list

--- a/gwpy/tests/mockutils.py
+++ b/gwpy/tests/mockutils.py
@@ -120,7 +120,7 @@ def mock_find_credential():
     return '/mock/cert/path', '/mock/key/path'
 
 def mock_datafind_connection(framefile):
-    from glue.lal import CacheEntry
+    from lal.utils import CacheEntry
     from glue import datafind
     ce = CacheEntry.from_T050017(framefile)
     frametype = ce.description

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -29,7 +29,9 @@ from tempfile import NamedTemporaryFile
 
 from six.moves.urllib.request import urlopen
 
-from glue.lal import (Cache, CacheEntry)
+from lal.utils import CacheEntry
+
+from glue.lal import Cache
 
 from astropy.io import registry
 from astropy.units import Quantity


### PR DESCRIPTION
This PR updates references to `CacheEntry` to import from `lal.utils`, and not `glue.lal`. This resolves a `DeprecationWarning` thrown by `glue.lal`.