### PR TITLE
Added methods for filtering tables, including on-the-fly filtering when reading

### DIFF
--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilies for filtering a `Table` using column slice definitions
+"""
+
+import operator
+import token
+from tokenize import generate_tokens
+
+from six.moves import StringIO
+
+import numpy
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+OPERATORS = {
+    '<': operator.lt,
+    '<=': operator.le,
+    '==': operator.eq,
+    '>=': operator.ge,
+    '>': operator.gt,
+    '!=': operator.ne,
+}
+
+OPERATORS_INV = {
+    '<': operator.ge,
+    '<=': operator.gt,
+    '>=': operator.lt,
+    '>': operator.le,
+}
+
+
+def parse_operator(mathstr):
+    """Parse a `str` as a function from the `operator` module
+
+    Parameters
+    ----------
+    mathstr : `str`
+        a `str` representing a mathematical operator
+
+    Returns
+    -------
+    op : `func`
+        a callable `operator` module function
+
+    Raises
+    ------
+    KeyError
+        if input `str` cannot be mapped to an `operator` function
+
+    Examples
+    --------
+    >>> parse_operator('>')
+    <built-in function gt>
+    """
+    try:
+        return OPERATORS[mathstr]
+    except KeyError as e:
+        e.args = ('Unrecognised operator %r' % mathstr,)
+        raise
+
+
+def parse_column_filter(definition):
+    """Parse a `str` of the form 'column>50'
+
+    Parameters
+    ----------
+    definition : `str`
+        a column filter definition of the form ``<name><operator><threshold>``
+        or ``<threshold><operator><name><operator><threshold>``, e.g.
+        ``frequency >= 10``, or ``50 < snr < 100``
+
+    Returns
+    -------
+    column : `str`
+        the name of the column on which to operate
+
+    math : `list` of (`str`, `callable`) pairs
+        the list of thresholds and their associated math operators
+
+    Raises
+    ------
+    ValueError
+        if the filter definition cannot be parsed
+
+    KeyError
+        if any parsed operator string cannnot be mapped to a function from
+        the `operator` module
+
+    Examples
+    --------
+    >>> parse_column_filter("frequency>10")
+    ('frequency', [(10.0, <built-in function gt>)])
+    >>> parse_column_filter("50 < snr < 100")
+    ('snr', [(50.0, <built-in function ge>), (100.0, <build-in function lt>)])
+    """
+    # parse definition into parts
+    parts = list(generate_tokens(StringIO(definition).readline))
+
+    # find column name
+    names = filter(lambda t: t[0] == token.NAME, parts)
+    if len(names) != 1:
+        raise ValueError("Multiple column names parsed from "
+                         "column filter definition %r" % definition)
+    name = names[0][1]
+
+    # parse thresholds and operators and divide into single operation pairs
+    thresholds = list(zip(*filter(lambda t: t[0] == token.NUMBER, parts)))[1]
+    operators = list(zip(*filter(lambda t: t[0] == token.OP, parts)))[1]
+    if len(thresholds) != len(operators):  # sanity check
+        ValueError("Number of thresholds doesn't match number of operators "
+                   "in column filter definition %r" % definition)
+    math = []
+    for lim, op in zip(thresholds, operators):
+        try:
+            # parse '1 < snr' as 'snr >= 1'
+            if (definition.find(lim) < definition.find(op) and
+                    op in OPERATORS_INV):
+                math.append((float(lim), OPERATORS_INV[op]))
+            else:
+                math.append((float(lim), OPERATORS[op]))
+        except KeyError as e:
+            e.args = ('Unrecognised math operator %r' % op,)
+            raise
+
+    return name, math
+
+
+def parse_column_filters(*definitions):
+    """Parse multiple compound column filter definitions
+
+    Examples
+    --------
+    >>> parse_column_filters('snr > 10', 'frequency < 1000')
+    [('snr', [(10.0, <built-in function gt>)]),
+     ('frequency', [(1000.0, <built-in function lt>)])]
+    >>> parse_column_filters('snr > 10 && frequency < 1000')
+    [('snr', [(10.0, <built-in function gt>)]),
+     ('frequency', [(1000.0, <built-in function lt>)])]
+    """
+    fltrs = []
+    for def_ in definitions:
+        for splitdef in def_.replace('&&', '&').split('&'):
+            fltrs.append(parse_column_filter(splitdef))
+    return fltrs
+
+
+def filter_table(table, *column_filters):
+    """Apply one or more column slice filters to a `Table`
+
+    Multiple column filters can be given, and will be applied
+    concurrently
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+        the table to filter
+
+    column_filter : `str`
+        a column slice filter definition, e.g. ``'snr > 10``
+
+    Returns
+    -------
+    table : `~astropy.table.Table`
+        a view of the input table with only those rows matching the filters
+
+    Examples
+    --------
+    >>> filter(my_table, 'snr>10', 'frequency<1000')
+    """
+    keep = numpy.ones(len(table), dtype=bool)
+    for name, math in parse_column_filters(*column_filters):
+        col = table[name].view(numpy.ndarray)
+        for threshold, oprtr in math:
+            keep &= oprtr(col, threshold)
+    return table[keep]

--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -114,7 +114,7 @@ def parse_column_filter(definition):
     parts = list(generate_tokens(StringIO(definition).readline))
 
     # find column name
-    names = filter(lambda t: t[0] == token.NAME, parts)
+    names = list(filter(lambda t: t[0] == token.NAME, parts))
     if len(names) != 1:
         raise ValueError("Multiple column names parsed from "
                          "column filter definition %r" % definition)

--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -155,10 +155,21 @@ def parse_column_filters(*definitions):
      ('frequency', [(1000.0, <built-in function lt>)])]
     """
     fltrs = []
-    for def_ in definitions:
+    for def_ in _flatten(definitions):
         for splitdef in def_.replace('&&', '&').split('&'):
             fltrs.append(parse_column_filter(splitdef))
     return fltrs
+
+
+def _flatten(container):
+    """Flatten arbitrary nested list into strings
+    """
+    for i in container:
+        if isinstance(i, (list, tuple)):
+            for j in _flatten(i):
+                yield j
+        else:
+            yield i
 
 
 def filter_table(table, *column_filters):

--- a/gwpy/table/io/hacr.py
+++ b/gwpy/table/io/hacr.py
@@ -38,6 +38,7 @@ from numpy.lib import recfunctions
 from ...segments import Segment
 from ...time import (to_gps, from_gps)
 from .. import EventTable
+from .utils import read_with_selection
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -88,6 +89,7 @@ def get_hacr_channels(db=None, gps=None, connection=None,
     return [r[0] for r in out]
 
 
+@read_with_selection
 def get_hacr_triggers(channel, start, end, columns=HACR_COLUMNS, pid=None,
                       monitor='chacr', **connectkwargs):
     """Fetch a table of HACR triggers in the given interval

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -32,6 +32,7 @@ except ImportError:
 from ...io import registry
 from ...io.ligolw import (table_from_file, write_tables)
 from .. import (Table, EventTable)
+from .utils import read_with_selection
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __all__ = []
@@ -42,6 +43,7 @@ GET_AS_EXCLUDE = ['get_column', 'get_table']
 
 # -- read ---------------------------------------------------------------------
 
+@read_with_selection
 def _table_from_ligolw(llwtable, target, copy, columns=None,
                        on_attributeerror='raise', get_as_columns=False,
                        rename={}):
@@ -192,6 +194,7 @@ def ligolw_io_factory(table_):
             'on_attributeerror': 'raise',
             'get_as_columns': False,
             'rename': {},
+            'selection': [],
         }
         for key in reckwargs:
             if key in kwargs:

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -94,7 +94,7 @@ def _table_from_ligolw(llwtable, target, copy, columns=None,
         orig_type = llwtable.validcolumns[column]
         try:
             if orig_type == 'ilwd:char':  # numpy tries long() which breaks
-                arr = map(int, llwtable.getColumnByName(column))
+                arr = list(map(int, llwtable.getColumnByName(column)))
             else:
                 arr = llwtable.getColumnByName(column)
         except AttributeError as e:

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -240,6 +240,7 @@ def ligolw_io_factory(table_):
 
     return _read_table, _write_table
 
+
 # -- register -----------------------------------------------------------------
 
 EVENT_TABLES = (

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -169,6 +169,7 @@ def identify_pycbc_live(origin, filepath, fileobj, *args, **kwargs):
         return True
     return False
 
+
 # register for unified I/O
 register_identifier(PYCBC_LIVE_FORMAT, EventTable, identify_pycbc_live)
 register_reader(PYCBC_LIVE_FORMAT, EventTable, table_from_file)
@@ -194,6 +195,7 @@ def get_new_snr(h5group, q=6., n=2.):
     newsnr[idx] *= _new_snr_scale(newsnr[idx], rchisq[idx], q=q, n=n)
     return newsnr
 
+
 GET_COLUMN['new_snr'] = get_new_snr
 
 
@@ -201,5 +203,6 @@ def get_mchirp(h5group):
     mass1 = h5group['mass1'][:]
     mass2 = h5group['mass2'][:]
     return (mass1 * mass2) ** (3/5.) / (mass1 + mass2) ** (1/5.)
+
 
 GET_COLUMN['mchirp'] = get_mchirp

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -27,6 +27,7 @@ import numpy
 from ...io.hdf5 import (identify_hdf5, with_read_hdf5)
 from ...io.registry import (register_reader, register_identifier)
 from .. import (Table, EventTable)
+from .utils import read_with_selection
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Nitz <alex.nitz@ligo.org>'
@@ -38,6 +39,7 @@ PYCBC_FILENAME = re.compile('([A-Z][0-9])+-Live-[0-9.]+-[0-9.]+.hdf')
 
 
 @with_read_hdf5
+@read_with_selection
 def table_from_file(source, ifo=None, columns=None, loudest=False):
     """Read a `Table` from a PyCBC live HDF5 file
     """

--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -43,6 +43,18 @@ def table_from_root(f, treename=None, include_names=None, **kwargs):
                           "astropy.table.Table.read kwargs, please update "
                           "your call.", DeprecationWarning)
 
+    # parse column filters into tree2array ``selection`` keyword
+    try:
+        filters = kwargs.pop('selection')
+    except KeyError:
+        pass
+    else:
+        if isinstance(filters, (list, tuple)):
+            filters = ' && '.join(filters)
+        kwargs['selection'] = filters
+
+    # find single tree (if only one tree present)
+
     files = file_list(f)
     if treename is None:
         trees = root_numpy.list_trees(files[0])
@@ -56,6 +68,7 @@ def table_from_root(f, treename=None, include_names=None, **kwargs):
                              "`treename='events'`. Available trees are: %s."
                              % (files[0], ', '.join(map(repr, trees))))
 
+    # read and return
     return Table(root_numpy.root2array(files, treename, branches=include_names,
                                        **kwargs))
 

--- a/gwpy/table/io/utils.py
+++ b/gwpy/table/io/utils.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for Table I/O
+"""
+
+from functools import wraps
+
+from six import string_types
+
+from ..filter import (filter_table, parse_column_filters)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def read_with_selection(func):
+    """Decorate a Table read method to apply ``selection`` keyword
+    """
+    @wraps(func)
+    def decorated_func(*args, **kwargs):
+        # parse selection
+        try:
+            selection = kwargs.pop('selection')
+        except KeyError:
+            selection = []
+        else:
+            if isinstance(selection, string_types):
+                selection = selection.replace('&&', '&').split('&')
+
+        # read table
+        tab = func(*args, **kwargs)
+
+        # apply selection
+        if selection:
+            return filter_table(tab, *selection)
+
+        return tab
+
+    return decorated_func

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -30,13 +30,10 @@ from astropy.table import (Table, Column, vstack)
 from astropy.io.registry import write as io_write
 
 from ..io.mp import read_multi as io_read_multi
+from .filter import (filter_table, parse_operator)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __all__ = ['EventColumn', 'EventTable']
-
-OPERATORS = {'<': _operator.lt, '<=': _operator.le, '=': _operator.eq,
-             '>=': _operator.ge, '>': _operator.gt, '==': _operator.is_,
-             '!=': _operator.is_not}
 
 
 class EventColumn(Column):
@@ -302,7 +299,7 @@ class EventTable(Table):
                 bins2.append((bin_, bins[i+1]))
             bins = bins2
         elif isinstance(operator, string_types):
-            op = OPERATORS[operator]
+            op = parse_operator(operator)
         else:
             op = operator
 
@@ -383,3 +380,21 @@ class EventTable(Table):
         """
         from gwpy.plotter import HistogramPlot
         return HistogramPlot(self, column, **kwargs)
+
+    def filter(self, *column_filters):
+        """Apply one or more column slice filters to this `EventTable`
+
+        Multiple column filters can be given, and will be applied
+        concurrently
+
+        Parameters
+        ----------
+        column_filter : `str`
+            a column slice filter definition, e.g. ``'snr > 10``
+
+        Returns
+        -------
+        table : `EventTable`
+            a new table with only those rows matching the filters
+        """
+        return filter_table(self, *column_filters)

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -32,6 +32,7 @@ from astropy import units
 from astropy.io.ascii import InconsistentTableError
 
 from gwpy.table import (Table, EventTable)
+from gwpy.table.filter import filter_table
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 
 import common
@@ -126,6 +127,11 @@ class TableTests(unittest.TestCase):
             self.assertEqual(
                 str(exc.exception),
                 'document must contain exactly one sngl_burst table')
+            # test with selection
+            table3 = self.TABLE_CLASS.read(TEST_XML_FILE,
+                                           format='ligolw.sngl_burst',
+                                           selection='snr>5')
+            self.assertTableEqual(filter_table(table, 'snr>5'), table3)
         finally:
             if os.path.isdir(tempdir):
                 shutil.rmtree(tempdir)
@@ -149,6 +155,11 @@ class TableTests(unittest.TestCase):
                 self.TABLE_CLASS.read(fp)
             self.assertTrue(str(exc.exception).startswith(
                 "Multiple trees found"))
+            # test with selection
+            table3 = self.TABLE_CLASS.read(fp, treename='test',
+                                           selection='frequency>500')
+            self.assertTableEqual(
+                filter_table(table2, 'frequency>500'), table3)
         except ImportError as e:
             self.skipTest(str(e))
         finally:
@@ -170,6 +181,12 @@ class TableTests(unittest.TestCase):
             table2 = self.TABLE_CLASS.read(fp, 'test_read_write_gwf',
                                            columns=columns)
             self.assertTableEqualTypeless(table, table2, meta=False)
+            # test with selection
+            table3 = self.TABLE_CLASS.read(fp, 'test_read_write_gwf',
+                                           columns=columns,
+                                           selection='frequency>500')
+            self.assertTableEqual(
+                filter_table(table2, 'frequency>500'), table3)
         except ImportError as e:
             self.skipTest(str(e))
         finally:
@@ -296,6 +313,11 @@ class EventTableTests(TableTests):
             mchirp = (table['mass1'] * table['mass2']) ** (3/5.) / (
                 table['mass1'] + table['mass2']) ** (1/5.)
             nptest.assert_array_equal(table2['mchirp'], mchirp)
+
+            # test with selection
+            table3 = self.TABLE_CLASS.read(fp, format='hdf5.pycbc_live',
+                                           ifo='X1', selection='snr>.5')
+            self.assertTableEqual(filter_table(table, 'snr>.5'), table3)
         finally:
             if os.path.exists(fp):
                 os.remove(fp)

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -299,3 +299,20 @@ class EventTableTests(TableTests):
         finally:
             if os.path.exists(fp):
                 os.remove(fp)
+
+    def test_filter(self):
+        table = self.TABLE_CLASS.read(TEST_OMEGA_FILE, format='ascii.omega')
+        # check simple filter
+        lowf = table.filter('frequency < 1000')
+        self.assertIsInstance(lowf, type(table))
+        self.assertEqual(len(lowf), 45)
+        self.assertLess(lowf['frequency'].max(), 1000)
+        # check filtering everything returns an empty table
+        self.assertEqual(
+            len(table.filter('frequency < 1000', 'frequency>=1000')), 0)
+        # check compounding works
+        loud = table.filter('normalizedEnergy>5000')
+        lowfloud = table.filter('frequency < 1000', 'normalizedEnergy>5000')
+        brute = type(table)(rows=[row for row in lowf if row in loud],
+                            names=table.dtype.names)
+        self.assertTableEqual(brute, lowfloud)


### PR DESCRIPTION
This PR adds methods to filter tables of events via 'selections', including adding on-the-fly filtering for all table readers in `gwpy.table.io`.