### PR TITLE
Fixed bug in typecasting when reading GWF data into TimeSeries

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -220,6 +220,13 @@ class TimeSeriesTestMixin(object):
         t = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel, format='gwf',
                                  end=end)
         self.assertTupleEqual(t.span, (TEST_SEGMENT[0], end))
+        # check type casting works
+        t = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel, format='gwf',
+                                 end=end, dtype='float32')
+        self.assertEqual(t.dtype, numpy.dtype('float32'))
+        t = self.TEST_CLASS.read(TEST_GWF_FILE, self.channel, format='gwf',
+                                 end=end, dtype={self.channel: 'float64'})
+        self.assertEqual(t.dtype, numpy.dtype('float64'))
         # check errors
         self.assertRaises((ValueError, RuntimeError), self.TEST_CLASS.read,
                           TEST_GWF_FILE, self.channel, format='gwf',

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -256,7 +256,8 @@ def register_gwf_api(library):
             if (resample.get(name) and
                     resample[name] != out[name].sample_rate.value):
                 out[name] = out[name].resample(resample[name])
-            if dtype.get(name) and numpy.dtype(dtype[name]) != out[name].dtype:
+            if dtype.get(name) is not None and (
+                    numpy.dtype(dtype[name]) != out[name].dtype):
                 out[name] = out[name].astype(dtype[name])
         return out
 


### PR DESCRIPTION
This PR fixes a bug in casting a `TimeSeries` to another data type as part of reading from GWF.