### PR TITLE
Fixed bugs in computing Rayleigh spectrogram

### DIFF
--- a/examples/frequencyseries/rayleigh.py
+++ b/examples/frequencyseries/rayleigh.py
@@ -40,7 +40,7 @@ from gwpy.timeseries import TimeSeries
 gwdata = TimeSeries.fetch_open_data('L1', 'Dec 26 2015 03:37',
                                     'Dec 26 2015 03:47', verbose=True)
 
-# Next, we can calculate a Rayleigh statistic `FrequencySeries` using the 
+# Next, we can calculate a Rayleigh statistic `FrequencySeries` using the
 # :meth:`~gwpy.timeseries.TimeSeries.rayleigh_spectrum` method of the
 # `~gwpy.timeseries.TimeSeries` with a 2-second FFT and 1-second overlap (50%):
 

--- a/examples/frequencyseries/rayleigh.py
+++ b/examples/frequencyseries/rayleigh.py
@@ -33,13 +33,12 @@ and recorded at a LIGO site.
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.frequencyseries'
 
-# To demonstate, we can download some public LIGO data from the sixth science
-# run (S6) for the H1 interferometer:
+# To demonstate this, we can load some data from the LIGO Livingston
+# intereferometer around the time of the GW151226 gravitational wave detection:
 
 from gwpy.timeseries import TimeSeries
-gwdata = TimeSeries.fetch_open_data(
-    'H1', 'September 16 2010 07:00', 'September 16 2010 07:10',
-    verbose=True)
+gwdata = TimeSeries.fetch_open_data('L1', 'Dec 26 2015 03:37',
+                                    'Dec 26 2015 03:47', verbose=True)
 
 # Next, we can calculate a Rayleigh statistic `FrequencySeries` using the 
 # :meth:`~gwpy.timeseries.TimeSeries.rayleigh_spectrum` method of the
@@ -51,13 +50,16 @@ rayleigh = gwdata.rayleigh_spectrum(2, 1)
 # strain data and plot both on the same figure:
 
 asd = gwdata.asd(2, 1)
-plot = asd.plot()
+plot = asd.plot(figsize=(8, 6))
 plot.add_frequencyseries(rayleigh, newax=True, sharex=plot.axes[0])
-plot.axes[0].set_xlabel('')
-plot.axes[0].set_xlim(40, 2000)
-plot.axes[0].set_ylim(1e-23, 5e-21)
-plot.axes[0].set_ylabel(r'[strain/\rtHz]')
-plot.axes[1].set_ylabel('Rayleigh statistic')
+asdax, rayax = plot.axes
+asdax.set_xlabel('')
+asdax.set_xlim(30, 1500)
+asdax.set_ylim(5e-24, 1e-21)
+asdax.set_ylabel(r'[strain/\rtHz]')
+rayax.set_ylim(0, 2)
+rayax.set_ylabel('Rayleigh statistic')
+asdax.set_title('Sensitivity of LIGO-Livingston around GW151226', fontsize=20)
 plot.show()
 
 # So, we see sharp dips at certain frequencies associated with 'lines' in

--- a/examples/spectrogram/rayleigh.py
+++ b/examples/spectrogram/rayleigh.py
@@ -19,26 +19,30 @@
 
 """Plotting a `Spectrogram` of the Rayleigh statistic
 
-I would like to study the gravitational wave strain spectrogram around the time of an interesting simulated signal during the last science run (S6).
+As described in :ref:`gwpy-example-frequencyseries-rayleigh`, the Rayleigh statistic can be used to study non-Gaussianity in a timeseries. We can study the time variance of these features by plotting a time-frequency spectrogram where we calculate the Rayleigh statistic for each time bin.
 """
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.spectrogram'
 
-# First, we import the :class:`~gwpy.timeseries.TimeSeries` and :meth:`~gwpy.timeseries.TimeSeries.get` the data:
+# To demonstate this, we can load some data from the LIGO Livingston
+# intereferometer around the time of the GW151226 gravitational wave detection:
+
 from gwpy.timeseries import TimeSeries
-gwdata = TimeSeries.get(
-    'H1:LDAS-STRAIN', 'September 16 2010 06:40', 'September 16 2010 06:50')
+gwdata = TimeSeries.fetch_open_data('L1', 'Dec 26 2015 03:37',
+                                    'Dec 26 2015 03:47', verbose=True)
 
 # Next, we can calculate a Rayleigh statistic `Spectrogram` using the 
-# :meth:`~gwpy.timeseries.TimeSeries.rayleigh_spectrogram` method of the #
+# :meth:`~gwpy.timeseries.TimeSeries.rayleigh_spectrogram` method of the
 # `~gwpy.timeseries.TimeSeries` and a 5-second stride with a 2-second FFT and 
 # 1-second overlap (50%):
 rayleigh = gwdata.rayleigh_spectrogram(5, fftlength=2, overlap=1)
 
 # and can make a plot using the :meth:`~Spectrogram.plot` method
 plot = rayleigh.plot(norm='log', vmin=0.25, vmax=4)
-plot.set_yscale('log')
-plot.set_ylim(40, 4000)
-plot.add_colorbar(cmap='BrBG_r', label=r'Rayleigh statistic')
+ax = plot.gca()
+ax.set_yscale('log')
+ax.set_ylim(30, 1500)
+ax.set_title('Sensitivity of LIGO-Livingston around GW151226')
+plot.add_colorbar(cmap='coolwarm', label='Rayleigh statistic')
 plot.show()

--- a/examples/spectrogram/rayleigh.py
+++ b/examples/spectrogram/rayleigh.py
@@ -19,7 +19,11 @@
 
 """Plotting a `Spectrogram` of the Rayleigh statistic
 
-As described in :ref:`gwpy-example-frequencyseries-rayleigh`, the Rayleigh statistic can be used to study non-Gaussianity in a timeseries. We can study the time variance of these features by plotting a time-frequency spectrogram where we calculate the Rayleigh statistic for each time bin.
+As described in :ref:`gwpy-example-frequencyseries-rayleigh`, the Rayleigh
+statistic can be used to study non-Gaussianity in a timeseries.
+We can study the time variance of these features by plotting a
+time-frequency spectrogram where we calculate the Rayleigh statistic for
+each time bin.
 """
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -32,9 +36,9 @@ from gwpy.timeseries import TimeSeries
 gwdata = TimeSeries.fetch_open_data('L1', 'Dec 26 2015 03:37',
                                     'Dec 26 2015 03:47', verbose=True)
 
-# Next, we can calculate a Rayleigh statistic `Spectrogram` using the 
+# Next, we can calculate a Rayleigh statistic `Spectrogram` using the
 # :meth:`~gwpy.timeseries.TimeSeries.rayleigh_spectrogram` method of the
-# `~gwpy.timeseries.TimeSeries` and a 5-second stride with a 2-second FFT and 
+# `~gwpy.timeseries.TimeSeries` and a 5-second stride with a 2-second FFT and
 # 1-second overlap (50%):
 rayleigh = gwdata.rayleigh_spectrogram(5, fftlength=2, overlap=1)
 

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -501,7 +501,7 @@ class TestTimeSeries(TestTimeSeriesBase):
     def losc(self):
         try:
             return self.TEST_CLASS.fetch_open_data(
-                LOSC_IFO, *LOSC_GW150914_SEGMENT)
+                LOSC_IFO, *LOSC_GW150914_SEGMENT, format='txt.gz')
         except URLError as e:
             pytest.skip(str(e))
 
@@ -509,7 +509,8 @@ class TestTimeSeries(TestTimeSeriesBase):
     def losc_16384(self):
         try:
             return self.TEST_CLASS.fetch_open_data(
-                LOSC_IFO, *LOSC_GW150914_SEGMENT, sample_rate=16384)
+                LOSC_IFO, *LOSC_GW150914_SEGMENT, sample_rate=16384,
+                format='txt.gz')
         except URLError as e:
             pytest.skip(str(e))
 

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -43,6 +43,13 @@ from ...detector.units import parse_unit
 from ...segments import (Segment, SegmentList)
 from ...time import to_gps
 
+try:
+    import h5py  # pylint: disable=unused-import
+except ImportError:
+    HAS_H5PY = False
+else:
+    HAS_H5PY = True
+
 # default URL
 LOSC_URL = 'https://losc.ligo.org'
 
@@ -86,7 +93,9 @@ def find_losc_urls(detector, start, end, host=LOSC_URL,
     start = int(start)
     end = int(end)
     span = SegmentList([Segment(start, end)])
-    if format is None:
+    if format is None and HAS_H5PY:  # loading HDF5 is much faster
+        formats = ['hdf5', 'txt.gz', 'gwf']
+    elif format is None:
         formats = ['txt.gz', 'hdf5', 'gwf']
     elif isinstance(format, string_types):
         formats = [format]

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -712,7 +712,7 @@ class TimeSeries(TimeSeriesBase):
                           overlap=overlap)
 
     def rayleigh_spectrogram(self, stride, fftlength=None, overlap=0,
-                             window='hann', nproc=1, **kwargs):
+                             nproc=1, **kwargs):
         """Calculate the Rayleigh statistic spectrogram of this `TimeSeries`
 
         Parameters
@@ -724,17 +724,11 @@ class TimeSeries(TimeSeriesBase):
             number of seconds in single FFT.
 
         overlap : `float`, optional
-            number of seconds of overlap between FFTs, defaults to the
-            recommended overlap for the given window (if given), or 0
+            number of seconds of overlap between FFTs, default: ``0``
 
-        window : `str`, `numpy.ndarray`, optional
-            window function to apply to timeseries prior to FFT,
-            see :func:`scipy.signal.get_window` for details on acceptable
-            formats
-
-        nproc : `int`, default: ``1``
+        nproc : `int`, optional
             maximum number of independent frame reading processes, default
-            is set to single-process file reading.
+            default: ``1``
 
         Returns
         -------
@@ -745,7 +739,7 @@ class TimeSeries(TimeSeriesBase):
         method_func = fft_registry.get_method('rayleigh', scaling='other')
         sg = fft_ui.average_spectrogram(self, method_func, stride,
                                         fftlength=fftlength, overlap=overlap,
-                                        window=window, nproc=nproc, **kwargs)
+                                        nproc=nproc, **kwargs)
         sg.override_unit('')
         return sg
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1612,7 +1612,7 @@ class TimeSeries(TimeSeriesBase):
         >>> plot.set_xlim(-.2, .2)
         >>> plot.set_epoch(0)
         >>> plot.show()
-        """
+        """  # nopep8
         from scipy.interpolate import (interp2d, InterpolatedUnivariateSpline)
         from ..frequencyseries import FrequencySeries
         from ..spectrogram import Spectrogram


### PR DESCRIPTION
This PR fixes a bug in the `TimeSeries.rayleigh_spectrogram` method - the `window` keyword is not supported for this method.

Associated with this fix are the following improvements

- [4e88c01] updated Rayleigh examples
- [5982538] optimised LOSC I/O (use HDF5 by default if `h5py` is installed)