### PR TITLE
TimeSeries.csd{_spectrogram}: fixed bugs introduced by v0.5

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -609,6 +609,14 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         self.assertEqual(sg.df, 4 * units.Hertz)
         self.assertEqual(sg.dt, 0.5 * units.second)
 
+        # check that `cross` keyword gets deprecated properly
+        # TODO: removed before 1.0 release
+        with pytest.warns(DeprecationWarning) as wng:
+            out = ts.spectrogram(0.5, fftlength=.25, cross=ts)
+        self.assertIn('`cross` keyword argument has been deprecated',
+                      wng[0].message.args[0])
+        self.assertArraysEqual(out, ts.csd_spectrogram(ts, 0.5, fftlength=.25))
+
     def test_spectrogram2(self):
         ts = self._read()
         # test defaults


### PR DESCRIPTION
This PR fixes bugs in the processing of cross spectra and spectrograms via `TimeSeries.csd` and (more importantly) `TimeSeries.csd_spectrogram.

In the process, I have depcrecated the `cross` keyword argument in `TimeSeries.spectrogram`, users should just use `TimeSeries.csd_spectrogram`, and added a test for the deprecation warning.