### PR TITLE
Fixed breakages introduced by astropy-2.0

### DIFF
--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -165,13 +165,14 @@ def burst_range_spectrum(psd, snr=8, energy=1e-2, unit='Mpc'):
     rangespec : `~gwpy.frequencyseries.FrequencySeries`
         the burst range `FrequencySeries` [Mpc (default)]
     """
-    unit = units.Unit(unit)
+    # calculate frequency dependent range in parsecs
     a = (constants.G.value * energy * constants.M_sun.value * 0.4 /
          (pi**2 * constants.c.value))**(1/2.)
     dspec = a / (snr * psd**(1/2.) * psd.frequencies) / constants.pc.value
-    conv = units.pc.get_converter(unit)
-    rspec = conv(dspec)
-    rspec.override_unit(unit)
+    dspec.override_unit(units.pc)
+    # convert to output unit
+    rspec = dspec.to(unit)
+    # rescale 0 Hertz (which has 0 range always)
     if rspec.f0.value == 0.0:
         rspec[0] = 0.0
     return rspec

--- a/gwpy/tests/test_astro.py
+++ b/gwpy/tests/test_astro.py
@@ -34,6 +34,18 @@ from gwpy.timeseries import TimeSeries
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+# hack up constants that changed between astropy 1.3 and 2.0
+# TODO: might want to do this in reverse, i.e. hard-coding the answers for 2.0
+from astropy import __version__ as astropy_version
+if astropy_version >= '2.0':
+    from astropy import constants
+    from astropy.constants import (si, astropyconst13)
+    units.M_sun._represents = units.Unit(astropyconst13.M_sun)
+    constants.M_sun = si.M_sun = astropyconst13.M_sun
+    constants.G = si.G = astropyconst13.G
+    constants.c = si.c = astropyconst13.c
+    constants.pc = si.pc = astropyconst13.pc
+
 # something changed in scyip 0.19, something FFT-related
 if scipy.__version__ < '0.19':
     TEST_RESULTS = {

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -108,7 +108,7 @@ class TableTests(unittest.TestCase):
             # overwrite=False, append=True
             table.write(fp, format='ligolw.sngl_burst', append=True)
             table5 = self.TABLE_CLASS.read(fp, format='ligolw.sngl_burst')
-            self.assertTableEqual(table2, table5)
+            self.assertTableEqualTypeless(table2, table5)
             # overwrite=True, append=True
             table.write(fp, format='ligolw.sngl_burst', append=True,
                         overwrite=True)

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -49,7 +49,7 @@ class TableTests(unittest.TestCase):
     TABLE_CLASS = Table
 
     def assertTableEqual(self, a, b, copy=None, meta=False):
-        assert a.colnames == b.colnames
+        assert sorted(a.colnames) == sorted(b.colnames)
         nptest.assert_array_equal(a.as_array(), b.as_array())
         if meta:
             assert a.meta == b.meta

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -973,7 +973,8 @@ class TimeSeriesListTestCase(unittest.TestCase):
     def test_coalesce(self):
         tsl = self.create()
         tsl2 = self.create().coalesce()
-        self.assertEqual(tsl2[0], tsl[0].append(tsl[1], inplace=False))
+        nptest.assert_array_equal(tsl2[0].value,
+                                  tsl[0].append(tsl[1], inplace=False).value)
 
 
 if __name__ == '__main__':

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -972,7 +972,7 @@ class TimeSeriesListTestCase(unittest.TestCase):
 
     def test_coalesce(self):
         tsl = self.create()
-        tsl2 = self.create().coalesce()
+        tsl2 = tsl.copy().coalesce()
         nptest.assert_array_equal(tsl2[0].value,
                                   tsl[0].append(tsl[1], inplace=False).value)
 

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1142,3 +1142,11 @@ class TimeSeriesBaseList(list):
 
     def __getslice__(self, i, j):
         return type(self)(*super(TimeSeriesBaseList, self).__getslice__(i, j))
+
+    def copy(self):
+        """Return a copy of this list with each element copied to new memory
+        """
+        out = type(self)()
+        for series in self:
+            out.append(series.copy())
+        return out

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -47,6 +47,7 @@ from math import ceil
 import numpy
 
 from astropy import units
+from astropy import __version__ as astropy_version
 
 from ..types import (Array2D, Series)
 from ..detector import (Channel, ChannelList)
@@ -58,6 +59,8 @@ from ..utils.compat import OrderedDict
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 __all__ = ['TimeSeriesBase', 'ArrayTimeSeries', 'TimeSeriesBaseDict']
+
+ASTROPY_2_0 = astropy_version >= '2.0'
 
 _UFUNC_STRING = {'less': '<',
                  'less_equal': '<=',
@@ -534,6 +537,25 @@ class TimeSeriesBase(Series):
                                 epoch=self.epoch.gps, copy=copy)
 
     # -- TimeSeries operations ------------------
+
+    if ASTROPY_2_0:
+        def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+            # this is new in numpy 1.13, astropy 2.0 adopts it, we need to
+            # work out how to handle this and __array_wrap__ together properly
+            out = super(TimeSeriesBase, self).__array_ufunc__(
+                ufunc, method, *inputs, **kwargs)
+            if out.dtype is numpy.dtype(bool):
+                from .statevector import StateTimeSeries
+                orig, value = inputs
+                try:
+                    op_ = _UFUNC_STRING[ufunc.__name__]
+                except KeyError:
+                    op_ = ufunc.__name__
+                out = out.view(StateTimeSeries)
+                out.__metadata_finalize__(orig)
+                out.override_unit('')
+                out.name = '%s %s %s' % (orig.name, op_, value)
+            return out
 
     def __array_wrap__(self, obj, context=None):
         # if output type is boolean, return a `StateTimeSeries`


### PR DESCRIPTION
This PR fixes two problems introduced by the release of astropy v2

- crappy test of `TimeSeriesList.coalesce` was exposed, needed fixes
- astropy 2 starts using numpy 1.13's new `__array_ufunc__` API, so we need to replicate that to get the `TimeSeries` -> `StateTimeSeries` conversion to work for numpy ufunc comparisons