### PR TITLE
Reinstated epydoc sphinx extension for glue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ extensions = [
     'sphinx.ext.linkcode',
     'numpydoc',
     'matplotlib.sphinxext.plot_directive',
+    'gwpy.utils.sphinx.epydoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -153,6 +154,12 @@ numpydoc_use_plots = True
 # configure inheritance diagram
 inheritance_graph_attrs = dict(rankdir='TB')
 
+# -- epydoc -------------------------------------
+
+# epydoc extension config for GLUE
+epydoc_mapping = {
+    'http://software.ligo.org/docs/glue/': [r'glue(\.|$)'],
+}
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/gwpy/frequencyseries/core.py
+++ b/gwpy/frequencyseries/core.py
@@ -139,12 +139,12 @@ class FrequencySeries(Series):
 
         Parameters
         ----------
-        source : `str`, `~glue.lal.Cache`
+        source : `str`, :class:`~glue.lal.Cache`
             source of data, any of the following:
 
             - `str` path of single data file
             - `str` path of LAL-format cache file
-            - `~glue.lal.Cache` describing one or more data files,
+            - :class:`~glue.lal.Cache` describing one or more data files,
 
         format : `str`, optional
             source format identifier. If not given, the format will be

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -152,12 +152,12 @@ class SpectralVariance(Array2D):
 
         Parameters
         ----------
-        source : `str`, `~glue.lal.Cache`
+        source : `str`, :class:`~glue.lal.Cache`
             source of data, any of the following:
 
             - `str` path of single data file
             - `str` path of LAL-format cache file
-            - `~glue.lal.Cache` describing one or more data files,
+            - :class:`~glue.lal.Cache` describing one or more data files,
 
         format : `str`, optional
             source format identifier. If not given, the format will be

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -142,7 +142,8 @@ def file_list(flist):
         - `str` representing a single file path (or comma-separated collection)
         - open `file` or `~gzip.GzipFile` object
         - `~lal.utils.CacheEntry`
-        - `~glue.lal.Cache` object or `str` with '.cache' or '.lcf extension
+        - :class:`~glue.lal.Cache` object or `str` with `.cache` or
+          `.lcf` extension
         - simple `list` or `tuple` of `str` paths
 
     Returns
@@ -228,7 +229,7 @@ def cache_segments(*caches):
 
     Parameters
     ----------
-    *cache : `~glue.lal.Cache`, `list`
+    *cache : :class:`~glue.lal.Cache`, `list`
         one of more `Cache` objects (or simple `list`)
 
     Returns

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -50,7 +50,7 @@ def connect(host=None, port=None):
 
     Returns
     -------
-    connection : `~glue.datafind.GWDataFindHTTPConnection`
+    connection : :class:`~glue.datafind.GWDataFindHTTPConnection`
         the new open connection
     """
     from glue import datafind

--- a/gwpy/plotter/segments.py
+++ b/gwpy/plotter/segments.py
@@ -50,9 +50,10 @@ class SegmentAxes(TimeSeriesAxes):
     This `SegmentAxes` provides custom methods for displaying any of
 
     - `~gwpy.segments.DataQualityFlag`
-    - `~gwpy.segments.Segment` or `glue.segments.segment`
-    - `~gwpy.segments.SegmentList` or `glue.segments.segmentlist`
-    - `~gwpy.segments.SegmentListDict` or `glue.segments.segmentlistdict`
+    - `~gwpy.segments.Segment` or :class:`glue.segments.segment`
+    - `~gwpy.segments.SegmentList` or :class:`glue.segments.segmentlist`
+    - `~gwpy.segments.SegmentListDict` or
+      :class:`glue.segments.segmentlistdict`
 
     Parameters
     ----------
@@ -95,7 +96,7 @@ class SegmentAxes(TimeSeriesAxes):
                 - `~gwpy.segments.SegmentList`
                 - `~gwpy.segments.SegmentListDict`
 
-            or equivalent types upstream from `glue.segments`
+            or equivalent types upstream from :mod:`glue.segments`
 
         kwargs
             keyword arguments applicable to `~matplotib.axes.Axes.plot`

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -570,7 +570,12 @@ class DataQualityFlag(object):
 
     @classmethod
     def from_veto_def(cls, veto):
-        """Define a `DataQualityFlag` from a `~glue.ligolw.lsctables.VetoDef`
+        """Define a `DataQualityFlag` from a `VetoDef`
+
+        Parameters
+        ----------
+        veto : :class:`~glue.ligolw.lsctables.VetoDef`
+            veto definition to convert from
         """
         name = '%s:%s' % (veto.ifo, veto.name)
         try:

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -216,12 +216,12 @@ class Spectrogram(Array2D):
 
         Parameters
         ----------
-        source : `str`, `~glue.lal.Cache`
+        source : `str`, :class:`~glue.lal.Cache`
             source of data, any of the following:
 
             - `str` path of single data file
             - `str` path of LAL-format cache file
-            - `~glue.lal.Cache` describing one or more data files,
+            - :class:`~glue.lal.Cache` describing one or more data files,
 
         format : `str`, optional
             source format identifier. If not given, the format will be

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -50,7 +50,7 @@ def open_data_source(source):
 
     Parameters
     ----------
-    source : `str`, `file`, `lal.Cache`, `glue.lal.Cache`
+    source : `str`, `file`, `lal.Cache`, :class:`glue.lal.Cache`
         data source to read
 
     Returns

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -520,12 +520,12 @@ class StateVector(TimeSeriesBase):
 
         Parameters
         ----------
-        source : `str`, `~glue.lal.Cache`
+        source : `str`, :class:`~glue.lal.Cache`
             source of data, any of the following:
 
             - `str` path of single data file
             - `str` path of LAL-format cache file
-            - `~glue.lal.Cache` describing one or more data files,
+            - :class:`~glue.lal.Cache` describing one or more data files,
 
         channel : `str`, `~gwpy.detector.Channel`
             the name of the channel to read, or a `Channel` object.
@@ -554,7 +554,7 @@ class StateVector(TimeSeriesBase):
             .. note::
 
                Parallel frame reading, via the ``nproc`` keyword argument,
-               is only available when giving a `~glue.lal.Cache` of
+               is only available when giving a :class:`~glue.lal.Cache` of
                frames, or using the ``format='cache'`` keyword argument.
 
         gap : `str`, optional
@@ -912,8 +912,8 @@ class StateVectorDict(TimeSeriesBaseDict):
 
         Parameters
         ----------
-        source : `str`, `~glue.lal.Cache`
-            a single file path `str`, or a `~glue.lal.Cache` containing
+        source : `str`, :class:`~glue.lal.Cache`
+            a single file path `str`, or a :class:`~glue.lal.Cache` containing
             a contiguous list of files.
 
         channels : `~gwpy.detector.channel.ChannelList`, `list`

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -135,12 +135,12 @@ class TimeSeries(TimeSeriesBase):
 
         Parameters
         ----------
-        source : `str`, `~glue.lal.Cache`
+        source : `str`, :class:`~glue.lal.Cache`
             source of data, any of the following:
 
             - `str` path of single data file
             - `str` path of LAL-format cache file
-            - `~glue.lal.Cache` describing one or more data files,
+            - :class:`~glue.lal.Cache` describing one or more data files,
 
         name : `str`, `~gwpy.detector.Channel`
             the name of the channel to read, or a `Channel` object.
@@ -165,7 +165,7 @@ class TimeSeries(TimeSeriesBase):
             .. note::
 
                Parallel frame reading, via the ``nproc`` keyword argument,
-               is only available when giving a `~glue.lal.Cache` of
+               is only available when giving a :class:`~glue.lal.Cache` of
                frames, or using the ``format='cache'`` keyword argument.
 
         gap : `str`, optional
@@ -1732,8 +1732,8 @@ class TimeSeriesDict(TimeSeriesBaseDict):
 
         Parameters
         ----------
-        source : `str`, `~glue.lal.Cache`
-            a single file path `str`, or a `~glue.lal.Cache` containing
+        source : `str`, :class:`~glue.lal.Cache`
+            a single file path `str`, or a :class:`~glue.lal.Cache` containing
             a contiguous list of files.
 
         channels : `~gwpy.detector.channel.ChannelList`, `list`

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -343,12 +343,12 @@ class Series(Array):
 
         Parameters
         ----------
-        source : `str`, `~glue.lal.Cache`
+        source : `str`, :class:`~glue.lal.Cache`
             source of data, any of the following:
 
             - `str` path of single data file
             - `str` path of LAL-format cache file
-            - `~glue.lal.Cache` describing one or more data files,
+            - :class:`~glue.lal.Cache` describing one or more data files,
 
         format : `str`, optional
             source format identifier. If not given, the format will be

--- a/gwpy/utils/sphinx/epydoc.py
+++ b/gwpy/utils/sphinx/epydoc.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2010, 2011, 2012, Sebastian Wiesner <lunaryorn@googlemail.com>
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+    sphinxcontrib.epydoc
+    ====================
+
+    Sphinx extension to cross-reference epydoc generated documentation
+
+    .. moduleauthor::  Sebastian Wiesner  <lunaryorn@googlemail.com>
+"""
+
+
+from __future__ import (print_function, division, unicode_literals,
+                        absolute_import)
+
+__version__ = '0.6'
+
+import re
+import posixpath
+
+from docutils import nodes
+
+
+def filename_for_object(objtype, name):
+    if objtype == 'exception':
+        # exceptions are classes for epydoc
+        objtype = 'class'
+    if not (objtype == 'module' or objtype == 'class'):
+        try:
+            name, attribute = name.rsplit('.', 1)
+        except ValueError:
+            anchor = ''
+        else:
+            anchor = '#{0}'.format(attribute)
+        if objtype == 'function' or objtype == 'data':
+            objtype = 'module'
+        else:
+            objtype = 'class'
+    else:
+        anchor = ''
+    return '{0}-{1}.html{2}'.format(name, objtype, anchor)
+
+
+def resolve_reference_to_epydoc(app, env, node, contnode):
+    """
+    Resolve a reference to an epydoc documentation.
+    """
+    domain = node.get('refdomain')
+    if domain != 'py':
+        # epydoc only holds Python docs
+        return
+
+    target = node['reftarget']
+
+    mapping = app.config.epydoc_mapping
+    matching_baseurls = (baseurl for baseurl in mapping if
+                         any(re.match(p, target) for p in mapping[baseurl]))
+    baseurl = next(matching_baseurls, None)
+    if not baseurl:
+        return
+
+    objtype = env.domains[domain].objtypes_for_role(node['reftype'])[0]
+    fn = filename_for_object(objtype, target)
+    uri = posixpath.join(baseurl, fn)
+
+    newobjtype = posixpath.splitext(fn)[0].rsplit('-', 1)[-1]
+    title = '{} {} at {}'.format(target, newobjtype, baseurl)
+
+    newnode = nodes.reference('', '')
+    newnode['class'] = 'external-xref'
+    newnode['refuri'] = uri
+    newnode['reftitle'] = title
+    newnode.append(contnode)
+    return newnode
+
+
+def setup(app):
+    app.require_sphinx('1.0')
+    app.add_config_value('epydoc_mapping', {}, 'env')
+    app.connect(str('missing-reference'), resolve_reference_to_epydoc)


### PR DESCRIPTION
The sphinxcontrib-epydoc extension seems to have died, this PR adds a fork of that extension into `gwpy.utils.sphinx` and sets the role for every glue object reference in docstrings (so they link properly).