### PR TITLE
Removed travis_wait from travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_install:
   # install full dependency list if not minimal build
   - >
     if [ "${MINIMAL}" != true ]; then
-        travis_wait source .travis/build-src-dependencies.sh;
+        source .travis/build-src-dependencies.sh;
         pip install ${PIP_FLAGS} -r requirements-dev.txt;
     fi
 


### PR DESCRIPTION
This PR removes the `travis_wait` prefix for the src builds on travis-ci.org, this was causing 20-minute timeouts on a lot of builds.