### PR TITLE
Improved handling of Channels in TimeSeries I/O

### DIFF
--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -67,9 +67,15 @@ class CommonTests(object):
         try:
             return self._TEST_ARRAY
         except AttributeError:
+            # create array
             self._TEST_ARRAY = self.create(name=CHANNEL_NAME, unit='meter',
                                            channel=CHANNEL_NAME,
                                            epoch=GPS_EPOCH)
+            # customise channel a wee bit
+            #    used to test pickle/unpickle when storing channel as
+            #    dataset attr in HDF5
+            self._TEST_ARRAY.channel.sample_rate = 128
+            self._TEST_ARRAY.channel.unit = 'm'
             return self.TEST_ARRAY
 
     def create(self, *args, **kwargs):

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -200,11 +200,12 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
                     # create array - need require() to prevent segfault
                     ts = numpy.require(
                         series_class(arr, t0=dimstart+a*dx, dt=dx, name=name,
-                                     channel=channel, unit=unit, copy=False),
+                                     channel=name, unit=unit, copy=False),
                         requirements=['O'])
                     # add information to channel
                     ts.channel.sample_rate = ts.sample_rate.value
                     ts.channel.unit = unit
+                    ts.channel.dtype = ts.dtype
                 else:
                     ts.append(arr)
         if ts is None:

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -202,6 +202,9 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
                         series_class(arr, t0=dimstart+a*dx, dt=dx, name=name,
                                      channel=channel, unit=unit, copy=False),
                         requirements=['O'])
+                    # add information to channel
+                    ts.channel.sample_rate = ts.sample_rate.value
+                    ts.channel.unit = unit
                 else:
                     ts.append(arr)
         if ts is None:


### PR DESCRIPTION
This PR improves the reading/writing of `Channel` objects as part of `TimeSeries` I/O as follows

- read new `Channel` as part of `TimeSeries` from GWF
- use `pickle` to serialise/deserialise `Channel` as part of `TimeSeries` from HDF5

This reverts #463.