### PR TITLE
Fixed a typo in an example [ci skip]

### DIFF
--- a/examples/frequencyseries/rayleigh.py
+++ b/examples/frequencyseries/rayleigh.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Plotting a Rayleigh-statistic `Spectum`
+"""Plotting a Rayleigh-statistic `Spectrum`
 
 In LIGO the 'Rayleigh' statistic is a calculation of the
 `coefficient of variation


### PR DESCRIPTION
This PR fixes a trivial typo in one of the examples.