### PR TITLE
Fixed bugs in docstrings for registry-style tables

### DIFF
--- a/gwpy/signal/fft/registry.py
+++ b/gwpy/signal/fft/registry.py
@@ -113,6 +113,7 @@ def update_doc(obj, scaling='density'):
     for method in METHODS[scaling]:
         f = METHODS[scaling][method]
         rows.append((method, '`%s.%s`' % (f.__module__, f.__name__)))
+    rows.sort(key=lambda x: x[1])
     format_str = Table(rows=rows, names=['Method name', 'Function']).pformat(
         max_lines=-1, max_width=80, align=('>', '<'))
     format_str[1] = format_str[1].replace('-', '=')

--- a/gwpy/table/io/fetch.py
+++ b/gwpy/table/io/fetch.py
@@ -118,6 +118,7 @@ def _update__doc__(data_class):
         max_lines=-1, max_width=80, align=('>', '<'))
     format_str[1] = format_str[1].replace('-', '=')
     format_str.insert(0, format_str[1])
+    format_str.append(format_str[0])
 
     lines.extend([' ' * indent + line for line in [header, ''] + format_str])
     # and overwrite the docstring

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -250,25 +250,31 @@ class TestSignalFftRegistry(object):
         """Test :func:`gwpy.signal.fft.registry.update_doc`
         """
         def fake_caller():
+            """Test method
+
+            Notes
+            -----"""
             pass
 
-        assert fake_caller.__doc__ is None
         fft_registry.update_doc(fake_caller)
-        print(fake_caller.__doc__)
-        assert fake_caller.__doc__ == (
-            'The available methods are:\n\n'
-            '============ =================================\n'
-            'Method name               Function            \n'
-            '============ =================================\n'
-            'lal_bartlett    `gwpy.signal.fft.lal.bartlett`\n'
-            ' median_mean `gwpy.signal.fft.lal.median_mean`\n'
-            '      median      `gwpy.signal.fft.lal.median`\n'
-            '   lal_welch       `gwpy.signal.fft.lal.welch`\n'
-            '    bartlett  `gwpy.signal.fft.scipy.bartlett`\n'
-            '       welch     `gwpy.signal.fft.scipy.welch`\n'
-            '============ =================================\n\n'
-            'See :ref:`gwpy-signal-fft` for more details\n'
-        )
+        assert fake_caller.__doc__ == """Test method
+
+            Notes
+            -----
+            The available methods are:
+            
+            ============ =================================
+            Method name               Function            
+            ============ =================================
+            lal_bartlett `gwpy.signal.fft.lal.bartlett`   
+             median_mean `gwpy.signal.fft.lal.median_mean`
+                  median `gwpy.signal.fft.lal.median`     
+               lal_welch `gwpy.signal.fft.lal.welch`      
+                bartlett `gwpy.signal.fft.scipy.bartlett` 
+                   welch `gwpy.signal.fft.scipy.welch`    
+            ============ =================================
+            
+            See :ref:`gwpy-signal-fft` for more details"""  # nopep8
 
 
 # -- gwpy.signal.fft.ui -------------------------------------------------------

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -72,11 +72,11 @@ class TimeSeries(TimeSeriesBase):
         GPS epoch associated with these data,
         any input parsable by `~gwpy.time.to_gps` is fine
 
-    dt : `float`, `~astropy.units.Quantity`, optional, default: `1`
+    dt : `float`, `~astropy.units.Quantity`, optional
         time between successive samples (seconds), can also be given inversely
         via `sample_rate`
 
-    sample_rate : `float`, `~astropy.units.Quantity`, optional, default: `1`
+    sample_rate : `float`, `~astropy.units.Quantity`, optional
         the rate of samples per second (Hertz), can also be given inversely
         via `dt`
 
@@ -94,10 +94,10 @@ class TimeSeries(TimeSeriesBase):
     dtype : `~numpy.dtype`, optional
         input data type
 
-    copy : `bool`, optional, default: `False`
+    copy : `bool`, optional
         choose to copy the input data to new memory
 
-    subok : `bool`, optional, default: `True`
+    subok : `bool`, optional
         allow passing of sub-classes by the array generator
 
     Notes
@@ -158,7 +158,7 @@ class TimeSeries(TimeSeriesBase):
             detected if possible. See below for list of acceptable
             formats.
 
-        nproc : `int`, optional, default: `1`
+        nproc : `int`, optional
             number of parallel processes to use, serial process by
             default.
 
@@ -334,8 +334,9 @@ class TimeSeries(TimeSeriesBase):
 
         Parameters
         ----------
-        fftlength : `float`, default: `TimeSeries.duration`
-            number of seconds in single FFT
+        fftlength : `float`
+            number of seconds in single FFT, defaults to a single FFT
+            covering the full duration
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, defaults to the
@@ -376,8 +377,9 @@ class TimeSeries(TimeSeriesBase):
 
         Parameters
         ----------
-        fftlength : `float`, default: `TimeSeries.duration`
-            number of seconds in single FFT
+        fftlength : `float`
+            number of seconds in single FFT, defaults to a single FFT
+            covering the full duration
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, defaults to the
@@ -418,8 +420,9 @@ class TimeSeries(TimeSeriesBase):
         other : `TimeSeries`
             the second `TimeSeries` in this CSD calculation
 
-        fftlength : `float`, default: `TimeSeries.duration`
-            number of seconds in single FFT
+        fftlength : `float`
+            number of seconds in single FFT, defaults to a single FFT
+            covering the full duration
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, defaults to the
@@ -477,7 +480,7 @@ class TimeSeries(TimeSeriesBase):
             FFT-averaging method, default: ``'welch'``,
             see *Notes* for more details
 
-        nproc : `int`, default: ``1``
+        nproc : `int`
             number of CPUs to use in parallel processing of FFTs
 
         Returns
@@ -637,33 +640,33 @@ class TimeSeries(TimeSeriesBase):
             see :func:`scipy.signal.get_window` for details on acceptable
             formats
 
-        nproc : `int`, default: ``1``
+        nproc : `int`
             maximum number of independent frame reading processes, default
             is set to single-process file reading.
 
         bins : `numpy.ndarray`, optional, default `None`
             array of histogram bin edges, including the rightmost edge
 
-        low : `float`, optional, default: `None`
+        low : `float`, optional
             left edge of lowest amplitude bin, only read
             if ``bins`` is not given
 
-        high : `float`, optional, default: `None`
+        high : `float`, optional
             right edge of highest amplitude bin, only read
             if ``bins`` is not given
 
-        nbins : `int`, optional, default: `500`
+        nbins : `int`, optional
             number of bins to generate, only read if ``bins`` is not
             given
 
-        log : `bool`, optional, default: `False`
+        log : `bool`, optional
             calculate amplitude bins over a logarithmic scale, only
             read if ``bins`` is not given
 
-        norm : `bool`, optional, default: `False`
+        norm : `bool`, optional
             normalise bin counts to a unit sum
 
-        density : `bool`, optional, default: `False`
+        density : `bool`, optional
             normalise bin counts to a unit integral
 
         Returns
@@ -692,8 +695,9 @@ class TimeSeries(TimeSeriesBase):
 
         Parameters
         ----------
-        fftlength : `float`, default: `TimeSeries.duration`
-            number of seconds in single FFT
+        fftlength : `float`
+            number of seconds in single FFT, defaults to a single FFT
+            covering the full duration
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, defaults to that of
@@ -765,7 +769,7 @@ class TimeSeries(TimeSeriesBase):
             see :func:`scipy.signal.get_window` for details on acceptable
             formats
 
-        nproc : `int`, default: ``1``
+        nproc : `int`
             maximum number of independent frame reading processes, default
             is set to single-process file reading.
 
@@ -995,15 +999,20 @@ class TimeSeries(TimeSeriesBase):
         ----------
         zeros : `array-like`
             list of zero frequencies
+
         poles : `array-like`
             list of pole frequencies
+
         gain : `float`
             DC gain of filter
-        analog : `bool`, optional, default: `True`
+
+        analog : `bool`, optional
             type of ZPK being applied, if `analog=True` all parameters
             will be converted in the Z-domain for digital filtering
-        unit : `str`, `~astropy.units.Unit`, optional, default: `'Hz'`
-            unit of zeros and poles, either 'Hz' or 'rad/s'
+
+        unit : `str`, `~astropy.units.Unit`, optional
+            unit of zeros and poles, either ``'Hz``' or ``'rad/s'``,
+            default is ``'Hz'``
 
         Returns
         -------
@@ -1086,7 +1095,7 @@ class TimeSeries(TimeSeriesBase):
             - ``(zeros, poles, gain)``
             - ``(A, B, C, D)`` 'state-space' representation
 
-        filtfilt : `bool`, optional, default: `False`
+        filtfilt : `bool`, optional
             filter forward and backwards to preserve phase
 
         **kwargs
@@ -1182,8 +1191,9 @@ class TimeSeries(TimeSeriesBase):
         other : `TimeSeries`
             `TimeSeries` signal to calculate coherence with
 
-        fftlength : `float`, optional, default: `TimeSeries.duration`
+        fftlength : `float`, optional
             number of seconds in single FFT, defaults to a single FFT
+            covering the full duration
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, defaults to the
@@ -1266,8 +1276,9 @@ class TimeSeries(TimeSeriesBase):
         dt : `float`
             duration (in seconds) of time-shift
 
-        fftlength : `float`, optional, default: `TimeSeries.duration`
+        fftlength : `float`, optional
             number of seconds in single FFT, defaults to a single FFT
+            covering the full duration
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, defaults to the
@@ -1333,7 +1344,7 @@ class TimeSeries(TimeSeriesBase):
             see :func:`scipy.signal.get_window` for details on acceptable
             formats
 
-        nproc : `int`, default: ``1``
+        nproc : `int`
             number of parallel processes to use when calculating
             individual coherence spectra.
 
@@ -1464,7 +1475,7 @@ class TimeSeries(TimeSeriesBase):
 
         Parameters
         ----------
-        detrend : `str`, optional, default: `constant`
+        detrend : `str`, optional
             the type of detrending.
 
         Returns
@@ -1496,8 +1507,10 @@ class TimeSeries(TimeSeriesBase):
         ----------
         frequency : `float`, `~astropy.units.Quantity`
             frequency (default in Hertz) at which to apply the notch
-        type : `str`, optional, default: 'iir'
+
+        type : `str`, optional
             type of filter to apply, currently only 'iir' is supported
+
         **kwargs
             other keyword arguments to pass to `scipy.signal.iirdesign`
 
@@ -1734,7 +1747,7 @@ class TimeSeriesDict(TimeSeriesBaseDict):
             detected if possible. See below for list of acceptable
             formats.
 
-        nproc : `int`, optional, default: ``1``
+        nproc : `int`, optional
             number of parallel processes to use, serial process by
             default.
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -360,8 +360,7 @@ class TimeSeries(TimeSeriesBase):
             a data series containing the PSD.
 
         Notes
-        -----
-        """
+        -----"""
         # get method
         scaling = kwargs.get('scaling', 'density')
         method_func = fft_registry.get_method(method, scaling=scaling)
@@ -488,8 +487,7 @@ class TimeSeries(TimeSeriesBase):
             input time-series.
 
         Notes
-        -----
-        """
+        -----"""
         # handle deprecated kwargs - TODO: remove before 1.0 release
         try:
             other = kwargs.pop('cross')
@@ -679,8 +677,7 @@ class TimeSeries(TimeSeriesBase):
             for details on specifying bins and weights
 
         Notes
-        -----
-        """
+        -----"""
         specgram = self.spectrogram(stride, fftlength=fftlength,
                                     overlap=overlap, method=method,
                                     window=window, nproc=nproc)
@@ -1428,8 +1425,7 @@ class TimeSeries(TimeSeriesBase):
         scipy.signal
 
         Notes
-        -----
-        """
+        -----"""
         # build whitener
         if asd is None:
             asd = self.asd(fftlength, overlap=overlap,


### PR DESCRIPTION
This PR fixes bugs in the tables embedded into method docstrings by registry-linked things, including for `EventTable.fetch` and `TimeSeries.psd` etc.

Also included are a few other miscellaneous docstrings fixes. No actual code was changed (other than code that generates the docstrings).