### PR TITLE
Fixed bug in handling open connection in TimeSeriesDict.fetch

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -399,7 +399,10 @@ class TimeSeriesTestMixin(object):
             mock_connection.return_value = nds_connection
             # use verbose=True to hit more lines
             ts = self.TEST_CLASS.fetch('X1:TEST', 1000000000, 1000000001,
-                                  verbose=True)
+                                       verbose=True)
+            # check open connection works
+            ts = self.TEST_CLASS.fetch('X1:TEST', 1000000000, 1000000001,
+                                       connection=nds_connection, verbose=True)
         self.assertIsInstance(ts, self.TEST_CLASS)
         nptest.assert_array_equal(ts.value, self.data)
         self.assertEqual(ts.sample_rate, self.data.shape[0] * units.Hz)

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -744,7 +744,7 @@ class TimeSeriesBaseDict(OrderedDict):
         # -- open a connection ------------------
 
         # open connection to specific host
-        if host is not None and connection is None:
+        if connection is None and host is not None:
             print_verbose("Opening new connection to {0}...".format(host),
                           end=' ', verbose=verbose)
             connection = io_nds2.auth_connect(host, port)
@@ -795,8 +795,8 @@ class TimeSeriesBaseDict(OrderedDict):
         istart = int(start)
         iend = int(ceil(end))
 
-        return fetch(channels, istart, iend, host=host,
-                     port=port, verbose=verbose, type=type,
+        return fetch(channels, istart, iend, connection=connection,
+                     host=host, port=port, verbose=verbose, type=type,
                      dtype=dtype, pad=pad, allow_tape=allow_tape,
                      series_class=cls.EntryClass).crop(start, end)
 


### PR DESCRIPTION
This PR fixes (and adds a regression test for) a bug in `TimeSeriesDict.fetch` whereby an open `nds2.connection` passed by the user would be recognised such that a host/port pair weren't generated, but then not passed to the underlying core `fetch()` method, causing a `TypeError` or similar trying to handle the NDS2 host `None`.