### PR TITLE
Register named IFO colours with matplotlib

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Working with data
 **Visualising data**
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    plotter/index
    cli/index

--- a/docs/plotter/colors.rst
+++ b/docs/plotter/colors.rst
@@ -1,0 +1,93 @@
+.. _currentmodule: gwpy.plotter
+
+.. _gwpy-plotter-colors:
+
+################################################
+The Gravitational-Wave Observatory colour scheme
+################################################
+
+In order to simplify visual identification of a specific gravitational-wave observatory (GWO) on a figure where many of them are plotted (e.g. amplitude spectral densities, or filtered strain time-series), the GWO standard colour scheme should be used:
+
+.. plot::
+    :include-source: False
+
+    from __future__ import division
+    import numpy
+    from matplotlib import pyplot
+    from matplotlib.colors import to_hex
+    from gwpy.plotter import rcParams
+
+    rcParams.update({
+        'text.usetex': False,
+        'font.size': 15
+    })
+
+    th = numpy.linspace(0, 2*numpy.pi, 512)
+    names = [
+         'gwpy:geo600',
+         'gwpy:kagra',
+         'gwpy:ligo-hanford',
+         'gwpy:ligo-india',
+         'gwpy:ligo-livingston',
+         'gwpy:virgo',
+    ]
+
+    fig = pyplot.figure(figsize=(5, 2))
+    ax = fig.gca()
+    ax.axis('off')
+
+    for j, name in enumerate(sorted(names)):
+        c = str(to_hex(name))
+        print(name, c)
+        v_offset = -(j / len(names))
+        ax.plot(th, .1*numpy.sin(th) + v_offset, color=c)
+        ax.annotate("{!r}".format(name), (0, v_offset), xytext=(-1.5, 0),
+                    ha='right', va='center', color=c,
+                    textcoords='offset points', family='monospace')
+        ax.annotate("{!r}".format(c), (2*numpy.pi, v_offset), xytext=(1.5, 0),
+                    ha='left', va='center', color=c,
+                    textcoords='offset points', family='monospace')
+
+    fig.subplots_adjust(**{'bottom': 0.0, 'left': 0.54,
+                           'right': 0.78, 'top': 1})
+    pyplot.show()
+
+For example:
+
+.. plot::
+
+    from gwpy.timeseries import TimeSeries
+    from gwpy.plotter import TimeSeriesPlot
+    h1 = TimeSeries.fetch_open_data('H1', 1126259457, 1126259467)
+    h1b = h1.bandpass(50, 250).notch(60).notch(120)
+    l1 = TimeSeries.fetch_open_data('L1', 1126259457, 1126259467)
+    l1b = l1.bandpass(50, 250).notch(60).notch(120)
+    plot = TimeSeriesPlot()
+    ax = plot.gca()
+    ax.plot(h1b, color='gwpy:ligo-hanford', label='LIGO-Hanford')
+    ax.plot(l1b, color='gwpy:ligo-livingston', label='LIGO-Livingston')
+    ax.set_epoch(1126259462.427)
+    ax.set_xlim(1126259462, 1126259462.6)
+    ax.set_ylim(-1e-21, 1e-21)
+    ax.set_ylabel('Strain noise')
+    ax.legend()
+    plot.show()
+
+The above code was adapted from the example :ref:`gwpy-example-signal-gw150914`.
+
+The colours can also be specified using the interferometer prefix (e.g. ``'H1'``) via the `gwpy.plotter.colors.GW_OBSERVATORY_COLORS` object:
+
+.. plot::
+
+    from matplotlib import pyplot
+    from gwpy.plotter.colors import GW_OBSERVATORY_COLORS
+    fig = pyplot.figure()
+    ax = fig.gca()
+    ax.plot([1, 2, 3, 4, 5], color=GW_OBSERVATORY_COLORS['L1'])
+    fig.show()
+
+.. note::
+
+   The ``'gwpy:<>'`` colours will not be available unless the `gwpy.plotter`
+   module has been imported. This will happen automatically when a plot is
+   made using the integrated `plot()` methods of a GWpy object.

--- a/docs/plotter/index.rst
+++ b/docs/plotter/index.rst
@@ -12,11 +12,11 @@ potential gravitational-wave signals they record.
 The :mod:`gwpy.plotter` module provides a number of plot classes, each
 representing display of a corresponding data type.
 
-=============
-Plotting data
-=============
+==============
+Basic plotting
+==============
 
-The majority of core data objects in GWpy come with a built-in :meth:`plot`
+The majority of core data objects in GWpy come with a built-in `plot()`
 method, allowing quick display of a single data set, for example:
 
 .. plot::
@@ -24,8 +24,8 @@ method, allowing quick display of a single data set, for example:
    :context:
 
     >>> from gwpy.timeseries import TimeSeries
-    >>> data = TimeSeries.fetch('H1:LDAS-STRAIN', 968654552, 968654562)
-    >>> plot = data.plot()
+    >>> h1 = TimeSeries.fetch_open_data('H1', 1126259457, 1126259467)
+    >>> plot = h1.plot()
     >>> plot.show()
 
 |
@@ -37,13 +37,25 @@ more complicated plots manually:
    :include-source:
    :context:
 
-    >>> data2 = TimeSeries.fetch('L1:LDAS-STRAIN', 968654552, 968654562)
+    >>> l1 = TimeSeries.fetch_open_data('L1', 1126259457, 1126259467)
     >>> from gwpy.plotter import TimeSeriesPlot
-    >>> plot2 = TimeSeriesPlot()
-    >>> ax2 = plot2.gca()
-    >>> ax2.plot(data, color='k', linestyle='--')
-    >>> ax2.plot(data2, color='r', linestyle=':')
-    >>> plot2.show()
+    >>> plot = TimeSeriesPlot()
+    >>> ax = plot.gca()
+    >>> ax.plot(h1, color='gwpy:ligo-hanford')
+    >>> ax.plot(l1, color='gwpy:ligo-livingston')
+    >>> ax.set_ylabel('Strain noise')
+    >>> plot.show()
+
+
+=================
+Plot applications
+=================
+
+.. toctree::
+   :titlesonly:
+
+   colors
+   filter
 
 ==========
 Plot types
@@ -53,13 +65,6 @@ The following diagram displays the available Plot objects and their
 inheritance from :class:`Plot`.
 
 .. inheritance-diagram:: core timeseries frequencyseries spectrogram table filter
-
-The following pages outline specific applications of some of the specialist plot types
-
-.. toctree::
-   :titlesonly:
-
-   filter
 
 ===============
 Class reference

--- a/examples/frequencyseries/hoff.py
+++ b/examples/frequencyseries/hoff.py
@@ -45,10 +45,9 @@ lloasd = llo.asd(4, 2)
 # We can then :meth:`~FrequencySeries.plot` the spectra using the 'standard'
 # colour scheme:
 
-from gwpy.plotter.colors import GW_OBSERVATORY_COLORS as GWO_COLORS
-plot = lhoasd.plot(color=GWO_COLORS['H1'], label='LIGO-Hanford')
+plot = lhoasd.plot(label='LIGO-Hanford', color='gwo:ligo-hanford')
 ax = plot.gca()
-ax.plot(lloasd, color=GWO_COLORS['L1'], label='LIGO-Livingston')
+ax.plot(lloasd, label='LIGO-Livingston', color='gwo:ligo-livingston')
 ax.set_xlim(10, 2000)
 ax.set_ylim(5e-24, 1e-21)
 plot.show()

--- a/examples/signal/gw150914.py
+++ b/examples/signal/gw150914.py
@@ -76,7 +76,7 @@ from gwpy.plotter import TimeSeriesPlot
 plot = TimeSeriesPlot(
     data.crop(*data.span.contract(1)),
     b.crop(*b.span.contract(1)),
-    figsize=[12, 8], sep=True, sharex=True)
+    figsize=[12, 8], sep=True, sharex=True, color='gwpy:ligo-hanford')
 plot.axes[0].set_title('LIGO-Hanford strain data around GW150914')
 plot.axes[0].text(
     1.0, 1.0, 'Unfiltered data',
@@ -90,7 +90,8 @@ plot.show()
 # We see now a spike around 16 seconds into the data, so let's zoom into
 # that time by using :meth:`~TimeSeries.crop` and :meth:`~TimeSeries.plot`:
 
-plot = b.crop(1126259462, 1126259462.6).plot(figsize=[12, 4])
+plot = b.crop(1126259462, 1126259462.6).plot(
+    figsize=[12, 4], color='gwpy:ligo-hanford')
 plot.set_title('LIGO-Hanford strain data around GW150914')
 plot.set_ylabel('Amplitude [strain]')
 plot.set_epoch(1126259462.427)

--- a/gwpy/plotter/colors.py
+++ b/gwpy/plotter/colors.py
@@ -20,6 +20,7 @@
 """
 
 from matplotlib import (__version__ as mpl_version, rcParams)
+from matplotlib.colors import _colors_full_map as color_map
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -44,19 +45,28 @@ else:  # just in case anyone expects DEFAULT_COLORS to exist for mpl 2
 
 # -- recommended defaults for current Gravitational-Wave Observatories --------
 # the below colours are designed to work well for the colour-blind, as well
-# as in grayscale, so are good for recommended for publications
+# as in grayscale, so are recommended for publications
 
-GW_OBSERVATORY_COLORS = {
-    # GEO-600
-    'G1': '#222222',  # dark gray
-    # LIGO-Hanford
-    'H1': '#ee0000',  # red
-    # LIGO-India
-    'I1': '#b0dd8b',  # light green
-    # KAGRA
-    'K1': '#ffb200',  # yellow/orange
-    # LIGO-Livingston
-    'L1': '#4ba6ff',  # blue
-    # Virgo
-    'V1': '#9b59b6',  # magenta/purple
-}
+GWPY_COLORS = {
+    'geo600':          '#222222',  # dark gray
+    'kagra':           '#ffb200',  # yellow/orange
+    'ligo-hanford':    '#ee0000',  # red
+    'ligo-india':      '#b0dd8b',  # light green
+    'ligo-livingston': '#4ba6ff',  # blue
+    'virgo':           '#9b59b6',  # magenta/purple
+}  # nopep8
+
+# provide user mapping by IFO prefix
+_GWO_PREFIX = {
+    'geo600':          'G1',
+    'kagra':           'K1',
+    'ligo-hanford':    'H1',
+    'ligo-india':      'I1',
+    'ligo-livingston': 'L1',
+    'virgo':           'V1',
+}  # nopep8
+GW_OBSERVATORY_COLORS = {_GWO_PREFIX[n]: GWPY_COLORS[n] for n in GWPY_COLORS}
+
+# set named colour upstream in matplotlib, so users can specify as
+# e.g. plot(..., color='gwpy:ligo-hanford')
+color_map.update({'gwpy:{}'.format(n): c for n, c in GWPY_COLORS.items()})


### PR DESCRIPTION
This PR modifies the `gwpy.plotter.colors` module to register the IFO colours (previously `GW_OBSERVATORY_COLORS`) with matplotlib so that they can be referenced as normal when plotting, e.g.:

```python
from gwpy.timeseries import TimeSeries
from gwpy.plotter import TimeSeriesPlot
h1 = TimeSeries.fetch_open_data('H1', 1126259457, 1126259467)
h1b = h1.bandpass(50, 250).notch(60).notch(120)
l1 = TimeSeries.fetch_open_data('L1', 1126259457, 1126259467)
l1b = l1.bandpass(50, 250).notch(60).notch(120)
plot = TimeSeriesPlot(figsize=(8, 4))
ax = plot.gca()
ax.plot(h1b, color='gwpy:ligo-hanford', label='LIGO-Hanford')
ax.plot(l1b, color='gwpy:ligo-livingston', label='LIGO-Livingston')
ax.set_xscale('seconds', epoch=1126259462)
ax.set_xlim(1126259462, 1126259462.6)
ax.set_xlabel('Time (seconds) from Sep 14 2015 09:50:45 UTC')
ax.set_ylim(-1e-21, 1e-21)
ax.set_ylabel('Strain noise')
ax.legend()
plot.show()
```

![image](https://user-images.githubusercontent.com/1618530/30966894-6a0417cc-a452-11e7-941f-99b15a848d47.png)

I added a new documentation page demonstrating the use of the colours.

