### PR TITLE
Improved docstrings and tests for gwpy.time

### DIFF
--- a/gwpy/tests/test_time.py
+++ b/gwpy/tests/test_time.py
@@ -21,14 +21,16 @@
 
 import datetime
 
-from compat import unittest
+from freezegun import freeze_time
 
+from compat import (unittest, mock)
+
+from astropy.time import Time
 from astropy.units import (UnitConversionError, Quantity)
 
-from gwpy import time
+from glue.lal import LIGOTimeGPS as GlueGPS
 
-DATE = datetime.datetime(2000, 1, 1, 0, 0)
-GPS = 630720013
+from gwpy import time
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -37,38 +39,74 @@ class TimeTests(unittest.TestCase):
     """`TestCase` for the time module
     """
     def test_to_gps(self):
-        # test datetime conversion
-        self.assertEqual(time.to_gps(DATE), GPS)
-        # test Time
-        self.assertEqual(
-            time.to_gps(DATE, format='datetime', scale='utc'), GPS)
-        # test tuple
-        self.assertEqual(time.to_gps(tuple(DATE.timetuple())[:6]), GPS)
-        # test Quantity
-        self.assertEqual(time.to_gps(Quantity(GPS, 's')), GPS)
-        # test errors
+        # str conversion
+        t = time.to_gps('Jan 1 2017')
+        self.assertIsInstance(t, time.LIGOTimeGPS)
+        self.assertEqual(t, 1167264018)
+        self.assertEqual(time.to_gps('Sep 14 2015 09:50:45.391'),
+                         time.LIGOTimeGPS(1126259462, 391000000))
+
+        # datetime conversion
+        self.assertEqual(time.to_gps(datetime.datetime(2017, 1, 1)), 1167264018)
+
+        # astropy.time.Time conversion
+        self.assertEqual(time.to_gps(Time(57754, format='mjd')), 1167264018)
+
+        # tuple
+        self.assertEqual(time.to_gps((2017, 1, 1)), 1167264018)
+
+        # Quantity
+        self.assertEqual(time.to_gps(Quantity(1167264018, 's')), 1167264018)
+
+        # keywords
+        with freeze_time('2015-09-14 09:50:45.391'):
+            self.assertEqual(time.to_gps('now'), 1126259462)
+            self.assertEqual(time.to_gps('today'), 1126224017)
+            self.assertEqual(time.to_gps('tomorrow'), 1126310417)
+            self.assertEqual(time.to_gps('yesterday'), 1126137617)
+
+        # errors
         self.assertRaises(UnitConversionError, time.to_gps, Quantity(1, 'm'))
-        self.assertRaises(ValueError, time.to_gps, 'random string')
+        with self.assertRaises(ValueError) as exc:
+            time.to_gps('random string')
+        self.assertIn('Cannot parse date string \'random string\': ',
+                      str(exc.exception))
 
     def test_from_gps(self):
-        date = time.from_gps(GPS)
-        self.assertEqual(date, DATE)
+        # basic
+        d = time.from_gps(1167264018)
+        self.assertIsInstance(d, datetime.datetime)
+        self.assertEqual(d, datetime.datetime(2017, 1, 1))
+
+        # str
+        self.assertEqual(time.from_gps('1167264018'),
+                         datetime.datetime(2017, 1, 1))
+
+        # float
+        self.assertEqual(time.from_gps(1126259462.391),
+                         datetime.datetime(2015, 9, 14, 9, 50, 45, 391000))
+        self.assertEqual(time.from_gps('1.13e9'),
+                         datetime.datetime(2015, 10, 27, 16, 53, 3))
+
+        # errors
+        self.assertRaises((RuntimeError, ValueError), time.from_gps, 'test')
 
     def test_tconvert(self):
         # from GPS
-        date = time.tconvert(GPS)
-        self.assertEqual(date, DATE)
+        self.assertEqual(time.tconvert(1126259462.391),
+                         datetime.datetime(2015, 9, 14, 9, 50, 45, 391000))
+
         # from GPS using LAL LIGOTimeGPS
-        try:
-            from lal import LIGOTimeGPS
-        except ImportError:
-            pass
-        else:
-            d = time.tconvert(LIGOTimeGPS(GPS))
-            self.assertEqual(d, DATE)
+        self.assertEqual(time.tconvert(time.LIGOTimeGPS(1126259462.391)),
+                         datetime.datetime(2015, 9, 14, 9, 50, 45, 391000))
+        self.assertEqual(time.tconvert(GlueGPS(1126259462.391)),
+                         datetime.datetime(2015, 9, 14, 9, 50, 45, 391000))
+
         # to GPS
-        gps = time.tconvert(date)
-        self.assertEqual(gps, GPS)
+        self.assertEqual(
+            time.tconvert(datetime.datetime(2015, 9, 14, 9, 50, 45, 391000)),
+            time.LIGOTimeGPS(1126259462, 391000000))
+
         # special cases
         now = time.tconvert()
         now2 = time.tconvert('now')

--- a/gwpy/tests/test_time.py
+++ b/gwpy/tests/test_time.py
@@ -28,8 +28,6 @@ from compat import (unittest, mock)
 from astropy.time import Time
 from astropy.units import (UnitConversionError, Quantity)
 
-from glue.lal import LIGOTimeGPS as GlueGPS
-
 from gwpy import time
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -99,8 +97,13 @@ class TimeTests(unittest.TestCase):
         # from GPS using LAL LIGOTimeGPS
         self.assertEqual(time.tconvert(time.LIGOTimeGPS(1126259462.391)),
                          datetime.datetime(2015, 9, 14, 9, 50, 45, 391000))
-        self.assertEqual(time.tconvert(GlueGPS(1126259462.391)),
-                         datetime.datetime(2015, 9, 14, 9, 50, 45, 391000))
+        try:
+            from glue.lal import LIGOTimeGPS as GlueGPS
+        except ImportError:
+            pass
+        else:
+            self.assertEqual(time.tconvert(GlueGPS(1126259462.391)),
+                             datetime.datetime(2015, 9, 14, 9, 50, 45, 391000))
 
         # to GPS
         self.assertEqual(

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -123,7 +123,10 @@ def to_gps(t, *args, **kwargs):
                 t = datetime.datetime.combine(t, datetime.time.min)
             t = Time(t, scale='utc')
         else:
-            return to_gps(UTCToGPS(t.timetuple()))
+            gps = to_gps(UTCToGPS(t.timetuple()))
+            if hasattr(t, 'microsecond'):
+                return gps + t.microsecond * 1e-6
+            return gps
     # and then into LIGOTimeGPS
     if isinstance(t, Time):
         return time_to_gps(t)
@@ -225,7 +228,7 @@ def str_to_datetime(datestr):
     else:
         try:
             date = dateparser.parse(datestr)
-        except TypeError as e:
+        except (ValueError, TypeError) as e:
             e.args = ("Cannot parse date string %r: %s"
                       % (datestr, e.args[0]),)
             raise

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -39,8 +39,8 @@ def tconvert(gpsordate='now'):
 
     Parameters
     ----------
-    gpsordate : `float`, `LIGOTimeGPS`, `Time`, `datetime.datetime`, ...
-        input gps or date to convert
+    gpsordate : `float`, `astropy.time.Time`, `datetime.datetime`, ...
+        input gps or date to convert, many input types are supported
 
     Returns
     -------
@@ -53,6 +53,30 @@ def tconvert(gpsordate='now'):
     it will get converted from GPS format into a
     `datetime.datetime`, otherwise the input will be converted
     into `LIGOTimeGPS`.
+
+    Examples
+    --------
+    Integers and floats are automatically converted from GPS to
+    `datetime.datetime`:
+
+    >>> from gwpy.time import tconvert
+    >>> tconvert(0)
+    datetime.datetime(1980, 1, 6, 0, 0)
+    >>> tconvert(1126259462.3910)
+    datetime.datetime(2015, 9, 14, 9, 50, 45, 391000)
+
+    while strings are automatically converted to `~gwpy.time.LIGOTimeGPS`:
+
+    >>> to_gps('Sep 14 2015 09:50:45.391')
+    LIGOTimeGPS(1126259462, 391000000)
+
+    Additionally, a few special-case words as supported, which all return
+    `~gwpy.time.LIGOTimeGPS`:
+
+    >>> tconvert('now')
+    >>> tconvert('today')
+    >>> tconvert('tomorrow')
+    >>> tconvert('yesterday')
     """
     # convert from GPS into datetime
     try:
@@ -95,6 +119,21 @@ def to_gps(t, *args, **kwargs):
     ValueError
         if the input cannot be cast as a `~astropy.time.Time` or
         `LIGOTimeGPS`.
+
+    Examples
+    --------
+    >>> to_gps('Jan 1 2017')
+    LIGOTimeGPS(1167264018, 0)
+    >>> to_gps('Sep 14 2015 09:50:45.391')
+    LIGOTimeGPS(1126259462, 391000000)
+
+    >>> import datetime
+    >>> to_gps(datetime.datetime(2017, 1, 1))
+    LIGOTimeGPS(1167264018, 0)
+
+    >>> from astropy.time import Time
+    >>> to_gps(Time(57754, format='mjd'))
+    LIGOTimeGPS(1167264018, 0)
     """
     # allow Time conversion to override type-checking
     if args or kwargs:
@@ -138,17 +177,24 @@ def to_gps(t, *args, **kwargs):
 
 
 def from_gps(gps):
-    """Convert a GPS time into a `datetime.datetime`.
+    """Convert a GPS time into a `datetime.datetime`
 
     Parameters
     ----------
-    gps : `LIGOTimeGPS`
+    gps : `LIGOTimeGPS`, `int`, `float`
         GPS time to convert
 
     Returns
     -------
     datetime : `datetime.datetime`
         ISO-format datetime equivalent of input GPS time
+
+    Examples
+    --------
+    >>> from_gps(1167264018)
+    datetime.datetime(2017, 1, 1, 0, 0)
+    >>> from_gps(1126259462.3910)
+    datetime.datetime(2015, 9, 14, 9, 50, 45, 391000)
     """
     try:
         gps = LIGOTimeGPS(gps)

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -230,10 +230,13 @@ def time_to_gps(t):
     t = t.utc
     dt = t.datetime
     gps = t.gps
+    # if datetime format has zero microseconds, force int(gps) to remove
+    # floating point precision errors from gps
     if ((isinstance(dt, datetime.datetime) and not dt.microsecond) or
             type(dt) is datetime.date):
-        gps = int(gps)
-    return LIGOTimeGPS(gps)
+        return LIGOTimeGPS(int(gps))
+    # use repr() to remove hidden floating point precision problems
+    return LIGOTimeGPS(repr(gps))
 
 
 def str_to_datetime(datestr):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,3 +23,4 @@ pytest>=2.8
 coveralls
 unittest2
 mock
+freezegun

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ extras_require['all'] = set(p for extra in extras_require.values()
 try:
     import lal
 except ImportError as e:
-    install_requires.append('ligotimegps')
+    install_requires.append('ligotimegps>=1.1')
 
 # test for OrderedDict
 try:

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ except ImportError:
 setup_requires.append('pytest-runner')
 tests_require = [
     'pytest>=2.8',
+    'freezegun',
 ]
 if sys.version < '3':
     tests_require.append('mock')


### PR DESCRIPTION
This PR adds `Examples` to all docstrings in `gwpy.time`, and updates the unit tests to be more complete.

This adds a new testing dependency on [`freezegun`](https://pypi.python.org/pypi/freezegun).