### PR TITLE
Bumped astropy requirement to 1.2.1

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,11 +41,11 @@ Linux
 
 The GWpy package has the following build-time dependencies (i.e. required for installation):
 
-* `glue <https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html>`_ >= 1.48
+* `glue <https://www.lsc-group.phys.uwm.edu/daswg/projects/glue.html>`_ >= 1.53
 * `python-dateutil <https://pypi.python.org/pypi/python-dateutil/>`_
-* `NumPy <http://www.numpy.org>`_ >= 1.5
+* `NumPy <http://www.numpy.org>`_ >= 1.10
 * `SciPy <http://www.scipy.org>`_ >= 0.16
-* `Matplotlib <http://matplotlib.org>`_ >= 1.3.0
+* `Matplotlib <http://matplotlib.org>`_ >= 1.4.1
 * `Astropy <http://astropy.org>`_ >= 1.2.1
 
 You should install these packages on your system using the instructions provided by their authors.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,7 +46,7 @@ The GWpy package has the following build-time dependencies (i.e. required for in
 * `NumPy <http://www.numpy.org>`_ >= 1.5
 * `SciPy <http://www.scipy.org>`_ >= 0.16
 * `Matplotlib <http://matplotlib.org>`_ >= 1.3.0
-* `Astropy <http://astropy.org>`_ >= 1.0
+* `Astropy <http://astropy.org>`_ >= 1.2.1
 
 You should install these packages on your system using the instructions provided by their authors.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 six>=1.5
 numpy>=1.10
 scipy>=0.16
-astropy>=1.2
+astropy>=1.2.1
 matplotlib>=1.4.1
 lscsoft-glue>=1.55.2

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     'numpy>=1.10',
     'scipy>=0.16.0',
     'matplotlib>=1.4.1',
-    'astropy>=1.2',
+    'astropy>=1.2.1',
     'six>=1.5',
     'lscsoft-glue>=1.55.2',
 ]


### PR DESCRIPTION
This PR bumps the minimum version requirement for astropy to 1.2.1, since this is the first version that provides `astropy.io.registry.IORegistryError`.