### PR TITLE
Fixed use of named colours for matplotlib 1.x

### DIFF
--- a/gwpy/plotter/colors.py
+++ b/gwpy/plotter/colors.py
@@ -20,7 +20,11 @@
 """
 
 from matplotlib import (__version__ as mpl_version, rcParams)
-from matplotlib.colors import _colors_full_map as color_map
+
+try:
+    from matplotlib.colors import _colors_full_map as color_map
+except ImportError:  # mpl < 2
+    from matplotlib.colors import cnames as color_map
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 


### PR DESCRIPTION
This PR fixes a version incompatibility introduced by #542 when using matplotlib 1.x.