### PR TITLE
Added support for non-HDF5 LOSC file formats

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -435,7 +435,7 @@ class TimeSeriesTestMixin(object):
     def test_fetch_open_data_ascii(self):
         # test ASCII first
         ts = self.fetch_open_data()
-        self.assertEqual(ts.span, LOSC_GW150914_SEGMENT)
+        self.assertTupleEqual(ts.span, LOSC_GW150914_SEGMENT)
         self.assertEqual(ts.sample_rate, 4096 * units.Hz)
         nptest.assert_allclose(
             ts.value[:10],

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -830,6 +830,10 @@ class StateVectorTestCase(TimeSeriesTestMixin, SeriesTestCase):
     def setUpClass(cls, dtype='uint32'):
         super(StateVectorTestCase, cls).setUpClass(dtype=dtype)
 
+    @unittest.skipUnless(HAS_H5PY, 'No module named h5py')
+    def fetch_open_data(self, **kwargs):
+        return super(StateVectorTestCase, self).fetch_open_data(**kwargs)
+
     def _test_losc_inner(self, loscfile):
         ts = self.TEST_CLASS.read(loscfile, 'quality/simple', format='losc')
         self.assertEqual(ts.x0, units.Quantity(931069952, 's'))

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -271,9 +271,9 @@ class TimeSeriesBase(Series):
             allow_tape=allow_tape, type=type, dtype=dtype)[str(channel)]
 
     @classmethod
-    def fetch_open_data(cls, ifo, start, end, name='strain/Strain',
-                        sample_rate=4096, host='https://losc.ligo.org',
-                        verbose=False):
+    def fetch_open_data(cls, ifo, start, end, sample_rate=4096,
+                        format=None, host='https://losc.ligo.org',
+                        verbose=False, **kwargs):
         """Fetch open-access data from the LIGO Open Science Center
 
         Parameters
@@ -290,26 +290,32 @@ class TimeSeriesBase(Series):
             GPS end time of required data, defaults to end of data found;
             any input parseable by `~gwpy.time.to_gps` is fine
 
-        name : `str`, optional
-            the full name of HDF5 dataset that represents the data you want,
-            e.g. `'strain/Strain'` for _h(t)_ data, or `'quality/simple'`
-            for basic data-quality information
-
         sample_rate : `float`, optional, default: `4096`
             the sample rate of desired data. Most data are stored
             by LOSC at 4096 Hz, however there may be event-related
             data releases with a 16384 Hz rate
+
+        format : `str`, optional
+            the data format to download and parse, defaults to 'txt.gz'
+            which requires no extra packages. Other options include
+
+            - ``'hdf5'`` - requires |h5py|_
+            - ``'gwf'`` - requires |LDAStools.frameCPP|_
 
         verbose : `bool`, optional, default: `False`
             print verbose output while fetching data
 
         host : `str`, optional
             HTTP host name of LOSC server to access
+
+        **kwargs
+            any other keyword arguments are passed to the `TimeSeries.read`
+            method that parses the file that was downloaded
         """
         from .io.losc import fetch_losc_data
-        return fetch_losc_data(ifo, start, end, channel=name, cls=cls,
-                               sample_rate=sample_rate, host=host,
-                               verbose=verbose)
+        return fetch_losc_data(ifo, start, end, cls=cls,
+                               sample_rate=sample_rate, format=format,
+                               host=host, verbose=verbose, **kwargs)
 
     @classmethod
     def find(cls, channel, start, end, frametype=None,

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -23,22 +23,26 @@ For more details, see https://losc.ligo.org
 
 from __future__ import print_function
 
+import os.path
 import sys
 import json
+import re
 from tempfile import NamedTemporaryFile
 
+from six import string_types
 from six.moves.urllib.request import urlopen
+
+import numpy
 
 from astropy.io import registry
 from astropy.units import Quantity
 
 from .. import (StateVector, TimeSeries)
-from ...utils.deps import with_import
-from ...io.cache import (file_list, cache_segments, file_segment)
-from ...io.hdf5 import open_hdf5
+from ...io import (hdf5 as io_hdf5, utils as io_utils)
+from ...io.cache import (cache_segments, file_segment)
 from ...detector.units import parse_unit
 from ...segments import (Segment, SegmentList)
-from ...time import (to_gps, LIGOTimeGPS)
+from ...time import to_gps
 
 # default URL
 LOSC_URL = 'https://losc.ligo.org'
@@ -83,66 +87,66 @@ def _losc_json_cache(metadata, detector, sample_rate=4096,
 
 
 def fetch_losc_url_cache(detector, start, end, host=LOSC_URL,
-                         sample_rate=4096, format='hdf5'):
+                         sample_rate=4096, format=None):
     """Fetch the metadata from LOSC regarding a given GPS interval
     """
     start = int(start)
     end = int(end)
     span = SegmentList([Segment(start, end)])
+    if format is None:
+        formats = ['txt.gz', 'hdf5', 'gwf']
+    elif isinstance(format, string_types):
+        formats = [format]
+    else:
+        formats = format
+
     # -- step 1: query the interval
     url = '%s/archive/%d/%d/json/' % (host, start, end)
     md = _fetch_losc_json(url)
+
     # -- step 2: try and get data from an event (smaller files)
-    for dstype in ['events', 'runs']:
-        for dataset in md[dstype]:
-            # validate IFO is present
-            if detector not in md[dstype][dataset]['detectors']:
-                continue
-            # get metadata for this dataset
-            if dstype == 'events':
-                url = '%s/archive/%s/json/' % (host, dataset)
-            else:
-                url = ('%s/archive/links/%s/%s/%d/%d/json/'
-                       % (host, dataset, detector, start, end))
-            emd = _fetch_losc_json(url)
-            # get cache and sieve for our segment
-            for duration in [32, 4096]:  # try short files for events first
-                cache = _losc_json_cache(
-                    emd['strain'], detector, sample_rate=sample_rate,
-                    format=format, duration=duration)
-                cache = [u for u in cache if
-                         file_segment(u).intersects(span[0])]
-                # if full span covered, return now
-                if not span - cache_segments(cache):
-                    return cache
+    for form in formats:
+        for dstype in ['events', 'runs']:
+            for dataset in md[dstype]:
+                # validate IFO is present
+                if detector not in md[dstype][dataset]['detectors']:
+                    continue
+                # get metadata for this dataset
+                if dstype == 'events':
+                    url = '%s/archive/%s/json/' % (host, dataset)
+                else:
+                    url = ('%s/archive/links/%s/%s/%d/%d/json/'
+                           % (host, dataset, detector, start, end))
+                emd = _fetch_losc_json(url)
+                # get cache and sieve for our segment
+                for duration in [32, 4096]:  # try short files for events first
+                    cache = _losc_json_cache(
+                        emd['strain'], detector, sample_rate=sample_rate,
+                        format=form, duration=duration)
+                    cache = [u for u in cache if
+                             file_segment(u).intersects(span[0])]
+                    # if full span covered, return now
+                    if not span - cache_segments(cache):
+                        return cache
     raise ValueError("Cannot find a LOSC dataset for %s covering [%d, %d)"
                      % (detector, start, end))
 
 
-def fetch_losc_data(detector, start, end, host=LOSC_URL,
-                    channel='strain/Strain', sample_rate=4096, cls=TimeSeries,
-                    verbose=False):
+def fetch_losc_data(detector, start, end, host=LOSC_URL, sample_rate=4096,
+                    format='hdf5', cls=TimeSeries, verbose=False, **kwargs):
     """Fetch LOSC data for a given detector
 
     This function is for internal purposes only, all users should instead
     use the interface provided by `TimeSeries.fetch_open_data` (and similar
     for `StateVector.fetch_open_data`).
     """
-    # check for h5py upfront, to prevent downloading data first
-    # when read() will fail anyway
-    try:
-        import h5py
-    except ImportError as e:
-        e.args = ('%s, h5py is required to read LOSC HDF5 files' % str(e),)
-        raise
-
     sample_rate = Quantity(sample_rate, 'Hz').value
     start = to_gps(start)
     end = to_gps(end)
     span = Segment(start, end)
     # get cache of URLS
     cache = fetch_losc_url_cache(detector, start, end, host=host,
-                                 sample_rate=sample_rate)
+                                 sample_rate=sample_rate, format=format)
     if verbose:
         print("Fetched list of %d URLs to read from %s for [%d .. %d)"
               % (len(cache), host, int(start), int(end)))
@@ -150,8 +154,8 @@ def fetch_losc_data(detector, start, end, host=LOSC_URL,
     out = None
     for url in cache:
         keep = file_segment(url) & span
-        new = _fetch_losc_data_file(url, host=host, channel=channel, cls=cls,
-                                    verbose=verbose).crop(*keep, copy=False)
+        new = _fetch_losc_data_file(url, cls=cls, verbose=verbose,
+                                    **kwargs).crop(*keep, copy=False)
         if out is None:
             out = new.copy()
         else:
@@ -163,8 +167,7 @@ def fetch_losc_data(detector, start, end, host=LOSC_URL,
                      % (detector, span))
 
 
-def _fetch_losc_data_file(url, host=LOSC_URL, channel='strain/Strain',
-                          cls=TimeSeries, verbose=False):
+def _fetch_losc_data_file(url, cls=TimeSeries, verbose=False, **kwargs):
     """Internal function for fetching a single LOSC file and returning a Series
     """
     if verbose:
@@ -178,16 +181,26 @@ def _fetch_losc_data_file(url, host=LOSC_URL, channel='strain/Strain',
         e.args = ("Failed to download LOSC data from %r: %s"
                   % (url, str(e)),)
         raise
-    with NamedTemporaryFile() as f:
+
+    # match file format
+    if url.endswith('.gz'):
+        ext = '.'.join([''] + url.rsplit('.', 2)[-2:])
+    else:
+        ext = os.path.splitext(url)[-1]
+    if ext == '.hdf5':
+        kwargs.setdefault('format', 'hdf5.losc')
+    elif ext == '.txt.gz':
+        kwargs.setdefault('format', 'ascii.losc')
+
+    with NamedTemporaryFile(suffix=ext) as f:
         f.write(response.read())
         f.seek(0)
         try:
-            return cls.read(f.name, channel, format='losc')
+            return cls.read(f.name, **kwargs)
         except Exception as e:
             if verbose:
                 print("")
-            e.args = ("Failed to read HDF-format LOSC data from %r: %s"
-                      % (url, str(e)),)
+            e.args = ("Failed to read LOSC data from %r: %s" % (url, str(e)),)
             raise
         finally:
             if verbose:
@@ -196,33 +209,24 @@ def _fetch_losc_data_file(url, host=LOSC_URL, channel='strain/Strain',
 
 # -- I/O ----------------------------------------------------------------------
 
-def read_losc_data(filename, channel, group=None, copy=False):
+@io_hdf5.with_read_hdf5
+def read_losc_hdf5(f, path='strain/Strain', start=None, end=None, copy=False):
     """Read a `TimeSeries` from a LOSC-format HDF file.
 
     Parameters
     ----------
-    filename : `str`
-        path to LOSC-format HDF5 file to read.
-    channel : `str`
+    f : `str`, `h5py.HLObject`
+        path of HDF5 file, or open `H5File`
+
+    path : `str`
         name of HDF5 dataset to read.
-    group : `str`, optional
-        name of containing HDF5 group for ``channel``. If not given,
-        the first dataset named ``channel`` will be assumed as the right
-        one.
-    start : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
-        start GPS time of desired data
-    end : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
-        end GPS time of desired data
 
     Returns
     -------
-    data : :class`~gwpy.timeseries.TimeSeries`
+    data : `~gwpy.timeseries.TimeSeries`
         a new `TimeSeries` containing the data read from disk
     """
-    h5file = open_hdf5(filename)
-    if group:
-        channel = '%s/%s' % (group, channel)
-    dataset = _find_dataset(h5file, channel)
+    dataset = io_hdf5.find_dataset(f, path)
     # read data
     nddata = dataset.value
     # read metadata
@@ -232,90 +236,41 @@ def read_losc_data(filename, channel, group=None, copy=False):
     unit = dataset.attrs['Yunits']
     # build and return
     return TimeSeries(nddata, epoch=epoch, sample_rate=(1/dt).to('Hertz'),
-                      unit=unit, name=channel.rsplit('/', 1)[0], copy=copy)
+                      unit=unit, name=path.rsplit('/', 1)[1],
+                      copy=copy).crop(start=start, end=end)
 
 
-def read_losc_data_cache(f, channel, start=None, end=None, resample=None,
-                         group=None, target=TimeSeries):
-    """Read a `TimeSeries` from a LOSC-format HDF file.
 
-    Parameters
-    ----------
-    source : `str`, `list`, `~glue.lal.Cache`
-        path to LOSC-format HDF5 file to read or cache of many files.
-    channel : `str`
-        name of HDF5 dataset to read.
-    group : `str`, optional
-        name of containing HDF5 group for ``channel``. If not given,
-        the first dataset named ``channel`` will be assumed as the right
-        one.
-    start : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
-        start GPS time of desired data
-    end : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
-        end GPS time of desired data
-
-    Returns
-    -------
-    data : :class`~gwpy.timeseries.TimeSeries`
-        a new `TimeSeries` containing the data read from disk
-    """
-    files = file_list(f)
-
-    out = None
-    for fp in files:
-        if target is TimeSeries:
-            new = read_losc_data(fp, channel, group=group, copy=False)
-        elif target is StateVector:
-            new = read_losc_state(fp, channel, group=group, copy=False)
-        else:
-            raise ValueError("Cannot read %s from LOSC data"
-                             % (target.__name__))
-        if out is None:
-            out = new.copy()
-        else:
-            out.append(new)
-
-    if resample:
-        out = out.resample(resample)
-
-    if start or end:
-        out = out.crop(start=start, end=end)
-
-    return out
-
-
-def read_losc_state(filename, channel, group=None, start=None, end=None,
-                    copy=False):
+@io_hdf5.with_read_hdf5
+def read_losc_hdf5_state(f, path='quality/simple', start=None, end=None,
+                         copy=False):
     """Read a `StateVector` from a LOSC-format HDF file.
 
     Parameters
     ----------
-    filename : `str`
-        path to LOSC-format HDF5 file to read.
-    channel : `str`
-        name of HDF5 dataset to read.
-    group : `str`, optional
-        name of containing HDF5 group for ``channel``. If not given,
-        the first dataset named ``channel`` will be assumed as the right
-        one.
+    f : `str`, `h5py.HLObject`
+        path of HDF5 file, or open `H5File`
+
+    path : `str`
+        path of HDF5 dataset to read.
+
     start : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
         start GPS time of desired data
+
     end : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
         end GPS time of desired data
+
     copy : `bool`, default: `False`
         create a fresh-memory copy of the underlying array
 
     Returns
     -------
-    data : :class`~gwpy.timeseries.TimeSeries`
+    data : `~gwpy.timeseries.TimeSeries`
         a new `TimeSeries` containing the data read from disk
     """
-    h5file = open_hdf5(filename)
-    if group:
-        channel = '%s/%s' % (group, channel)
     # find data
-    dataset = _find_dataset(h5file, '%s/DQmask' % channel)
-    maskset = _find_dataset(h5file, '%s/DQDescriptions' % channel)
+    dataset = io_hdf5.find_dataset(f, '%s/DQmask' % path)
+    maskset = io_hdf5.find_dataset(f, '%s/DQDescriptions' % path)
     # read data
     nddata = dataset.value
     bits = list(map(lambda b: bytes.decode(bytes(b), 'utf-8'), maskset.value))
@@ -329,67 +284,52 @@ def read_losc_state(filename, channel, group=None, start=None, end=None,
         xunit = parse_unit(dataset.attrs['Xunits'])
         dt = Quantity(dt, xunit)
     return StateVector(nddata, bits=bits, epoch=epoch, name='Data quality',
-                       dx=dt, copy=copy)
+                       dx=dt, copy=copy).crop(start=start, end=end)
 
 
-def read_losc_state_cache(*args, **kwargs):
-    """Read a `StateVector` from a LOSC-format HDF file.
+# register
+registry.register_reader('hdf5.losc', TimeSeries, read_losc_hdf5)
+registry.register_reader('hdf5.losc', StateVector, read_losc_hdf5_state)
+# DEPRECATED -- remove prior to 1.0 release
+registry.register_reader('losc', TimeSeries, read_losc_hdf5)
+registry.register_reader('losc', StateVector, read_losc_hdf5_state)
 
-    Parameters
-    ----------
-    source : `str`, `list`
-        path to LOSC-format HDF5 file to read or cache of many files.
-    channel : `str`
-        name of HDF5 dataset to read.
-    group : `str`, optional
-        name of containing HDF5 group for ``channel``. If not given,
-        the first dataset named ``channel`` will be assumed as the right
-        one.
-    start : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
-        start GPS time of desired data
-    end : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
-        end GPS time of desired data
+re_losc_ascii_header = re.compile('\A# starting GPS (?P<epoch>\d+) '
+                                  'duration (?P<duration>\d+)\Z')
 
 
-    Returns
-    -------
-    data : :class:`~gwpy.timeseries.statevector.StateVector`
-        a new `TimeSeries` containing the data read from disk
+def read_losc_ascii(fobj):
+    """Read a LOSC ASCII file into a `TimeSeries`
     """
-    kwargs.setdefault('target', StateVector)
-    return read_losc_data_cache(*args, **kwargs)
+    # read file path
+    if isinstance(fobj, string_types):
+        with io_utils.gopen(fobj) as f:
+            return read_losc_ascii(f)
+
+    # read header to get metadata
+    metadata = {}
+    pos = fobj.tell()
+    for line in fobj:
+        if not line.startswith('#'):  # stop iterating, and rewind one line
+            fobj.seek(pos)
+            break
+        if line.startswith('# starting GPS'):  # parse metadata
+            m = re_losc_ascii_header.match(line.rstrip('\n'))
+            if m:
+                metadata.update(m.groupdict())
+        pos = fobj.tell()
+
+    # work out sample_rate from metadata
+    try:
+        dur = float(metadata.pop('duration'))
+    except KeyError:
+        raise ValueError("Failed to parse data duration from LOSC ASCII file")
+
+    data = numpy.loadtxt(fobj, dtype=float, comments='#', usecols=0)
+
+    metadata['sample_rate'] = data.size / dur
+    return TimeSeries(data, **metadata)
 
 
-@with_import('h5py')
-def _find_dataset(h5group, name):
-    """Find the named :class:`h5py.Dataset` in an HDF file.
-
-    Parameters
-    ----------
-    h5group : :class:`h5py.File`, :class:`h5py.Group`
-        open HDF file or group
-    name : `str`
-        name of :class:`h5py.Dataset` to find
-
-    Returns
-    -------
-    data : :class:`h5ile.Dataset`
-        HDF dataset
-    """
-    # find dataset directly
-    if not isinstance(h5group, h5py.Group):
-        raise ValueError("_find_dataset must be handed a h5py.Group object, "
-                         "not %s" % h5group.__class__.__name__)
-    if name in h5group and isinstance(h5group[name], h5py.Dataset):
-        return h5group[name]
-    # otherwise trawl through member groups
-    for group in h5group.values():
-        try:
-            return _find_dataset(group, name)
-        except ValueError:
-            continue
-    raise ValueError("Cannot find channel '%s' in file HDF object" % name)
-
-
-registry.register_reader('losc', TimeSeries, read_losc_data_cache)
-registry.register_reader('losc', StateVector, read_losc_state_cache)
+# ASCII
+registry.register_reader('ascii.losc', TimeSeries, read_losc_ascii)

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -294,16 +294,16 @@ def read_losc_ascii(fobj):
 
     # read header to get metadata
     metadata = {}
-    pos = fobj.tell()
     for line in fobj:
         if not line.startswith('#'):  # stop iterating, and rewind one line
-            fobj.seek(pos)
             break
         if line.startswith('# starting GPS'):  # parse metadata
             m = re_losc_ascii_header.match(line.rstrip('\n'))
             if m:
                 metadata.update(m.groupdict())
-        pos = fobj.tell()
+
+    # rewind to make sure we don't miss the first data point
+    fobj.seek(0)
 
     # work out sample_rate from metadata
     try:

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -80,7 +80,7 @@ def _parse_losc_json(metadata, detector, sample_rate=4096,
 # -- file discovery -----------------------------------------------------------
 
 def find_losc_urls(detector, start, end, host=LOSC_URL,
-                         sample_rate=4096, format=None):
+                   sample_rate=4096, format=None):
     """Fetch the metadata from LOSC regarding a given GPS interval
     """
     start = int(start)
@@ -145,8 +145,6 @@ def _fetch_losc_data_file(url, cls=TimeSeries, verbose=False, **kwargs):
         kwargs.setdefault('format', 'ascii.losc')
 
     with get_readable_fileobj(url, show_progress=False) as remote:
-        #local.write(remote.read())
-        #local.seek(0)
         try:
             return cls.read(remote, **kwargs)
         except Exception as e:
@@ -175,7 +173,7 @@ def fetch_losc_data(detector, start, end, host=LOSC_URL, sample_rate=4096,
     span = Segment(start, end)
     # get cache of URLS
     cache = find_losc_urls(detector, start, end, host=host,
-                                 sample_rate=sample_rate, format=format)
+                           sample_rate=sample_rate, format=format)
     if verbose:
         print("Fetched list of %d URLs to read from %s for [%d .. %d)"
               % (len(cache), host, int(start), int(end)))
@@ -227,7 +225,6 @@ def read_losc_hdf5(f, path='strain/Strain', start=None, end=None, copy=False):
     return TimeSeries(nddata, epoch=epoch, sample_rate=(1/dt).to('Hertz'),
                       unit=unit, name=path.rsplit('/', 1)[1],
                       copy=copy).crop(start=start, end=end)
-
 
 
 @io_hdf5.with_read_hdf5

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -635,7 +635,7 @@ class StateVector(TimeSeriesBase):
         return new
 
     @classmethod
-    def fetch_open_data(cls, ifo, start, end, name='quality/simple',
+    def fetch_open_data(cls, ifo, start, end, format='hdf5',
                         host='https://losc.ligo.org', verbose=False):
         """Fetch open-access data from the LIGO Open Science Center
 
@@ -653,10 +653,9 @@ class StateVector(TimeSeriesBase):
             GPS end time of required data, defaults to end of data found;
             any input parseable by `~gwpy.time.to_gps` is fine
 
-        name : `str`, optional
-            the full name of HDF5 dataset that represents the data you want,
-            e.g. `'strain/Strain'` for _h(t)_ data, or `'quality/simple'`
-            for basic data-quality information
+        format : `str`, optional
+            the data format to download and parse, defaults to ``'hdf5'``
+            which relies upon |h5py|_
 
         host : `str`, optional
             HTTP host name of LOSC server to access
@@ -664,9 +663,13 @@ class StateVector(TimeSeriesBase):
         verbose : `bool`, optional, default: `False`
             print verbose output while fetching data
 
+        Returns
+        -------
+        state : `~gwpy.timeseries.StateVector`
+            the data-quality statevector recorded by LOSC for this period
         """
         from .io.losc import fetch_losc_data
-        return fetch_losc_data(ifo, start, end, channel=name, cls=cls,
+        return fetch_losc_data(ifo, start, end, format=format, cls=cls,
                                host=host, verbose=verbose)
 
     @classmethod


### PR DESCRIPTION
This PR adds support for downloading data from losc.ligo.org in formats other than HDF5, namely 'txt.gz' and 'gwf'. This helps the test suite because it means we can test LOSCy things, and other methods using LOSC data without requiring h5py.