### PR TITLE
Implemented abs instance method for Array objects

### DIFF
--- a/examples/timeseries/pycbc-snr.py
+++ b/examples/timeseries/pycbc-snr.py
@@ -69,7 +69,7 @@ import numpy
 from pycbc.filter import matched_filter
 snr = matched_filter(hp, zoom.to_pycbc(), psd=psd.to_pycbc(),
                      low_frequency_cutoff=15)
-snrts = numpy.abs(TimeSeries.from_pycbc(snr))
+snrts = TimeSeries.from_pycbc(snr).abs()
 
 # We can plot the SNR `TimeSeries` around the region of interest:
 plot = snrts.plot()

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -225,6 +225,12 @@ class CommonTests(object):
         ts2 = pickle.loads(pkl)
         self.assertArraysEqual(ts, ts2)
 
+    # -- test methods ---------------------------
+
+    def test_abs(self):
+        arr = self.create()
+        self.assertArraysEqual(arr.abs(), numpy.abs(arr))
+
     # -- test I/O -------------------------------
 
     def _test_read_write(self, format, extension=None, auto=True, exclude=[],

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -375,6 +375,10 @@ class Array(Quantity):
 
     # -- array methods --------------------------
 
+    def abs(self, axis=None, **kwargs):
+        return self._wrap_function(numpy.abs, axis, **kwargs)
+    abs.__doc__ = numpy.abs.__doc__
+
     def median(self, axis=None, **kwargs):
         return self._wrap_function(numpy.median, axis, **kwargs)
     median.__doc__ = numpy.median.__doc__


### PR DESCRIPTION
This PR implements the `Array.abs` instance method, using the underlying `numpy.abs` method, for convenience.