### PR TITLE
Fixed iteration over Array2D

### DIFF
--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -195,6 +195,11 @@ class Array2D(Series):
         if getattr(self, '_yindex', 0) is None:
             del self.yindex
 
+    def __iter__(self):
+        # astropy Quantity.__iter__ does something fancy that we don't need
+        # because we overload __getitem__
+        return super(Quantity, self).__iter__()
+
     # -- Array2d properties ---------------------
 
     # y0


### PR DESCRIPTION
This PR fixes iterating over an `Array2D` (including a `Spectrogram`). Since we overload `__getitem__` to return a custom column class, we need to bypass `astropy.units.Quantity.__iter__` to just call out to `__getitem__`.