### PR TITLE
Use environment markers to only install pycbc for python-2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,22 +47,12 @@ env:
   # normal build, normal tests
   - PIP_FLAGS="--upgrade" MINIMAL=false TEST_FLAGS=""
 
-  # normal build, pedantic tests
-  - PIP_FLAGS="--upgrade" MINIMAL=false TEST_FLAGS="--strict"
-
   # pre-release build, pedantic tests
   - PIP_FLAGS="--upgrade --pre" MINIMAL=false TEST_FLAGS="--strict"
 
 matrix:
   allow_failures:
-    - python: '2.7'
-      env: PIP_FLAGS="--upgrade --pre" MINIMAL=false TEST_FLAGS="--strict"
-    - python: '3.5'
-      env: PIP_FLAGS="--upgrade" MINIMAL=false TEST_FLAGS=""
-    - python: '3.5'
-      env: PIP_FLAGS="--upgrade" MINIMAL=false TEST_FLAGS="--strict"
-    - python: '3.5'
-      env: PIP_FLAGS="--upgrade --pre" MINIMAL=false TEST_FLAGS="--strict"
+    - env: PIP_FLAGS="--upgrade --pre" MINIMAL=false TEST_FLAGS="--strict"
   fast_finish: true
 
 before_install:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ h5py>=1.3
 pymysql
 dqsegdb
 https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
-pycbc
+pycbc; python_version == '2.7'
 git+https://github.com/duncanmmacleod/ligo.org.git
 
 # docs


### PR DESCRIPTION
This PR adds an environment marker [see [PEP 508](https://www.python.org/dev/peps/pep-0508/)] to `requirements-dev.txt` to only install pycbc for python 2.7. This should allow the python3 CI builds to complete.