### PR TITLE
Check FrVect name when reading GWF with frameCPP

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -172,6 +172,11 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
                 elif start and dataend < start:  # don't need this frame
                     continue
             for vect in data.data:  # loop hopefully over single vector
+                # only read FrVect with matching name
+                #    frame spec allows for arbitrary other FrVects
+                #    to hold other information
+                if vect.GetName() != name:
+                    continue
                 # decompress data
                 arr = vect.GetDataArray()
                 dim = vect.GetDim(0)


### PR DESCRIPTION
This PR adds filtering on the `Name` attribute of an `FrVect`, fixing an issue reading some `V1_llhoft` frames whereby two `FrVect`s were being stored in a single `FrProcData`, and only one of which actually contained channel data.