### PR TITLE
Bumped pytest version requirement to 3.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ sphinx-bootstrap-theme
 sphinxcontrib-programoutput
 
 # tests
-pytest>=2.8
+pytest>=3.1
 coveralls
 mock
 freezegun

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #           [use requirements-dev.txt for a full development environment
 #            including docs and testing dependencies]
 six>=1.5
-numpy>=1.10
+numpy>=1.11
 scipy>=0.16
 astropy>=1.2.1
 matplotlib>=1.4.1

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ cmdclass.update(versioneer.get_cmdclass())
 setup_requires = [
 ]
 install_requires = [
-    'numpy>=1.10',
+    'numpy>=1.11',
     'scipy>=0.16.0',
     'matplotlib>=1.4.1',
     'astropy>=1.2.1',

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ except ImportError:
 
 setup_requires.append('pytest-runner')
 tests_require = [
-    'pytest>=2.8',
+    'pytest>=3.1',
     'freezegun',
     'sqlparse',
 ]


### PR DESCRIPTION
This PR bumps the version requirement on `pytest` from 2.8 to 3.1, this is the lowest version that provides the `pytest.param` function [[ref](https://docs.pytest.org/en/latest/changelog.html#id52)].