### PR TITLE
Use trusty dist for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+sudo: false
+dist: trusty
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
This PR forces the travis-ci build to use the (beta) `dist: trusty` option, which should prevent src build timeouts (LAL etc).