### PR TITLE
Updated travis-ci src builds to use cmake for nds2-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,4 +114,4 @@ before_cache:
   - rm -f ./python-${TRAVIS_PYTHON_VERSION}-ldas-tools-al/config.log
   - rm -f ./python-${TRAVIS_PYTHON_VERSION}-framecpp/config.log
   - rm -f ./python-${TRAVIS_PYTHON_VERSION}-lalframe/config.log
-  - rm -f ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/config.log
+  - rm -f ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/CMakeFiles/CMakeError.log ./python-${TRAVIS_PYTHON_VERSION}-nds2-client/CMakeFiles/CMakeOutput.log

--- a/.travis/build-src-dependencies.sh
+++ b/.travis/build-src-dependencies.sh
@@ -40,7 +40,7 @@ bash .travis/build-with-autotools.sh \
 
 bash .travis/build-with-autotools.sh \
     python-${TRAVIS_PYTHON_VERSION}-nds2-client \
-    ${NDS2_CLIENT} --disable-swig-java --disable-mex-matlab || FAILURES="$FAILURES nds2-client"
+    ${NDS2_CLIENT} -DENABLE_SWIG_JAVA=false -DENABLE_SWIG_MATLAB=false || FAILURES="$FAILURES nds2-client"
 
 # -- exit ---------------------------------------------------------------------
 

--- a/.travis/build-with-autotools.sh
+++ b/.travis/build-with-autotools.sh
@@ -37,11 +37,17 @@ else
     elif [ -f ./autogen.sh ]; then
         ./autogen.sh
     fi
-    ./configure --enable-silent-rules --prefix=$target $@
+    if [ -f ./CMakeLists.txt ]; then
+        cmake . -DCMAKE_INSTALL_PREFIX=$target $@
+    else
+        ./configure --enable-silent-rules --prefix=$target $@
+    fi
 fi
 
 # configure if the makefile still doesn't exist
-if [ ! -f ./Makefile ]; then
+if [ ! -f ./Makefile ] && [ -f ./CMakeLists.txt ]; then
+    cmake . -DCMAKE_INSTALL_PREFIX=$target $@
+elif [ ! -f ./Makefile ]; then
     ./configure --enable-silent-rules --prefix=$target $@
 fi
 


### PR DESCRIPTION
This PR updates the autotools build scripts in `/.travis/` to support `cmake` builds, and updated the arguments for the NDS2-client builds to use those. `cmake` is the build system for that package as of the latest release, 0.14.