### PR TITLE
Improved default build/test environment

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ First steps
    :maxdepth: 1
 
    What is GWpy? <overview>
-   How do I install GWpy? <install>
+   How do I install GWpy? <install/index>
 
 Working with data
 ~~~~~~~~~~~~~~~~~

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -1,0 +1,109 @@
+.. include:: ../references.txt
+
+.. _gwpy-install:
+
+############
+Installation
+############
+
+GWpy is currently not packaged for the 'standard' package manager on any operating system, however, it is easily installed via `pip <//pip.pypa.io/>`_.
+See the sections below to install dependencies using the system package manager, if appropriate, or skip to :ref:`gwpy-install-pip`.
+
+================
+Install on macOS
+================
+
+GWpy dependencies are easiest to install using `MacPorts <//www.macports.org/>`_, `follow these instructions <https://www.macports.org/install.php>`_ to install the MacPorts package on your Mac.
+
+The core dependencies can be installed via:
+
+.. code-block:: bash
+
+   sudo port install python27 python_select py27-numpy py27-scipy py27-matplotlib +latex +dvipng texlive-latex-extra py27-astropy glue
+   sudo port select --set python python27
+
+Optional extras can be installed via:
+
+.. code-block:: bash
+
+   sudo port install py27-ipython nds2-client kerberos5 py27-pykerberos py27-h5py py27-lal py27-ldas-tools-framecpp
+
+Finally, to install GWpy, skip to :ref:`gwpy-install-pip`.
+
+.. _gwpy-install-linux:
+
+================
+Install on Linux
+================
+
+The GWpy package has the following build-time dependencies (i.e. required for installation):
+
+* |numpy|_ `>= 1.5`
+* |scipy|_ `>= 0.16`
+* |matplotlib|_ `>= 1.4.1`
+* |astropy|_ `>= 1.2.1`
+* |dateutil|_
+* |lal|_ `>= 6.18.0`
+* |glue|_ `>= 1.53`
+
+You should install these packages on your system using the instructions provided by their authors.
+
+You can also install the following optional dependencies - packages that, when present, enhance the functionality of GWpy:
+
+* |lalframe|_
+* |nds2|_
+
+Finally, to install GWpy, skip to :ref:`gwpy-install-pip`.
+
+.. _gwpy-install-pip:
+
+===================
+Installing with pip
+===================
+
+.. warning::
+
+   GWpy is dependent on |lal|_, which cannot be installed via `pip`, see :ref:`gwpy-install-lal` before continuing to install GWpy.
+
+Once LAL is installed, the easiest way to install GWpy is via `pip <//pip.pypa.io/>`_:
+
+.. code-block:: bash
+
+   pip install gwpy
+
+This will install GWpy and a minimal set of required dependencies that provide basic functionality.
+
+A more complete set of packages that include optional extras can be installed via
+
+.. code-block:: bash
+
+   pip install gwpy[all]
+
+.. _gwpy-install-available:
+
+#############################################################
+Available installations for the LIGO Scientific Collaboration
+#############################################################
+
+If you are a member of the LIGO Scientific Collaboration, a `virtualenv <https://virtualenv.pypa.io/en/latest/>`_ is available for you to use on the LIGO Data Grid, providing an isolated environment including GWpy and its dependencies.
+
+How you enter this environment depends on which shell you are using:
+
+**Bash**
+
+.. code-block:: bash
+
+   . ~detchar/opt/gwpysoft/bin/activate
+
+**Csh**
+
+.. code-block:: csh
+
+   . ~detchar/opt/gwpysoft/bin/activate.csh
+
+In either case, once you are finished with your work, if you want to return to your original environment, you can `deactivate` the virtualenv:
+
+.. code-block:: bash
+
+   deactivate
+

--- a/docs/install/lal.rst
+++ b/docs/install/lal.rst
@@ -1,0 +1,121 @@
+.. _gwpy-install-lal:
+
+##############
+Installing LAL
+##############
+
+The LIGO Algorithm Library is a C-language library with optional python bindings built using SWIG.
+LAL is officially supported on the latest stable releases of Debian and Red-hat Linux, with best-effort support for macOS.
+See the relevant section below for the best instructions on installing LAL on your system, or from source (e.g. for an isolated virtualenv)
+
+- :ref:`gwpy-install-lal-debian`
+- :ref:`gwpy-install-lal-sl`
+- :ref:`gwpy-install-lal-macos`
+- :ref:`gwpy-install-lal-source`
+
+.. _gwpy-install-lal-debian:
+
+======
+Debian
+======
+
+**Official instructions can be found at** https://wiki.ligo.org/DASWG/SoftwareDownloads
+
+To install on Debian 7 (codename 'jessie'), first add the LSCSoft repository to your system by adding creating ``/etc/apt/sources.list/lscsoft.list`` with the following contents:
+
+.. code-block:: none
+
+   deb http://software.ligo.org/lscsoft/debian jessie contrib
+   deb-src http://software.ligo.org/lscsoft/debian jessie contrib
+
+Then update your package lists as follows:
+
+.. code-block:: bash
+
+   $ apt-get update
+   $ apt-get install lscsoft-archive-keyring
+
+Finally, you can install LAL for python2 via
+
+.. code-block:: bash
+
+   $ apt-get install lal-python
+
+OR, for python3:
+
+.. code-block:: bash
+
+   $ apt-get install lal-python3
+
+
+.. _gwpy-install-lal-sl:
+
+================
+Scientific linux
+================
+
+**Official instructions can be found at** https://wiki.ligo.org/DASWG/SoftwareDownloads
+
+To install on Scientific Linux 7, firat download and install the RPM configuration for the LSCSoft repository:
+
+.. code-block:: bash
+
+   $ http://software.ligo.org/lscsoft/scientific/7.2/x86_64/production/lscsoft-production-config-1.3-1.el7.noarch.rpm
+   $ rpm -ivh lscsoft-production-config-1.3-1.el7.noarch.rpm
+   $ yum clean all
+   $ yum makecache
+
+Finally, you can install LAL (for python2 or python3) via
+
+.. code-block:: bash
+
+   $ yum install lal-python
+
+
+.. _gwpy-install-lal-macos:
+
+=====
+macOS
+=====
+
+macOS support is provided via `MacPorts <//www.macports.org>`_.
+To install LAL, simply install the ``pyXY-lal`` port based on your ``X.Y`` version of Python.
+For example, for python 2.7, simply run
+
+.. code-block:: bash
+
+   $ sudo port install py27-lal
+
+.. _gwpy-install-lal-source:
+
+============
+Source build
+============
+
+.. note::
+
+   Building LAL from source requires numpy to be present on your system, either
+   install numpy using your sytem package manager, or via `pip`:
+
+   .. code-block:: bash
+
+      $ pip install numpy
+
+To build LAL from source, first identify the latest release tarball by visiting `http://software.ligo.org/lscsoft/source/lalsuite/ <http://software.ligo.org/lscsoft/source/lalsuite/?C=M;O=D>`_ and identifying the most recent release tarball of the form ``lal-X.Y.Z.tar.xz``.
+Then you can download and install this package via
+
+.. code-block:: bash
+
+   $ LAL_VERSION="6.18.0"  # change as appropriate
+   $ LAL_INSTALL_PREFIX="${VIRTUAL_ENV}"  # change as appropriate
+
+   $ builddir=`mktemp -d`
+   $ cd $builddir
+   $ wget http://software.ligo.org/lscsoft/source/lalsuite/lal-${LAL_VERSION}.tar.xz
+   $ tar -xf lal-${LAL_VERSION}.tar.xz
+   $ cd lal-${LAL_VERSION}
+   $ ./configure --prefix ${LAL_PREFIX} --quiet --enable-swig-python
+   $ make
+   $ make install
+   $ cd
+   $ rm -rf ${builddir}

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -1,26 +1,44 @@
+.. |numpy| replace:: `numpy`
+.. _numpy: //numpy.org/
+
+.. |scipy| replace:: `scipy`
+.. _scipy: //www.scipy.org/
+
+.. |matplotlib| replace:: `matplotlib`
+.. _matplotlib: //matplotlib.org/
+
+.. |astropy| replace:: `astropy`
+.. _astropy: //astropy.org/
+
+.. |dateutil| replace:: `dateutil`
+.. _dateutil: //pypi.python.org/pypi/python-dateutil/
+
 .. |root_numpy| replace:: `root_numpy`
-.. _root_numpy: https://rootpy.github.io/root_numpy/
+.. _root_numpy: //rootpy.github.io/root_numpy/
 
 .. |h5py| replace:: `h5py`
-.. _h5py: http://docs.h5py.org/en/latest/
+.. _h5py: //docs.h5py.org/en/latest/
 
 .. |glue| replace:: `glue`
-.. _glue: http://software.ligo.org/docs/glue/
+.. _glue: //software.ligo.org/docs/glue/
 
 .. |glue.ligolw| replace:: `glue.ligolw`
-.. _glue.ligolw: http://software.ligo.org/docs/glue/glue.ligolw-module.html
+.. _glue.ligolw: //software.ligo.org/docs/glue/glue.ligolw-module.html
 
 .. |glue.segments| replace:: `glue.segments`
-.. _glue.segments: http://software.ligo.org/docs/glue/glue.segments-module.html
+.. _glue.segments: //software.ligo.org/docs/glue/glue.segments-module.html
 
 .. |LDAStools.frameCPP| replace:: `LDAStools.frameCPP`
-.. _LDAStools.frameCPP: https://ldas-jobs.ligo.caltech.edu/~emaros/share/doc/ldas-tools/framecpp/html/
+.. _LDAStools.frameCPP: //ldas-jobs.ligo.caltech.edu/~emaros/share/doc/ldas-tools/framecpp/html/
+
+.. |lal| replace:: `lal`
+.. _lal: //software.ligo.org/docs/lalsuite/lal/
 
 .. |lalframe| replace:: `lalframe`
-.. _lalframe: https://software.ligo.org/docs/lalsuite/lalframe/
+.. _lalframe: //software.ligo.org/docs/lalsuite/lalframe/
 
 .. |nds2| replace:: `nds2`
-.. _nds2: https://www.lsc-group.phys.uwm.edu/daswg/projects/nds-client/doc/manual/
+.. _nds2: //www.lsc-group.phys.uwm.edu/daswg/projects/nds-client/doc/manual/
 
 .. |dqsegdb| replace:: `dqsegdb`
-.. _dqsegdb: https://wiki.ligo.org/DASWG/DQSEGDB
+.. _dqsegdb: //wiki.ligo.org/DASWG/DQSEGDB

--- a/gwpy/tests/compat.py
+++ b/gwpy/tests/compat.py
@@ -30,3 +30,17 @@ try:
     from unittest import mock
 except ImportError:
     import mock
+
+try:
+    import h5py
+except ImportError:
+    HAS_H5PY = False
+else:
+    HAS_H5PY = True
+
+try:
+    import dqsegdb
+except ImportError:
+    HAS_DQSEGDB = False
+else:
+    HAS_DQSEGDB = True

--- a/gwpy/tests/test_astro.py
+++ b/gwpy/tests/test_astro.py
@@ -23,7 +23,7 @@ import os
 import os.path
 import tempfile
 
-from compat import unittest
+from compat import (unittest, HAS_H5PY)
 
 import scipy
 
@@ -58,6 +58,7 @@ class AstroTests(unittest.TestCase):
                              'HLV-GW100916-968654552-1.hdf')
     tmpfile = '%s.%%s' % tempfile.mktemp(prefix='gwpy_test_')
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def setUp(self):
         # read data
         self.data = TimeSeries.read(self.framefile, 'L1:LDAS-STRAIN')

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -105,7 +105,12 @@ class FrequencySeriesTestCase(SeriesTestCase):
         self.assertArraysEqual(array, array2, 'units', 'df', 'f0')
 
     def test_read_write_hdf5(self):
-        self._test_read_write('hdf5', auto=False)
+        try:
+            self._test_read_write('hdf5', auto=False)
+        except ImportError as e:
+            if str(e) == 'No module named h5py':
+                self.skipTest(str(e))
+            raise
         self._test_read_write('hdf5', auto=True,
                               writekwargs={'overwrite': True})
 

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -37,7 +37,7 @@ from matplotlib.collections import (PathCollection, PatchCollection,
 
 from astropy import units
 
-from compat import unittest
+from compat import (unittest, HAS_H5PY)
 
 from gwpy.segments import (DataQualityFlag,
                            Segment, SegmentList, SegmentListDict)
@@ -288,6 +288,7 @@ class TimeSeriesMixin(object):
     FIGURE_CLASS = TimeSeriesPlot
     AXES_CLASS = TimeSeriesAxes
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def setUp(self):
         self.ts = TimeSeries.read(TEST_HDF_FILE, 'H1:LDAS-STRAIN')
         self.sg = self.ts.spectrogram2(0.5, 0.49)
@@ -415,6 +416,7 @@ class FrequencySeriesMixin(object):
     FIGURE_CLASS = FrequencySeriesPlot
     AXES_CLASS = FrequencySeriesAxes
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def setUp(self):
         self.ts = TimeSeries.read(TEST_HDF_FILE, 'H1:LDAS-STRAIN')
         self.asd = self.ts.asd(1)
@@ -645,6 +647,7 @@ class HistogramMixin(object):
     FIGURE_CLASS = HistogramPlot
     AXES_CLASS = HistogramAxes
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def setUp(self):
         self.ts = TimeSeries.read(TEST_HDF_FILE, 'H1:LDAS-STRAIN')
 

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -38,7 +38,7 @@ from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 from gwpy.plotter import (SegmentPlot, SegmentAxes)
 
-from compat import (unittest, mock)
+from compat import (unittest, mock, HAS_H5PY, HAS_DQSEGDB)
 import common
 import mockutils
 
@@ -167,6 +167,7 @@ class SegmentClassTestsMixin(object):
             return self.assertDataQualityDictEqual(a, b)
         return self.assertEqual(a, b)
 
+    @unittest.skipUnless(HAS_DQSEGDB, 'No module named dqsegdb')
     def _mock_query(self, cm, result, *args, **kwargs):
         """Query for segments using a mock of the dqsegdb API
         """
@@ -180,6 +181,7 @@ class SegmentClassTestsMixin(object):
                             mockutils.mock_query_times(result)):
                 return cm(*args, **kwargs)
 
+    @unittest.skipUnless(HAS_DQSEGDB, 'No module named dqsegdb')
     def _mock_query_versionless(self, cm, result, *args, **kwargs):
         """Query for segments using a mock of the dqsegdb API
         """
@@ -217,6 +219,7 @@ class SegmentListTests(unittest.TestCase, SegmentClassTestsMixin):
     def test_read_write_segwizard(self):
         return self._test_read_write('segwizard', extension='txt', auto=True)
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def test_read_write_hdf5(self):
         self._test_read_write('hdf5', auto=False,
                               writekwargs={'path': 'test-segmentlist'},
@@ -397,6 +400,7 @@ class DataQualityFlagTests(unittest.TestCase, SegmentClassTestsMixin):
         self._test_read_write('ligolw', extension='xml', auto=True,
                               writekwargs={'overwrite': True})
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def test_read_write_hdf5(self):
         kwargs = {'writekwargs': {'path': 'test-dqflag'},
                   'readkwargs': {'path': 'test-dqflag'}}
@@ -430,7 +434,7 @@ class DataQualityFlagTests(unittest.TestCase, SegmentClassTestsMixin):
         try:
             result = self.TEST_CLASS.query_segdb(flag, QUERY_START, QUERY_END,
                                                  url=QUERY_URL_SEGDB)
-        except (SystemExit, LDBDClientException) as e:
+        except (SystemExit, LDBDClientException, ImportError) as e:
             self.skipTest(str(e))
         self.assertEqual(result.known, QUERY_RESULT[flag].known)
         self.assertEqual(result.active, QUERY_RESULT[flag].active)
@@ -507,6 +511,7 @@ class DataQualityDictTests(unittest.TestCase, SegmentClassTestsMixin):
         return self._test_read_write('ligolw', extension='xml', auto=True,
                                      writekwargs={'overwrite': True})
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def test_read_write_hdf5(self):
         self._test_read_write('hdf5', auto=False)
         self._test_read_write('hdf5', auto=True,
@@ -568,7 +573,7 @@ class DataQualityDictTests(unittest.TestCase, SegmentClassTestsMixin):
         try:
             result = self.TEST_CLASS.query_segdb(
                 QUERY_FLAGS, QUERY_START, QUERY_END, url=QUERY_URL_SEGDB)
-        except (SystemExit, LDBDClientException) as e:
+        except (SystemExit, LDBDClientException, ImportError) as e:
             self.skipTest(str(e))
         self.assertListEqual(list(result.keys()), QUERY_FLAGS)
         for flag in result:

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -26,7 +26,7 @@ import tempfile
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import URLError
 
-from compat import (unittest, mock)
+from compat import (unittest, mock, HAS_H5PY)
 
 import pytest
 
@@ -371,6 +371,7 @@ class TimeSeriesTestMixin(object):
         self.assertTupleEqual(ts.span, (1000000000, 1000000001))
         self.assertEqual(ts.unit, units.meter)
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def fetch_open_data(self):
         try:
             return self._open_data
@@ -408,6 +409,7 @@ class TimeSeriesTestMixin(object):
         self.assertRaises(ValueError, self.TEST_CLASS.fetch_open_data,
                           self.channel[:2], 0, 1)
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def test_losc(self):
         _, tmpfile = tempfile.mkstemp(prefix='GWPY-TEST_LOSC_', suffix='.hdf')
         try:
@@ -445,6 +447,7 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
             numpy.random.normal(loc=1, size=16384 * 10), sample_rate=16384,
             epoch=-5)
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def _read(self):
         return self.TEST_CLASS.read(TEST_HDF_FILE, self.channel)
 
@@ -652,6 +655,7 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         # test breaks when you try and 'fir' notch
         self.assertRaises(NotImplementedError, ts.notch, 10, type='fir')
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
     def _test_losc_inner(self, loscfile):
         ts = self.TEST_CLASS.read(loscfile, 'Strain', format='losc')
         self.assertEqual(ts.x0, units.Quantity(931069952, 's'))

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -128,6 +128,14 @@ def fetch_losc_data(detector, start, end, host=LOSC_URL,
     use the interface provided by `TimeSeries.fetch_open_data` (and similar
     for `StateVector.fetch_open_data`).
     """
+    # check for h5py upfront, to prevent downloading data first
+    # when read() will fail anyway
+    try:
+        import h5py
+    except ImportError as e:
+        e.args = ('%s, h5py is required to read LOSC HDF5 files' % str(e),)
+        raise
+
     sample_rate = Quantity(sample_rate, 'Hz').value
     start = to_gps(start)
     end = to_gps(end)

--- a/gwpy/utils/auth.py
+++ b/gwpy/utils/auth.py
@@ -30,8 +30,6 @@ from six.moves import http_cookiejar
 from six.moves.urllib import request as http_request
 from six.moves.urllib.error import HTTPError
 
-from glue.auth.saml import HTTPNegotiateAuthHandler
-
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 COOKIE_JAR = os.path.join(tempfile.gettempdir(), getpass.getuser())
@@ -54,6 +52,8 @@ def request(url, debug=False, timeout=None):
     debug : `bool`, optional
         Query in verbose debugging mode, default `False`
     """
+    from glue.auth.saml import HTTPNegotiateAuthHandler
+
     # set debug to 1 to see all HTTP(s) traffic
     debug = int(debug)
 

--- a/setup.py
+++ b/setup.py
@@ -72,11 +72,16 @@ install_requires = [
     'python-dateutil',
 ]
 extras_require = {
-    'nds': ['nds2-client'],
+    'hdf5': ['h5py>=1.3'],
+    'root': ['root_numpy'],
+    'segments': ['dqsegdb'],
     'docs': ['sphinx', 'numpydoc', 'sphinx-bootstrap-theme',
              'sphinxcontrib-programoutput'],
-    'hdf5': ['h5py>=1.3'],
 }
+
+# define 'all' as the intersection of all extras
+extras_require['all'] = set(p for extra in extras_require.values()
+                            for p in extra)
 
 # test for OrderedDict
 try:

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,15 @@ from distutils.dist import Distribution
 from distutils.cmd import Command
 from distutils.command.clean import (clean, log, remove_tree)
 
-# check python version
-if sys.version < '2.7':
-    raise ImportError("Python versions older than 2.7 are not supported.")
+# check LAL
+try:
+    import lal
+except ImportError as e:
+    e.args = ('%s. LAL is required by GWpy, please install before '
+              'continuing, see '
+              'https://gwpy.github.io/docs/stable/install/lal.html '
+              'for details' % str(e),)
+    raise
 
 # set basic metadata
 PACKAGENAME = 'gwpy'

--- a/setup.py
+++ b/setup.py
@@ -96,10 +96,10 @@ setup_requires.append('pytest-runner')
 tests_require = [
     'pytest',
 ]
+if sys.version < '3':
+    tests_require.append('mock')
 if sys.version < '2.7':
     tests_require.append('unittest2')
-if 'ordereddict>=1.1' in install_requires:
-    tests_require.append('ordereddict>=1.1')
 
 
 # -- custom clean command -----------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ install_requires = [
     'astropy>=1.2.1',
     'six>=1.5',
     'lscsoft-glue>=1.55.2',
+    'python-dateutil',
 ]
 extras_require = {
     'nds': ['nds2-client'],


### PR DESCRIPTION
This PR modifies the build script (`setup.py`) and the test suite to ensure that the tests run end-to-end without any failures on a minimal install, e.g. after

```
git clone https://github.com/gwpy/gwpy
cd gwpy
pip install .
```

followed by

```
python setup.py test
```

The commits are individually simple and amount to

- making sure all required dependencies are listed in `install_requires` or `tests_require` as appropriate
- moving some optional imports to fail at run time rather than import
- adding `skipUnless` decorators to all tests requiring `h5py` or `dqsegdb`