### PR TITLE
Improved default Q-transform whitening duration

### DIFF
--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -121,6 +121,10 @@ class QTiling(QObject):
         """
         return numpy.array(list(self._iter_qs()))
 
+    @property
+    def whitening_duration(self):
+        return max(t.whitening_duration for t in self)
+
     def _iter_qs(self):
         """Iterate over the Q values
         """
@@ -215,6 +219,10 @@ class QPlane(QBase):
         f = self.frequencies
         bandwidths = 2 * pi ** (1/2.) * f / self.q
         return f - bandwidths / 2.
+
+    @property
+    def whitening_duration(self):
+        return 2 ** (round(log(self.q / (2 * self.frange[0]), 2)))
 
     def transform(self, fseries, normalized=True, epoch=None):
         """Calculate the energy `TimeSeries` for the given fseries

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1042,7 +1042,7 @@ class TestTimeSeries(TestTimeSeriesBase):
 
     def test_q_transform(self, losc):
         # test simple q-transform
-        qspecgram = losc.q_transform(method='welch')
+        qspecgram = losc.q_transform(method='welch', fftlength=2)
         assert isinstance(qspecgram, Spectrogram)
         assert qspecgram.shape == (4000, 2403)
         assert qspecgram.q == 5.65685424949238

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -624,7 +624,6 @@ class TestTimeSeries(TestTimeSeriesBase):
                         comb, array.append(a2, inplace=False),
                         exclude=['channel'])
 
-
     @utils.skip_missing_dependency('h5py')
     @pytest.mark.parametrize('ext', ('hdf5', 'h5'))
     def test_read_write_hdf5(self, ext):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1637,7 +1637,9 @@ class TimeSeries(TimeSeriesBase):
                 overlap = fftlength / 2.
             else:
                 method = asd_kw.pop('method', 'median-mean')
-                fftlength = asd_kw.pop('fftlength', min(2, self.duration.value))
+                fftlength = asd_kw.pop(
+                    'fftlength',
+                    min(planes.whitening_duration, self.duration.value))
                 overlap = asd_kw.pop('overlap', None)
                 if overlap is None and fftlength == self.duration.value:
                     method = 'welch'


### PR DESCRIPTION
This PR uses an improved default for the `fftlength` option to `TimeSeries.q_transform`, duplicating what the original matlab implementation did.

Also, I have improved the defaults for the other ASD kwargs (see 598fbde).