### PR TITLE
Updated normalisation in q-transform to median by default

### DIFF
--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -28,6 +28,7 @@ from __future__ import division
 import warnings
 from math import (log, ceil, pi, isinf, exp)
 
+from six import string_types
 from six.moves import xrange
 
 import numpy
@@ -224,15 +225,16 @@ class QPlane(QBase):
     def whitening_duration(self):
         return 2 ** (round(log(self.q / (2 * self.frange[0]), 2)))
 
-    def transform(self, fseries, normalized=True, epoch=None):
+    def transform(self, fseries, norm=True, epoch=None):
         """Calculate the energy `TimeSeries` for the given fseries
 
         Parameters
         ----------
         fseries : `~gwpy.frequencyseries.FrequencySeries`
             the complex FFT of a time-series data set
-        normalized : `bool`, optional
-            normalize the energy of the output, if `False` the output
+        norm : `bool`, `str`, optional
+            normalize the energy of the output by the median (if `True` or
+            ``'median'``) or the ``'mean'``, if `False` the output
             is the complex `~numpy.fft.ifft` output of the Q-tranform
         epoch : `~gwpy.time.LIGOTimeGPS`, `float`, optional
             the epoch of these data, only used for metadata in the output
@@ -255,7 +257,7 @@ class QPlane(QBase):
         out = []
         for qtile in self:
             # get energy from transform
-            out.append(qtile.transform(fseries, normalized=normalized,
+            out.append(qtile.transform(fseries, norm=norm,
                                        epoch=epoch))
         return self.frequencies, out
 
@@ -327,15 +329,16 @@ class QTile(QBase):
         pad = self.ntiles - self.windowsize
         return (int((pad - 1)/2.), int((pad + 1)/2.))
 
-    def transform(self, fseries, normalized=True, epoch=None):
+    def transform(self, fseries, norm=True, epoch=None):
         """Calculate the energy `TimeSeries` for the given fseries
 
         Parameters
         ----------
         fseries : `~gwpy.frequencyseries.FrequencySeries`
             the complex FFT of a time-series data set
-        normalized : `bool`, optional
-            normalize the energy of the output, if `False` the output
+        norm : `bool`, `str`, optional
+            normalize the energy of the output by the median (if `True` or
+            ``'median'``) or the ``'mean'``, if `False` the output
             is the complex `~numpy.fft.ifft` output of the Q-tranform
         epoch : `~gwpy.time.LIGOTimeGPS`, `float`, optional
             the epoch of these data, only used for metadata in the output
@@ -359,11 +362,18 @@ class QTile(QBase):
         tdenergy = npfft.ifft(wenergy)
         cenergy = TimeSeries(tdenergy, x0=epoch,
                              dx=self.duration/tdenergy.size, copy=False)
-        if normalized:
+        if norm:
+            if isinstance(norm, string_types):
+                norm = norm.lower()
             energy = type(cenergy)(
                 cenergy.value.real ** 2. + cenergy.value.imag ** 2.,
                 x0=cenergy.x0, dx=cenergy.dx, copy=False)
-            meanenergy = energy.mean()
+            if norm in (True, 'median'):
+                meanenergy = energy.median()
+            elif norm in ('mean',):
+                meanenergy = energy.mean()
+            else:
+                raise ValueError("Invalid normalisation %r" % norm)
             return energy / meanenergy
         else:
             return cenergy

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1063,7 +1063,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         assert isinstance(qspecgram, Spectrogram)
         assert qspecgram.shape == (4000, 2403)
         assert qspecgram.q == 5.65685424949238
-        nptest.assert_almost_equal(qspecgram.value.max(), 58.696743273955391)
+        nptest.assert_almost_equal(qspecgram.value.max(), 146.61970478954652)
 
         # test whitening args
         asd = losc.asd(2, 1)
@@ -1079,6 +1079,14 @@ class TestTimeSeries(TestTimeSeriesBase):
         with pytest.warns(UserWarning):
             qspecgram = losc.q_transform(method='welch', frange=(0, 10000))
             nptest.assert_almost_equal(qspecgram.yspan[1], 1291.5316316157107)
+
+        # test other normalisations work (or don't)
+        q2 = losc.q_transform(method='welch', norm='median')
+        utils.assert_quantity_sub_equal(qspecgram, q2)
+        losc.q_transform(method='welch', norm='mean')
+        losc.q_transform(method='welch', norm=False)
+        with pytest.raises(ValueError):
+            losc.q_transform(method='welch', norm='blah')
 
     def test_boolean_statetimeseries(self, array):
         comp = array >= 2 * array.unit

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1531,8 +1531,8 @@ class TimeSeries(TimeSeriesBase):
         return self.filter(*zpk, filtfilt=filtfilt)
 
     def q_transform(self, qrange=(4, 64), frange=(0, numpy.inf),
-                    gps=None, search=.5, tres=.001, fres=.5, outseg=None,
-                    whiten=True, **asd_kw):
+                    gps=None, search=.5, tres=.001, fres=.5, norm='median',
+                    outseg=None, whiten=True, **asd_kw):
         """Scan a `TimeSeries` using a multi-Q transform
 
         Parameters
@@ -1557,6 +1557,11 @@ class TimeSeries(TimeSeriesBase):
             desired frequency resolution (Hertz) of output `Spectrogram`,
             give `None` to skip this step and return the original resolution,
             e.g. if you're going to do your own interpolation
+
+        norm : `bool`, `str`, optional
+            whether to normalize the returned Q-transform output, or how,
+            default: `True` (``'median'``), other options: `False`,
+            ``'mean'``
 
         outseg : `~gwpy.segments.Segment`, optional
             GPS `[start, stop)` segment for output `Spectrogram`
@@ -1669,7 +1674,7 @@ class TimeSeries(TimeSeriesBase):
 
         # Q-transform data for each `(Q, frequency)` tile
         for plane in planes:
-            f, normenergies = plane.transform(fdata, normalized=True,
+            f, normenergies = plane.transform(fdata, normalized=norm,
                                               epoch=self.x0)
             # find peak energy in this plane and record if loudest
             for ts in normenergies:

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1674,7 +1674,7 @@ class TimeSeries(TimeSeriesBase):
 
         # Q-transform data for each `(Q, frequency)` tile
         for plane in planes:
-            f, normenergies = plane.transform(fdata, normalized=norm,
+            f, normenergies = plane.transform(fdata, norm=norm,
                                               epoch=self.x0)
             # find peak energy in this plane and record if loudest
             for ts in normenergies:


### PR DESCRIPTION
This PR improves the default normalisation of the Q-transform output (via `TimeSeries.q_transform`) to use the median, instead of the mean, and add support for using the mean via `norm='mean'`.