### PR TITLE
Fixed orientation for adding colorbar with location='top'

### DIFF
--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -317,6 +317,10 @@ class Plot(figure.Figure):
             kwargs.setdefault('ticks', LogLocator(subs=numpy.arange(1, 11)))
             kwargs.setdefault('format', CombinedLogFormatterMathtext())
 
+        # set orientation
+        if location in ('top', 'bottom'):
+            kwargs.setdefault('orientation', 'horizontal')
+
         # make colour bar
         colorbar = self.colorbar(mappable, cax=cax, ax=ax, **kwargs)
 


### PR DESCRIPTION
This PR fixes a 'feature' in `Plot.add_colorbar` so that specifying `location='top'` will default to having a horizontal colour bar, rather than a very short vertical one.