### PR TITLE
Rework of NDS2 interface (gwpy.io.nds) (without segfault)

### DIFF
--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -34,7 +34,7 @@ from astropy import units
 from astropy.io import registry as io_registry
 
 try:
-    from ..io.nds import (NDS2_CHANNEL_TYPE, NDS2_CHANNEL_TYPESTR)
+    from ..io.nds2 import (NDS2_CHANNEL_TYPE, NDS2_CHANNEL_TYPESTR)
 except ImportError:
     NDS2_CHANNEL_TYPESTR = {
         1: 'online',
@@ -824,7 +824,7 @@ class ChannelList(list):
 
            A `host` is required if an open `connection` is not given
         """
-        from ..io.nds import (auth_connect, NDSWarning)
+        from ..io.nds2 import (auth_connect, NDSWarning)
         out = cls()
         # connect
         if connection is None:

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -26,7 +26,7 @@ import numpy
 import warnings
 import subprocess
 import sys
-from math import log
+from math import (log, ceil)
 
 from six import string_types
 
@@ -812,89 +812,44 @@ class ChannelList(list):
         return cls(map(Channel.from_nds2, ndschannels))
 
     @classmethod
-    @with_import('nds2')
-    def query_nds2_availability(cls, channels, start, end,
-                                host, port=None):
+    @io_nds2.open_connection
+    def query_nds2_availability(cls, channels, start, end, ctype=126,
+                                connection=None, host=None, port=None):
         """Query for when data are available for these channels in NDS2
 
         Parameters
         ----------
         channels : `list`
             list of `Channel` or `str` for which to search
+
         start : `int`
             GPS start time of search, or any acceptable input to
             :meth:`~gwpy.time.to_gps`
+
         end : `int`
             GPS end time of search, or any acceptable input to
             :meth:`~gwpy.time.to_gps`
-        host : `str`
-            name of NDS server
+
+        connection : `nds2.connection`, optional
+            open connection to an NDS(2) server, if not given, one will be
+            created based on ``host`` and ``port`` keywords
+
+        host : `str`, optional
+            name of NDS server host
+
         port : `int`, optional
             port number for NDS connection
 
         Returns
         -------
-        nested dict
-            a `dict` of (channel, `dict`) pairs where the nested `dict`
-            is over (frametype, SegmentList) segment-availability pairs
+        segdict : `~gwpy.segments.SegmentListDict`
+            dict of ``(name, SegmentList)`` pairs
         """
-        from ..segments import (Segment, SegmentList, SegmentListDict)
-        names = []
-        for c in channels:
-            name = str(c)
-            if isinstance(c, Channel) and c.sample_rate:
-                name += '%%%d' % c.sample_rate.value
-            names.append(name)
-
-        span = Segment(int(to_gps(start)), int(to_gps(end)))
-        # build nds2_channel_source call
-        cmd = ['nds2_channel_source', '-a',
-               '-s', str(span[0]),
-               '-n', host]
-        if port is not None:
-            cmd.extend(['-p', str(port)])
-        cmd.extend(names)
-        # call
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        out, err = proc.communicate()
-        retcode = proc.poll()
-        if retcode:
-            print(err, file=sys.stderr)
-            raise subprocess.CalledProcessError(retcode, ' '.join(cmd),
-                                                output=out)
-
-        # parse output
-        re_seg = re.compile('\A(?P<obs>[A-Z])-(?P<type>\w+):'
-                            '(?P<start>\d+)-(?P<end>(\d+|inf))\Z')
-        segs = {}
-        i = 0
-        for line in out.splitlines():
-            if line.startswith('Requested source list:'):
-                continue
-            elif line.startswith('Error in daq'):
-                raise RuntimeError(line)
-            elif not line.startswith(re.split('[,%]', names[i])[0]):
-                raise RuntimeError("Error parsing nds2_channel_source output")
-            chan = channels[i]
-            i += 1
-            segs[chan] = SegmentListDict()
-            for seg in line.split(' ', 1)[1].strip('{').rstrip('}').split(' '):
-                try:
-                    m = re_seg.search(seg).groupdict()
-                except AttributeError:
-                    if not seg:
-                        continue
-                    raise RuntimeError("Error parsing nds2_channel_source "
-                                       "output:\n%s" % line)
-                ftype = m['type']
-                try:
-                    seg = Segment(float(m['start']), float(m['end'])) & span
-                except ValueError:
-                    continue
-                if ftype in segs[chan]:
-                    segs[chan][ftype].append(seg)
-                else:
-                    segs[chan][ftype] = SegmentList([seg])
-            segs[chan].coalesce()
-        return segs
+        start = int(to_gps(start))
+        end = int(ceil(to_gps(end)))
+        chans = io_nds2.find_channels(channels, connection=connection,
+                                      unique=True, epoch=(start, end),
+                                      type=ctype)
+        availability = io_nds2.get_availability(chans, start, end,
+                                                connection=connection)
+        return type(availability)(zip(chans, availability.values()))

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -265,7 +265,7 @@ def auth_connect(host, port=None):
     try:
         connection = _connect()
     except RuntimeError as e:
-        if str(e).startswith('Request SASL authentication'):
+        if 'Request SASL authentication' in str(e):
             print('\nError authenticating against %s' % host,
                   file=sys.stderr)
             kinit()

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -51,6 +51,7 @@ DEFAULT_HOSTS = OrderedDict([
     ('C1', ('nds40.ligo.caltech.edu', 31200)),
     ('C0', ('nds40.ligo.caltech.edu', 31200))])
 
+
 # -- enums --------------------------------------------------------------------
 
 class Nds2Enum(enum.Enum):
@@ -71,6 +72,7 @@ NDS2_TYPE_NAME = {
     32: 'test-pt',
     64: 'static',
 }
+
 
 class Nds2ChannelType(Nds2Enum):
     """`~enum.Enum` of NDS2 channel types

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -153,24 +153,6 @@ class Nds2DataType(Nds2Enum):
 
 # -- warning suppression ------------------------------------------------------
 
-class NDSOutputContext(object):
-    def __init__(self, stdout=sys.stdout, stderr=sys.stderr):
-        self._stdout = stdout or sys.stdout
-        self._stderr = stderr or sys.stderr
-
-    def __enter__(self):
-        self.old_stdout, self.old_stderr = sys.stdout, sys.stderr
-        self.old_stdout.flush()
-        self.old_stderr.flush()
-        sys.stdout, sys.stderr = self._stdout, self._stderr
-
-    def __exit__(self, *args):
-        self._stdout.flush()
-        self._stderr.flush()
-        sys.stdout = self.old_stdout
-        sys.stderr = self.old_stderr
-
-
 class NDSWarning(UserWarning):
     pass
 

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -25,6 +25,7 @@ from __future__ import (absolute_import, print_function)
 import enum
 import operator
 import os
+import re
 import sys
 import warnings
 
@@ -37,6 +38,8 @@ from .kerberos import kinit
 from ..utils.compat import OrderedDict
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+NDS1_HOSTNAME = re.compile('[a-z]1nds[0-9]\Z')
 
 DEFAULT_HOSTS = OrderedDict([
     (None, ('nds.ligo.caltech.edu', 31200)),
@@ -233,6 +236,10 @@ def auth_connect(host, port=None):
     port : `int`, optional
         connection port
     """
+    # set default port for NDS1 connections (required, I think)
+    if port is None and NDS1_HOSTNAME.match(host):
+        port = 8088
+
     if port is None:
         def _connect():
             return nds2.connection(host)

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -20,7 +20,7 @@
 to LIGO data.
 """
 
-from __future__ import print_function
+from __future__ import (absolute_import, print_function)
 
 import os
 import sys

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -32,7 +32,12 @@ from functools import wraps
 
 import numpy
 
-import nds2
+try:
+    import nds2
+except ImportError:
+    HAS_NDS2 = False
+else:
+    HAS_NDS2 = True
 
 from ..time import to_gps
 from .kerberos import kinit
@@ -254,6 +259,9 @@ def auth_connect(host, port=None):
     port : `int`, optional
         connection port
     """
+    if not HAS_NDS2:
+        raise ImportError("No module named nds2")
+
     # set default port for NDS1 connections (required, I think)
     if port is None and NDS1_HOSTNAME.match(host):
         port = 8088

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -47,6 +47,8 @@ DEFAULT_HOSTS = OrderedDict([
     ('C1', ('nds40.ligo.caltech.edu', 31200)),
     ('C0', ('nds40.ligo.caltech.edu', 31200))])
 
+# -- enums --------------------------------------------------------------------
+
 class Nds2Enum(enum.Enum):
     """`~enum.Enum` providing `any` property with logical OR of members
     """
@@ -136,6 +138,8 @@ class Nds2DataType(Nds2Enum):
     UINT32 = 64
 
 
+# -- warning suppression ------------------------------------------------------
+
 class NDSOutputContext(object):
     def __init__(self, stdout=sys.stdout, stderr=sys.stderr):
         self._stdout = stdout or sys.stdout
@@ -160,6 +164,8 @@ class NDSWarning(UserWarning):
 
 warnings.simplefilter('always', NDSWarning)
 
+
+# -- connection utilities -----------------------------------------------------
 
 def host_resolution_order(ifo, env='NDSSERVER', epoch='now',
                           lookback=14*86400):

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -96,11 +96,11 @@ class Nds2ChannelType(Nds2Enum):
     def find(cls, name):
         try:
             return cls._member_map_[name]
-        except KeyError as e:
+        except KeyError:
             for ctype in cls._member_map_.values():
                 if ctype.name == name:
                     return ctype
-            raise e
+            raise
 
     UNKNOWN = 0
     ONLINE = 1
@@ -137,7 +137,7 @@ class Nds2DataType(Nds2Enum):
         except KeyError as e:
             dtype = numpy.dtype(dtype).type
             for ndstype in cls._member_map_.values():
-                if ndstype.numpy_dtype is dtype:
+                if ndstype.value and ndstype.numpy_dtype is dtype:
                     return ndstype
             raise e
 

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -30,6 +30,8 @@ import sys
 import warnings
 from functools import wraps
 
+from six.moves import reduce
+
 import numpy
 
 try:

--- a/gwpy/tests/compat.py
+++ b/gwpy/tests/compat.py
@@ -58,3 +58,10 @@ except ImportError:
     HAS_M2CRYPTO = False
 else:
     HAS_M2CRYPTO = True
+
+try:
+    import nds2
+except ImportError:
+    HAS_NDS2 = False
+else:
+    HAS_NDS2 = True

--- a/gwpy/tests/mockutils.py
+++ b/gwpy/tests/mockutils.py
@@ -97,7 +97,9 @@ def mock_nds2_channel(name, sample_rate, unit):
     channel.name = name
     channel.sample_rate = sample_rate
     channel.signal_units = unit
+    channel.channel_type = 2
     channel.channel_type_to_string.return_value = 'raw'
+    channel.data_type = 8
     return channel
 
 
@@ -109,7 +111,9 @@ def mock_nds2_connection(buffers):
     except AttributeError:
         # nds2-client < 0.12 doesn't have {get,set}_parameter
         pass
+    NdsConnection.get_host.return_value = 'nds.test.gwpy'
     NdsConnection.iterate.return_value = [buffers]
+    NdsConnection.find_channels.return_value = [b.channel for b in buffers]
     return NdsConnection
 
 

--- a/gwpy/tests/mockutils.py
+++ b/gwpy/tests/mockutils.py
@@ -103,7 +103,7 @@ def mock_nds2_channel(name, sample_rate, unit):
     return channel
 
 
-def mock_nds2_connection(buffers):
+def mock_nds2_connection(host='nds.test.gwpy', port=31200, buffers=[]):
     import nds2
     NdsConnection = mock.create_autospec(nds2.connection)
     try:
@@ -111,7 +111,8 @@ def mock_nds2_connection(buffers):
     except AttributeError:
         # nds2-client < 0.12 doesn't have {get,set}_parameter
         pass
-    NdsConnection.get_host.return_value = 'nds.test.gwpy'
+    NdsConnection.get_host.return_value = host
+    NdsConnection.get_port.return_value = int(port)
     NdsConnection.iterate.return_value = [buffers]
     NdsConnection.find_channels.return_value = [b.channel for b in buffers]
     return NdsConnection

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -31,6 +31,7 @@ from astropy import units
 
 from gwpy.detector import (Channel, ChannelList)
 from gwpy.detector.units import parse_unit
+from gwpy.segments import (Segment, SegmentList, SegmentListDict)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -286,6 +287,30 @@ class ChannelListTestCase(unittest.TestCase):
         except IOError as e:
             self.skipTest(str(e))
         self.assertEqual(len(cl), 5)
+
+    def test_query_nds2_availability(self):
+        try:
+            import nds2
+        except ImportError as e:
+            self.skipTest(str(e))
+        try:
+            from gwpy.io import kerberos
+            kerberos.which('kinit')
+        except ValueError as e:
+            self.skipTest(str(e))
+        try:
+            avail = ChannelList.query_nds2_availability(
+                self.REAL_CHANNELS[:1], 'Jan 1 2017', 'Jan 2 2017',
+                host=NDSHOST)
+        except RuntimeError as e:
+            self.skipTest(str(e))
+        self.assertIsInstance(avail, SegmentListDict)
+        self.assertListEqual(list(avail.values())[0],
+                             SegmentList([Segment(1167264018, 1167350418)]))
+        avail = ChannelList.query_nds2_availability(
+            self.REAL_CHANNELS[:1], 'Jan 1 2017', 'Jan 2 2017',
+            host=NDSHOST, ctype=1)
+        self.assertListEqual(list(avail.values())[0], SegmentList())
 
 
 if __name__ == '__main__':

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -117,7 +117,7 @@ class NdsIoTestCase(unittest.TestCase):
                   ('nds.ligo-la.caltech.edu', 31200),
                   ('nds.ligo.caltech.edu', 31200)])
 
-    unittest.skipUnless(HAS_NDS2, 'No module named nds2')
+    @unittest.skipUnless(HAS_NDS2, 'No module named nds2')
     def test_connect(self):
         import nds2
         nds_connection = mockutils.mock_nds2_connection(host='nds.test.gwpy')

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -45,20 +45,20 @@ class NdsIoTestCase(unittest.TestCase):
         """Test `host_resolution_order` with `None` IFO
         """
         try:
-            from gwpy.io import nds
+            from gwpy.io import nds2 as io_nds2
         except ImportError as e:
             self.skipTest(str(e))
-        hro = nds.host_resolution_order(None, env=None)
+        hro = io_nds2.host_resolution_order(None, env=None)
         self.assertListEqual(hro, [('nds.ligo.caltech.edu', 31200)])
 
     def test_nds2_host_order_ifo(self):
         """Test `host_resolution_order` with `ifo` argument
         """
         try:
-            from gwpy.io import nds
+            from gwpy.io import nds2 as io_nds2
         except ImportError as e:
             self.skipTest(str(e))
-        hro = nds.host_resolution_order('L1', env=None)
+        hro = io_nds2.host_resolution_order('L1', env=None)
         self.assertListEqual(
             hro, [('nds.ligo-la.caltech.edu', 31200),
                   ('nds.ligo.caltech.edu', 31200)])
@@ -67,15 +67,15 @@ class NdsIoTestCase(unittest.TestCase):
         """Test `host_resolution_order` with default env set
         """
         try:
-            from gwpy.io import nds
+            from gwpy.io import nds2 as io_nds2
         except ImportError as e:
             self.skipTest(str(e))
         os.environ['NDSSERVER'] = 'test1.ligo.org:80,test2.ligo.org:43'
-        hro = nds.host_resolution_order(None)
+        hro = io_nds2.host_resolution_order(None)
         self.assertListEqual(
             hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
                   ('nds.ligo.caltech.edu', 31200)])
-        hro = nds.host_resolution_order('L1')
+        hro = io_nds2.host_resolution_order('L1')
         self.assertListEqual(
             hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
                   ('nds.ligo-la.caltech.edu', 31200),
@@ -85,11 +85,11 @@ class NdsIoTestCase(unittest.TestCase):
         """Test `host_resolution_order` with non-default env set
         """
         try:
-            from gwpy.io import nds
+            from gwpy.io import nds2 as io_nds2
         except ImportError as e:
             self.skipTest(str(e))
         os.environ['TESTENV'] = 'test1.ligo.org:80,test2.ligo.org:43'
-        hro = nds.host_resolution_order(None, env='TESTENV')
+        hro = io_nds2.host_resolution_order(None, env='TESTENV')
         self.assertListEqual(
             hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
                   ('nds.ligo.caltech.edu', 31200)])
@@ -98,22 +98,22 @@ class NdsIoTestCase(unittest.TestCase):
         """Test `host_resolution_order` with old GPS epoch
         """
         try:
-            from gwpy.io import nds
+            from gwpy.io import nds2 as io_nds2
         except ImportError as e:
             self.skipTest(str(e))
         # test kwarg doesn't change anything
-        hro = nds.host_resolution_order('L1', epoch='now', env=None)
+        hro = io_nds2.host_resolution_order('L1', epoch='now', env=None)
         self.assertListEqual(
             hro, [('nds.ligo-la.caltech.edu', 31200),
                   ('nds.ligo.caltech.edu', 31200)])
         # test old epoch puts CIT ahead of LLO
-        hro = nds.host_resolution_order('L1', epoch='Jan 1 2015', env=None)
+        hro = io_nds2.host_resolution_order('L1', epoch='Jan 1 2015', env=None)
         self.assertListEqual(
             hro, [('nds.ligo.caltech.edu', 31200),
                   ('nds.ligo-la.caltech.edu', 31200)])
         # test epoch doesn't operate with env
         os.environ['TESTENV'] = 'test1.ligo.org:80,test2.ligo.org:43'
-        hro = nds.host_resolution_order('L1', epoch='now', env='TESTENV')
+        hro = io_nds2.host_resolution_order('L1', epoch='now', env='TESTENV')
         self.assertListEqual(
             hro, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
                   ('nds.ligo-la.caltech.edu', 31200),

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -62,20 +62,12 @@ class NdsIoTestCase(unittest.TestCase):
     def test_nds2_host_order_none(self):
         """Test `host_resolution_order` with `None` IFO
         """
-        try:
-            from gwpy.io import nds2 as io_nds2
-        except ImportError as e:
-            self.skipTest(str(e))
         hro = io_nds2.host_resolution_order(None, env=None)
         self.assertListEqual(hro, [('nds.ligo.caltech.edu', 31200)])
 
     def test_nds2_host_order_ifo(self):
         """Test `host_resolution_order` with `ifo` argument
         """
-        try:
-            from gwpy.io import nds2 as io_nds2
-        except ImportError as e:
-            self.skipTest(str(e))
         hro = io_nds2.host_resolution_order('L1', env=None)
         self.assertListEqual(
             hro, [('nds.ligo-la.caltech.edu', 31200),
@@ -84,10 +76,6 @@ class NdsIoTestCase(unittest.TestCase):
     def test_nds2_host_order_ndsserver(self):
         """Test `host_resolution_order` with default env set
         """
-        try:
-            from gwpy.io import nds2 as io_nds2
-        except ImportError as e:
-            self.skipTest(str(e))
         os.environ['NDSSERVER'] = 'test1.ligo.org:80,test2.ligo.org:43'
         hro = io_nds2.host_resolution_order(None)
         self.assertListEqual(
@@ -102,10 +90,6 @@ class NdsIoTestCase(unittest.TestCase):
     def test_nds2_host_order_env(self):
         """Test `host_resolution_order` with non-default env set
         """
-        try:
-            from gwpy.io import nds2 as io_nds2
-        except ImportError as e:
-            self.skipTest(str(e))
         os.environ['TESTENV'] = 'test1.ligo.org:80,test2.ligo.org:43'
         hro = io_nds2.host_resolution_order(None, env='TESTENV')
         self.assertListEqual(
@@ -115,10 +99,6 @@ class NdsIoTestCase(unittest.TestCase):
     def test_nds2_host_order_epoch(self):
         """Test `host_resolution_order` with old GPS epoch
         """
-        try:
-            from gwpy.io import nds2 as io_nds2
-        except ImportError as e:
-            self.skipTest(str(e))
         # test kwarg doesn't change anything
         hro = io_nds2.host_resolution_order('L1', epoch='now', env=None)
         self.assertListEqual(

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -42,6 +42,20 @@ TEST_CHANNELS = [
 
 class NdsIoTestCase(unittest.TestCase):
 
+    def test_channel_type_find(self):
+        self.assertIs(io_nds2.Nds2ChannelType.find('m-trend'),
+                      io_nds2.Nds2ChannelType.MTREND)
+        self.assertIs(io_nds2.Nds2ChannelType.find('MTREND'),
+                      io_nds2.Nds2ChannelType.MTREND)
+        self.assertRaises(KeyError, io_nds2.Nds2ChannelType.find, 'blah')
+
+    def test_data_type_find(self):
+        self.assertIs(io_nds2.Nds2DataType.find(float),
+                      io_nds2.Nds2DataType.FLOAT64)
+        self.assertIs(io_nds2.Nds2DataType.find('uint32'),
+                      io_nds2.Nds2DataType.UINT32)
+        self.assertRaises(TypeError, io_nds2.Nds2DataType.find, 'blah')
+
     def test_parse_nds_env(self):
         os.environ['NDSSERVER'] = 'test1.ligo.org:80,test2.ligo.org:43'
         hosts = io_nds2.parse_nds_env()

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -22,10 +22,10 @@
 import os
 
 from common import skip_missing_import
-from compat import (unittest, mock, HAS_LAL)
+from compat import (unittest, mock, HAS_LAL, HAS_NDS2)
 import mockutils
 
-from gwpy.io import (datafind, gwf)
+from gwpy.io import (datafind, gwf, nds2 as io_nds2)
 from gwpy.io.cache import (cache_segments, flatten, find_contiguous)
 from gwpy.segments import (Segment, SegmentList)
 
@@ -137,6 +137,22 @@ class NdsIoTestCase(unittest.TestCase):
                   ('nds.ligo-la.caltech.edu', 31200),
                   ('nds.ligo.caltech.edu', 31200)])
 
+    unittest.skipUnless(HAS_NDS2, 'No module named nds2')
+    def test_connect(self):
+        import nds2
+        nds_connection = mockutils.mock_nds2_connection(host='nds.test.gwpy')
+        with mock.patch('nds2.connection') as mock_connection:
+            mock_connection.return_value = nds_connection
+            conn = io_nds2.connect('nds.test.gwpy')
+            self.assertEqual(conn.get_host(), 'nds.test.gwpy')
+            self.assertEqual(conn.get_port(), 31200)
+        nds_connection = mockutils.mock_nds2_connection(host='nds2.test.gwpy',
+                                                        port=8088)
+        with mock.patch('nds2.connection') as mock_connection:
+            mock_connection.return_value = nds_connection
+            conn = io_nds2.connect('nds2.test.gwpy')
+            self.assertEqual(conn.get_host(), 'nds2.test.gwpy')
+            self.assertEqual(conn.get_port(), 8088)
 
 # -- gwpy.io.cache ------------------------------------------------------------
 

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -41,6 +41,24 @@ TEST_CHANNELS = [
 # -- gwpy.io.nds --------------------------------------------------------------
 
 class NdsIoTestCase(unittest.TestCase):
+
+    def test_parse_nds_env(self):
+        os.environ['NDSSERVER'] = 'test1.ligo.org:80,test2.ligo.org:43'
+        hosts = io_nds2.parse_nds_env()
+        self.assertListEqual(
+            hosts, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+        os.environ['NDSSERVER'] = ('test1.ligo.org:80,test2.ligo.org:43,'
+                                   'test.ligo.org,test2.ligo.org:43')
+        hosts = io_nds2.parse_nds_env()
+        self.assertListEqual(
+            hosts, [('test1.ligo.org', 80), ('test2.ligo.org', 43),
+                    ('test.ligo.org', None)])
+
+        os.environ['TESTENV'] = 'test1.ligo.org:80,test2.ligo.org:43'
+        hosts = io_nds2.parse_nds_env('TESTENV')
+        self.assertListEqual(
+            hosts, [('test1.ligo.org', 80), ('test2.ligo.org', 43)])
+
     def test_nds2_host_order_none(self):
         """Test `host_resolution_order` with `None` IFO
         """

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -388,7 +388,7 @@ class TimeSeriesTestMixin(object):
                 'X1:TEST', self.data, 1000000000, self.data.shape[0], 'm')
         except ImportError as e:
             self.skipTest(str(e))
-        nds_connection = mockutils.mock_nds2_connection([nds_buffer])
+        nds_connection = mockutils.mock_nds2_connection(buffers=[nds_buffer])
         with mock.patch('nds2.connection') as mock_connection, \
              mock.patch('nds2.buffer', nds_buffer):
             mock_connection.return_value = nds_connection

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -750,7 +750,7 @@ class TimeSeriesBaseDict(OrderedDict):
             from NDS.
         """
         from ..segments import (Segment, SegmentList)
-        from ..io import nds as ndsio
+        from ..io import nds2 as io_nds2
         # parse times
         start = to_gps(start)
         end = to_gps(end)
@@ -778,7 +778,7 @@ class TimeSeriesBaseDict(OrderedDict):
         if host is not None and port is not None and connection is None:
             if verbose:
                 gprint("Connecting to %s:%s..." % (host, port), end=' ')
-            connection = ndsio.auth_connect(host, port)
+            connection = io_nds2.auth_connect(host, port)
             if verbose:
                 gprint("Connected.")
         elif connection is not None and verbose:
@@ -791,7 +791,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 ifo = list(ifos)[0]
             else:
                 ifo = None
-            hostlist = ndsio.host_resolution_order(ifo, epoch=start)
+            hostlist = io_nds2.host_resolution_order(ifo, epoch=start)
             if allow_tape is None:
                 tapes = [False, True]
             else:
@@ -807,7 +807,7 @@ class TimeSeriesBaseDict(OrderedDict):
                         if verbose:
                             gprint('Something went wrong:', file=sys.stderr)
                             # if user supplied their own server, raise
-                            warnings.warn(str(e), ndsio.NDSWarning)
+                            warnings.warn(str(e), io_nds2.NDSWarning)
 
                 # if we got this far, we can't get all channels in one go
                 if len(channels) > 1:
@@ -834,7 +834,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 warnings.warn("This version of the nds2-client does not "
                               "support the allow_tape. This operation will "
                               "continue using whatever default is set by the "
-                              "target NDS server", ndsio.NDSWarning)
+                              "target NDS server", io_nds2.NDSWarning)
 
         # verify channels
         if verify:
@@ -842,7 +842,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 gprint("Checking channels against the NDS database...",
                        end=' ')
             else:
-                warnings.filterwarnings('ignore', category=ndsio.NDSWarning,
+                warnings.filterwarnings('ignore', category=io_nds2.NDSWarning,
                                         append=False)
             try:
                 qchannels = ChannelList.query_nds2(channels,
@@ -889,7 +889,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 segs = ChannelList.query_nds2_availability(
                     channels, istart, iend, host=connection.get_host())
             except (RuntimeError, CalledProcessError) as e:
-                warnings.warn(str(e), ndsio.NDSWarning)
+                warnings.warn(str(e), io_nds2.NDSWarning)
             else:
                 for channel in segs:
                     try:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -42,7 +42,6 @@ from __future__ import (division, print_function)
 import os
 import sys
 import warnings
-import re
 from math import ceil
 
 import numpy
@@ -51,7 +50,7 @@ from astropy import units
 
 from ..types import (Array2D, Series)
 from ..detector import (Channel, ChannelList)
-from ..io import (datafind, nds2 as io_nds2)
+from ..io import datafind
 from ..time import (Time, LIGOTimeGPS, to_gps)
 from ..utils import (gprint, with_import)
 from ..utils.compat import OrderedDict
@@ -225,7 +224,7 @@ class TimeSeriesBase(Series):
     @with_import('nds2')
     def fetch(cls, channel, start, end, host=None, port=None, verbose=False,
               connection=None, verify=False, pad=None, allow_tape=None,
-              type=io_nds2.Nds2ChannelType.any(), dtype=None):
+              type=None, dtype=None):
         """Fetch data from NDS
 
         Parameters
@@ -687,7 +686,7 @@ class TimeSeriesBaseDict(OrderedDict):
     @with_import('nds2')
     def fetch(cls, channels, start, end, host=None, port=None,
               verify=False, verbose=False, connection=None,
-              pad=None, allow_tape=None, type=io_nds2.Nds2ChannelType.any(),
+              pad=None, allow_tape=None, type=None,
               dtype=None):
         """Fetch data from NDS for a number of channels.
 
@@ -739,39 +738,19 @@ class TimeSeriesBaseDict(OrderedDict):
             a new `TimeSeriesBaseDict` of (`str`, `TimeSeries`) pairs fetched
             from NDS.
         """
-        from ..segments import (Segment, SegmentList)
         from ..io import nds2 as io_nds2
-        # parse times
-        start = to_gps(start)
-        end = to_gps(end)
-        istart = start.gpsSeconds
-        iend = ceil(end)
+        from .io.nds2 import (print_verbose, fetch)
 
-        # test S6 h(t) channel so that it gets ,rds appends
-        if any(re.match('[HL]1:LDAS-STRAIN\Z', str(c)) for c in channels):
-            verify = True
+        # -- open a connection ------------------
 
-        # parse dtype
-        if isinstance(dtype, (tuple, list)):
-            dtype = [numpy.dtype(r) if r is not None else None for r in dtype]
-            dtype = dict(zip(channels, dtype))
-        elif not isinstance(dtype, dict):
-            if dtype is not None:
-                dtype = numpy.dtype(dtype)
-            dtype = dict((channel, dtype) for channel in channels)
-
-        # open connection for specific host
-        if connection is None and host is not None:
-            if verbose:
-                gprint("Connecting to %s..." % host, end=' ')
+        # open connection to specific host
+        if host is not None and connection is None:
+            print_verbose("Opening new connection to {0}...".format(host),
+                          end=' ', verbose=verbose)
             connection = io_nds2.auth_connect(host, port)
-            if verbose:
-                gprint("Connected.")
-        elif connection is not None and verbose:
-            gprint("Received connection to %s:%d."
-                   % (connection.get_host(), connection.get_port()))
+            print_verbose('connected', verbose=verbose)
         # otherwise cycle through connections in logical order
-        if connection is None:
+        elif connection is None:
             ifos = set([Channel(channel).ifo for channel in channels])
             if len(ifos) == 1:
                 ifo = list(ifos)[0]
@@ -787,11 +766,12 @@ class TimeSeriesBaseDict(OrderedDict):
                     try:
                         return cls.fetch(channels, start, end, host=host,
                                          port=port, verbose=verbose, type=type,
-                                         verify=verify, dtype=dtype, pad=pad,
+                                         dtype=dtype, pad=pad,
                                          allow_tape=allow_tape)
                     except (RuntimeError, ValueError) as e:
                         if verbose:
-                            gprint('Something went wrong:', file=sys.stderr)
+                            print_verbose('something went wrong:',
+                                          file=sys.stderr, verbose=verbose)
                             # if user supplied their own server, raise
                             warnings.warn(str(e), io_nds2.NDSWarning)
 
@@ -810,140 +790,17 @@ class TimeSeriesBaseDict(OrderedDict):
                       "see detailed failures.")
             raise RuntimeError(e)
 
-        # at this point we must have an open connection, so we can proceed
-        # normally
+        # -- at this point we have an open connection, so perform fetch
 
-        if allow_tape is not None:
-            try:
-                connection.set_parameter('ALLOW_DATA_ON_TAPE', str(allow_tape))
-            except AttributeError:
-                warnings.warn("This version of the nds2-client does not "
-                              "support the allow_tape. This operation will "
-                              "continue using whatever default is set by the "
-                              "target NDS server", io_nds2.NDSWarning)
+        start = to_gps(start)
+        end = to_gps(end)
+        istart = int(start)
+        iend = int(ceil(end))
 
-        # verify channels
-        if verify:
-            if verbose:
-                gprint("Checking channels against the NDS database...",
-                       end=' ')
-            else:
-                warnings.filterwarnings('ignore', category=io_nds2.NDSWarning,
-                                        append=False)
-            try:
-                qchannels = ChannelList.query_nds2(channels,
-                                                   connection=connection,
-                                                   type=type, unique=True)
-            except ValueError as e:
-                try:
-                    channels2 = ['%s*' % c for c in map(str, channels)]
-                    qchannels = ChannelList.query_nds2(channels2,
-                                                       connection=connection,
-                                                       type=type, unique=True)
-                except ValueError:
-                    raise e
-            if verbose:
-                gprint("Complete.")
-            else:
-                warnings.filters.pop(0)
-        else:
-            qchannels = ChannelList(map(Channel, channels))
-
-        # test for minute trends
-        if (any([c.type == 'm-trend' for c in qchannels]) and
-                (start % 60 or end % 60)):
-            warnings.warn("Requested at least one minute trend, but "
-                          "start and stop GPS times are not modulo "
-                          "60-seconds (from GPS epoch). Times will be "
-                          "expanded outwards to compensate")
-            if start % 60:
-                start = int(start) // 60 * 60
-                istart = start
-            if end % 60:
-                end = int(end) // 60 * 60 + 60
-                iend = end
-            have_minute_trends = True
-        else:
-            have_minute_trends = False
-
-        # get segments for data
-        allsegs = SegmentList([Segment(istart, iend)])
-        qsegs = SegmentList([Segment(istart, iend)])
-        if pad is not None:
-            from subprocess import CalledProcessError
-            try:
-                segs = ChannelList.query_nds2_availability(
-                    channels, istart, iend, host=connection.get_host())
-            except (RuntimeError, CalledProcessError) as e:
-                warnings.warn(str(e), io_nds2.NDSWarning)
-            else:
-                for channel in segs:
-                    try:
-                        csegs = sorted(segs[channel].values(),
-                                       key=lambda x: abs(x))[-1]
-                    except IndexError:
-                        csegs = SegmentList([])
-                    qsegs &= csegs
-
-            if verbose:
-                gprint('Found %d viable segments of data with %.2f%% coverage'
-                       % (len(qsegs), abs(qsegs) / abs(allsegs) * 100))
-
-        out = cls()
-        for (istart, iend) in qsegs:
-            istart = int(istart)
-            iend = int(iend)
-            # fetch data
-            if verbose:
-                gprint('Downloading data... ', end='\r')
-
-            # determine buffer duration
-            data = connection.iterate(istart, iend,
-                                      [c.ndsname for c in qchannels])
-            nsteps = 0
-            i = 0
-            try:
-                for buffers in data:
-                    for buffer_, c in zip(buffers, channels):
-                        ts = cls.EntryClass.from_nds2_buffer(
-                            buffer_, dtype=dtype.get(c))
-                        out.append({c: ts}, pad=pad,
-                                   gap=pad is None and 'raise' or 'pad')
-                    if not nsteps:
-                        if have_minute_trends:
-                            dur = buffer_.length * 60
-                        else:
-                            dur = buffer_.length / buffer_.channel.sample_rate
-                        nsteps = ceil((iend - istart) / dur)
-                    i += 1
-                    if verbose:
-                        gprint('Downloading data... %d%%'
-                               % (100 * i // nsteps), end='\r')
-                        if i == nsteps:
-                            gprint('')
-            except RuntimeError as e:
-                if 'Requested data is on tape' in str(e) and not allow_tape:
-                    e.args = ('Requested data are on tape, set allow_tape=True'
-                              ' to allow access from tape. Please note that'
-                              ' retrieving data from tape is slow, and may'
-                              ' take several minutes or longer.',)
-                raise
-
-        # pad to end of request if required
-        if len(qsegs) and iend < float(end):
-            dt = float(end) - float(iend)
-            for channel in out:
-                nsamp = dt * out[channel].sample_rate.value
-                out[channel].append(
-                    numpy.ones(nsamp, dtype=out[channel].dtype) * pad)
-        # match request exactly
-        for channel in out:
-            if istart > start or iend < end:
-                out[channel] = out[channel].crop(start, end)
-
-        if verbose:
-            gprint('Success.')
-        return out
+        return fetch(channels, istart, iend, host=host,
+                     port=port, verbose=verbose, type=type,
+                     dtype=dtype, pad=pad,
+                     allow_tape=allow_tape).crop(start, end)
 
     @classmethod
     def find(cls, channels, start, end, frametype=None,

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -761,13 +761,9 @@ class TimeSeriesBaseDict(OrderedDict):
             dtype = dict((channel, dtype) for channel in channels)
 
         # open connection for specific host
-        if host and not port and re.match('[a-z]1nds[0-9]\Z', host):
-            port = 8088
-        elif host and not port:
-            port = 31200
-        if host is not None and port is not None and connection is None:
+        if connection is None and host is not None:
             if verbose:
-                gprint("Connecting to %s:%s..." % (host, port), end=' ')
+                gprint("Connecting to %s..." % host, end=' ')
             connection = io_nds2.auth_connect(host, port)
             if verbose:
                 gprint("Connected.")

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -49,19 +49,9 @@ import numpy
 
 from astropy import units
 
-try:
-    import nds2
-except ImportError:
-    NDS2_FETCH_TYPE_MASK = None
-else:
-    NDS2_FETCH_TYPE_MASK = (nds2.channel.CHANNEL_TYPE_RAW |
-                            nds2.channel.CHANNEL_TYPE_RDS |
-                            nds2.channel.CHANNEL_TYPE_TEST_POINT |
-                            nds2.channel.CHANNEL_TYPE_STATIC)
-
 from ..types import (Array2D, Series)
 from ..detector import (Channel, ChannelList)
-from ..io import datafind
+from ..io import (datafind, nds2 as io_nds2)
 from ..time import (Time, LIGOTimeGPS, to_gps)
 from ..utils import (gprint, with_import)
 from ..utils.compat import OrderedDict
@@ -235,7 +225,7 @@ class TimeSeriesBase(Series):
     @with_import('nds2')
     def fetch(cls, channel, start, end, host=None, port=None, verbose=False,
               connection=None, verify=False, pad=None, allow_tape=None,
-              type=NDS2_FETCH_TYPE_MASK, dtype=None):
+              type=io_nds2.Nds2ChannelType.any(), dtype=None):
         """Fetch data from NDS
 
         Parameters
@@ -697,7 +687,7 @@ class TimeSeriesBaseDict(OrderedDict):
     @with_import('nds2')
     def fetch(cls, channels, start, end, host=None, port=None,
               verify=False, verbose=False, connection=None,
-              pad=None, allow_tape=None, type=NDS2_FETCH_TYPE_MASK,
+              pad=None, allow_tape=None, type=io_nds2.Nds2ChannelType.any(),
               dtype=None):
         """Fetch data from NDS for a number of channels.
 

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""NDS2 data query routines for the TimeSeries
+"""
+
+import sys
+
+import operator
+import warnings
+from math import ceil
+
+from six.moves import reduce
+
+from ...io import nds2 as io_nds2
+from ...segments import (Segment, SegmentList)
+from ...utils import gprint
+from .. import (TimeSeries)
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+
+def print_verbose(*args, **kwargs):
+    if kwargs.pop('verbose', False):
+        gprint(*args, **kwargs)
+
+
+def parse_nds_enum_dict_param(channels, key, value):
+    enum = io_nds2.Nds2ChannelType if key == 'type' else io_nds2.Nds2DataType
+    default = enum.any()
+    # set default
+    if value is None:
+        value = default
+    # parse non-int enum representation
+    if not isinstance(value, (dict, int)):
+        value = enum.find(value).value
+    # return dict of ints
+    if isinstance(value, int):
+        return dict((c, value) for c in channels)
+    # here we know ``value`` is a dict, so just fill in the blanks
+    value = value.copy()
+    for chan in channels:
+        value.setdefault(chan, default)
+    return value
+
+
+@io_nds2.open_connection
+def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
+          connection=None, host=None, port=None, pad=None, verbose=False,
+          series_class=TimeSeries):
+
+    # set allow_tape parameter in connection
+    if allow_tape is not None:
+        try:
+            io_nds2.set_parameter(connection, 'ALLOW_DATA_ON_TAPE',
+                                  str(allow_tape))
+        except AttributeError:
+            warnings.warn("This version of the nds2-client does not "
+                          "support the allow_tape. This operation will "
+                          "continue using whatever default is set by the "
+                          "target NDS server", io_nds2.NDSWarning)
+
+    type = parse_nds_enum_dict_param(channels, 'type', type)
+    dtype = parse_nds_enum_dict_param(channels, 'dtype', dtype)
+
+    # verify channels exist
+    print_verbose("Checking channels list against NDS2 database...", end=' ',
+                  verbose=verbose)
+    utype = reduce(operator.or_, type.values())  # logical OR of types
+    udtype = reduce(operator.or_, dtype.values())
+    ndschannels = io_nds2.find_channels(channels, connection=connection,
+                                        type=utype, dtype=udtype, unique=True,
+                                        epoch=(start, end))
+    names = ['%s,%s' % (c.name, c.channel_type_to_string(c.channel_type)) for
+             c in ndschannels]
+    print_verbose('done', verbose=verbose)
+
+    # handle minute trend timing
+    if (any(c.endswith('m-trend') for c in names) and
+            (start % 60 or end % 60)):
+        warnings.warn("Requested at least one minute trend, but "
+                      "start and stop GPS times are not multiples of "
+                      "60. Times will be expanded outwards to compensate")
+        start, end = io_nds2.minute_trend_times(start, end)
+
+    # get data availability
+    span = SegmentList([Segment(start, end)])
+    if pad is None:
+        qsegs = span
+        gap = None
+    else:
+        print_verbose("Querying for data availability...", end=' ',
+                      verbose=verbose)
+        gap = 'pad'
+        qsegs = io_nds2.get_availability(
+            ndschannels, start, end, connection=connection).intersection()
+        qsegs &= span
+        print_verbose('done\nFound {0} viable segments of data with {1}%% '
+                      'coverage'.format(len(qsegs),
+                                        abs(qsegs) / abs(span) * 100),
+                      verbose=verbose)
+        if span - qsegs:
+            warnings.warn("Gaps were found in data available from {0}, "
+                          "but will be padded with {1}".format(
+                              connection.get_host(), pad))
+
+    # query for each segment
+    out = series_class.DictClass()
+    for seg in qsegs:
+        print_verbose("Downloading data... ", end='\r', verbose=verbose)
+        data = connection.iterate(int(seg[0]), int(seg[1]), names)
+        nsteps = i = 0
+        for i, buffers in enumerate(data):
+            for buffer_, c in zip(buffers, channels):
+                ts = series_class.from_nds2_buffer(buffer_)
+                out.append({c: ts}, pad=pad, gap=gap)
+            if not nsteps:  # work out how many chunks we're going to get
+                dur = int(buffer_.length / buffer_.channel.sample_rate)
+                nsteps = ceil((abs(seg) / dur))
+            print_verbose("Downloading data... {0}%%".format(
+                              100 * (i + 1) // nsteps),
+                          end='\r', verbose=verbose)
+        print_verbose('', verbose=verbose)
+
+    return out

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -36,10 +36,11 @@ from astropy.units import Quantity
 from astropy.io import registry as io_registry
 
 from .core import (TimeSeriesBase, TimeSeriesBaseDict, TimeSeriesBaseList,
-                   NDS2_FETCH_TYPE_MASK, as_series_dict_class)
+                   as_series_dict_class)
 from ..types import Array2D
 from ..detector import Channel
 from ..time import Time
+from ..io.nds2 import Nds2ChannelType
 
 if sys.version_info[0] < 3:
     range = xrange
@@ -586,7 +587,7 @@ class StateVector(TimeSeriesBase):
 
     @classmethod
     def fetch(cls, channel, start, end, bits=None, host=None, port=None,
-              verbose=False, connection=None, type=NDS2_FETCH_TYPE_MASK):
+              verbose=False, connection=None, type=Nds2ChannelType.any()):
         """Fetch data from NDS into a `StateVector`.
 
         Parameters

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,12 @@ try:
 except ImportError:
     install_requires.append('importlib>=1.0.3')
 
+# enum34 required for python < 3.4
+try:
+    import enum
+except ImportError:
+    install_requires.append('enum34')
+
 # -- set test dependencies ----------------------------------------------------
 
 setup_requires.append('pytest-runner')


### PR DESCRIPTION
This PR attempts to simplify the nds2 API by centralising more of the query methods in the `gwpy.io.nds2` module, hopefully reducing the complexity of methods for the `TimeSeries` and `Channel{List}`.

additionally, the `TimeSeries.fetch` method has been separated into two parts with a new `gwpy.timeseries.io.nds2` module providing the low-level iterate wrapper.

This is a duplicate of #456 just without the segmentation fault.