### PR TITLE
Removed channel modifications in timeseries.io.gwf.framecpp

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -202,9 +202,6 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
                         series_class(arr, t0=dimstart+a*dx, dt=dx, name=name,
                                      channel=channel, unit=unit, copy=False),
                         requirements=['O'])
-                    # add information to channel
-                    ts.channel.sample_rate = ts.sample_rate.value
-                    ts.channel.unit = unit
                 else:
                     ts.append(arr)
         if ts is None:


### PR DESCRIPTION
This PR removes lines that modify channel objects in place when reading `TimeSeries` using frameCPP, as this can change the hash of that channel, which causes problems when that is a `dict` key.