### PR TITLE
Added generic SQL fetcher (from table.io.gravityspy)

### DIFF
--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -23,6 +23,7 @@ import operator
 import token
 import re
 from tokenize import generate_tokens
+from collections import OrderedDict
 
 from six.moves import StringIO
 
@@ -30,22 +31,22 @@ import numpy
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-OPERATORS = {
-    '<': operator.lt,
-    '<=': operator.le,
-    '=': operator.eq,
-    '==': operator.eq,
-    '>=': operator.ge,
-    '>': operator.gt,
-    '!=': operator.ne,
-}
+OPERATORS = OrderedDict([
+    ('<', operator.lt),
+    ('<=', operator.le),
+    ('=', operator.eq),
+    ('==', operator.eq),
+    ('>=', operator.ge),
+    ('>', operator.gt),
+    ('!=', operator.ne),
+])
 
-OPERATORS_INV = {
-    '<=': operator.ge,
-    '<': operator.gt,
-    '>': operator.lt,
-    '>=': operator.le,
-}
+OPERATORS_INV = OrderedDict([
+    ('<=', operator.ge),
+    ('<', operator.gt),
+    ('>', operator.lt),
+    ('>=', operator.le),
+])
 
 re_quote = re.compile(r'^[\s\"\']+|[\s\"\']+$')
 re_delim = re.compile(r'(and|&+)', re.I)

--- a/gwpy/table/io/fetch.py
+++ b/gwpy/table/io/fetch.py
@@ -86,7 +86,7 @@ def get_fetcher(data_format, data_class):
 
 
 def _update__doc__(data_class):
-    header = "The available formats are:"
+    header = "The available named formats are:"
     fetch = data_class.fetch
 
     # if __doc__ isn't a string, bail-out now
@@ -108,7 +108,7 @@ def _update__doc__(data_class):
 
     # now re-write the format list
     formats = []
-    for fmt, cls in _FETCHERS:
+    for fmt, cls in sorted(_FETCHERS, key=lambda x: x[0]):
         if cls is not data_class:
             continue
         usage = _FETCHERS[(fmt, cls)][1]

--- a/gwpy/table/io/gravityspy.py
+++ b/gwpy/table/io/gravityspy.py
@@ -28,20 +28,20 @@ connections in the following environment variables
 These can be found https://secrets.ligo.org/secrets/144/. The description
 is the username and thesecret is the password.
 """
+
 import os
 
 from astropy.table import Table
 
+from .sql import fetch
 from .fetch import register_fetcher
 from .. import GravitySpyTable
 from .. import EventTable
-from ..filter import (OPERATORS, parse_column_filters)
 
 __author__ = 'Scott Coughlin <scott.coughlin@ligo.org>'
 
 
-def get_gravityspy_triggers(tablename, engine=None, columns=None,
-                            selection=None, **kwargs):
+def get_gravityspy_triggers(tablename, engine=None, **kwargs):
     """Fetch data into an `GravitySpyTable`
 
     Parameters
@@ -64,7 +64,6 @@ def get_gravityspy_triggers(tablename, engine=None, columns=None,
     -------
     table : `GravitySpyTable`
     """
-    import pandas as pd
     from sqlalchemy.engine import create_engine
     from sqlalchemy.exc import ProgrammingError
 
@@ -79,30 +78,8 @@ def get_gravityspy_triggers(tablename, engine=None, columns=None,
         connectionStr = connectStr(**conn_kw)
         engine = create_engine(connectionStr)
 
-    # parse columns for SQL query
-    if columns is None:
-        columnstr = '*'
-    else:
-        columnstr = ', '.join('"%s"' % c for c in columns)
-
-    # parse selection for SQL query
-    if selection is None:
-        selectionstr = ''
-    else:
-        selections = []
-        for col, def_ in parse_column_filters(selection):
-            for thresh, op_ in def_:
-                opstr = [key for key in OPERATORS if OPERATORS[key] is op_][0]
-                selections.append('{0} {1} {2}'.format(col, opstr, thresh))
-        if selections:
-            selectionstr = 'where %s' % ' AND '.join(selections)
-
-    # build SQL query
-    qstr = 'SELECT %s FROM %s %s' % (columnstr, tablename, selectionstr)
-
-    # perform query
     try:
-        tab = pd.read_sql(qstr, engine, **kwargs)
+        return GravitySpyTable(fetch(engine, tablename, **kwargs))
     except ProgrammingError as e:
         if 'relation "%s" does not exist' % tablename in str(e):
             msg = e.args[0]
@@ -113,13 +90,8 @@ def get_gravityspy_triggers(tablename, engine=None, columns=None,
             e.args = (msg,)
         raise
 
-    tab = Table.from_pandas(tab)
-
-    # and return
-    return GravitySpyTable(tab.filled())
 
 # -- utilities ----------------------------------------------------------------
-
 
 def connectStr(db='gravityspy', host='gravityspy.ciera.northwestern.edu',
                user=os.getenv('GRAVITYSPY_DATABASE_USER', None),

--- a/gwpy/table/io/hacr.py
+++ b/gwpy/table/io/hacr.py
@@ -36,8 +36,8 @@ from dateutil.relativedelta import relativedelta
 from ...segments import Segment
 from ...time import (to_gps, from_gps)
 from .. import EventTable
-from ..filter import (OPERATORS, parse_column_filters)
 from .fetch import register_fetcher
+from .sql import format_db_selection
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -97,15 +97,8 @@ def get_hacr_triggers(channel, start, end, columns=HACR_COLUMNS, pid=None,
     columns = list(columns)
     span = Segment(*map(to_gps, (start, end)))
 
-    # parse selections and map to column indices
-    if selection is None:
-        selectionstr = ''
-    else:
-        selectionstr = ''
-        for col, def_ in parse_column_filters(selection):
-            for thresh, op_ in def_:
-                opstr = [key for key in OPERATORS if OPERATORS[key] is op_][0]
-                selectionstr += ' and {0} {1} {2}'.format(col, opstr, thresh)
+    # parse selection for SQL query (removing leading 'where ')
+    selectionstr = 'and %s' % format_db_selection(selection, engine=None)[6:]
 
     # get database names and loop over each on
     databases = get_database_names(start, end)

--- a/gwpy/table/io/sql.py
+++ b/gwpy/table/io/sql.py
@@ -36,7 +36,7 @@ def format_db_selection(selection, engine=None):
         if engine and engine.name == 'postgresql':
             col = '"%s"' % col
         for value, op_ in def_:
-            opstr = [key for key in OPERATORS if OPERATORS[key] is op_][-1]
+            opstr = [key for key in OPERATORS if OPERATORS[key] is op_][0]
             selections.append('{0} {1} {2!r}'.format(col, opstr, value))
     if selections:
         return 'WHERE %s' % ' AND '.join(selections)

--- a/gwpy/table/io/sql.py
+++ b/gwpy/table/io/sql.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Scott Coughlin (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for database queries
+"""
+
+from astropy.table import Table
+
+from .. import EventTable
+from ..filter import (OPERATORS, parse_column_filters)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def format_db_selection(selection, engine=None):
+    # parse selection for SQL query
+    if selection is None:
+        return ''
+    selections = []
+    for col, def_ in parse_column_filters(selection):
+        if engine and engine.name == 'postgresql':
+            col = '"%s"' % col
+        for value, op_ in def_:
+            opstr = [key for key in OPERATORS if OPERATORS[key] is op_][-1]
+            selections.append('{0} {1} {2!r}'.format(col, opstr, value))
+    if selections:
+        return 'WHERE %s' % ' AND '.join(selections)
+    return ''
+
+
+def fetch(engine, tablename, columns=None, selection=None, **kwargs):
+    """Fetch data from an SQL table into an `EventTable`
+
+    Parameters
+    ----------
+    engine : `sqlalchemy.engine.Engine`
+        the database engine to use when connecting
+
+    table : `str`,
+        The name of table you are attempting to receive triggers
+        from.
+
+    selection
+        other filters you would like to supply
+        underlying reader method for the given format
+
+    .. note::
+
+       For now it will attempt to automatically connect you
+       to a specific DB. In the future, this may be an input
+       argument.
+
+    Returns
+    -------
+    table : `GravitySpyTable`
+    """
+    import pandas as pd
+    from sqlalchemy.exc import ProgrammingError
+
+    # parse columns for SQL query
+    if columns is None:
+        columnstr = '*'
+    else:
+        columnstr = ', '.join('"%s"' % c for c in columns)
+
+    # parse selection for SQL query
+    selectionstr = format_db_selection(selection, engine=engine)
+
+    # build SQL query
+    qstr = 'SELECT %s FROM %s %s' % (columnstr, tablename, selectionstr)
+
+    # perform query
+    tab = pd.read_sql(qstr, engine, **kwargs)
+
+    return Table.from_pandas(tab).filled()

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -237,7 +237,7 @@ class EventTable(Table):
 
         To download a table of all blip glitches from the Gravity Spy database:
 
-        >>> EventTable.fetch('gravityspy', 'glitches', selection='Label = Blip')
+        >>> EventTable.fetch('gravityspy', 'glitches', selection='Label=Blip')
 
         To download a table from any SQL-type server
 


### PR DESCRIPTION
This PR separates the SQL query stuff from `gwpy.table.io.gravityspy` into a generic SQL fetch system, where users can pass their own `sqlalchemy.engine.Engine` to query any database.

This required a re-write of the selection parser.