### PR TITLE
Fixed test failures in add_legend

### DIFF
--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -23,6 +23,7 @@ import numpy
 
 from matplotlib import (backends, figure, pyplot, colors as mcolors,
                         _pylab_helpers)
+from matplotlib.rcsetup import interactive_bk as INTERACTIVE_BACKENDS
 from matplotlib.backend_bases import FigureManagerBase
 from matplotlib.axes import SubplotBase
 from matplotlib.cbook import iterable
@@ -49,7 +50,7 @@ else:
 def interactive_backend():
     """Returns `True` if the current backend is interactive
     """
-    return pyplot.get_backend() in backends.interactive_bk
+    return pyplot.get_backend() in INTERACTIVE_BACKENDS
 
 
 class Plot(figure.Figure):

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -227,8 +227,6 @@ class TestPlot(PlottingTestBase):
 
     def test_add_legend(self):
         fig, ax = self.new()
-        with pytest.warns(UserWarning):
-            assert fig.add_legend() is None
         ax.plot([1, 2, 3, 4], label='Plot')
         assert isinstance(fig.add_legend(), Legend)
         self.save_and_close(fig)


### PR DESCRIPTION
This PR fixes errors in the test suite when asserting warnings for an empty legend. matplotlib 2.1 doesn't seem to warn any more...