### PR TITLE
Attempt to fix travis timeout buildling LAL for python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
   # install full dependency list if not minimal build
   - >
     if [ "${MINIMAL}" != true ]; then
-        source .travis/build-src-dependencies.sh;
+        travis_wait source .travis/build-src-dependencies.sh;
         pip install ${PIP_FLAGS} -r requirements-dev.txt;
     fi
 


### PR DESCRIPTION
This PR attempts to fix the LAL build timeout for python3 by adding `travis_wait`.