### PR TITLE
Improved parsing of filenames with non-integer GPS times

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -161,7 +161,7 @@ def file_segment(filename):
             e.args = ('Failed to parse %r as LIGO-T050017-compatible filename'
                       % filename,)
             raise
-        s = int(s)
+        s = float(s)
         e = int(e.split('.')[0])
         return Segment(s, s+e)
 

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -155,7 +155,12 @@ def file_segment(filename):
     except AttributeError:  # otherwise parse from T050017 spec
         from ..segments import Segment
         base = os.path.basename(filename)
-        _, _, s, e = base.split('-')
+        try:
+            _, _, s, e = base.split('-')
+        except ValueError as e:
+            e.args = ('Failed to parse %r as LIGO-T050017-compatible filename'
+                      % filename,)
+            raise
         s = int(s)
         e = int(e.split('.')[0])
         return Segment(s, s+e)

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -33,7 +33,7 @@ from gwpy.segments import (Segment, SegmentList)
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 TEST_GWF_FILE = os.path.join(os.path.split(__file__)[0], 'data',
-                          'HLV-GW100916-968654552-1.gwf')
+                             'HLV-GW100916-968654552-1.gwf')
 TEST_CHANNELS = [
     'H1:LDAS-STRAIN', 'L1:LDAS-STRAIN', 'V1:h_16384Hz',
 ]
@@ -223,6 +223,7 @@ class CacheIoTestCase(unittest.TestCase):
 
 def mock_call(*args, **kwargs):
     raise OSError("")
+
 
 class GwfIoTestCase(unittest.TestCase):
 

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -26,7 +26,8 @@ from compat import (unittest, mock, HAS_LAL, HAS_NDS2)
 import mockutils
 
 from gwpy.io import (datafind, gwf, nds2 as io_nds2)
-from gwpy.io.cache import (cache_segments, flatten, find_contiguous)
+from gwpy.io.cache import (cache_segments, flatten, find_contiguous,
+                           file_segment)
 from gwpy.segments import (Segment, SegmentList)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -187,6 +188,17 @@ class CacheIoTestCase(unittest.TestCase):
         self.assertEquals(sl, segs)
         sl = cache_segments(cache[:2], cache[2:])
         self.assertEquals(sl, segs)
+
+    def test_file_segment(self):
+        self.assertTupleEqual(file_segment('A-B-1-2.ext'), (1, 3))
+        self.assertTupleEqual(file_segment('A-B-1-2.ext.gz'), (1, 3))
+        self.assertTupleEqual(file_segment('A-B-1.23-4.ext.gz'), (1.23, 5.23))
+        # test errors
+        with self.assertRaises(ValueError) as exc:
+            file_segment('blah')
+        self.assertEqual(
+            'Failed to parse \'blah\' as LIGO-T050017-compatible filename',
+            str(exc.exception))
 
     def test_flatten(self):
         # check flattened version of single cache is unchanged


### PR DESCRIPTION
This PR updates the `gwpy.io.cache.cache_segments` method to handle non-integer (i.e. `float`) GPS times in filename strings. This is required to handle PyCBC Live filenames where the are bending the rules of LIGO-T050017.