### PR TITLE
Removed import of deps submodule from gwpy.utils

### DIFF
--- a/gwpy/utils/__init__.py
+++ b/gwpy/utils/__init__.py
@@ -23,8 +23,6 @@ from __future__ import print_function
 
 from sys import stdout
 
-from .deps import *
-
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 


### PR DESCRIPTION
This PR removes the import of the `.deps` submodule from `gwpy.utils.__init__`. This module is deprecated, so the import invokes the `DeprecationWarning` unnecessarily. Users can still import the module and its contents directly:

```python
>>> from gwpy.utils.deps import *
```