### PR TITLE
Fixed fetch tape bug

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -26,7 +26,7 @@ import tempfile
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import URLError
 
-from compat import (unittest, mock, HAS_H5PY)
+from compat import (unittest, mock, HAS_H5PY, HAS_NDS2)
 
 import pytest
 
@@ -382,12 +382,10 @@ class TimeSeriesTestMixin(object):
     def test_io_identify(self):
         common.test_io_identify(self.TEST_CLASS, ['txt', 'hdf5', 'gwf'])
 
+    @unittest.skipUnless(HAS_NDS2, 'No module named nds2')
     def test_fetch(self):
-        try:
-            nds_buffer = mockutils.mock_nds2_buffer(
-                'X1:TEST', self.data, 1000000000, self.data.shape[0], 'm')
-        except ImportError as e:
-            self.skipTest(str(e))
+        nds_buffer = mockutils.mock_nds2_buffer(
+            'X1:TEST', self.data, 1000000000, self.data.shape[0], 'm')
         nds_connection = mockutils.mock_nds2_connection(buffers=[nds_buffer])
         with mock.patch('nds2.connection') as mock_connection, \
              mock.patch('nds2.buffer', nds_buffer):

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -769,11 +769,9 @@ class TimeSeriesBaseDict(OrderedDict):
                                          dtype=dtype, pad=pad,
                                          allow_tape=allow_tape)
                     except (RuntimeError, ValueError) as e:
-                        if verbose:
-                            print_verbose('something went wrong:',
-                                          file=sys.stderr, verbose=verbose)
-                            # if user supplied their own server, raise
-                            warnings.warn(str(e), io_nds2.NDSWarning)
+                        print_verbose('something went wrong:',
+                                      file=sys.stderr, verbose=verbose)
+                        warnings.warn(str(e), io_nds2.NDSWarning)
 
                 # if we got this far, we can't get all channels in one go
                 if len(channels) > 1:

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -67,8 +67,7 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
     # set allow_tape parameter in connection
     if allow_tape is not None:
         try:
-            io_nds2.set_parameter(connection, 'ALLOW_DATA_ON_TAPE',
-                                  str(allow_tape))
+            connection.set_parameter('ALLOW_DATA_ON_TAPE', str(allow_tape))
         except AttributeError:
             warnings.warn("This version of the nds2-client does not "
                           "support the allow_tape. This operation will "


### PR DESCRIPTION
This PR fixes a bug introduced by #457 in `TimeSeries.fetch` when using `allow_tape` (in that `allow_tape` was being totally ignored).