### PR TITLE
Improved GPS axis tick labelling

### DIFF
--- a/gwpy/plotter/gps.py
+++ b/gwpy/plotter/gps.py
@@ -72,10 +72,10 @@ class GPSMixin(object):
     def set_epoch(self, epoch):
         if epoch is None:
             self._epoch = None
-        elif isinstance(epoch, Time):
-            self._epoch = epoch.utc.gps
-        else:
-            self._epoch = float(epoch)
+            return
+        if isinstance(epoch, Time):
+            epoch = epoch.utc.gps
+        self._epoch = float(epoch)
 
     epoch = property(fget=get_epoch, fset=set_epoch,
                      doc=get_epoch.__doc__)

--- a/gwpy/plotter/gps.py
+++ b/gwpy/plotter/gps.py
@@ -20,6 +20,7 @@
 """
 
 import re
+from numbers import Number
 
 import numpy
 
@@ -94,7 +95,7 @@ class GPSMixin(object):
             self._unit = unit
             return
         # convert float to custom unit in seconds
-        if isinstance(unit, float):
+        if isinstance(unit, Number):
             unit = units.Unit(unit * units.second)
         # otherwise, should be able to convert to a time unit
         try:

--- a/gwpy/plotter/gps.py
+++ b/gwpy/plotter/gps.py
@@ -361,6 +361,7 @@ class GPSScale(GPSMixin, LinearScale):
         axis.set_minor_locator(GPSAutoMinorLocator(epoch=self.epoch))
         axis.set_minor_formatter(ticker.NullFormatter())
 
+
 register_scale(GPSScale)
 
 
@@ -368,6 +369,7 @@ class AutoGPSScale(GPSScale):
     """Automagic GPS scaling based on visible data
     """
     name = 'auto-gps'
+
 
 register_scale(AutoGPSScale)
 
@@ -380,6 +382,7 @@ def gps_scale_factory(unit):
         def __init__(self, axis, epoch=None):
             super(FixedGPSScale, self).__init__(axis, epoch=epoch, unit=unit)
     return FixedGPSScale
+
 
 for _unit in TIME_UNITS:
     register_scale(gps_scale_factory(_unit))

--- a/gwpy/plotter/gps.py
+++ b/gwpy/plotter/gps.py
@@ -19,7 +19,6 @@
 """This module defines a locators/formatters and a scale for GPS data.
 """
 
-import re
 from decimal import Decimal
 from numbers import Number
 


### PR DESCRIPTION
This PR improves the labelling of scaled GPS times on an axis with a GPS scale. The key is to use `Decimal` for all GPS time conversions to avoid ridiculous python/numpy float precision corrections.