### PR TITLE
Fixed missing minute_trend_times method

### DIFF
--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -465,3 +465,36 @@ def get_availability(channels, start, end,
         out[name] = SegmentList([Segment(s.gps_start, s.gps_stop) for s in
                                  result.simple_list()])
     return out
+
+
+def minute_trend_times(start, end):
+    """Expand a [start, end) interval for use in querying for minute trends
+
+    NDS2 requires start and end times for minute trends to be a multiple of
+    60 (to exactly match the time of a minute-trend sample), so this function
+    expands the given ``[start, end)`` interval to the nearest multiples.
+
+    Parameters
+    ----------
+    start : `int`
+        GPS start time of query
+
+    end : `int`
+        GPS end time of query
+
+    Returns
+    -------
+    mstart : `int`
+        ``start`` rounded down to nearest multiple of 60
+    mend : `int`
+        ``end`` rounded up to nearest multiple of 60
+    """
+    warnings.warn("Requested at least one minute trend, but "
+                  "start and stop GPS times are not modulo "
+                  "60-seconds (from GPS epoch). Times will be "
+                  "expanded outwards to compensate")
+    if start % 60:
+        start = int(start) // 60 * 60
+    if end % 60:
+        end = int(end) // 60 * 60 + 60
+    return int(start), int(end)

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -148,6 +148,16 @@ class NdsIoTestCase(unittest.TestCase):
             self.assertEqual(conn.get_host(), 'nds2.test.gwpy')
             self.assertEqual(conn.get_port(), 8088)
 
+    def test_minute_trend_times(self):
+        self.assertTupleEqual(io_nds2.minute_trend_times(0, 60), (0, 60))
+        self.assertTupleEqual(io_nds2.minute_trend_times(1, 60), (0, 60))
+        self.assertTupleEqual(io_nds2.minute_trend_times(0, 61), (0, 120))
+        self.assertTupleEqual(io_nds2.minute_trend_times(59, 61), (0, 120))
+        self.assertTupleEqual(
+            io_nds2.minute_trend_times(1167264018, 1198800018),
+            (1167264000, 1198800060))
+
+
 # -- gwpy.io.cache ------------------------------------------------------------
 
 class CacheIoTestCase(unittest.TestCase):

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -202,9 +202,6 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
                         series_class(arr, t0=dimstart+a*dx, dt=dx, name=name,
                                      channel=channel, unit=unit, copy=False),
                         requirements=['O'])
-                    # add information to channel
-                    ts.channel.sample_rate = ts.sample_rate.value
-                    ts.channel.unit = unit
                 else:
                     ts.append(arr)
         if ts is None:


### PR DESCRIPTION
This PR fixes #465 by adding the missing `gwpy.io.nds2.minute_trend_times` function that got forgotten in the confusion between #456 and #457, unit tests included.