### PR TITLE
Improved handling of plurals in custom unit parser 

### DIFF
--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -61,6 +61,7 @@ class PluralFormat(Generic):
             raise exc
 
 
+# pylint: disable=redefined-builtin
 def parse_unit(name, parse_strict='warn', format=PluralFormat):
     """Attempt to intelligently parse a `str` as a `~astropy.units.Unit`
 
@@ -89,6 +90,7 @@ def parse_unit(name, parse_strict='warn', format=PluralFormat):
     if name is None:
         return None
 
+    # pylint: disable=unexpected-keyword-arg
     return units.Unit(name, parse_strict=parse_strict, format=format)
 
 

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -19,24 +19,62 @@
 """This module registers a number of custom units used in GW astronomy.
 """
 
+import re
+
 from astropy import units
+from astropy.units.format.generic import Generic
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
-# enable imperial units
-units.add_enabled_units(units.imperial)
+# -- parser to handle plurals -------------------------------------------------
 
 
-def parse_unit(name, parse_strict='warn'):
+class PluralFormat(Generic):
+    """Sub-class of the `Generic` unit parser that handles plurals
+
+    This just enables uses to specify a unit as 'meters' instead of just
+    'meter', and have the parse handle things as well as can be expected.
+    """
+    re_closest_unit = re.compile(r'Did you mean (.*)\?\Z')
+    re_closest_unit_delim = re.compile('(, | or )')
+
+    @classmethod
+    def _get_unit(cls, t):
+        # match as normal
+        try:
+            return cls._parse_unit(t.value)
+        except ValueError as exc:
+            # if error message suggests one alternative that is just the
+            # singular of the unit given, use it, otherwise re-raise the
+            # original exception
+            match = cls.re_closest_unit.search(str(exc))
+            try:  # split 'A, B, or C' -> ['A', 'B', 'C']
+                alts = cls.re_closest_unit_delim.split(match.groups()[0])[::2]
+            except AttributeError:
+                raise exc
+            alts = list(set(map(str.lower, alts)))
+            if len(alts) == 1 and '%ss' % alts[0] == t.value.lower():
+                try:
+                    return cls._parse_unit(alts[0])
+                except ValueError:
+                    raise exc
+            raise exc
+
+
+def parse_unit(name, parse_strict='warn', format=PluralFormat):
     """Attempt to intelligently parse a `str` as a `~astropy.units.Unit`
 
     Parameters
     ----------
     name : `str`
         unit name to parse
+
     parse_strict : `str`
         one of 'silent', 'warn', or 'raise' depending on how pedantic
         you want the parser to be
+
+    format : `~astropy.units.format.Base`
+        the formatter class to use when parsing the unit string
 
     Returns
     -------
@@ -48,30 +86,18 @@ def parse_unit(name, parse_strict='warn'):
     ValueError
         if the unit cannot be parsed and `parse_strict='raise'`
     """
-    if name is None or isinstance(name, units.UnitBase):
-        return name
-    if isinstance(name, bytes):
-        name = name.decode('utf-8')
-    else:
-        name = str(name)
-    # try simple parse
-    try:
-        return units.Unit(name)
-    except ValueError:
-        pass
-    # try plural parsing
-    if name.endswith('s'):
-        try:
-            return units.Unit(name[:-1])
-        except ValueError:
-            pass
-    # otherwise allow a loose parsing
-    return units.Unit(name, parse_strict=parse_strict)
+    if name is None:
+        return None
+
+    return units.Unit(name, parse_strict=parse_strict, format=format)
 
 
-# -----------------------------------------------------------------------------
-# instrumental units
+# -- custom units -------------------------------------------------------------
 
+# enable imperial units
+units.add_enabled_units(units.imperial)
+
+# custom GWO units
 units.add_enabled_units([
     units.def_unit(['counts'], represents=units.Unit('count')),
     units.def_unit(['undef'], doc='No unit has been defined for these data'),

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -54,10 +54,7 @@ class PluralFormat(Generic):
                 raise exc
             alts = list(set(map(str.lower, alts)))
             if len(alts) == 1 and '%ss' % alts[0] == t.value.lower():
-                try:
-                    return cls._parse_unit(alts[0])
-                except ValueError:
-                    raise exc
+                return cls._parse_unit(alts[0])
             raise exc
 
 

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -111,6 +111,7 @@ channels =
     (units.m, units.m),
     ('meter', units.m),
     ('Volts', units.V),
+    ('meters/second', units.m / units.s),
     ('blah', units.Unit('blah', parse_strict='silent')),
 ])
 def test_parse_unit(arg, unit):

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -78,7 +78,7 @@ OMEGA_CONFIG = """
   plotNormalizedEnergyRange:   [0 25.5]
   alwaysPlotFlag:              0
 }
-"""
+"""  # nopep8
 
 CLF = """
 [group-1]
@@ -97,7 +97,7 @@ channels =
 	H1:ISI-GND_STS_HAM2_X_DQ 512 safe flat
 	H1:ISI-GND_STS_HAM2_Y_DQ 256 unsafe flat
 	H1:ISI-GND_STS_HAM2_Z_DQ 512 glitchy
-"""
+"""  # nopep8
 
 
 # -----------------------------------------------------------------------------
@@ -599,7 +599,7 @@ class TestChannelList(object):
             assert a.frametype == 'H1_HOFT_C00'
             assert a.frequency_range[0] == 4. * units.Hz
             assert a.frequency_range[1] == float('inf') * units.Hz
-            assert a.safe == False
+            assert a.safe is False
             assert a.params == {'qhigh': '150', 'safe': 'unsafe',
                                 'fidelity': 'clean'}
             b = cl[1]
@@ -609,10 +609,10 @@ class TestChannelList(object):
             c = cl[2]
             assert c.name == 'H1:ISI-GND_STS_HAM2_Y_DQ'
             assert c.sample_rate == 256 * units.Hz
-            assert c.safe == False
+            assert c.safe is False
             d = cl[3]
             assert d.name == 'H1:ISI-GND_STS_HAM2_Z_DQ'
-            assert d.safe == True
+            assert d.safe is True
             assert d.params['fidelity'] == 'glitchy'
         finally:
             if os.path.isfile(f.name):


### PR DESCRIPTION
This PR improves the handling of plural unit names in `gwpy.detector.units.parse_unit`, so that multiple plural components in a compound name get handled individually. The upshot is that something like `meters/second` now gets parsed as `m/s`.