### PR TITLE
Fixed bug in output type for TimeSeriesDict.fetch

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -391,8 +391,9 @@ class TimeSeriesTestMixin(object):
              mock.patch('nds2.buffer', nds_buffer):
             mock_connection.return_value = nds_connection
             # use verbose=True to hit more lines
-            ts = TimeSeries.fetch('X1:TEST', 1000000000, 1000000001,
+            ts = self.TEST_CLASS.fetch('X1:TEST', 1000000000, 1000000001,
                                   verbose=True)
+        self.assertIsInstance(ts, self.TEST_CLASS)
         nptest.assert_array_equal(ts.value, self.data)
         self.assertEqual(ts.sample_rate, self.data.shape[0] * units.Hz)
         self.assertTupleEqual(ts.span, (1000000000, 1000000001))

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -797,8 +797,8 @@ class TimeSeriesBaseDict(OrderedDict):
 
         return fetch(channels, istart, iend, host=host,
                      port=port, verbose=verbose, type=type,
-                     dtype=dtype, pad=pad,
-                     allow_tape=allow_tape).crop(start, end)
+                     dtype=dtype, pad=pad, allow_tape=allow_tape,
+                     series_class=cls.EntryClass).crop(start, end)
 
     @classmethod
     def find(cls, channels, start, end, frametype=None,


### PR DESCRIPTION
This PR fixes a bug in `TimeSeriesDict.fetch` introduced by #457 by actually using the `series_class` keyword of the `gwpy.timeseries.io.nds2.fetch` method (that does the actual query). This is required to get a `StateVector` back from `StateVector.fetch`.