### PR TITLE
Workaround for unset tRange in GWF frames

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -164,7 +164,12 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
             except AttributeError:  # not proc channel
                 pass
             else:
-                if start and dataend < start:  # don't need this frame
+                if datastart == dataend:  # tRange not set
+                    # tRange is not required, so if it is 0, it may have been
+                    # omitted, rather than actually representing an empty
+                    # data set
+                    pass
+                elif start and dataend < start:  # don't need this frame
                     continue
             for vect in data.data:  # loop hopefully over single vector
                 # decompress data


### PR DESCRIPTION
This PR updates the frameCPP.py API to handle an unset `tRange` attribute in `FrProcData` structures. `tRange` is not required, so if it is set to 0 it might have been omitted, so carry on trying to read the frame; if the dataset is actually empty, that will get picked up further down the line.