### PR TITLE
Improve empty() file checker for pycbc io

### DIFF
--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -154,7 +154,7 @@ def empty_hdf5_file(h5f, ifo=None):
     h5f = h5f.file
     if list(h5f) == []:
         return True
-    if ifo is not None and list(h5f[ifo]) == ['psd']:
+    if ifo is not None and (ifo not in h5f or list(h5f[ifo]) == ['psd']):
         return True
     return False
 


### PR DESCRIPTION
This PR patches the `table.io.pycbc.empty_hdf5_file` to return `True` (i.e. 'empty') if there isn't a group for the given `ifo`. Previously if there were groups for other IFOs, the function would then try to `list()` the given one, which meant if it didn't exist, you would end up with a `KeyError`.