### PR TITLE
Fixed typo in example text

### DIFF
--- a/examples/timeseries/pycbc-snr.py
+++ b/examples/timeseries/pycbc-snr.py
@@ -63,7 +63,7 @@ hp, _ = get_fd_waveform(approximant="IMRPhenomD", mass1=40, mass2=32,
 # At this point we are ready to calculate the SNR, so we import the
 # :func:`~pycbc.filter.matched_filter` method, and pass it our template,
 # the data, and the PSD, using the :meth:`~TimeSeries.to_pycbc` methods of
-# the `TimeSeries` and `~gwpy.frequencyseries.FrequencySeries objects:
+# the `TimeSeries` and `~gwpy.frequencyseries.FrequencySeries` objects:
 
 import numpy
 from pycbc.filter import matched_filter

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -202,9 +202,6 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
                         series_class(arr, t0=dimstart+a*dx, dt=dx, name=name,
                                      channel=channel, unit=unit, copy=False),
                         requirements=['O'])
-                    # add information to channel
-                    ts.channel.sample_rate = ts.sample_rate.value
-                    ts.channel.unit = unit
                 else:
                     ts.append(arr)
         if ts is None:


### PR DESCRIPTION
This PR fixes a trivial typo in the text for the pycbc SNR example.