### PR TITLE
Update to unit parser to forgive all errors

### DIFF
--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -20,20 +20,26 @@
 """
 
 import re
+import warnings
 
 from astropy import units
 from astropy.units.format.generic import Generic
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
-# -- parser to handle plurals -------------------------------------------------
 
+# -- parser to handle any unit ------------------------------------------------
 
-class PluralFormat(Generic):
-    """Sub-class of the `Generic` unit parser that handles plurals
+class GWpyFormat(Generic):
+    """Sub-class of the `Generic` unit parser that is more forgiving
 
-    This just enables uses to specify a unit as 'meters' instead of just
-    'meter', and have the parse handle things as well as can be expected.
+    This format tries to work around 'human' errors in unit naming,
+    including plurals, and capitalisation, and if nothing else works
+    it just defines a new unit matching the given string.
+
+    New units are not registered, so cannot be referred to later, but are
+    created so that mathematical operations will work. Conversions to other
+    units will explicitly not work.
     """
     re_closest_unit = re.compile(r'Did you mean (.*)\?\Z')
     re_closest_unit_delim = re.compile('(, | or )')
@@ -44,22 +50,39 @@ class PluralFormat(Generic):
         try:
             return cls._parse_unit(t.value)
         except ValueError as exc:
-            # if error message suggests one alternative that is just the
-            # singular of the unit given, use it, otherwise re-raise the
-            # original exception
+            name = t.value
+            sname = name[:-1] if name.endswith('s') else ''
+
+            # parse alternative units from the error message
             match = cls.re_closest_unit.search(str(exc))
             try:  # split 'A, B, or C' -> ['A', 'B', 'C']
                 alts = cls.re_closest_unit_delim.split(match.groups()[0])[::2]
             except AttributeError:
-                raise exc
-            alts = list(set(map(str.lower, alts)))
-            if len(alts) == 1 and '%ss' % alts[0] == t.value.lower():
-                return cls._parse_unit(alts[0])
-            raise exc
+                alts = []
+            alts = list(set(alts))
+
+            # match uppercase to titled (e.g. MPC -> Mpc)
+            if name.title() in alts:
+                alt = name.title()
+            # match titled unit to lower-case (e.g. Amp -> amp)
+            elif name.lower() in alts:
+                alt = name.lower()
+            # match plural to singular (e.g. meters -> meter)
+            elif sname in alts:
+                alt = sname
+            elif sname.lower() in alts:
+                alt = sname.lower()
+            else:
+                warnings.warn('{0}. Mathematical operations using this unit '
+                              'should work, but conversions to other units '
+                              'will not.'.format(str(exc).rstrip(',. ')),
+                              category=units.UnitsWarning)
+                return units.def_unit(name, doc='Unrecognized unit')
+            return cls._parse_unit(alt)
 
 
 # pylint: disable=redefined-builtin
-def parse_unit(name, parse_strict='warn', format=PluralFormat):
+def parse_unit(name, parse_strict='warn', format=GWpyFormat):
     """Attempt to intelligently parse a `str` as a `~astropy.units.Unit`
 
     Parameters
@@ -88,20 +111,68 @@ def parse_unit(name, parse_strict='warn', format=PluralFormat):
         return None
 
     # pylint: disable=unexpected-keyword-arg
+    if parse_strict in ('raise',):
+        return units.Unit(name, parse_strict=parse_strict)
     return units.Unit(name, parse_strict=parse_strict, format=format)
 
 
 # -- custom units -------------------------------------------------------------
+# pylint: disable=no-member,invalid-name
 
 # enable imperial units
 units.add_enabled_units(units.imperial)
 
-# custom GWO units
-units.add_enabled_units([
-    units.def_unit(['counts'], represents=units.Unit('count')),
-    units.def_unit(['undef'], doc='No unit has been defined for these data'),
-    units.def_unit(['coherence'], represents=units.dimensionless_unscaled),
-    units.def_unit(['strain'], represents=units.dimensionless_unscaled),
-    units.def_unit(['Degrees_C'], represents=units.Unit('Celsius')),
-    units.def_unit(['Degrees_F'], represents=units.Unit('Fahrenheit')),
-])
+# -- custom units settings
+# the following happens in two sets
+#     1) alternative names for standard units where SI prefices will not
+#        be used
+#     2) new units or alternative names for standard units where SI prefices
+#        _will_ be used
+#
+# for developers: when adding a new custom unit, please remember to add it
+# to the list of tested units in `test_detector.py`
+
+# 1) alternative names
+registry = units.get_current_unit_registry().registry
+for alias, unit in [
+        ('Degrees_C', units.Unit('Celsius')),
+        ('Degrees_F', units.Unit('Fahrenheit')),
+]:
+    unit.names.append(alias)
+    registry[alias] = unit
+
+# 2) new units
+_ns = {}
+
+# LIGO-Lab standard for 'no unit defined'
+units.def_unit(['NONE', 'undef'], namespace=_ns,
+               doc='No unit has been defined for these data')
+
+# other dimenionless units
+units.def_unit('strain', namespace=_ns)
+units.def_unit('coherence', namespace=_ns)
+
+# alias for 'second' but with prefices
+units.def_unit((['sec'], ['sec']), represents=units.second, prefixes=True,
+               namespace=_ns)
+
+# alternative Pressure unit for LIGO UHV
+units.def_unit((['torr'], ['torr']), represents=101325/760.*units.pascal,
+               prefixes=True, namespace=_ns)
+
+# pounds per square inch gauge
+units.def_unit('psig', represents=units.imperial.psi, prefixes=True,
+               namespace=_ns, doc='Pound per square inch gauge: pressure')
+
+# cubic feet
+units.def_unit('cf', represents=units.imperial.foot**3, namespace=_ns)
+
+# cubic feet per minute
+units.def_unit('cfm', represents=_ns['cf']/units.minute, namespace=_ns)
+
+# particles (as in dust)
+units.def_unit(['ptcls', 'particles', 'particulates'], prefixes=True,
+               namespace=_ns)
+
+# -- register units -----------------------------
+units.add_enabled_units(_ns)

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -74,9 +74,9 @@ class GWpyFormat(Generic):
             elif sname.lower() in alts:
                 alt = sname.lower()
             else:
-                warnings.warn('{0}. Mathematical operations using this unit '
+                warnings.warn('{0} Mathematical operations using this unit '
                               'should work, but conversions to other units '
-                              'will not.'.format(str(exc).rstrip(',. ')),
+                              'will not.'.format(str(exc).rstrip(' ')),
                               category=units.UnitsWarning)
                 return units.def_unit(name, doc='Unrecognized unit')
             return cls._parse_unit(alt)

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -41,6 +41,7 @@ class GWpyFormat(Generic):
     created so that mathematical operations will work. Conversions to other
     units will explicitly not work.
     """
+    name = 'gwpy'
     re_closest_unit = re.compile(r'Did you mean (.*)\?\Z')
     re_closest_unit_delim = re.compile('(, | or )')
 
@@ -82,7 +83,7 @@ class GWpyFormat(Generic):
 
 
 # pylint: disable=redefined-builtin
-def parse_unit(name, parse_strict='warn', format=GWpyFormat):
+def parse_unit(name, parse_strict='warn', format='gwpy'):
     """Attempt to intelligently parse a `str` as a `~astropy.units.Unit`
 
     Parameters

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -118,7 +118,7 @@ class TestArray(object):
         # test unrecognised units
         with pytest.warns(units.UnitsWarning):
             array = self.create(unit='blah')
-        assert isinstance(array.unit, units.UnrecognizedUnit)
+        assert isinstance(array.unit, units.IrreducibleUnit)
         assert str(array.unit) == 'blah'
 
         # test setting unit doesn't work
@@ -247,14 +247,14 @@ class TestArray(object):
         # check parse_strict works for each of 'raise' (default), 'warn',
         # and 'silent'
         with pytest.raises(ValueError):
-            array.override_unit('blah')
+            array.override_unit('blah', parse_strict='raise')
 
         with pytest.warns(units.UnitsWarning):
             array.override_unit('blah', parse_strict='warn')
 
         array.override_unit('blah', parse_strict='silent')
-        assert isinstance(array.unit, units.UnrecognizedUnit)
-        assert array.unit == units.Unit('blah', parse_strict='silent')
+        assert isinstance(array.unit, units.IrreducibleUnit)
+        assert str(array.unit) == 'blah'
 
     # -- test I/O -------------------------------
 

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -124,17 +124,16 @@ def test_parse_unit_strict():
     # check that errors get raise appropriately
     with pytest.raises(ValueError) as exc:
         parse_unit('metre', parse_strict='raise')
-    assert str(exc.value) == ("'metre' did not parse as unit: "
-                              "metre is not a valid unit. Did you mean meter?")
 
     # check that warnings get posted, and a custom NamedUnit gets returned
     with pytest.warns(units.UnitsWarning) as exc:
         u = parse_unit('metre', parse_strict='warn')
-    assert str(exc.value) == ('metre is not a valid unit. Mathematical '
-                              'operations using this unit should work, but '
-                              'conversions to other units will not.')
-    assert isinstance(u, units.NamedUnit)
-    assert u == unrecognised.Unit('metre')
+    assert str(exc[0].message) == ('metre is not a valid unit. Did you mean '
+                                   'meter? Mathematical operations using this '
+                                   'unit should work, but conversions to '
+                                   'other units will not.')
+    assert isinstance(u, units.IrreducibleUnit)
+    assert str(u) == 'metre'
 
 
 @pytest.mark.parametrize('name', [
@@ -229,7 +228,6 @@ class TestChannel(object):
     @pytest.mark.parametrize('arg, unit', [
         (None, None),
         ('m', units.m),
-        ('blah', units.Unit('blah', parse_strict='silent')),
     ])
     def test_unit(self, arg, unit):
         new = self.TEST_CLASS('test', unit=arg)


### PR DESCRIPTION
This PR updates the `parse_unit` method to forgive any and all problems in the unit naming, by creating a new `NamedUnit` on-the-fly whenever a problem is created. This should allow mathematical operations on any and all frame data (including from NDS2), but does not allow conversions from these custom units into other units. The new units are also not registered, so that they cannot be compared to other physical units.

This also extends the format subclass to try and mangle the given name into a form it recognises, and defines a bunch of new LIGO-specific unit formats (e.g. `ptcls`) so that a custom `NamedUnit` is created only as a last resort.

Fixes #523.

cc: @areeda

