### PR TITLE
Improved tex escaping of strings for labelling

### DIFF
--- a/gwpy/plotter/tex.py
+++ b/gwpy/plotter/tex.py
@@ -144,18 +144,18 @@ def unit_to_latex(unit):
             positives, negatives = unit_utils.get_grouped_by_powers(
                 unit.bases, unit.powers)
             if len(negatives) == 1:
-                negatives = format_unit_list(negatives)
-                positives = positives and format_unit_list(positives) or 1
+                negatives = _format_unit_list(negatives)
+                positives = positives and _format_unit_list(positives) or 1
                 s += r'{0}/{1}'.format(positives, negatives)
             elif len(negatives):
                 if len(positives):
-                    positives = format_unit_list(positives)
+                    positives = _format_unit_list(positives)
                 else:
                     positives = ''
-                negatives = format_unit_list(negatives, negative=True)
+                negatives = _format_unit_list(negatives, negative=True)
                 s += r'{0}\,{1}'.format(positives, negatives)
             else:
-                positives = format_unit_list(positives)
+                positives = _format_unit_list(positives)
                 s += positives
     elif isinstance(unit, units.UnitBase):
         return s.to_string('latex_inline')
@@ -167,7 +167,7 @@ def unit_to_latex(unit):
         return ''
 
 
-def format_unit_list(unitlist, negative=False):
+def _format_unit_list(unitlist, negative=False):
     from astropy.units.format import latex
 
     out = []

--- a/gwpy/plotter/tex.py
+++ b/gwpy/plotter/tex.py
@@ -24,7 +24,7 @@ from __future__ import division
 import os
 import re
 
-__author__ = "Duncan M. Macleod <duncan.macleod@ligo.org>"
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 # -- tex configuration --------------------------------------------------------
 
@@ -61,8 +61,15 @@ def float_to_latex(x, format="%.2g"):
 
     Examples
     --------
+    >>> from gwpy.plotter.tex import float_to_latex
+    >>> float_to_latex(1)
+    '1'
     >>> float_to_latex(2000)
     '2\times 10^{3}'
+    >>> float_to_latex(100)
+    '10^{2}'
+    >>> float_to_latex(-500)
+    r'-5\!\!\times\!\!10^{2}'
     """
     base_str = format % x
     if "e" not in base_str:
@@ -128,6 +135,26 @@ def label_to_latex(text):
 
 
 def unit_to_latex(unit):
+    """Convert a `~astropy.units.Unit` to a latex string
+
+    Parameters
+    ----------
+    unit : `~astropy.units.Unit`
+        input unit to represent
+
+    Returns
+    -------
+    tex : `str`
+        a tex-formatted version of the unit
+
+    Examples
+    --------
+    >>> from gwpy.plotter.tex import unit_to_latex
+    >>> unit_to_latex(units.Hertz)
+    '$\mathrm{Hz}$'
+    >>> unit_to_latex(units.Volt.decompose())
+    '$\mathrm{m^{2}\,kg\,A^{-1}\,s^{-3}}$'
+    """
     from astropy import units
     from astropy.units.format import utils as unit_utils
 

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -809,9 +809,13 @@ class TexTestCase(Mixin, unittest.TestCase):
         self.assertRaises(TypeError, float_to_latex, '1')
 
     def test_label_to_latex(self):
+        self.assertEqual(label_to_latex(None), '')
+        self.assertEqual(label_to_latex(''), '')
         self.assertEqual(label_to_latex('Test'), 'Test')
         self.assertEqual(label_to_latex('Test_with_underscore'),
                          r'Test\_with\_underscore')
+        self.assertEqual(label_to_latex(r'Test_with\_escaped\%characters'),
+                         r'Test\_with\_escaped\%characters')
 
     def test_unit_to_latex(self):
         t = unit_to_latex(units.Hertz)


### PR DESCRIPTION
This PR improves the `gwpy.plotter.tex.label_to_latex` method used to escape LaTeX control characters in labels for plotting. The behaviour now is to avoid doubly-escaping already escaped strings. See the new function documentation for examples.

This PR also includes improvements to the documentation of the other public methods in the `gwpy.plotter.tex` module.