### PR TITLE
Added gwpy.signal.window module to help with FFT routines

### DIFF
--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -294,9 +294,6 @@ def bartlett(timeseries, segmentlength, noverlap=None, window=None, plan=None):
     --------
     lal.REAL8AverageSpectrumWelch
     """
-    if noverlap:
-        raise TypeError("bartlett() got an unexpected keyword argument "
-                        "'noverlap'")
     return _lal_spectrum(timeseries, segmentlength, noverlap=0,
                          method='welch', window=window, plan=plan)
 

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -34,7 +34,7 @@ from astropy.units import Quantity
 
 from . import utils as fft_utils
 from ...utils import mp as mp_utils
-from ..window import recommended_overlap
+from ..window import (canonical_name, recommended_overlap)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -102,6 +102,10 @@ def normalize_fft_params(series, kwargs={}):
     samp = series.sample_rate
     fftlength = kwargs.pop('fftlength', None)
     overlap = kwargs.pop('overlap', None)
+
+    # get canonical window name
+    if isinstance(kwargs.get('window', None), str):
+        kwargs['window'] = canonical_name(kwargs['window'])
 
     # fftlength -> nfft
     if fftlength is None:

--- a/gwpy/signal/window.py
+++ b/gwpy/signal/window.py
@@ -70,6 +70,7 @@ ROV = {
     'triang': .5
 }
 
+
 def recommended_overlap(name, nfft=None):
     """Returns the recommended fractional overlap for the given window
 

--- a/gwpy/signal/window.py
+++ b/gwpy/signal/window.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for signal-processing with windows
+"""
+
+from math import ceil
+
+from scipy.signal import windows as scipy_windows
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def canonical_name(name):
+    """Find the canonical name for the given window in scipy.signal
+
+    Parameters
+    ----------
+    name : `str`
+        the name of the window you want
+
+    Returns
+    -------
+    realname : `str`
+        the name of the window as implemented in `scipy.signal.window`
+
+    Examples
+    --------
+    >>> from gwpy.signal.window import canonical_name
+    >>> canonical_name('hanning')
+    'hann'
+    >>> canonical_name('ksr')
+    'kaiser'
+    """
+    try:
+        return scipy_windows._win_equiv[name.lower()].__name__
+    except KeyError as e:
+        raise ValueError('no window function in scipy.signal equivalent to %r'
+                         % name,)
+        raise
+
+
+# -- recommended overlap ------------------------------------------------------
+# source: http://edoc.mpg.de/395068
+
+ROV = {
+    'boxcar': 0,
+    'bartlett': .5,
+    'barthann': .5,
+    'blackmanharris': .661,
+    'flattop': .8,
+    'hann': .5,
+    'hamming': .5,
+    'nuttall': .656,
+    'triang': .5
+}
+
+def recommended_overlap(name, nfft=None):
+    """Returns the recommended fractional overlap for the given window
+
+    If ``nfft`` is given, the return is in samples
+
+    Parameters
+    ----------
+    name : `str`
+        the name of the window you are using
+
+    nfft : `int`, optional
+        the length of the window
+
+    Returns
+    -------
+    rov : `float`, `int`
+        the recommended overlap (ROV) for the given window, in samples if
+        ``nfft` is given (`int`), otherwise fractional (`float`)
+
+    Examples
+    --------
+    >>> from gwpy.signal.window import recommended_overlap
+    >>> recommended_overlap('hann')
+    0.5
+    >>> recommended_overlap('blackmanharris', nfft=128)
+    85
+    """
+    try:
+        name = canonical_name(name)
+    except KeyError as e:
+        raise ValueError(str(e))
+    try:
+        rov = ROV[name]
+    except KeyError:
+        raise ValueError("no recommended overlap for %r window" % name)
+    if nfft:
+        return int(ceil(nfft * rov))
+    return rov

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -542,6 +542,9 @@ class TimeSeriesTestCase(TimeSeriesTestMixin, SeriesTestCase):
         ts.psd(fftlength=0.4, overlap=0.2, method='median')
         # test LAL method with window specification
         ts.psd(fftlength=0.4, overlap=0.2, method='median-mean', window='hann')
+        # test LAL method with non-canonical window specification
+        ts.psd(fftlength=0.4, overlap=0.2, method='median-mean',
+               window='hanning')
         # test check for at least two averages (defaults to single FFT)
         self.assertRaises(ValueError, ts.psd, method='median-mean')
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -367,7 +367,7 @@ class TimeSeries(TimeSeriesBase):
 
         # calculate PSD using UI method
         return fft_ui.psd(self, method_func, fftlength=fftlength,
-                          overlap=overlap, **kwargs)
+                          overlap=overlap, window=window, **kwargs)
 
     @_update_doc_with_fft_methods
     def asd(self, fftlength=None, overlap=None, window='hann',

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -256,13 +256,14 @@ class TimeSeries(TimeSeriesBase):
             number of seconds in single FFT, default, use
             whole `TimeSeries`
 
-        overlap : `float`
-            numbers of seconds by which to overlap neighbouring FFTs,
-            by default, no overlap is used.
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
 
-        window : `str`, :class:`numpy.ndarray`
-            name of the window function to use, or an array of length
-            ``fftlength * TimeSeries.sample_rate`` to use as the window.
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
 
         Returns
         -------
@@ -326,7 +327,8 @@ class TimeSeries(TimeSeriesBase):
         return mean
 
     @_update_doc_with_fft_methods
-    def psd(self, fftlength=None, overlap=None, method='welch', **kwargs):
+    def psd(self, fftlength=None, overlap=None, window='hann',
+            method='welch', **kwargs):
         """Calculate the PSD `FrequencySeries` for this `TimeSeries`
 
         Parameters
@@ -334,12 +336,18 @@ class TimeSeries(TimeSeriesBase):
         fftlength : `float`, default: `TimeSeries.duration`
             number of seconds in single FFT
 
-        overlap : `float`, optional, default: `None`
-            number of seconds of overlap between FFTs, defaults to that of
-            the relevant method.
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
 
-        method : `str`, optional, default: ``'welch'``
-            PSD-generation method, see below for more details
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
+        method : `str`, optional
+            FFT-averaging method, default: ``'welch'``,
+            see *Notes* for more details
 
         **kwargs
             other keyword arguments are passed to the underlying
@@ -362,7 +370,8 @@ class TimeSeries(TimeSeriesBase):
                           overlap=overlap, **kwargs)
 
     @_update_doc_with_fft_methods
-    def asd(self, fftlength=None, overlap=None, method='welch', **kwargs):
+    def asd(self, fftlength=None, overlap=None, window='hann',
+            method='welch', **kwargs):
         """Calculate the ASD `FrequencySeries` of this `TimeSeries`
 
         Parameters
@@ -370,12 +379,18 @@ class TimeSeries(TimeSeriesBase):
         fftlength : `float`, default: `TimeSeries.duration`
             number of seconds in single FFT
 
-        overlap : `float`, optional, default: `None`
-            number of seconds of overlap between FFTs, defaults to that of
-            the relevant method.
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
 
-        method : `str`, optional, default: ``'welch'``
-            FFT-averaging method, see below for more details
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
+        method : `str`, optional
+            FFT-averaging method, default: ``'welch'``,
+            see *Notes* for more details
 
         Returns
         -------
@@ -394,18 +409,26 @@ class TimeSeries(TimeSeriesBase):
         return self.psd(method=method, fftlength=fftlength, overlap=overlap,
                         **kwargs) ** (1/2.)
 
-    def csd(self, other, fftlength=None, overlap=None, **kwargs):
+    def csd(self, other, fftlength=None, overlap=None, window='hann',
+            **kwargs):
         """Calculate the CSD `FrequencySeries` for two `TimeSeries`
 
         Parameters
         ----------
         other : `TimeSeries`
             the second `TimeSeries` in this CSD calculation
+
         fftlength : `float`, default: `TimeSeries.duration`
             number of seconds in single FFT
-        overlap : `float`, optional, default: `None`
-            number of seconds of overlap between FFTs, defaults to that of
-            the relevant method.
+
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
+
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
 
         Returns
         -------
@@ -421,7 +444,7 @@ class TimeSeries(TimeSeriesBase):
 
     @_update_doc_with_fft_methods
     def spectrogram(self, stride, fftlength=None, overlap=0,
-                    method='welch', window='hann', nproc=1, **kwargs):
+                    window='hann', method='welch', nproc=1, **kwargs):
         """Calculate the average power spectrogram of this `TimeSeries`
         using the specified average spectrum method.
 
@@ -441,16 +464,18 @@ class TimeSeries(TimeSeriesBase):
         fftlength : `float`
             number of seconds in single FFT.
 
-        overlap : `int`, optional, default: 0
-            number of seconds between FFTs.
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
 
-        method : `str`, optional, default: ``'welch'``
-            FFT-averaging method, see below for more details
-
-        window : `str`, `numpy.ndarray`, optional, default: `None`
+        window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,
-            see `scipy.signal.get_window` for details on acceptable
+            see :func:`scipy.signal.get_window` for details on acceptable
             formats
+
+        method : `str`, optional
+            FFT-averaging method, default: ``'welch'``,
+            see *Notes* for more details
 
         nproc : `int`, default: ``1``
             number of CPUs to use in parallel processing of FFTs
@@ -496,12 +521,13 @@ class TimeSeries(TimeSeriesBase):
             number of seconds in single FFT.
 
         overlap : `float`, optional
-            number of seconds between FFTs.
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
 
-        window : `str` or `tuple` or `array-like`, optional
-            desired window to use. See `~scipy.signal.get_window` for a list
-            of windows and required parameters. If `window` is array_like it
-            will be used directly as the window.
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
 
         scaling : [ 'density' | 'spectrum' ], optional
             selects between computing the power spectral density ('density')
@@ -599,14 +625,18 @@ class TimeSeries(TimeSeriesBase):
         fftlength : `float`
             number of seconds in single FFT
 
-        method : `str`, optional, default: ``'welch'``
-            FFT-averaging method, see below for more details
+        method : `str`, optional
+            FFT-averaging method, default: ``'welch'``,
+            see *Notes* for more details
 
-        overlap : `int`, optiona, default: fftlength
-            number of seconds between FFTs
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
 
-        window : `timeseries.window.Window`, optional, default: `None`
-            window function to apply to timeseries prior to FFT
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
 
         nproc : `int`, default: ``1``
             maximum number of independent frame reading processes, default
@@ -667,7 +697,7 @@ class TimeSeries(TimeSeriesBase):
         fftlength : `float`, default: `TimeSeries.duration`
             number of seconds in single FFT
 
-        overlap : `float`, optional, default: `None`
+        overlap : `float`, optional
             number of seconds of overlap between FFTs, defaults to that of
             the relevant method.
 
@@ -688,12 +718,19 @@ class TimeSeries(TimeSeriesBase):
         ----------
         stride : `float`
             number of seconds in single PSD (column of spectrogram).
+
         fftlength : `float`
             number of seconds in single FFT.
-        overlap : `int`, optiona, default: fftlength
-            number of seconds between FFTs.
-        window : `numpy.ndarray`, `str`, optional, default: `None`
-            window to apply to timeseries prior to FFT.
+
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
+
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
         nproc : `int`, default: ``1``
             maximum number of independent frame reading processes, default
             is set to single-process file reading.
@@ -720,14 +757,22 @@ class TimeSeries(TimeSeriesBase):
         ----------
         other : `~gwpy.timeseries.TimeSeries`
             second time-series for cross spectral density calculation
+
         stride : `float`
             number of seconds in single PSD (column of spectrogram).
+
         fftlength : `float`
             number of seconds in single FFT.
-        overlap : `int`, optional, default: fftlength
-            number of seconds between FFTs.
-        window : `numpy.ndarray`, `str`, optional, default: `None`
-            window to apply to timeseries prior to FFT.
+
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
+
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
         nproc : `int`, default: ``1``
             maximum number of independent frame reading processes, default
             is set to single-process file reading.
@@ -906,11 +951,15 @@ class TimeSeries(TimeSeriesBase):
         ----------
         rate : `float`
             rate to which to resample this `Series`
-        window : array_like, callable, string, float, or tuple, optional
-            specifies the window applied to the signal in the Fourier
-            domain, only used for `ftype='fir'` or irregular downsampling
+
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to signal in the Fourier domain,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats, only used for `ftype='fir'` or irregular downsampling
+
         ftype : `str`, optional
             type of filter, either 'fir' or 'iir', defaults to 'fir'
+
         n : `int`, optional
             if `ftype='fir'` the number of taps in the filter, otherwise
             the order of the Chebyshev type I IIR filter
@@ -1140,14 +1189,19 @@ class TimeSeries(TimeSeriesBase):
         ----------
         other : `TimeSeries`
             `TimeSeries` signal to calculate coherence with
+
         fftlength : `float`, optional, default: `TimeSeries.duration`
             number of seconds in single FFT, defaults to a single FFT
-        overlap : `float`, optional, default: `None`
-            number of seconds of overlap between FFTs, defaults to no
-            overlap
-        window : `timeseries.window.Window`, optional, default: `HanningWindow`
+
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
+
+        window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,
-            default HanningWindow of the relevant size
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
         **kwargs
             any other keyword arguments accepted by
             :func:`matplotlib.mlab.cohere` except ``NFFT``, ``window``,
@@ -1219,14 +1273,19 @@ class TimeSeries(TimeSeriesBase):
         ----------
         dt : `float`
             duration (in seconds) of time-shift
+
         fftlength : `float`, optional, default: `TimeSeries.duration`
             number of seconds in single FFT, defaults to a single FFT
-        overlap : `int`, optiona, default: fftlength
-            number of seconds of overlap between FFTs, defaults to no
-            overlap
-        window : `timeseries.window.Window`, optional, default: `HanningWindow`
+
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
+
+        window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,
-            default HanningWindow of the relevant size
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
         **kwargs
             any other keyword arguments accepted by
             :func:`matplotlib.mlab.cohere` except ``NFFT``, ``window``,
@@ -1266,15 +1325,22 @@ class TimeSeries(TimeSeriesBase):
         ----------
         other : `TimeSeries`
             the second `TimeSeries` in this CSD calculation
+
         stride : `float`
             number of seconds in single PSD (column of spectrogram)
+
         fftlength : `float`
             number of seconds in single FFT
-        overlap : `int`, optiona, default: fftlength
-            number of seconds of overlap between FFTs, defaults to no
-            overlap
-        window : `timeseries.window.Window`, optional, default: `None`
-            window function to apply to timeseries prior to FFT
+
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
+
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
         nproc : `int`, default: ``1``
             number of parallel processes to use when calculating
             individual coherence spectra.
@@ -1328,16 +1394,18 @@ class TimeSeries(TimeSeriesBase):
         fftlength : `float`
             number of seconds in single FFT
 
-        overlap : `float`, optional, default: 0
-            numbers of seconds by which to overlap neighbouring FFTs,
-            by default, no overlap is used.
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
 
-        method : `str`, optional, default: ``'welch'``
-            FFT-averaging method, see below for more details
+        method : `str`, optional
+            FFT-averaging method, default: ``'welch'``,
+            see *Notes* for more details
 
-        window : `str`, `numpy.ndarray`
-            name of the window function to use, or an array of length
-            ``fftlength * TimeSeries.sample_rate`` to use as the window.
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
 
         detrend : `str`, optional
             type of detrending to do before FFT (see `~TimeSeries.detrend`

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -421,7 +421,7 @@ class TimeSeries(TimeSeriesBase):
 
     @_update_doc_with_fft_methods
     def spectrogram(self, stride, fftlength=None, overlap=0,
-                    method='welch', window=None, nproc=1, **kwargs):
+                    method='welch', window='hann', nproc=1, **kwargs):
         """Calculate the average power spectrogram of this `TimeSeries`
         using the specified average spectrum method.
 
@@ -586,7 +586,7 @@ class TimeSeries(TimeSeriesBase):
 
     @_update_doc_with_fft_methods
     def spectral_variance(self, stride, fftlength=None, overlap=None,
-                          method='welch', window=None, nproc=1,
+                          method='welch', window='hann', nproc=1,
                           filter=None, bins=None, low=None, high=None,
                           nbins=500, log=False, norm=False, density=False):
         """Calculate the `SpectralVariance` of this `TimeSeries`.
@@ -681,7 +681,7 @@ class TimeSeries(TimeSeriesBase):
                           overlap=overlap)
 
     def rayleigh_spectrogram(self, stride, fftlength=None, overlap=0,
-                             window=None, nproc=1, **kwargs):
+                             window='hann', nproc=1, **kwargs):
         """Calculate the Rayleigh statistic spectrogram of this `TimeSeries`
 
         Parameters
@@ -712,7 +712,7 @@ class TimeSeries(TimeSeriesBase):
         return sg
 
     def csd_spectrogram(self, other, stride, fftlength=None, overlap=0,
-                        window=None, nproc=1, **kwargs):
+                        window='hann', nproc=1, **kwargs):
         """Calculate the cross spectral density spectrogram of this
            `TimeSeries` with 'other'.
 
@@ -1132,7 +1132,7 @@ class TimeSeries(TimeSeriesBase):
         return new
 
     def coherence(self, other, fftlength=None, overlap=None,
-                  window=None, **kwargs):
+                  window='hann', **kwargs):
         """Calculate the frequency-coherence between this `TimeSeries`
         and another.
 
@@ -1206,7 +1206,7 @@ class TimeSeries(TimeSeriesBase):
         return out
 
     def auto_coherence(self, dt, fftlength=None, overlap=None,
-                       window=None, **kwargs):
+                       window='hann', **kwargs):
         """Calculate the frequency-coherence between this `TimeSeries`
         and a time-shifted copy of itself.
 
@@ -1258,7 +1258,7 @@ class TimeSeries(TimeSeriesBase):
                                overlap=overlap, window=window, **kwargs)
 
     def coherence_spectrogram(self, other, stride, fftlength=None,
-                              overlap=None, window=None, nproc=1):
+                              overlap=None, window='hann', nproc=1):
         """Calculate the coherence spectrogram between this `TimeSeries`
         and other.
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -106,7 +106,7 @@ class TimeSeries(TimeSeriesBase):
     returned via the :attr:`~TimeSeries.times` property.
 
     All comparison operations performed on a `TimeSeries` will return a
-    :class:`~gwpy.timeseries.statevector.StateTimeSeries` - a boolean array
+    `~gwpy.timeseries.StateTimeSeries` - a boolean array
     with metadata copied from the starting `TimeSeries`.
 
     Examples
@@ -214,7 +214,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        out : :class:`~gwpy.frequencyseries.FrequencySeries`
+        out : `~gwpy.frequencyseries.FrequencySeries`
             the normalised, complex-valued FFT `FrequencySeries`.
 
         See Also
@@ -267,7 +267,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        out : complex-valued :class:`~gwpy.frequencyseries.FrequencySeries`
+        out : complex-valued `~gwpy.frequencyseries.FrequencySeries`
             the transformed output, with populated frequencies array
             metadata
 
@@ -394,7 +394,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        psd :  :class:`~gwpy.frequencyseries.FrequencySeries`
+        psd :  `~gwpy.frequencyseries.FrequencySeries`
             a data series containing the PSD.
 
         See also
@@ -432,7 +432,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        csd :  :class:`~gwpy.frequencyseries.FrequencySeries`
+        csd :  `~gwpy.frequencyseries.FrequencySeries`
             a data series containing the CSD.
         """
         # get method
@@ -578,7 +578,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        fftgram : :class:`~gwpy.spectrogram.core.Spectrogram`
+        fftgram : `~gwpy.spectrogram.Spectrogram`
             a Fourier-gram
         """
         from ..spectrogram import Spectrogram
@@ -642,7 +642,7 @@ class TimeSeries(TimeSeriesBase):
             maximum number of independent frame reading processes, default
             is set to single-process file reading.
 
-        bins : :class:`~numpy.ndarray`, optional, default `None`
+        bins : `numpy.ndarray`, optional, default `None`
             array of histogram bin edges, including the rightmost edge
 
         low : `float`, optional, default: `None`
@@ -703,7 +703,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        psd :  :class:`~gwpy.frequencyseries.FrequencySeries`
+        psd :  `~gwpy.frequencyseries.FrequencySeries`
             a data series containing the PSD.
         """
         method_func = fft_registry.get_method('rayleigh', scaling='other')
@@ -779,7 +779,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        spectrogram : :class:`~gwpy.spectrogram.Spectrogram`
+        spectrogram : `~gwpy.spectrogram.Spectrogram`
             time-frequency cross spectrogram as generated from the
             two input time-series.
         """
@@ -1087,7 +1087,7 @@ class TimeSeries(TimeSeriesBase):
         *filt
             one of:
 
-            - :class:`scipy.signal.lti`
+            - `scipy.signal.lti`
             - `MxN` `numpy.ndarray` of second-order-sections
               (`scipy` >= 0.16 only)
             - ``(numerator, denominator)`` polynomials
@@ -1210,7 +1210,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        coherence : :class:`~gwpy.frequencyseries.FrequencySeries`
+        coherence : `~gwpy.frequencyseries.FrequencySeries`
             the coherence `FrequencySeries` of this `TimeSeries`
             with the other
 
@@ -1294,7 +1294,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        coherence : :class:`~gwpy.frequencyseries.FrequencySeries`
+        coherence : `~gwpy.frequencyseries.FrequencySeries`
             the coherence `FrequencySeries` of this `TimeSeries`
             with the other
 
@@ -1347,7 +1347,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        spectrogram : :class:`~gwpy.spectrogram.core.Spectrogram`
+        spectrogram : `~gwpy.spectrogram.Spectrogram`
             time-frequency coherence spectrogram as generated from the
             input time-series.
         """

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1249,7 +1249,7 @@ class TimeSeries(TimeSeriesBase):
         else:
             fftlength = int((fftlength * self_.sample_rate).decompose().value)
         if window is not None:
-            kwargs['window'] = window
+            kwargs['window'] = signal.get_window(window, fftlength)
         coh, f = mlab.cohere(self_.value, other.value, NFFT=fftlength,
                              Fs=sampling, noverlap=overlap, **kwargs)
         out = coh.view(FrequencySeries)


### PR DESCRIPTION
This PR adds a new module `gwpy.signal.window` which provides two simple routines

- `canonical_name`: translates arbitrary window name into one understood by scipy (e.g. `ksr` -> `kaiser`)
- `recommended_overlap`: uses [Heinzel, Rüdiger, & Schilling [2002]](http://edoc.mpg.de/395068) to return the recommended overlap for a given FFTlength and window combination

The `recommended_overlap` method is now used to set the default overlap for all `TimeSeries` FFT routines, unless specified by the user.