### PR TITLE
Fixed bug in auto-detecting keys reading TimeSeriesDict from HDF5

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1118,6 +1118,10 @@ class TestTimeSeriesDict(TestTimeSeriesBaseDict):
             new = self.TEST_CLASS.read(f.name, instance.keys())
             for key in new:
                 utils.assert_quantity_sub_equal(new[key], instance[key])
+            # check auto-detection of names
+            new = self.TEST_CLASS.read(f.name)
+            for key in new:
+                utils.assert_quantity_sub_equal(new[key], instance[key])
 
 
 # -- TimeSeriesList -----------------------------------------------------------

--- a/gwpy/timeseries/io/hdf5.py
+++ b/gwpy/timeseries/io/hdf5.py
@@ -53,9 +53,9 @@ def read_hdf5_dict(h5f, names=None, group=None, **kwargs):
 
     # find list of names to read
     if names is None:
-        # TODO: improved the TimeSeries -> HDF5 format to make detecting
+        # TODO: improve the TimeSeries -> HDF5 format to make detecting
         #       a TimeSeries easier
-        names = [key for key in h5g if 'dx' in h5g[dset].attrs['name']]
+        names = [key for key in h5g if 'dx' in h5g[key]]
 
     # read names
     out = kwargs.pop('dict_type', TimeSeriesDict)()


### PR DESCRIPTION
This PR fixes a bug in auto-detecting `TimeSeries` datasets in an HDF5 file.