### PR TITLE
Clean up of gwpy.signal.fft.ui

### DIFF
--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -33,7 +33,8 @@ if HAS_LAL:
 
 from gwpy import signal as gwpy_signal
 from gwpy.signal.fft import (lal as fft_lal, utils as fft_utils,
-                             registry as fft_registry)
+                             registry as fft_registry, ui as fft_ui)
+from gwpy.timeseries import TimeSeries
 
 ONE_HZ = units.Quantity(1, 'Hz')
 
@@ -114,6 +115,23 @@ class FFTRegistryTests(unittest.TestCase):
             '============ =================================\n\n'
             'See :ref:`gwpy-signal-fft` for more details\n',
         )
+
+
+# -- gwpy.signal.fft.ui -------------------------------------------------------
+
+class FFTUITests(unittest.TestCase):
+    def test_seconds_to_samples(self):
+        self.assertEqual(fft_ui.seconds_to_samples(4, 256), 1024)
+        self.assertEqual(fft_ui.seconds_to_samples(1 * units.minute, 16), 960)
+        self.assertEqual(fft_ui.seconds_to_samples(
+            4 * units.second, 16.384 * units.kiloHertz), 65536)
+
+    def test_normalize_fft_params(self):
+        self.assertDictEqual(
+            fft_ui.normalize_fft_params(
+                TimeSeries(numpy.zeros(1024), sample_rate=256)),
+            {'nfft': 1024, 'noverlap': 0})
+
 
 # -- gwpy.signal.fft.utils ----------------------------------------------------
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -533,7 +533,11 @@ class TimeSeries(TimeSeriesBase):
         a triangular window centred on that chunk which most overlaps the
         given `Spectrogram` time sample.
         """
-        return fft_ui.spectrogram(self, fftlength=fftlength, overlap=overlap,
+        # set kwargs for periodogram()
+        kwargs.setdefault('fs', self.sample_rate.to('Hz').value)
+        # run
+        return fft_ui.spectrogram(self, signal.periodogram,
+                                  fftlength=fftlength, overlap=overlap,
                                   **kwargs)
 
     def fftgram(self, stride):


### PR DESCRIPTION
This PR cleans up the `gwpy.signal.fft.ui` module a wee bit, mainly with reference to hacky checks that we're not including the wrong kwargs in 'rayleigh' or other methods.