### PR TITLE
Improved support for non-latex image generation

### DIFF
--- a/gwpy/plotter/rc.py
+++ b/gwpy/plotter/rc.py
@@ -46,10 +46,12 @@ DEFAULT_PARAMS = {
     # ticks
     'axes.formatter.limits': (-3, 4),
     # fonts
-    'axes.titlesize': 24,
-    'axes.labelsize': 20,
-    'xtick.labelsize': 18,
-    'ytick.labelsize': 18,
+    'axes.labelpad': 5,
+    'axes.titlesize': 20,
+    'axes.labelsize': 18,
+    'xtick.labelsize': 16,
+    'ytick.labelsize': 16,
+    'font.sans-serif': ['FreeSans'] + rcParams['font.sans-serif'],
     # image
     'image.aspect': 'auto',
     'image.interpolation': 'nearest',
@@ -70,8 +72,15 @@ except KeyError:
 # set latex options
 rcParams['text.latex.preamble'].extend(tex.MACROS)
 if usetex:
-    DEFAULT_PARAMS['text.usetex'] = True
-    DEFAULT_PARAMS['font.family'] = 'serif'
+    DEFAULT_PARAMS.update({
+        'text.usetex': True,
+        'font.family': 'serif',
+        'axes.labelpad': 4,
+        'axes.labelsize': 20,
+        'axes.titlesize': 24,
+        'xtick.labelsize': 16,
+        'ytick.labelsize': 16,
+    })
     if mpl_version < '2.0':
         DEFAULT_PARAMS['font.serif'] = ['Computer Modern']
 

--- a/gwpy/plotter/rc.py
+++ b/gwpy/plotter/rc.py
@@ -19,6 +19,8 @@
 """Custom default figure configuration
 """
 
+import os
+
 from matplotlib import (rcParams, rc_params, __version__ as mpl_version)
 from matplotlib.figure import SubplotParams
 
@@ -59,9 +61,15 @@ DEFAULT_PARAMS = {
     'legend.fancybox': False,
 }
 
+# select tex formatting (or not)
+try:  # allow user to override from environment
+    usetex = os.environ['GWPY_USETEX'].lower() in ['1', 'true', 'yes', 'y']
+except KeyError:
+    usetex = rcParams['text.usetex'] or tex.HAS_TEX
+
 # set latex options
 rcParams['text.latex.preamble'].extend(tex.MACROS)
-if rcParams['text.usetex'] or tex.HAS_TEX:
+if usetex:
     DEFAULT_PARAMS['text.usetex'] = True
     DEFAULT_PARAMS['font.family'] = 'serif'
     if mpl_version < '2.0':


### PR DESCRIPTION
This PR improves the user-selection for using LaTeX in figure generation, by adding a `GWPY_USETEX` environment variable, and improving the default `rcParams` when `text.usetex=False`.