### PR TITLE
Improved whitening options for TimeSeries.q_transform

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -750,6 +750,16 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         self.assertTupleEqual(qspecgram.shape, (32000, 2560))
         self.assertAlmostEqual(qspecgram.q, 11.31370849898476)
         self.assertAlmostEqual(qspecgram.value.max(), 37.035843858490509)
+
+        # test whitening args
+        asd = ts.asd(2, 1)
+        qsg2 = ts.q_transform(method='welch', whiten=asd)
+        self.assertArraysEqual(qspecgram, qsg2)
+        asd = ts.asd(.5, .25)
+        qsg2 = ts.q_transform(method='welch', whiten=asd)
+        qsg3 = ts.q_transform(method='welch', fftlength=.5, overlap=.25)
+        self.assertArraysEqual(qsg2, qsg3)
+
         # make sure frequency too high presents warning
         with pytest.warns(UserWarning):
             qspecgram = ts.q_transform(method='welch', frange=(0, 10000))

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -759,6 +759,8 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         qsg2 = ts.q_transform(method='welch', whiten=asd)
         qsg3 = ts.q_transform(method='welch', fftlength=.5, overlap=.25)
         self.assertArraysEqual(qsg2, qsg3)
+        ts2 = ts.crop(ts.x0.value, ts.x0.value+1)
+        ts2.q_transform()
 
         # make sure frequency too high presents warning
         with pytest.warns(UserWarning):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1500,16 +1500,6 @@ class TimeSeries(TimeSeriesBase):
         specgram : `~gwpy.spectrogram.Spectrogram`
             output `Spectrogram` of normalised Q energy
 
-        Notes
-        -----
-        It is highly recommended to use the `outseg` keyword argument when
-        only a small window around a given GPS time is of interest. This
-        will speed up this method a little, but can greatly speed up
-        rendering the resulting `~gwpy.spectrogram.Spectrogram` using
-        `~matplotlib.axes.Axes.pcolormesh`.
-
-        If you aren't going to use `pcolormesh` in the end, don't worry.
-
         See Also
         --------
         TimeSeries.asd
@@ -1524,6 +1514,38 @@ class TimeSeries(TimeSeriesBase):
             cast all frequency rows to the same time-axis, and then
             `~scipy.interpolate.interpd` to apply the desired frequency
             resolution across the band.
+
+        Notes
+        -----
+        It is highly recommended to use the `outseg` keyword argument when
+        only a small window around a given GPS time is of interest. This
+        will speed up this method a little, but can greatly speed up
+        rendering the resulting `~gwpy.spectrogram.Spectrogram` using
+        `~matplotlib.axes.Axes.pcolormesh`.
+
+        If you aren't going to use `pcolormesh` in the end, don't worry.
+
+        Examples
+        --------
+        >>> from numpy.random import normal
+        >>> from scipy.signal import gausspulse
+        >>> from gwpy.timeseries import TimeSeries
+
+        Generate a `TimeSeries` containing Gaussian noise sampled at 4096 Hz,
+        centred on GPS time 0, with a sine-Gaussian pulse ('glitch') at
+        500 Hz:
+
+        >>> noise = TimeSeries(normal(loc=1, size=4096*4), sample_rate=4096, epoch=-2)
+        >>> glitch = TimeSeries(gausspulse(noise.times.value, fc=500) * 4, sample_rate=4096)
+        >>> data = noise + glitch
+
+        Compute and plot the Q-transform of these data:
+
+        >>> q = data.q_transform()
+        >>> plot = q.plot()
+        >>> plot.set_xlim(-.2, .2)
+        >>> plot.set_epoch(0)
+        >>> plot.show()
         """
         from scipy.interpolate import (interp2d, InterpolatedUnivariateSpline)
         from ..frequencyseries import FrequencySeries


### PR DESCRIPTION
This PR fixes #464 by improving the default whitening arguments (`fftlength`, `overlap`, `method`) for `TimeSeries.q_transform`.

It also adds support for users to supply their own whitening ASD, by passing `whiten=fs` where `fs` is a `gwpy.frequencyseries.FrequencySeries`, as described in the function docstring.