### PR TITLE
Deprecation of gwpy.utils.deps and @with_import decorator

### DIFF
--- a/gwpy/detector/__init__.py
+++ b/gwpy/detector/__init__.py
@@ -24,7 +24,6 @@
 
 import datetime
 
-from ..utils.deps import with_import
 from . import units
 from .channel import *
 from .io import *
@@ -49,8 +48,8 @@ def get_timezone(ifo):
         raise
 
 
-@with_import('pytz')
 def get_timezone_offset(ifo, dt=None):
+    import pytz
     dt = dt or datetime.datetime.now()
     offset = pytz.timezone(get_timezone(ifo)).utcoffset(dt)
     return offset.days * 86400 + offset.seconds + offset.microseconds * 1e-6

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -37,7 +37,6 @@ from astropy.io import registry as io_registry
 
 from ..io import (datafind, nds2 as io_nds2)
 from ..time import to_gps
-from ..utils.deps import with_import
 from .units import parse_unit
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -427,7 +426,6 @@ class Channel(object):
         return channellist[0]
 
     @classmethod
-    @with_import('nds2')
     def query_nds2(cls, name, host=None, port=None, connection=None,
                    type=None):
         """Query an NDS server for channel information

--- a/gwpy/frequencyseries/core.py
+++ b/gwpy/frequencyseries/core.py
@@ -30,7 +30,6 @@ from astropy.io import registry as io_registry
 
 from ..types import Series
 from ..detector import Channel
-from ..utils import with_import
 
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org"
@@ -341,7 +340,6 @@ class FrequencySeries(Series):
         return self.filter(*args, **kwargs)
 
     @classmethod
-    @with_import('lal')
     def from_lal(cls, lalfs, copy=True):
         """Generate a new `FrequencySeries` from a LAL `FrequencySeries` of any type
         """
@@ -356,7 +354,6 @@ class FrequencySeries(Series):
                    df=lalfs.deltaF, epoch=float(lalfs.epoch),
                    dtype=lalfs.data.data.dtype, copy=copy)
 
-    @with_import('lal')
     def to_lal(self):
         """Convert this `FrequencySeries` into a LAL FrequencySeries.
 
@@ -371,16 +368,15 @@ class FrequencySeries(Series):
         Currently, this function is unable to handle unit string
         conversion.
         """
+        import lal
         from ..utils.lal import (LAL_TYPE_STR_FROM_NUMPY, to_lal_unit)
+
         typestr = LAL_TYPE_STR_FROM_NUMPY[self.dtype.type]
         try:
             unit = to_lal_unit(self.unit)
         except ValueError as e:
             warnings.warn("%s, defaulting to lal.DimensionlessUnit" % str(e))
-            try:
-                unit = lal.DimensionlessUnit
-            except AttributeError:
-                unit = lal.lalDimensionlessUnit
+            unit = lal.DimensionlessUnit
         create = getattr(lal, 'Create%sFrequencySeries' % typestr.upper())
         if self.epoch is None:
             epoch = 0

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -23,7 +23,6 @@ import os.path
 import re
 
 from ..time import to_gps
-from ..utils import with_import
 from .gwf import (num_channels, channel_in_frame)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -34,7 +33,6 @@ SECOND_TREND_TYPE = re.compile('\A(.*_)?T\Z')  # T or anything ending in _T
 MINUTE_TREND_TYPE = re.compile('\A(.*_)?M\Z')  # M or anything ending in _M
 
 
-@with_import('glue.datafind')
 def connect(host=None, port=None):
     """Open a new datafind connection
 
@@ -51,6 +49,8 @@ def connect(host=None, port=None):
     connection : `~glue.datafind.GWDataFindHTTPConnection`
         the new open connection
     """
+    from glue import datafind
+
     port = port and int(port)
     if port is not None and port != 80:
         cert, key = datafind.find_credential()

--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -22,7 +22,7 @@
 import six
 
 from ..time import to_gps
-from ..utils import (shell, with_import)
+from ..utils import shell
 from .cache import open_cache
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -149,7 +149,6 @@ def create_frame(time=0, duration=None, name='gwpy', run=-1, ifos=[]):
 
 # -- utilities ----------------------------------------------------------------
 
-@with_import('lalframe')
 def num_channels(framefile):
     """Find the total number of channels in this framefile
 
@@ -171,7 +170,6 @@ def num_channels(framefile):
     return len(get_channel_names(framefile))
 
 
-@with_import('lalframe')
 def get_channel_type(channel, framefile):
     """Find the channel type in a given frame file
 
@@ -193,6 +191,8 @@ def get_channel_type(channel, framefile):
     ValueError
         if the channel is not found in the table-of-contents
     """
+    import lalframe
+
     name = str(channel)
     # read frame and table of contents
     frfile = lalframe.FrameUFrFileOpen(framefile, "r")

--- a/gwpy/tests/test_utils.py
+++ b/gwpy/tests/test_utils.py
@@ -26,7 +26,7 @@ from six import PY2
 import pytest
 
 from gwpy.utils import shell
-from gwpy.utils import deps
+from gwpy.utils import deps  # deprecated
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -53,7 +53,7 @@ from ..types import (Array2D, Series)
 from ..detector import (Channel, ChannelList)
 from ..io import datafind
 from ..time import (Time, LIGOTimeGPS, to_gps)
-from ..utils import (gprint, with_import)
+from ..utils import gprint
 from ..utils.compat import OrderedDict
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -224,7 +224,6 @@ class TimeSeriesBase(Series):
     # -- TimeSeries accessors -------------------
 
     @classmethod
-    @with_import('nds2')
     def fetch(cls, channel, start, end, host=None, port=None, verbose=False,
               connection=None, verify=False, pad=None, allow_tape=None,
               type=None, dtype=None):
@@ -432,7 +431,6 @@ class TimeSeriesBase(Series):
         return TimeSeriesPlot(self, **kwargs)
 
     @classmethod
-    @with_import('nds2')
     def from_nds2_buffer(cls, buffer_, **metadata):
         """Construct a new `TimeSeries` from an `nds2.buffer` object
 
@@ -465,7 +463,6 @@ class TimeSeriesBase(Series):
         return cls(buffer_.data, **metadata)
 
     @classmethod
-    @with_import('lal')
     def from_lal(cls, lalts, copy=True):
         """Generate a new TimeSeries from a LAL TimeSeries of any type.
         """
@@ -484,20 +481,17 @@ class TimeSeriesBase(Series):
         else:
             return out
 
-    @with_import('lal')
     def to_lal(self):
         """Convert this `TimeSeries` into a LAL TimeSeries.
         """
+        import lal
         from ..utils.lal import (LAL_TYPE_STR_FROM_NUMPY, to_lal_unit)
         typestr = LAL_TYPE_STR_FROM_NUMPY[self.dtype.type]
         try:
             unit = to_lal_unit(self.unit)
         except ValueError as e:
             warnings.warn("%s, defaulting to lal.DimensionlessUnit" % str(e))
-            try:
-                unit = lal.DimensionlessUnit
-            except AttributeError:
-                unit = lal.lalDimensionlessUnit
+            unit = lal.DimensionlessUnit
         create = getattr(lal, 'Create%sTimeSeries' % typestr.upper())
         lalts = create(self.name, lal.LIGOTimeGPS(self.epoch.gps), 0,
                        self.dt.value, unit, self.size)
@@ -711,7 +705,6 @@ class TimeSeriesBaseDict(OrderedDict):
         return self
 
     @classmethod
-    @with_import('nds2')
     def fetch(cls, channels, start, end, host=None, port=None,
               verify=False, verbose=False, connection=None,
               pad=None, allow_tape=None, type=None,

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -49,7 +49,6 @@ else:
 
 from ....segments import Segment
 from ....time import to_gps
-from ....utils.deps import import_method_dependency
 from ....io.gwf import identify_gwf
 from ....io.cache import (FILE_LIKE, read_cache, find_contiguous)
 from ....io.registry import (register_reader,

--- a/gwpy/utils/deps.py
+++ b/gwpy/utils/deps.py
@@ -21,9 +21,13 @@ dependencies within GWpy code.
 """
 
 import inspect
+import warnings
 from functools import wraps
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+warnings.warn('The gwpy.utils.deps module has been deprecated and will be '
+              'removed in an upcoming release', DeprecationWarning)
 
 
 def import_method_dependency(module, stacklevel=1):


### PR DESCRIPTION
This PR deprecates the `gwpy.utils.deps` module, including the `@with_import` decorator. This construct obfuscates imports, making the code harder to read, and confuses the hell out of any code inspection tools.