### PR TITLE
Improved PyCBC conversion methods

### DIFF
--- a/examples/timeseries/index.rst
+++ b/examples/timeseries/index.rst
@@ -14,3 +14,4 @@
    blrms
    statevector
    qscan
+   pycbc-snr

--- a/examples/timeseries/pycbc-snr.py
+++ b/examples/timeseries/pycbc-snr.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Calculating the SNR associated with a given astrophysical signal model
+
+The example :ref:`gwpy-example-timeseries-gw150914` showed us we can visually
+extract a signal from the noise using basic signal-processing techniques.
+
+However, an actual astrophysical search algorithm detects signals by
+calculating the signal-to-noise ratio (SNR) of data for each in a large bank
+of signal models, known as templates.
+
+Using |pycbc|_ (the actual search code), we can do that.
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+__currentmodule__ = 'gwpy.timeseries'
+
+# First, as always, we fetch some of the public data from the LIGO Open
+# Science Center
+
+from gwpy.timeseries import TimeSeries
+data = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
+
+# and condition it by applying a highpass at 15 Hz
+high = data.highpass(15)
+
+# This is important to remove noise at lower frequencies that isn't
+# accurately calibrated, and swamps smaller noises at higher frequencies.
+
+# For this example, we want to calculate the SNR over a 4 second segment, so
+# we calculate a Power Spectral Density with a 4 second FFT length (using all
+# of the data), then :meth:`~TimeSeries.crop` the data:
+
+psd = high.psd(4, 2)
+zoom = high.crop(1126259460, 1126259464)
+
+# In order to calculate signal-to-noise ratio, we need a signal model
+# against which to compare our data.
+# For this we import :func:`~pycbc.waveform.get_fd_waveform` and generate a
+# template `~pycbc.types.frequencyseries.FrequencySeries`:
+
+from pycbc.waveform import get_fd_waveform
+hp, _ = get_fd_waveform(approximant="IMRPhenomD", mass1=40, mass2=32,
+                        f_lower=20, f_final=2048, delta_f=psd.df.value)
+
+# At this point we are ready to calculate the SNR, so we import the
+# :func:`~pycbc.filter.matched_filter` method, and pass it our template,
+# the data, and the PSD, using the :meth:`~TimeSeries.to_pycbc` methods of
+# the `TimeSeries` and `~gwpy.frequencyseries.FrequencySeries objects:
+
+import numpy
+from pycbc.filter import matched_filter
+snr = matched_filter(hp, zoom.to_pycbc(), psd=psd.to_pycbc(),
+                     low_frequency_cutoff=15)
+snrts = numpy.abs(TimeSeries.from_pycbc(snr))
+
+# We can plot the SNR `TimeSeries` around the region of interest:
+plot = snrts.plot()
+ax = plot.gca()
+ax.set_xlim(1126259461, 1126259463)
+ax.set_epoch(1126259462.427)
+ax.set_ylabel('Signal-to-noise ratio (SNR)')
+ax.set_title('LIGO-Hanford signal-correlation for GW150914')
+plot.show()
+
+# We can clearly see a large spike (above 17!) at the time of the GW150914
+# signal!
+# This is, in principle, how the full, blind, CBC search is performed, using
+# all of the available data, and a bank of tens of thousand of signal models.

--- a/gwpy/frequencyseries/core.py
+++ b/gwpy/frequencyseries/core.py
@@ -388,7 +388,7 @@ class FrequencySeries(Series):
         return lalfs
 
     @classmethod
-    def from_pycbc(cls, fs):
+    def from_pycbc(cls, fs, copy=True):
         """Convert a `pycbc.types.frequencyseries.FrequencySeries` into
         a `FrequencySeries`
 
@@ -398,12 +398,15 @@ class FrequencySeries(Series):
             the input PyCBC `~pycbc.types.frequencyseries.FrequencySeries`
             array
 
+        copy : `bool`, optional, default: `True`
+            if `True`, copy these data to a new array
+
         Returns
         -------
         spectrum : `FrequencySeries`
             a GWpy version of the input frequency series
         """
-        return cls(fs.data, f0=0, df=fs.delta_f, epoch=fs.epoch)
+        return cls(fs.data, f0=0, df=fs.delta_f, epoch=fs.epoch, copy=copy)
 
     def to_pycbc(self, copy=True):
         """Convert this `FrequencySeries` into a

--- a/gwpy/frequencyseries/core.py
+++ b/gwpy/frequencyseries/core.py
@@ -405,10 +405,9 @@ class FrequencySeries(Series):
         """
         return cls(fs.data, f0=0, df=fs.delta_f, epoch=fs.epoch)
 
-    @with_import('pycbc.types')
     def to_pycbc(self, copy=True):
         """Convert this `FrequencySeries` into a
-        `pycbc.types.frequencyseries.FrequencySeries`
+        `~pycbc.types.frequencyseries.FrequencySeries`
 
         Parameters
         ----------
@@ -420,9 +419,12 @@ class FrequencySeries(Series):
         frequencyseries : `pycbc.types.frequencyseries.FrequencySeries`
             a PyCBC representation of this `FrequencySeries`
         """
+        from pycbc import types
+
         if self.epoch is None:
             epoch = None
         else:
             epoch = self.epoch.gps
-        return types.FrequencySeries(self.data, delta_f=self.df.to('Hz').value,
+        return types.FrequencySeries(self.value,
+                                     delta_f=self.df.to('Hz').value,
                                      epoch=epoch, copy=copy)

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -22,7 +22,7 @@
 import os.path
 import tempfile
 
-from numpy import (testing as nptest, arange, linspace)
+from numpy import (testing as nptest, arange, linspace, may_share_memory)
 
 from scipy import signal
 
@@ -90,19 +90,28 @@ class FrequencySeriesTestCase(SeriesTestCase):
         self.assertArraysEqual(array, array2, 'units', 'df', 'f0')
 
     def test_to_from_pycbc(self):
-        array = self.create()
         try:
-            pycbcarray = array.to_pycbc()
-        except (ValueError, ImportError) as e:
-            # catch dodgy error on missing dependency
-            if isinstance(e, ValueError) and (
-                'insecure string pickle' not in str(e)):
-                raise
-            else:
-                self.skipTest(str(e))
-        nptest.assert_array_equal(pycbcarray.data, array.value)
-        array2 = type(array).from_pycbc(pycbcarray)
-        self.assertArraysEqual(array, array2, 'units', 'df', 'f0')
+            from pycbc.types import FrequencySeries as PyCBCFrequencySeries
+        except ImportError as e:
+            self.skipTest(str(e))
+        fs = self.create()
+        # test default conversion
+        pycbcfs = fs.to_pycbc()
+        self.assertIsInstance(pycbcfs, PyCBCFrequencySeries)
+        nptest.assert_array_equal(fs.value, pycbcfs.data)
+        self.assertEqual(fs.df.value, pycbcfs.delta_f)
+        # go back and check we get back what we put in in the first place
+        fs2 = type(fs).from_pycbc(pycbcfs)
+        nptest.assert_array_equal(fs.value, fs2.value)
+        self.assertQuantityEqual(fs.f0, fs2.f0)
+        self.assertQuantityEqual(fs.df, fs2.df)
+        self.assertIs(fs2.unit, units.dimensionless_unscaled)
+        # test copy=False
+        pycbcfs = fs.to_pycbc(copy=False)
+        assert may_share_memory(fs.value, pycbcfs.data)
+        fs2 = type(fs).from_pycbc(pycbcfs, copy=False)
+        assert may_share_memory(fs.value, fs2.value)
+        assert may_share_memory(fs2.value, pycbcfs.data)
 
     def test_read_write_hdf5(self):
         try:

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -31,7 +31,7 @@ from compat import (unittest, mock, HAS_H5PY)
 import pytest
 
 import numpy
-from numpy import testing as nptest
+from numpy import (may_share_memory, testing as nptest)
 
 from scipy import signal
 
@@ -349,6 +349,31 @@ class TimeSeriesTestMixin(object):
         self.assertEqual(lalts.sampleUnits, lal.DimensionlessUnit)
         ts2 = self.TEST_CLASS.from_lal(lalts)
         self.assertIs(ts2.unit, units.dimensionless_unscaled)
+
+    def test_to_from_pycbc(self):
+        try:
+            from pycbc.types import TimeSeries as PyCBCTimeSeries
+        except ImportError as e:
+            self.skipTest(str(e))
+        ts = self.create()
+        # test default conversion
+        pycbcts = ts.to_pycbc()
+        self.assertIsInstance(pycbcts, PyCBCTimeSeries)
+        nptest.assert_array_equal(ts.value, pycbcts.data)
+        self.assertEqual(ts.t0.value, pycbcts.start_time)
+        self.assertEqual(ts.dt.value, pycbcts.delta_t)
+        # go back and check we get back what we put in in the first place
+        ts2 = type(ts).from_pycbc(pycbcts)
+        nptest.assert_array_equal(ts.value, ts2.value)
+        self.assertQuantityEqual(ts.t0, ts2.t0)
+        self.assertQuantityEqual(ts.dt, ts2.dt)
+        self.assertIs(ts2.unit, units.dimensionless_unscaled)
+        # test copy=False
+        pycbcts = ts.to_pycbc(copy=False)
+        assert may_share_memory(ts.value, pycbcts.data)
+        ts2 = type(ts).from_pycbc(pycbcts, copy=False)
+        assert may_share_memory(ts.value, ts2.value)
+        assert may_share_memory(ts2.value, pycbcts.data)
 
     def test_io_identify(self):
         common.test_io_identify(self.TEST_CLASS, ['txt', 'hdf5', 'gwf'])

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -507,7 +507,7 @@ class TimeSeriesBase(Series):
         return lalts
 
     @classmethod
-    def from_pycbc(cls, ts):
+    def from_pycbc(cls, ts, copy=True):
         """Convert a `pycbc.types.timeseries.TimeSeries` into a `TimeSeries`
 
         Parameters
@@ -515,12 +515,15 @@ class TimeSeriesBase(Series):
         ts : `pycbc.types.timeseries.TimeSeries`
             the input PyCBC `~pycbc.types.timeseries.TimeSeries` array
 
+        copy : `bool`, optional, default: `True`
+            if `True`, copy these data to a new array
+
         Returns
         -------
         timeseries : `TimeSeries`
             a GWpy version of the input timeseries
         """
-        return cls(ts.data, epoch=ts.start_time, sample_rate=1/ts.delta_t)
+        return cls(ts.data, t0=ts.start_time, dt=ts.delta_t, copy=copy)
 
     def to_pycbc(self, copy=True):
         """Convert this `TimeSeries` into a PyCBC

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -522,7 +522,6 @@ class TimeSeriesBase(Series):
         """
         return cls(ts.data, epoch=ts.start_time, sample_rate=1/ts.delta_t)
 
-    @with_import('pycbc.types')
     def to_pycbc(self, copy=True):
         """Convert this `TimeSeries` into a PyCBC
         `~pycbc.types.timeseries.TimeSeries`
@@ -537,7 +536,8 @@ class TimeSeriesBase(Series):
         timeseries : `~pycbc.types.timeseries.TimeSeries`
             a PyCBC representation of this `TimeSeries`
         """
-        return types.TimeSeries(self.data,
+        from pycbc import types
+        return types.TimeSeries(self.value,
                                 delta_t=self.dt.to('s').value,
                                 epoch=self.epoch.gps, copy=copy)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ h5py>=1.3
 MySQL-python
 dqsegdb
 https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
+pycbc
 
 # docs
 sphinx


### PR DESCRIPTION
This PR fixes bugs and improves functionality in the `{TimeSeries,FrequencySeries}.{to,from}_pycbc` conversion methods, and the unit tests of those methods. This also adds a new example showing calculating the SNR for the GW150914 event detection.