### PR TITLE
Fixed pickle of Channel in py3 when writing to Array to HDF5

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -628,6 +628,7 @@ class TestTimeSeries(TestTimeSeriesBase):
     @pytest.mark.parametrize('ext', ('hdf5', 'h5'))
     def test_read_write_hdf5(self, ext):
         array = self.create()
+        array.channel = 'X1:TEST-CHANNEL'
 
         with tempfile.NamedTemporaryFile(suffix='.%s' % ext) as f:
             # check array with no name fails

--- a/gwpy/types/io/hdf5.py
+++ b/gwpy/types/io/hdf5.py
@@ -98,7 +98,7 @@ def create_array_dataset(h5g, array, path=None, compression='gzip', **kwargs):
         if isinstance(mdval, Quantity):
             dset.attrs[attr] = mdval.value
         elif isinstance(mdval, Channel):
-            dset.attrs[attr] = pickle.dumps(mdval)
+            dset.attrs[attr] = pickle.dumps(mdval, protocol=0)
         elif isinstance(mdval, UnitBase):
             dset.attrs[attr] = str(mdval)
         elif isinstance(mdval, (Decimal, LIGOTimeGPS)):


### PR DESCRIPTION
This PR fixes a problem storing pickled `Channel` objects in python3 as HDF5 attributes. We require to use the simple ASCII protocol '0'.