### PR TITLE
Added tests for ChannelList I/O with LIGO channel list files (CLF)

### DIFF
--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -77,6 +77,7 @@ from numpy import inf
 
 from ...io import registry
 from ...io.utils import identify_factory
+from ...io.cache import FILE_LIKE
 from ...utils.compat import OrderedDict
 from .. import (Channel, ChannelList)
 
@@ -162,7 +163,7 @@ def write_channel_list_file(channels, fobj):
             out.set(group, 'channels', '\n%s' % entry)
         else:
             out.set(group, 'channels', cl + '\n%s' % entry)
-    if isinstance(fobj, file):
+    if isinstance(fobj, FILE_LIKE):
         close = False
     else:
         fobj = open(fobj, 'w')

--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -77,7 +77,7 @@ from numpy import inf
 
 from ...io import registry
 from ...io.utils import identify_factory
-from ...io.cache import FILE_LIKE
+from ...io.cache import (file_list, FILE_LIKE)
 from ...utils.compat import OrderedDict
 from .. import (Channel, ChannelList)
 
@@ -96,7 +96,7 @@ def read_channel_list_file(*source):
     """
     # read file(s)
     config = configparser.ConfigParser(dict_type=OrderedDict)
-    source = [f.name for f in source if isinstance(f, file) or f]
+    source = file_list(source)
     success_ = config.read(*source)
     if len(success_) != len(source):
         raise IOError("Failed to read one or more CLF files")

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -587,7 +587,8 @@ class TestChannelList(object):
     def test_read_write_clf(self):
         # write clf to file and read it back
         try:
-            with NamedTemporaryFile(suffix='.ini', delete=False) as f:
+            with NamedTemporaryFile(suffix='.ini', delete=False,
+                                    mode='w') as f:
                 f.write(CLF)
             cl = ChannelList.read(f.name)
             assert len(cl) == 4

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -247,6 +247,25 @@ class TestIoCache(object):
         with pytest.raises(ValueError):
             io_cache.file_list(1)
 
+    def test_file_name(self):
+        cache = self.make_cache()[0]
+
+        # check file_name(<str>)
+        assert io_cache.file_name('test.txt') == 'test.txt'
+
+        # check file_name(<file>)
+        with tempfile.NamedTemporaryFile() as f:
+            assert io_cache.file_name(f) == f.name
+
+        # check file_name(<CacheEntry>)
+        assert io_cache.file_name(cache[0]) == cache[0].path
+
+        # check that anything else fails
+        with pytest.raises(ValueError):
+            io_cache.file_name(1)
+        with pytest.raises(ValueError):
+            io_cache.file_name(['test.txt'])
+
     def test_cache_segments(self):
         """Test :func:`gwpy.io.cache.cache_segments`
         """


### PR DESCRIPTION
This PR adds unit tests for `ChannelList.read()` and `ChannelList.write()` I/O with LIGO Channel List Files (CLF).