### PR TITLE
Simpler implementation of LIGO_LW interface

### DIFF
--- a/docs/table/histogram.rst
+++ b/docs/table/histogram.rst
@@ -18,7 +18,7 @@ Using the above method we can generate a histogram as follows
    :include-source:
 
    >>> from gwpy.table import EventTable
-   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst', columns=['snr'])
+   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['snr'])
    >>> plot = events.hist('snr', weights=1/10., logbins=True, bins=50, histtype='stepfilled')
    >>> ax = plot.gca()
    >>> ax.set_xlabel('Signal-to-noise ratio (SNR)')

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -49,19 +49,19 @@ but is **not** backported to for use with :meth:`Table.read`.
 **Additional dependencies:** |glue.ligolw|_
 
 The LIGO Scientific Collaboration uses a custom scheme of XML in which to
-store tabular data, called the ``LIGO_LW`` scheme.
+store tabular data, called ``LIGO_LW``.
 Complementing the scheme is a python library - :mod:`glue.ligolw` - which
 allows users to read and write all of the different types of tabular data
 produced by gravitational-wave searches.
 
-Reading and writing tables in ``LIGO_LW`` XML format is supported with ``format='ligolw.<tablename>'`` where ``<tablename>`` can be any of the supported LSC table names (see below for a full list).
+Reading and writing tables in ``LIGO_LW`` XML format is supported with ``format='ligolw', tablename=<tablename>'`` where ``<tablename>`` can be any of the supported LSC table names (see :mod:`glue.ligolw.lsctables`).
 
 Reading
 -------
 
-When reading, the `format` keyword argument must be given, to identify the table in the file, as follows::
+When reading, the ``tablename`` keyword argument should be given to identify the table in the file, as follows::
 
-    >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst')
+    >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst')
 
 The result should be something similar to this::
 
@@ -105,80 +105,41 @@ The result should be something similar to this::
      H1 968654560    311523438  968654560 ...  11.367717   0.0       4.0       4.0
     Length = 2052 rows
 
+The ``tablename`` keyword can be omitted if there is only a single table in the file.
+
 To restrict the columns returned in the new `EventTable`, use the `columns` keyword argument::
 
-    >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst', columns=['peak_time', 'peak_time_ns', 'snr', 'peak_frequency'])
+    >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['peak_time', 'peak_time_ns', 'snr', 'peak_frequency'])
 
-Many LIGO_LW table objects (as defined in :mod:`glue.ligolw.lsctables`) include utility functions to create new columns by combining others, e.g. to calculate the Q of a sine-Gaussian pulse from the duration and central frequency. To have the returned `EventTable` include these processed columns, use the ``get_as_columns`` keyword argument, which will call each discovered :meth:`get_xxx` method into a column called ``xxx``::
+Many LIGO_LW table objects (as defined in :mod:`glue.ligolw.lsctables`) include utility functions to create new columns by combining others, e.g. to calculate the Q of a sine-Gaussian pulse from the duration and central frequency.
+These 'columns' can be requested directly, providing the :class:`glue.ligolw.table.Table` representation of the data has a :meth:`get_<name>` method for that name::
 
-   >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst', columns=['snr', 'q', 'duration', 'central_freq'], get_as_columns=True)
+   >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['snr', 'q', 'duration', 'central_freq'])
 
 .. note::
 
-   When using `get_as_columns=True`, all required input columns for a processed column must be included in the `columns` keyword list
+   When reading a processed column in this manner, all required input columns for a processed column must be included in the `columns` keyword list. To exclude these columns from the returned data, use the ``ligolw_columns=`` keyword to specify the columns required to provide the output columns::
+
+      >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['snr', 'q'], ligolw_columns=['snr', 'duration', 'central_freq'])
 
 Writing
 -------
 
 A table can be written as follows::
 
-    >>> t.write('new-table.xml', format='ligolw.sngl_burst')
+    >>> t.write('new-table.xml', format='ligolw', tablename='sngl_burst')
+
+Because ``LIGO_LW`` isn't the only scheme of XML, the ``format`` keyword is required for all `.write()` operations.
 
 If the target file already exists, an :class:`~exceptions.IOError` will be raised, use ``overwrite=True`` to force a new file to be written.
 
 To write a table to an existing file, use ``append=True``::
 
-    >>> t.write('new-table.xml', format='ligolw.sngl_burst', append=True)
+    >>> t.write('new-table.xml', format='ligolw', tablename='sngl_burst', append=True)
 
 To replace an existing table of the given type in an existing file, while preserving other tables, use *both* ``append=True`` and ``overwrite=True``::
 
-    >>> t.write('new-table.xml', format='ligolw.sngl_burst', append=True, overwrite=True)
-
-
-Supported LIGO_LW tables
-------------------------
-
-========================  =================================
-Table name                Format name
-========================  =================================
-`coinc_definer`           ``ligolw.coinc_definer``
-`coinc_event`             ``ligolw.coinc_event``
-`coinc_event_map`         ``ligolw.coinc_event_map``
-`coinc_inspiral`          ``ligolw.coinc_inspiral``
-`coinc_ringdown`          ``ligolw.coinc_ringdown``
-`dq_list`                 ``ligolw.dq_list``
-`experiment`              ``ligolw.experiment``
-`experiment_map`          ``ligolw.experiment_map``
-`experiment_summary`      ``ligolw.experiment_summary``
-`external_trigger`        ``ligolw.external_trigger``
-`filter`                  ``ligolw.filter``
-`gds_trigger`             ``ligolw.gds_trigger``
-`lfn`                     ``ligolw.lfn``
-`ligolw_mon`              ``ligolw.ligolw_mon``
-`multi_burst`             ``ligolw.multi_burst``
-`multi_inspiral`          ``ligolw.multi_inspiral``
-`process`                 ``ligolw.process``
-`process_params`          ``ligolw.process_params``
-`search_summary`          ``ligolw.search_summary``
-`search_summvars`         ``ligolw.search_summvars``
-`segment`                 ``ligolw.segment``
-`segment_definer`         ``ligolw.segment_definer``
-`segment_summary`         ``ligolw.segment_summary``
-`sim_burst`               ``ligolw.sim_burst``
-`sim_inspiral`            ``ligolw.sim_inspiral``
-`sim_inst_params`         ``ligolw.sim_inst_params``
-`sim_ringdown`            ``ligolw.sim_ringdown``
-`sngl_burst`              ``ligolw.sngl_burst``
-`sngl_inspiral`           ``ligolw.sngl_inspiral``
-`sngl_ringdown`           ``ligolw.sngl_ringdown``
-`stochastic`              ``ligolw.stochastic``
-`stochsumm`               ``ligolw.stochsumm``
-`summ_mime`               ``ligolw.summ_mime``
-`summ_value`              ``ligolw.summ_value``
-`time_slide`              ``ligolw.time_slide``
-`time_slide_segment_map`  ``ligolw.time_slide_segment_map``
-`veto_definer`            ``ligolw.veto_definer``
-========================  =================================
+    >>> t.write('new-table.xml', format='ligolw', tablename='sngl_burst', append=True, overwrite=True)
 
 
 .. _gwpy-table-io-ascii-cwb:

--- a/docs/table/plot.rst
+++ b/docs/table/plot.rst
@@ -21,7 +21,7 @@ x-axis, y-axis, and optionally colouring:
    :include-source:
 
    >>> from gwpy.table import EventTable
-   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst', columns=['time', 'central_freq', 'snr'])
+   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['time', 'central_freq', 'snr'])
    >>> plot = events.plot('time', 'central_freq', color='snr')
    >>> ax = plot.gca()
    >>> ax.set_epoch(968654552)
@@ -42,7 +42,7 @@ These tiles can be plotted in a similar manner to simple triggers.
    :context:
    :include-source:
 
-   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst', columns=['time', 'central_freq', 'snr', 'duration', 'bandwidth'])
+   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['time', 'central_freq', 'snr', 'duration', 'bandwidth'])
    >>> plot = events.plot('time', 'central_freq', 'duration', 'bandwidth', color='snr')
    >>> ax = plot.gca()
    >>> ax.set_epoch(968654552)

--- a/docs/table/rate.rst
+++ b/docs/table/rate.rst
@@ -23,10 +23,12 @@ For example, using the same data as before we can calculate and plot the
 event rate on a 1-second stride:
 
 .. plot::
-   :context:
+   :context: reset
    :include-source:
 
-   >>> rate = events.event_rate(1, start=968654552, end=968654562)
+   >>> from gwpy.table import EventTable
+   >>> events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['peak', 'central_freq', 'snr'])
+   >>> rate = events.event_rate(1, start=968654552, end=968654562, timecolumn='peak')
    >>> plot = rate.plot()
    >>> ax = plot.gca()
    >>> ax.set_ylabel('Event rate [Hz]')
@@ -53,7 +55,7 @@ signal-to-noise ratio (SNR) above some threshold, for the same table as above.
    :context:
    :include-source:
 
-   >>> rates = events.binned_event_rates(1, 'snr', [2, 3, 5, 8], operator='>=', start=968654552, end=968654562)
+   >>> rates = events.binned_event_rates(1, 'snr', [2, 3, 5, 8], operator='>=', start=968654552, end=968654562, timecolumn='peak')
    >>> plot = rates.plot()
    >>> ax = plot.gca()
    >>> ax.set_ylabel('Event rate [Hz]')

--- a/examples/table/histogram.py
+++ b/examples/table/histogram.py
@@ -37,7 +37,7 @@ __currentmodule__ = 'gwpy.table'
 # :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read(
-    'H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst',
+    'H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst',
     columns=['time', 'snr'])
 
 # .. note::

--- a/examples/table/rate.py
+++ b/examples/table/rate.py
@@ -37,7 +37,7 @@ __currentmodule__ = 'gwpy.table'
 # :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz',
-                         format='ligolw.sngl_burst', columns=['time', 'snr'])
+                         tablename='sngl_burst', columns=['time', 'snr'])
 
 # .. note::
 #

--- a/examples/table/rate_binned.py
+++ b/examples/table/rate_binned.py
@@ -36,9 +36,8 @@ __currentmodule__ = 'gwpy.table'
 # a LIGO_LW-format XML file containing a
 # :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
-events = EventTable.read(
-    'H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst',
-    columns=['time', 'snr'])
+events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz',
+                         tablename='sngl_burst', columns=['time', 'snr'])
 
 # .. note::
 #

--- a/examples/table/scatter.py
+++ b/examples/table/scatter.py
@@ -36,7 +36,7 @@ __currentmodule__ = 'gwpy.table'
 # :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read(
-    'H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst',
+    'H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst',
     columns=['time', 'central_freq', 'snr'])
 
 # .. note::

--- a/examples/table/tiles.py
+++ b/examples/table/tiles.py
@@ -36,7 +36,7 @@ __currentmodule__ = 'gwpy.table'
 # :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read(
-    'H1-LDAS_STRAIN-968654552-10.xml.gz', format='ligolw.sngl_burst',
+    'H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst',
     columns=['time', 'central_freq', 'bandwidth', 'duration', 'snr'])
 
 # .. note::

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -22,12 +22,11 @@
 from __future__ import division
 
 import os.path
-from math import ceil
-from multiprocessing import (cpu_count, Process, Queue as ProcessQueue)
-from six import string_types
 import tempfile
 import warnings
 from gzip import GzipFile
+from math import ceil
+from multiprocessing import (cpu_count, Process, Queue as ProcessQueue)
 
 from six import string_types
 from six.moves import StringIO

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -30,6 +30,7 @@ import warnings
 from gzip import GzipFile
 
 from six import string_types
+from six.moves import StringIO
 
 from numpy import recarray
 from numpy.lib import recfunctions
@@ -181,7 +182,7 @@ def file_name(fobj):
     """
     if isinstance(fobj, string_types):
         return fobj
-    if isinstance(fobj, FILE_LIKE):
+    if isinstance(fobj, FILE_LIKE) and not isinstance(fobj, StringIO):
         return fobj.name
     if HAS_CACHE and isinstance(fobj, CacheEntry):
         return fobj.path

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -183,7 +183,7 @@ def with_read_ligolw(func=None, contenthandler=None):
 
 def read_table(source, tablename=None, columns=None, contenthandler=None,
                **kwargs):
-    """Read a `~glue.ligolw.table.Table` from one or more LIGO_LW files
+    """Read a :class:`~glue.ligolw.table.Table` from one or more LIGO_LW files
 
     Parameters
     ----------
@@ -195,7 +195,7 @@ def read_table(source, tablename=None, columns=None, contenthandler=None,
         - a `str` pointing to a file path on disk
         - a formatted `~lal.utils.CacheEntry` representing one file
         - a `list` of `str` file paths
-        - a formatted `~glue.lal.Cache` representing many files
+        - a formatted :class:`~glue.lal.Cache` representing many files
 
     tablename : `str`
         name of the table to read.

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -23,56 +23,174 @@ an 'io' subdirectory of the containing directory for that class.
 """
 
 import os.path
-import warnings
+from functools import wraps
 
 from six import string_types
 
-from ..utils import gprint
 from .cache import (file_list, FILE_LIKE)
-from .utils import identify_factory
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+XML_SIGNATURE = b'<?xml'
+LIGOLW_SIGNATURE = b'<!doctype ligo_lw'
 
 
 # -- content handling ---------------------------------------------------------
 
-def get_partial_contenthandler(table):
-    """Build a `~glue.ligolw.ligolw.PartialLIGOLWContentHandler` for this table
+def get_partial_contenthandler(element):
+    """Build a `PartialLIGOLWContentHandler` to read only this element
 
     Parameters
     ----------
-    table : `type`
-        the table class to be read
+    element : `type`
+        the element class to be read, subclass of
+        :class:`~glue.ligolw.ligolw.Element`
 
     Returns
     -------
     contenthandler : `type`
-        a subclass of `~glue.ligolw.ligolw.PartialLIGOLWContentHandler` to
-        read only the given `table`
+        a subclass of :class:`~glue.ligolw.ligolw.PartialLIGOLWContentHandler`
+        to read only the given `element`
     """
     from glue.ligolw.ligolw import PartialLIGOLWContentHandler
+    from glue.ligolw.table import Table
 
-    def _element_filter(name, attrs):
-        return table.CheckProperties(name, attrs)
+    if issubclass(element, Table):
+        def _element_filter(name, attrs):
+            # pylint: disable=unused-argument
+            return element.CheckProperties(name, attrs)
+    else:
+        def _element_filter(name, attrs):
+            # pylint: disable=unused-argument
+            return name == element.tagName
 
-    class _ContentHandler(PartialLIGOLWContentHandler):
+    return build_content_handler(PartialLIGOLWContentHandler, _element_filter)
+
+
+def get_filtering_contenthandler(element):
+    """Build a `FilteringLIGOLWContentHandler` to exclude this element
+
+    Parameters
+    ----------
+    element : `type`, subclass of :class:`~glue.ligolw.ligolw.Element`
+        the element to exclude (and its children)
+
+    Returns
+    -------
+    contenthandler : `type`
+        a subclass of
+        :class:`~glue.ligolw.ligolw.FilteringLIGOLWContentHandler` to
+        exclude an element and its children
+    """
+    from glue.ligolw.ligolw import FilteringLIGOLWContentHandler
+    from glue.ligolw.table import Table
+
+    if issubclass(element, Table):
+        def _element_filter(name, attrs):
+            # pylint: disable=unused-argument
+            return ~element.CheckProperties(name, attrs)
+    else:
+        def _element_filter(name, attrs):
+            # pylint: disable=unused-argument
+            return name != element.tagName
+
+    return build_content_handler(FilteringLIGOLWContentHandler,
+                                 _element_filter)
+
+
+def build_content_handler(parent, filter_func):
+    """Build a `~xml.sax.handler.ContentHandler` with a given filter
+    """
+    from glue.ligolw.lsctables import use_in
+
+    class _ContentHandler(parent):
+        # pylint: disable=too-few-public-methods
         def __init__(self, document):
-            super(_ContentHandler, self).__init__(document, _element_filter)
+            super(_ContentHandler, self).__init__(document, filter_func)
 
-    return _ContentHandler
+    return use_in(_ContentHandler)
 
 
 # -- reading ------------------------------------------------------------------
 
-def table_from_file(f, tablename, columns=None, filt=None,
-                    contenthandler=None, nproc=1, verbose=False):
-    """Read a `~glue.ligolw.table.Table` from a LIGO_LW file.
+def read_ligolw(source, contenthandler=None, verbose=False,
+                non_lsc_tables_ok=True):
+    """Read one or more LIGO_LW format files
 
     Parameters
     ----------
-    f : `file`, `str`, `CacheEntry`, `list`, `Cache`
+    source : `str`, `file`, `list`
+        one or more open files or file paths to read
+
+    contenthandler : `~xml.sax.handler.ContentHandler`, optional
+        content handler used to parse document
+
+    verbose : `bool`, optional
+        be verbose when reading files, default: `False`
+
+    non_lsc_tables_ok : `bool`, optional
+        if `False` error on unrecognised tables in documents, default: `True`
+
+    Returns
+    -------
+    xmldoc : :class:`~glue.ligolw.ligolw.Document`
+        the document object as parsed from the file(s)
+    """
+    from glue.ligolw.ligolw import (Document, LIGOLWContentHandler)
+    from glue.ligolw.utils.ligolw_add import ligolw_add
+    from glue.ligolw.lsctables import use_in
+
+    # set default content handler
+    if contenthandler is None:
+        contenthandler = use_in(LIGOLWContentHandler)
+
+    # read one or more files into a single Document
+    return ligolw_add(Document(), file_list(source),
+                      contenthandler=contenthandler, verbose=verbose,
+                      non_lsc_tables_ok=non_lsc_tables_ok)
+
+
+def with_read_ligolw(func=None, contenthandler=None):
+    """Decorate a LIGO_LW-reading function to open a filepath if needed
+
+    ``func`` should be written to presume a
+    :class:`~glue.ligolw.ligolw.Document` as the first positional argument
+    """
+    def decorator(func_):
+        # pylint: disable=missing-docstring
+        @wraps(func_)
+        def decorated_func(source, *args, **kwargs):
+            # pylint: disable=missing-docstring
+            from glue.ligolw.ligolw import Document
+            if not isinstance(source, Document):
+                read_kw = {
+                    'contenthandler': kwargs.pop('contenthandler',
+                                                 contenthandler),
+                    'verbose': kwargs.pop('verbose', False),
+                    'non_lsc_tables_ok': kwargs.pop('non_lsc_tables_ok', True),
+                }
+                return func_(read_ligolw(source, **read_kw), *args, **kwargs)
+            return func_(source, *args, **kwargs)
+
+        return decorated_func
+
+    if func is not None:
+        return decorator(func)
+    return decorator
+
+
+# -- reading ------------------------------------------------------------------
+
+def read_table(source, tablename=None, columns=None, contenthandler=None,
+               **kwargs):
+    """Read a `~glue.ligolw.table.Table` from one or more LIGO_LW files
+
+    Parameters
+    ----------
+    source : `Document`, `file`, `str`, `CacheEntry`, `list`, `Cache`
         object representing one or more files. One of
 
+        - a LIGO_LW :class:`~glue.ligolw.ligolw.Document`
         - an open `file`
         - a `str` pointing to a file path on disk
         - a formatted `~lal.utils.CacheEntry` representing one file
@@ -81,88 +199,95 @@ def table_from_file(f, tablename, columns=None, filt=None,
 
     tablename : `str`
         name of the table to read.
+
     columns : `list`, optional
         list of column name strings to read, default all.
-    filt : `function`, optional
-        function by which to `filter` events. The callable must accept as
-        input a row of the table event and return `True`/`False`.
-    contenthandler : `~glue.ligolw.ligolw.LIGOLWContentHandler`
+
+    contenthandler : `~xml.sax.handler.ContentHandler`, optional
         SAX content handler for parsing LIGO_LW documents.
+
+    **kwargs
+        other keyword arguments are passed to `~gwpy.io.ligolw.read_ligolw`
 
     Returns
     -------
-    table : `~glue.ligolw.table.Table`
-        `Table` of data with given columns filled
+    table : :class:`~glue.ligolw.table.Table`
+        `Table` of data
     """
     from glue.ligolw.ligolw import Document
     from glue.ligolw import (table, lsctables)
-    from glue.ligolw.utils.ligolw_add import ligolw_add
 
-    # find table class
-    tableclass = lsctables.TableByName[table.Table.TableName(tablename)]
+    # get content handler to read only this table (if given)
+    if tablename is not None:
+        tableclass = lsctables.TableByName[table.Table.TableName(tablename)]
+        if contenthandler is None:
+            contenthandler = get_partial_contenthandler(tableclass)
 
-    # get content handler
-    if contenthandler is None:
-        contenthandler = get_partial_contenthandler(tableclass)
-
-    # allow cache multiprocessing
-    if nproc != 1:
-        return tableclass.read(f, columns=columns,
-                               contenthandler=contenthandler,
-                               nproc=nproc, format='cache')
-
-    lsctables.use_in(contenthandler)
-
-    # set columns to read
-    if columns is not None:
+        # overwrite loading column names to get just what was asked for
         _oldcols = tableclass.loadcolumns
-        tableclass.loadcolumns = columns
+        if columns is not None:
+            tableclass.loadcolumns = columns
 
-    # generate Document and populate
-    files = file_list(f)
-    xmldoc = Document()
-    ligolw_add(xmldoc, files, non_lsc_tables_ok=True,
-               contenthandler=contenthandler, verbose=verbose)
+    # read document
+    if isinstance(source, Document):
+        xmldoc = source
+    else:
+        try:
+
+            xmldoc = read_ligolw(source, contenthandler=contenthandler,
+                                 **kwargs)
+        finally:  # reinstate original set of loading column names
+            if tablename is not None:
+                tableclass.loadcolumns = _oldcols
+
+    # now find the right table
+    if tablename is None:
+        tables = list_tables(xmldoc)
+        if not tables:
+            raise ValueError("No tables found in LIGO_LW document(s)")
+        if len(tables) > 1:
+            tlist = "'{}'".format("', '".join(tables))
+            raise ValueError("Multiple tables found in LIGO_LW document(s), "
+                             "please specify the table to read via the "
+                             "``tablename=`` keyword argument. The following "
+                             "tables were found: {}".format(tlist))
+        tableclass = lsctables.TableByName[table.Table.TableName(tables[0])]
 
     # extract table
-    out = tableclass.get_table(xmldoc)
-    if verbose:
-        gprint('%d rows found in %s table' % (len(out), out.tableName))
-
-    # filter output
-    if filt:
-        if verbose:
-            gprint('filtering rows ...', end=' ')
-        try:
-            out_ = out.copy()
-        except AttributeError:
-            out_ = table.new_from_template(out)
-        out_.extend(filter(filt, out))
-        out = out_
-        if verbose:
-            gprint('%d rows remaining\n' % len(out))
-
-    # reset loadcolumns and return
-    if columns is not None:
-        tableclass.loadcolumns = _oldcols
-
-    return out
+    return tableclass.get_table(xmldoc)
 
 
 # -- writing ------------------------------------------------------------------
 
-def open_xmldoc(f, **kwargs):
+def open_xmldoc(fobj, **kwargs):
     """Try and open an existing LIGO_LW-format file, or create a new Document
+
+    Parameters
+    ----------
+    fobj : `str`, `file`
+        file path or open file object to read
+
+    **kwargs
+        other keyword arguments to pass to
+        :func:`~glue.ligolw.utils.load_filename`, or
+        :func:`~glue.ligolw.utils.load_fileobj` as appropriate
+
+    Returns
+    --------
+    xmldoc : :class:`~glue.ligolw.ligolw.Document`
+        either the `Document` as parsed from an existing file, or a new, empty
+        `Document`
     """
     from glue.ligolw.lsctables import use_in
-    from glue.ligolw.ligolw import Document
+    from glue.ligolw.ligolw import (Document, LIGOLWContentHandler)
     from glue.ligolw.utils import load_filename, load_fileobj
-    use_in(kwargs['contenthandler'])
     try:  # try and load existing file
-        if isinstance(f, string_types):
-            return load_filename(f, **kwargs)
-        if isinstance(f, FILE_LIKE):
-            return load_fileobj(f, **kwargs)[0]
+        if isinstance(fobj, string_types):
+            kwargs.setdefault('contenthandler', use_in(LIGOLWContentHandler))
+            return load_filename(fobj, **kwargs)
+        if isinstance(fobj, FILE_LIKE):
+            kwargs.setdefault('contenthandler', use_in(LIGOLWContentHandler))
+            return load_fileobj(fobj, **kwargs)[0]
     except (OSError, IOError):  # or just create a new Document
         return Document()
 
@@ -208,7 +333,7 @@ def write_tables_to_document(xmldoc, tables, overwrite=False):
     for table in tables:
         try:  # append new data to existing table
             old = lsctables.TableByName[
-                table.TableName(table.tableName)].get_table(xmldoc)
+                table.TableName(table.Name)].get_table(xmldoc)
         except ValueError:  # or create a new table
             llw.appendChild(table)
         else:
@@ -222,15 +347,15 @@ def write_tables_to_document(xmldoc, tables, overwrite=False):
     return xmldoc
 
 
-def write_tables(f, tables, append=False, overwrite=False, **kwargs):
+def write_tables(target, tables, append=False, overwrite=False, **kwargs):
     """Write an LIGO_LW table to file
 
     Parameters
     ----------
-    f : `str`, `file`, :class:`~glue.ligolw.ligolw.Document`
+    target : `str`, `file`, :class:`~glue.ligolw.ligolw.Document`
         the file or document to write into
 
-    tables : `list` of :class:`~glue.ligolw.table.Table`
+    tables : `list`, `tuple` of :class:`~glue.ligolw.table.Table`
         the tables to write
 
     append : `bool`, optional, default: `False`
@@ -239,21 +364,27 @@ def write_tables(f, tables, append=False, overwrite=False, **kwargs):
     overwrite : `bool`, optional, default: `False`
         if `True`, delete an existing instance of the table type, otherwise
         append new rows
+
+    **kwargs
+        other keyword arguments to pass to
+        :func:`~glue.ligolw.utils.load_filename`, or
+        :func:`~glue.ligolw.utils.load_fileobj` as appropriate
     """
     from glue.ligolw.ligolw import (Document, LIGO_LW, LIGOLWContentHandler)
     from glue.ligolw import utils as ligolw_utils
 
     # allow writing directly to XML
-    if isinstance(f, (Document, LIGO_LW)):
-        xmldoc = f
+    if isinstance(target, (Document, LIGO_LW)):
+        xmldoc = target
     # open existing document, if possible
     elif append and not overwrite:
         xmldoc = open_xmldoc(
-            f, contenthandler=kwargs.pop('contenthandler',
-                                         LIGOLWContentHandler))
+            target, contenthandler=kwargs.pop('contenthandler',
+                                              LIGOLWContentHandler))
     # fail on existing document and not overwriting
-    elif not overwrite and isinstance(f, string_types) and os.path.isfile(f):
-        raise IOError("File exists: %s" % f)
+    elif (not overwrite and isinstance(target, string_types) and
+          os.path.isfile(target)):
+        raise IOError("File exists: {}".format(target))
     else:  # or create a new document
         xmldoc = Document()
 
@@ -261,14 +392,84 @@ def write_tables(f, tables, append=False, overwrite=False, **kwargs):
     write_tables_to_document(xmldoc, tables, overwrite=overwrite)
 
     # write file
-    if isinstance(f, string_types):
-        kwargs.setdefault('gz', f.endswith('.gz'))
-        ligolw_utils.write_filename(xmldoc, f, **kwargs)
-    elif not isinstance(f, Document):
-        kwargs.setdefault('gz', f.name.endswith('.gz'))
-        ligolw_utils.write_fileobj(xmldoc, f, **kwargs)
+    if isinstance(target, string_types):
+        kwargs.setdefault('gz', target.endswith('.gz'))
+        ligolw_utils.write_filename(xmldoc, target, **kwargs)
+    elif isinstance(target, FILE_LIKE):
+        kwargs.setdefault('gz', target.name.endswith('.gz'))
+        ligolw_utils.write_fileobj(xmldoc, target, **kwargs)
+
+
+# -- utilities ----------------------------------------------------------------
+
+def list_tables(source):
+    # pylint: disable=line-too-long
+    """List the names of all tables in this file(s)
+
+    Parameters
+    ----------
+    source : `file`, `str`, :class:`~glue.ligolw.ligolw.Document`, `list`
+        one or more open files, file paths, or LIGO_LW `Document`s
+
+    Examples
+    --------
+    >>> from gwpy.io.ligolw import list_tables
+    >>> print(list_tables('H1-LDAS_STRAIN-968654552-10.xml.gz'))
+    ['process', 'process_params', 'sngl_burst', 'search_summary', 'segment_definer', 'segment_summary', 'segment']
+    """  # nopep8
+    from glue.ligolw.ligolw import (Document, Stream)
+    from glue.ligolw.table import Table
+
+    # read file object
+    if isinstance(source, Document):
+        xmldoc = source
+    else:
+        filt = get_filtering_contenthandler(Stream)
+        xmldoc = read_ligolw(source, contenthandler=filt)
+
+    # get list of table names
+    tables = []
+    for tbl in xmldoc.childNodes[0].childNodes:
+        if isinstance(tbl, Table):
+            tables.append(tbl.TableName(tbl.Name))
+    return tables
 
 
 # -- identify -----------------------------------------------------------------
 
-identify_ligolw = identify_factory('xml', 'xml.gz')
+def is_ligolw(origin, filepath, fileobj, *args, **kwargs):
+    """Identify a file object as LIGO_LW-format XML
+    """
+    # pylint: disable=unused-argument
+    if fileobj is not None:
+        loc = fileobj.tell()
+        fileobj.seek(0)
+        try:
+            line1 = fileobj.readline().lower()
+            line2 = fileobj.readline().lower()
+            return (line1.startswith(XML_SIGNATURE) and
+                    line2.startswith(LIGOLW_SIGNATURE))
+        finally:
+            fileobj.seek(loc)
+    try:
+        from glue.ligolw.ligolw import Element
+    except ImportError:
+        return False
+    else:
+        return len(args) > 0 and isinstance(args[0], Element)
+
+
+def is_xml(origin, filepath, fileobj, *args, **kwargs):
+    """Identify a file object as XML (any format)
+    """
+    # pylint: disable=unused-argument
+    if fileobj is not None:
+        loc = fileobj.tell()
+        fileobj.seek(0)
+        try:
+            sig = fileobj.read(5).lower()
+            return sig == XML_SIGNATURE
+        finally:
+            fileobj.seek(loc)
+    elif filepath is not None:
+        return filepath.endswith(('.xml', '.xml.gz'))

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -28,6 +28,7 @@ for handling multiple flags over the same global time interval.
 
 from __future__ import absolute_import
 
+import datetime
 import json
 import operator
 import re
@@ -48,7 +49,8 @@ from numpy import inf
 from astropy.io import registry as io_registry
 from astropy.utils.data import get_readable_fileobj
 
-from ..time import to_gps
+from ..io.mp import read_multi as io_read_multi
+from ..time import to_gps, LIGOTimeGPS
 from ..utils.compat import OrderedDict
 from .segments import Segment, SegmentList
 
@@ -376,8 +378,9 @@ class DataQualityFlag(object):
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments
 
-        url : `str`, optional, default: ``'https://segments.ligo.org'``
-            URL of the segment database
+        url : `str`, optional
+            URL of the segment database,
+            default: ``'https://segments.ligo.org'``
 
         See Also
         --------
@@ -566,7 +569,10 @@ class DataQualityFlag(object):
 
         Notes
         -----"""
-        return io_registry.read(cls, source, *args, **kwargs)
+        def _combine(flags):
+            return reduce(operator.or_, flags)
+
+        return io_read_multi(_combine, cls, source, *args, **kwargs)
 
     @classmethod
     def from_veto_def(cls, veto):
@@ -823,9 +829,10 @@ class DataQualityFlag(object):
 
         Parameters
         ----------
-        name : `str`
+        name : `str`, `None`
             the full name of a `DataQualityFlag` to parse, e.g.
-            ``'H1:DMT-SCIENCE:1'``
+            ``'H1:DMT-SCIENCE:1'``, or `None` to set all components
+            to `None`
 
         Returns
         -------
@@ -1170,8 +1177,11 @@ class DataQualityDict(OrderedDict):
 
         Notes
         -----"""
-        return io_registry.read(cls, source, flags=flags, format=format,
-                                **kwargs)
+        def _combine(flags):
+            return reduce(operator.or_, flags)
+
+        return io_read_multi(_combine, cls, source, flags=flags, format=format,
+                             **kwargs)
 
     @classmethod
     def from_veto_definer_file(cls, fp, start=None, end=None, ifo=None,
@@ -1207,21 +1217,20 @@ class DataQualityDict(OrderedDict):
         >>> flags.populate()
 
         """
-        from ..io.ligolw import table_from_file
-
         if format != 'ligolw':
             raise NotImplementedError("Reading veto definer from non-ligolw "
                                       "format file is not currently "
                                       "supported")
 
+        # read veto definer file
+        with get_readable_fileobj(fp, show_progress=False) as f:
+            from ..io.ligolw import read_table as read_ligolw_table
+            veto_def_table = read_ligolw_table(f, 'veto_definer')
+
         if start is not None:
             start = to_gps(start)
         if end is not None:
             end = to_gps(end)
-
-        # read veto definer file
-        with get_readable_fileobj(fp, show_progress=False) as f:
-            veto_def_table = table_from_file(f, 'veto_definer')
 
         # parse flag definitions
         out = cls()
@@ -1245,6 +1254,139 @@ class DataQualityDict(OrderedDict):
             else:
                 out[flag.name] = flag
         return out
+
+    @classmethod
+    def from_ligolw_tables(cls, segmentdeftable, segmentsumtable,
+                           segmenttable, names=None, gpstype=LIGOTimeGPS):
+        """Build a `DataQualityDict` from a set of LIGO_LW segment tables
+
+        Parameters
+        ----------
+        segmentdeftable : :class:`~glue.ligolw.lsctables.SegmentDefTable`
+            the ``segment_definer`` table to read
+
+        segmentsumtable : :class:`~glue.ligolw.lsctables.SegmentSumTable`
+            the ``segment_summary`` table to read
+
+        segmenttable : :class:`~glue.ligolw.lsctables.SegmentTable`
+            the ``segment`` table to read
+
+        names : `list` of `str`, optional
+            a list of flag names to read, defaults to returning all
+
+        gpstype : `type`, `callable`, optional
+            class to use for GPS times in returned objects, can be a function
+            to convert GPS time to something else, default is
+            `~gwpy.time.LIGOTimeGPS`
+
+        Returns
+        -------
+        dqdict : `DataQualityDict`
+            a dict of `DataQualityFlag` objects populated from the LIGO_LW
+            tables
+        """
+        out = cls()
+
+        id_ = dict()  # need to record relative IDs from LIGO_LW
+
+        # read segment definers and generate DataQualityFlag object
+        for row in segmentdeftable:
+            ifos = row.get_ifos()
+            ifo = ''.join(ifos) if ifos else None
+            tag = row.name
+            version = row.version
+            name = ':'.join([str(k) for k in (ifo, tag, version) if
+                             k is not None])
+            if names is None or name in names:
+                out[name] = DataQualityFlag(name)
+                try:
+                    id_[name].append(row.segment_def_id)
+                except (AttributeError, KeyError):
+                    id_[name] = [row.segment_def_id]
+
+        # verify all requested flags were found
+        if names is not None:
+            for flag in names:
+                if flag not in out:
+                    raise ValueError("No segment definition found for flag=%r "
+                                     "in file." % flag)
+
+        # read segment summary table as 'known'
+        for row in segmentsumtable:
+            for flag in out:
+                # match row ID to list of IDs found for this flag
+                if row.segment_def_id in id_[flag]:
+                    out[flag].known.append(
+                        Segment(*map(gpstype, row.segment)))
+                    break
+
+        # read segment table as 'active'
+        for row in segmenttable:
+            for flag in out:
+                if row.segment_def_id in id_[flag]:
+                    out[flag].active.append(
+                        Segment(*map(gpstype, row.segment)))
+                    break
+
+        return out
+
+    def to_ligolw_tables(self):
+        """Convert this `DataQualityDict` into a trio of LIGO_LW segment tables
+
+        Returns
+        -------
+        segmentdeftable : :class:`~glue.ligolw.lsctables.SegmentDefTable`
+            the ``segment_definer`` table
+
+        segmentsumtable : :class:`~glue.ligolw.lsctables.SegmentSumTable`
+            the ``segment_summary`` table
+
+        segmenttable : :class:`~glue.ligolw.lsctables.SegmentTable`
+            the ``segment`` table
+        """
+        from glue.ligolw.lsctables import (SegmentTable, SegmentSumTable,
+                                           SegmentDefTable, New as new_table)
+
+        segdeftab = new_table(SegmentDefTable)
+        segsumtab = new_table(SegmentSumTable)
+        segtab = new_table(SegmentTable)
+
+        # write flags to tables
+        for flag in self.values():
+            # segment definer
+            segdef = segdeftab.RowType()
+            for col in segdeftab.columnnames:  # default all columns to None
+                setattr(segdef, col, None)
+            segdef.set_ifos([flag.ifo])
+            segdef.name = flag.tag
+            segdef.version = flag.version
+            segdef.comment = flag.description
+            segdef.insertion_time = to_gps(datetime.datetime.now()).gpsSeconds
+            segdef.segment_def_id = SegmentDefTable.get_next_id()
+            segdeftab.append(segdef)
+
+            # write segment summary (known segments)
+            for vseg in flag.known:
+                segsum = segsumtab.RowType()
+                for col in segsumtab.columnnames:  # default all columns to None
+                    setattr(segsum, col, None)
+                segsum.segment_def_id = segdef.segment_def_id
+                segsum.set(map(LIGOTimeGPS, vseg))
+                segsum.comment = None
+                segsum.segment_sum_id = SegmentSumTable.get_next_id()
+                segsumtab.append(segsum)
+
+            # write segment table (active segments)
+            for aseg in flag.active:
+                seg = segtab.RowType()
+                for col in segtab.columnnames:  # default all columns to None
+                    setattr(seg, col, None)
+                seg.segment_def_id = segdef.segment_def_id
+                seg.set(map(LIGOTimeGPS, aseg))
+                seg.segment_id = SegmentTable.get_next_id()
+                segtab.append(seg)
+
+        return segdeftab, segsumtab, segtab
 
     # -----------------------------------------------------------------------
     # instance methods
@@ -1315,7 +1457,7 @@ class DataQualityDict(OrderedDict):
             tmp = type(self).query(self.keys(), segments, url=source.geturl(),
                                    on_error=on_error, **kwargs)
         elif not source.netloc:
-            tmp = type(self).read(source.geturl(), self.name, **kwargs)
+            tmp = type(self).read(source.geturl(), **kwargs)
         # apply padding and wrap to given known segments
         for key in self:
             if segments is None and source.netloc:

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -19,202 +19,105 @@
 """Read/write segment XML in LIGO_LW format into DataQualityFlags
 """
 
-import datetime
+import operator
 
-from six import string_types
+from six.moves import reduce
 
-from ...time import (LIGOTimeGPS, to_gps)
-from ...io import registry
-from ...io.ligolw import (identify_ligolw, write_tables)
-from ...io.cache import (file_list, FILE_LIKE)
-from ...segments import (Segment, DataQualityFlag, DataQualityDict)
+from astropy.io import registry as io_registry
+
+from ...time import LIGOTimeGPS
+from ...io.ligolw import (is_xml, build_content_handler, read_ligolw,
+                          write_tables)
+from ...segments import (DataQualityFlag, DataQualityDict)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 
+def segment_content_handler():
+    """Build a `~xml.sax.handlers.ContentHandler` to read segment XML tables
+    """
+    from glue.ligolw.lsctables import (SegmentTable, SegmentDefTable,
+                                       SegmentSumTable)
+    from glue.ligolw.ligolw import PartialLIGOLWContentHandler
+
+    def _filter(name, attrs):
+        return reduce(
+            operator.or_,
+            [table_.CheckProperties(name, attrs) for
+             table_ in (SegmentTable, SegmentDefTable, SegmentSumTable)])
+
+    return build_content_handler(PartialLIGOLWContentHandler, _filter)
+
+
 # -- read ---------------------------------------------------------------------
 
-def read_ligolw_dict(f, flags=None, gpstype=LIGOTimeGPS, coalesce=False,
-                     contenthandler=None, nproc=1):
+def read_ligolw_dict(source, flags=None, gpstype=LIGOTimeGPS, coalesce=False):
     """Read segments for the given flag from the LIGO_LW XML file.
 
     Parameters
     ----------
-    fp : `str`
-        path of XML file to read.
+    source : `file`, `str`, :class:`~glue.ligolw.ligolw.Document`, `list`
+        one (or more) open files or file paths, or LIGO_LW `Document` objects
+
     flags : `list`, `None`, optional
         list of flags to read or `None` to read all into a single
         `DataQualityFlag`.
 
+    gpstype : `type`, `callable`, optional
+        class to use for GPS times in returned objects, can be a function
+        to convert GPS time to something else, default is
+        `~gwpy.time.LIGOTimeGPS`
+
+    coalesce : `bool`, optional
+        if `True`, coalesce all parsed `DataQualityFlag` objects before
+        returning, default: `False`
+
     Returns
     -------
-    flagdict : :class:`~gwpy.segments.flag.DataQualityDict`
+    flagdict : `DataQualityDict`
         a new `DataQualityDict` of `DataQualityFlag` entries with ``active``
         and ``known`` segments seeded from the XML tables in the given
         file ``fp``.
     """
-    if nproc != 1:
-        return DataQualityDict.read(f, flags, coalesce=coalesce,
-                                    gpstype=gpstype,
-                                    contenthandler=contenthandler,
-                                    format='cache', nproc=nproc)
+    from glue.ligolw.lsctables import (SegmentTable, SegmentDefTable,
+                                       SegmentSumTable)
 
-    from glue.ligolw import lsctables
-    from glue.ligolw.ligolw import (Document, LIGOLWContentHandler)
-    from glue.ligolw.utils.ligolw_add import ligolw_add
+    # read file(s)
+    xmldoc = read_ligolw(source, contenthandler=segment_content_handler())
 
-    if contenthandler is None:
-        contenthandler = LIGOLWContentHandler
+    # extract tables
+    tables = [table_.get_table(xmldoc) for
+              table_ in (SegmentDefTable, SegmentSumTable, SegmentTable)]
 
-    lsctables.use_in(contenthandler)
+    # parse tables
+    out = DataQualityDict.from_ligolw_tables(*tables, names=flags,
+                                             gpstype=gpstype)
 
-    # generate Document and populate
-    xmldoc = Document()
-    files = [fp.name if isinstance(fp, FILE_LIKE) else fp
-             for fp in file_list(f)]
-    ligolw_add(xmldoc, files, non_lsc_tables_ok=True,
-               contenthandler=contenthandler)
-
-    # read segment definers and generate DataQualityFlag object
-    seg_def_table = lsctables.SegmentDefTable.get_table(xmldoc)
-
-    # find flags
-    if isinstance(flags, string_types):
-        flags = flags.split(',')
-    out = DataQualityDict()
-    id_ = dict()
-    if flags is not None and len(flags) == 1 and flags[0] is None:
-        out[None] = DataQualityFlag()
-        id_[None] = []
-    for row in seg_def_table:
-        ifos = row.get_ifos()
-        name = row.name
-        if ifos and name:
-            name = ':'.join([''.join(row.get_ifos()), row.name])
-            if row.version is not None:
-                name += ':%d' % row.version
-        else:
-            name = None
-        if flags is None or name in flags:
-            out[name] = DataQualityFlag(name)
-            try:
-                id_[name].append(row.segment_def_id)
-            except (AttributeError, KeyError):
-                id_[name] = [row.segment_def_id]
-    if flags is None and not len(out.keys()):
-        raise RuntimeError("No segment definitions found in file.")
-    elif flags is not None and len(out.keys()) != len(flags):
-        for flag in flags:
-            if flag not in out:
-                raise ValueError("No segment definition found for flag=%r "
-                                 "in file." % flag)
-    # read segment summary table as 'known'
-    seg_sum_table = lsctables.SegmentSumTable.get_table(xmldoc)
-    for row in seg_sum_table:
+    # coalesce
+    if coalesce:
         for flag in out:
-            if not id_[flag] or row.segment_def_id in id_[flag]:
-                try:
-                    s = row.get()
-                except AttributeError:
-                    s = row.start_time, row.end_time
-                out[flag].known.append(Segment(gpstype(s[0]), gpstype(s[1])))
-    for dqf in out:
-        if coalesce:
-            out[dqf].coalesce()
-    # read segment table as 'active'
-    seg_table = lsctables.SegmentTable.get_table(xmldoc)
-    for row in seg_table:
-        for flag in out:
-            if not id_[flag] or row.segment_def_id in id_[flag]:
-                try:
-                    s = row.get()
-                except AttributeError:
-                    s = row.start_time, row.end_time
-                out[flag].active.append(Segment(gpstype(s[0]), gpstype(s[1])))
-    for dqf in out:
-        if coalesce:
-            out[dqf].coalesce()
+            out[flag].coalesce()
+
     return out
 
 
-def read_ligolw_flag(fp, flag=None, **kwargs):
+def read_ligolw_flag(source, flag=None, **kwargs):
     """Read a single `DataQualityFlag` from a LIGO_LW XML file
     """
-    return read_ligolw_dict(fp, flags=flag, **kwargs).values()[0]
+    return read_ligolw_dict(source, flags=flag, **kwargs).values()[0]
 
 
 # -- write --------------------------------------------------------------------
 
-def dqdict_to_ligolw_tables(dqdict):
-    """Convert a `DataQualityDict` into LIGO_LW segment tables
-
-    Parameters
-    ----------
-    dqdict : `~gwpy.segments.DataQualityDict`
-        the dict of flags to write
-
-    Returns
-    -------
-    segdeftab : :class:`~glue.ligolw.lsctables.SegmentDefTable`
-        the ``segment_definer`` table defining each flag
-    segsumtab : :class:`~glue.ligolw.lsctables.SegmentSumTable`
-        the ``segment_summary`` table containing the known segments
-    segtab : :class:`~glue.ligolw.lsctables.SegmentTable`
-        the ``segment`` table containing the active segments
-    """
-    from glue.ligolw import lsctables
-
-    segdeftab = lsctables.New(lsctables.SegmentDefTable)
-    segsumtab = lsctables.New(lsctables.SegmentSumTable)
-    segtab = lsctables.New(lsctables.SegmentTable)
-
-    # write flags to tables
-    for flag in dqdict.values():
-        # segment definer
-        segdef = segdeftab.RowType()
-        for col in segdeftab.columnnames:  # default all columns to None
-            setattr(segdef, col, None)
-        segdef.set_ifos([flag.ifo])
-        segdef.name = flag.tag
-        segdef.version = flag.version
-        segdef.comment = flag.description
-        segdef.insertion_time = to_gps(datetime.datetime.now()).gpsSeconds
-        segdef.segment_def_id = lsctables.SegmentDefTable.get_next_id()
-        segdeftab.append(segdef)
-
-        # write segment summary (known segments)
-        for vseg in flag.known:
-            segsum = segsumtab.RowType()
-            for col in segsumtab.columnnames:  # default all columns to None
-                setattr(segsum, col, None)
-            segsum.segment_def_id = segdef.segment_def_id
-            segsum.set(map(LIGOTimeGPS, vseg))
-            segsum.comment = None
-            segsum.segment_sum_id = lsctables.SegmentSumTable.get_next_id()
-            segsumtab.append(segsum)
-
-        # write segment table (active segments)
-        for aseg in flag.active:
-            seg = segtab.RowType()
-            for col in segtab.columnnames:  # default all columns to None
-                setattr(seg, col, None)
-            seg.segment_def_id = segdef.segment_def_id
-            seg.set(map(LIGOTimeGPS, aseg))
-            seg.segment_id = lsctables.SegmentTable.get_next_id()
-            segtab.append(seg)
-
-    return segdeftab, segsumtab, segtab
-
-
-def write_ligolw(flags, f, **kwargs):
+def write_ligolw(flags, target, **kwargs):
     """Write this `DataQualityFlag` to the given LIGO_LW Document
 
     Parameters
     ----------
     flags : `DataQualityFlag`, `DataQualityDict`
-        `gwpy.segments` object to wriet
+        `gwpy.segments` object to write
 
-    f : `str`, `file`, :class:`~glue.ligolw.ligolw.Document`
+    target : `str`, `file`, :class:`~glue.ligolw.ligolw.Document`
         the file or document to write into
 
     **kwargs
@@ -223,23 +126,22 @@ def write_ligolw(flags, f, **kwargs):
     See also
     --------
     gwpy.io.ligolw.write_ligolw_tables
-        for details of acceptabled keyword arguments
+        for details of acceptable keyword arguments
     """
     if isinstance(flags, DataQualityFlag):
-        flags = {flags.name: flags}
+        flags = DataQualityDict({flags.name: flags})
 
-    llwtables = dqdict_to_ligolw_tables(flags)
-    return write_tables(f, llwtables, **kwargs)
+    return write_tables(target, flags.to_ligolw_tables(), **kwargs)
 
 
 # -- register -----------------------------------------------------------------
 
 # register methods for DataQualityDict
-registry.register_reader('ligolw', DataQualityFlag, read_ligolw_flag)
-registry.register_writer('ligolw', DataQualityFlag, write_ligolw)
-registry.register_identifier('ligolw', DataQualityFlag, identify_ligolw)
+io_registry.register_reader('ligolw', DataQualityFlag, read_ligolw_flag)
+io_registry.register_writer('ligolw', DataQualityFlag, write_ligolw)
+io_registry.register_identifier('ligolw', DataQualityFlag, is_xml)
 
 # register methods for DataQualityDict
-registry.register_reader('ligolw', DataQualityDict, read_ligolw_dict)
-registry.register_writer('ligolw', DataQualityDict, write_ligolw)
-registry.register_identifier('ligolw', DataQualityDict, identify_ligolw)
+io_registry.register_reader('ligolw', DataQualityDict, read_ligolw_dict)
+io_registry.register_writer('ligolw', DataQualityDict, write_ligolw)
+io_registry.register_identifier('ligolw', DataQualityDict, is_xml)

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -30,7 +30,8 @@ except ImportError:
     TableByName = dict()
 
 from ...io import registry
-from ...io.ligolw import (table_from_file, write_tables)
+from ...io.ligolw import (is_ligolw, read_table as read_ligolw_table,
+                          write_tables as write_ligolw_tables)
 from .. import (Table, EventTable)
 from .utils import read_with_selection
 
@@ -41,138 +42,164 @@ __all__ = []
 GET_AS_EXCLUDE = ['get_column', 'get_table']
 
 
-def handle_attributeerror(action, func, *args, **kwargs):
-    try:
-        return func(*args, **kwargs)
-    except AttributeError as e:
-        if action == 'ignore':
-            pass
-        elif action == 'warn':
-            warnings.warn('Caught %s: %s' % (type(e).__name__, str(e)))
-        else:
-            raise
+# -- conversions --------------------------------------------------------------
 
+def to_astropy_table(llwtable, apytable, copy=False, columns=None,
+                     rename=None, on_attributeerror=None, get_as_columns=None):
+    """Convert a `~glue.ligolw.table.Table` to an `~astropy.tableTable`
 
-# -- read ---------------------------------------------------------------------
+    This method is designed as an internal method to be attached to
+    :class:`~glue.ligolw.table.Table` objects as `__astropy_table__`.
 
-@read_with_selection
-def _table_from_ligolw(llwtable, target, copy, columns=None,
-                       on_attributeerror='raise', get_as_columns=False,
-                       rename={}):
-    """Convert this `~glue.ligolw.table.Table` to an `~astropy.tableTable`
+    Parameters
+    ----------
+    llwtable : :class:`~glue.ligolw.table.Table`
+        the LIGO_LW table to convert from
 
-        Parameters
-        ----------
-        columns : `list` of `str`, optional
-            the columns to populate, if not given, all columns present in the
-            table are mapped
+    apytable : `type`
+        `astropy.table.Table` class or subclass
 
-        on_attributeerror : `str`, optional, default: `'raise'`
-            how to handle `AttributeError` when accessing rows, one of
+    copy : `bool`, optional
+        if `True` copy the input data, otherwise return a reference,
+        default: `False`
 
-            - 'raise' : raise normal exception
-            - 'ignore' : silently ignore this column
-            - 'warn' : verbosely ignore this column
+    columns : `list` of `str`, optional
+        the columns to populate, if not given, all columns present in the
+        table are mapped
 
-            .. note::
+    rename : `dict`, optional
+        dict of ('old name', 'new name') pairs to rename columns
+        from the original LIGO_LW table
 
-               this option is ignored if a `columns` list is given
+    on_attributeerror
+        DEPRECATED, do not use
 
-        get_as_columns : `bool`, optional
-            convert all `get_xxx()` methods into fields in the
-            `~numpy.recarray`; the default is to _not_ do this.
+    get_as_columns
+        DEPRECATED, do not use
 
-        rename : `dict`, optional
-            dict of ('old name', 'new name') pairs to rename columns
-            from the original LIGO_LW table
-
-        Returns
-        -------
-        table : `EventTable`
-            a view of the original data
+    Returns
+    -------
+    table : `EventTable`
+        a view of the original data
     """
-    from glue.ligolw.lsctables import LIGOTimeGPS
+    # handle deprecated keywords
+    if get_as_columns is not None:
+        warnings.warn("the ``get_as_columns`` keyword has been deprecated and "
+                      "will be removed in an upcoming release, simply refer "
+                      "to the columns you want via the ``columns`` keyword",
+                      DeprecationWarning)
+    if on_attributeerror is not None:
+        warnings.warn("the ``on_attributeerror`` keyword has been deprecated, "
+                      "and will be removed in an upcoming release, it will be "
+                      "ignored for now", DeprecationWarning)
 
+    # set default keywords
     if rename is None:
         rename = {}
-    # create table
-    names = []
+    if columns is None:
+        columns = llwtable.columnnames
+
+    # get names of get_xxx() methods for this table
+    getters = [
+        name.split('_', 1)[1] for (name, _) in
+        inspect.getmembers(llwtable, predicate=inspect.ismethod) if
+        name.startswith('get_') and name not in GET_AS_EXCLUDE and
+        name not in llwtable.columnnames]
+
+    # extract columns from LIGO_LW table as astropy.table.Column
     data = []
+    for colname in columns:
+        # work out how to extract the column
+        if colname in getters:
+            arr = getattr(llwtable, 'get_{}'.format(colname))()
+        else:
+            arr = llwtable.getColumnByName(colname)
+        # get the data
+        copythis = False if colname in getters else copy
+        data.append(to_astropy_column(arr, apytable.Column, copy=copythis,
+                                      name=rename.get(colname, colname)))
 
-    # and fill it
-    for column in llwtable.columnnames:
-        if columns and column not in columns:  # skip if not wanted
-            continue
-        orig_type = llwtable.validcolumns[column]
-        col = handle_attributeerror(
-            on_attributeerror, llwtable.getColumnByName, column)
-        if col is not None:
-            # get correct dtype
-            if orig_type == 'ilwd:char':  # numpy tries long() which breaks
-                arr = list(map(int, col))
-            elif orig_type == 'lstring':  # let astropy handle it
-                arr = col
-            else:
-                arr = col.asarray()
-            # store data (with optional renaming)
-            try:
-                data.append(target.Column(name=rename[column], data=arr))
-            except KeyError:
-                data.append(target.Column(name=column, data=arr))
-
-    # fill out get_xxx columns
-    if get_as_columns:
-        getters = filter(
-            lambda x: x[0].startswith('get_') and x[0] not in GET_AS_EXCLUDE,
-            inspect.getmembers(llwtable, predicate=inspect.ismethod))
-        for name, meth in getters:
-            column = name.split('_', 1)[1]
-            if column in names:  # don't overwrite existing columns
-                continue
-            if columns and column not in columns:  # skip if not wanted
-                continue
-            arr = handle_attributeerror(on_attributeerror, meth)
-            if arr is None:
-                continue
-            try:
-                dtype = arr.dtype
-            except AttributeError:
-                try:
-                    dtype = type(arr[0])
-                except (TypeError, KeyError):
-                    continue
-                except IndexError:
-                    dtype = None
-            if dtype == LIGOTimeGPS:
-                dtype = numpy.float64
-            names.append(column)
-            try:
-                data.append(target.Column(name=rename[column], data=arr,
-                                          dtype=dtype))
-            except KeyError:
-                data.append(target.Column(name=column, data=arr, dtype=dtype))
-
-    # sort data columns into user-specified order
-    if columns:
-        names = [rename[n] if n in rename else n for n in columns]
-        data.sort(key=lambda col: names.index(col.name))
     # build table and return
-    return target(data, copy=copy,
-                  meta={'type': 'ligolw.%s' % str(llwtable.Name)})
+    return apytable(data, copy=False, meta={'tablename': str(llwtable.Name)})
 
 
-# -- write --------------------------------------------------------------------
+def to_astropy_column(llwcol, cls, copy=False, dtype=None, **kwargs):
+    """Convert a `glue.ligolw.table.Column` to `astropy.table.Column`
+
+    Parameters
+    -----------
+    llwcol : :class:`~glue.ligolw.table.Column`, `numpy.ndarray`, iterable
+        the LIGO_LW column to convert, or an iterable
+
+    cls : `~astropy.table.Column`
+        the Astropy `~astropy.table.Column` or subclass to convert to
+
+    copy : `bool`, optional
+        if `True` copy the input data, otherwise return a reference,
+        default: `False`
+
+    dtype : `type`, optional
+        the data type to convert to when creating the `~astropy.table.Column`
+
+    **kwargs
+        other keyword arguments are passed to the `~astropy.table.Column`
+        creator
+
+    Returns
+    -------
+    column : `~astropy.table.Column`
+        an Astropy version of the given LIGO_LW column
+    """
+    if dtype is None:
+        dtype = _get_column_dtype(llwcol)
+    return cls(data=llwcol, copy=copy, dtype=dtype, **kwargs)
+
+
+def _get_column_dtype(llwcol):
+    """Get the data type of a LIGO_LW `Column`
+
+    Parameters
+    ----------
+    llwcol : :class:`~glue.ligolw.table.Column`, `numpy.ndarray`, iterable
+        a LIGO_LW column, a numpy array, or an iterable
+
+    Returns
+    -------
+    dtype : `type`, None
+        the object data type for values in the given column, `None` is
+        returned if ``llwcol`` is a `numpy.ndarray` with `numpy.object_`
+        dtype, or no data type can be parsed (e.g. empty list)
+    """
+    try:  # maybe its a numpy array already!
+        dtype = llwcol.dtype
+        if dtype is numpy.dtype('O'):  # don't convert
+            return None
+        return dtype
+    except AttributeError:  # dang
+        try:  # glue.ligolw.table.Column
+            llwtype = llwcol.parentNode.validcolumns[llwcol.Name]
+        except AttributeError:  # custom iterator
+            try:
+                return type(llwcol[0])
+            except IndexError:
+                return None
+        else:
+            from glue.ligolw.types import (ToPyType, ToNumPyType)
+            try:
+                return ToNumPyType[llwtype]
+            except KeyError:
+                return ToPyType[llwtype]
+
 
 def table_to_ligolw(table, tablename):
-    """Convert a `astropy.table.Table` to a :class:`glue.ligolw.table.Table`
+    """Convert a `astropy.table.Table` to a :class:`~glue.ligolw.table.Table`
     """
     from glue.ligolw import (lsctables, types)
     from glue.ligolw.ilwd import get_ilwdchar_class
 
     # create new LIGO_LW table
     columns = table.columns.keys()
-    table_class = lsctables.TableByName[tablename]
-    llwtable = lsctables.New(table_class, columns=columns)
+    llwtable = lsctables.New(lsctables.TableByName[tablename], columns=columns)
 
     # map rows across
     for row in table:
@@ -191,34 +218,58 @@ def table_to_ligolw(table, tablename):
     return llwtable
 
 
-# -- I/O factory --------------------------------------------------------------
+# -- read ---------------------------------------------------------------------
 
-def ligolw_io_factory(table_):
-    """Define a read and write method for the given LIGO_LW table
+@read_with_selection
+def read_table(source, tablename=None, **kwargs):
+    """Read a `Table` from one or more LIGO_LW XML documents
+
+    source : `file`, `str`, :class:`~glue.ligolw.ligolw.Document`, `list`
+        one or more open files, file paths, or LIGO_LW `Document` objects
+
+    tablename : `str`, optional
+        the `Name` of the relevant `Table` to read, if not given a table will
+        be returned if only one exists in the document(s)
+
+    **kwargs
+        keyword arguments for the read, or conversion functions
+
+    See Also
+    --------
+    gwpy.io.ligolw.read_table
+        for details of keyword arguments for the read operation
+    gwpy.table.io.ligolw.to_astropy_table
+        for details of keyword arguments for the conversion operation
     """
-    tablename = table_.TableName(table_.tableName)
+    from glue.ligolw import table as ligolw_table
 
-    def _read_table(f, *args, **kwargs):
-        # set up keyword arguments
-        llwcolumns = kwargs.pop('ligolw_columns', kwargs.get('columns', None))
-        reckwargs = {
-            'on_attributeerror': 'raise',
-            'get_as_columns': False,
-            'rename': {},
-            'selection': [],
-        }
-        for key in reckwargs:
-            if key in kwargs:
-                reckwargs[key] = kwargs.pop(key)
-        reckwargs['columns'] = kwargs.pop('columns', llwcolumns)
-        kwargs['columns'] = llwcolumns
-        if reckwargs['rename'] is None:
-            reckwargs['rename'] = {}
+    # -- keyword handling -----------------------
 
-        # handle requests for 'time' as a special case
-        needtime = (reckwargs['columns'] is not None and
-                    'time' in reckwargs['columns'] and
-                    'time' not in table_.validcolumns)
+    # separate keywords for reading and converting from LIGO_LW to Astropy
+    read_kw = kwargs  # rename for readability
+    convert_kw = {
+        'on_attributeerror': None,  # deprecated
+        'get_as_columns': None,  # deprecated
+        'rename': {},
+    }
+    for key in convert_kw:
+        if key in kwargs:
+            convert_kw[key] = kwargs.pop(key)
+    if convert_kw['rename'] is None:
+        convert_kw['rename'] = {}
+
+    # allow user to specify LIGO_LW columns to read to provide the
+    # desired output columns
+    llwcolumns = kwargs.pop('ligolw_columns', kwargs.get('columns', None))
+    convert_kw['columns'] = kwargs.pop('columns', llwcolumns)
+    read_kw['columns'] = llwcolumns
+
+    # handle requests for 'time' as a special case
+    if tablename:
+        tableclass = TableByName[ligolw_table.Table.TableName(tablename)]
+        needtime = (convert_kw['columns'] is not None and
+                    'time' in convert_kw['columns'] and
+                    'time' not in tableclass.validcolumns)
         if needtime:
             if tablename.endswith('_burst'):
                 tname = 'peak'
@@ -231,52 +282,71 @@ def ligolw_io_factory(table_):
                                  "doesn't supply it or have a good proxy "
                                  "(e.g. 'peak_time')")
             # replace 'time' with get_xxx method name
-            reckwargs['columns'] = list(reckwargs['columns'])
-            idx = reckwargs['columns'].index('time')
-            reckwargs['columns'].insert(idx, tname)
-            reckwargs['columns'].pop(idx+1)
-            reckwargs['rename'][tname] = 'time'
-            reckwargs['get_as_columns'] = True
-            # add required LIGO_LW columns to read kwargs
-            kwargs['columns'] = list(set(
-                kwargs['columns'] + ['%s_time' % tname, '%s_time_ns' % tname]))
+            cols = convert_kw['columns'] = list(convert_kw['columns'])
+            cols[cols.index('time')] = tname
+            convert_kw['rename'][tname] = 'time'
+            # add required LIGO_LW columns to read read_kw
+            read_kw['columns'] = list(set(read_kw['columns'] + [tname]))
 
-        # read from LIGO_LW
-        llw = table_from_file(f, table_.tableName, *args, **kwargs)
-        return Table(llw, **reckwargs)
+    # -- read -----------------------------------
 
-    def _write_table(table, f, *args, **kwargs):
-        return write_tables(f, [table_to_ligolw(table, tablename)],
-                            *args, **kwargs)
+    return Table(read_ligolw_table(source, tablename=tablename, **read_kw),
+                 **convert_kw)
 
-    return _read_table, _write_table
+
+# -- write --------------------------------------------------------------------
+
+def write_table(table, target, tablename=None, **kwargs):
+    """Write a `~astropy.table.Table` to file in LIGO_LW XML format
+    """
+    if tablename is None:  # try and get tablename from metadata
+        tablename = table.meta.get('tablename', None)
+    if tablename is None:  # panic
+        raise ValueError("please pass ``tablename=`` to specify the target "
+                         "LIGO_LW Table Name")
+    return write_ligolw_tables(target, [table_to_ligolw(table, tablename)],
+                               **kwargs)
 
 
 # -- register -----------------------------------------------------------------
 
-EVENT_TABLES = (
-    'sngl_burst', 'multi_burst',
-    'sngl_inspiral', 'multi_inspiral',
-    'sngl_ringdown',
-)
+for table_class in (Table, EventTable):
+    registry.register_reader('ligolw', table_class, read_table)
+    registry.register_writer('ligolw', table_class, write_table)
+    registry.register_identifier('ligolw', table_class, is_ligolw)
 
-# register reader and auto-id for LIGO_LW
-for table in TableByName.values():
-    tname = table.TableName(table.tableName)
-    name = 'ligolw.%s' % tname
 
+# -- DEPRECATED - remove before 1.0 release -----------------------------------
+
+def _ligolw_io_factory(table):
+    """Define a read and write method for the given LIGO_LW table
+
+    This system has been deprecated in favour of the simpler
+    `Table.read(format='ligolw', tablename='...')` syntax.
+    """
+    tablename = table.TableName(table.tableName)
+    wng = ("``format='ligolw.{0}'`` has been deprecated, please "
+           "read using ``format='ligolw', tablename={0}'``".format(tablename))
+
+    def _read_ligolw_table(source, tablename=tablename, **kwargs):
+        warnings.warn(wng, DeprecationWarning)
+        return read_table(source, tablename=tablename, **kwargs)
+
+    def _write_table(tbl, target, tablename=tablename, **kwargs):
+        warnings.warn(wng, DeprecationWarning)
+        return write_table(tbl, target, tablename=tablename, **kwargs)
+
+    return _read_ligolw_table, _write_table
+
+
+for table_ in TableByName.values():
     # build readers for this table
-    read_, write_, = ligolw_io_factory(table)
+    read_, write_, = _ligolw_io_factory(table_)
 
     # register conversion from LIGO_LW to astropy Table
-    table.__astropy_table__ = _table_from_ligolw
+    table_.__astropy_table__ = to_astropy_table
 
     # register table-specific reader for Table and EventTable
-    registry.register_reader(name, Table, read_)
-    registry.register_writer(name, Table, write_)
-
-    if tname in EVENT_TABLES:
-        # this is done explicitly so that the docstring for table.read()
-        # shows the format
-        registry.register_reader(name, EventTable, read_)
-        registry.register_writer(name, EventTable, write_)
+    fmt = 'ligolw.%s' % table_.TableName(table_.tableName)
+    registry.register_reader(fmt, Table, read_)
+    registry.register_writer(fmt, Table, write_)

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Read LIGO_LW documents into glue.ligolw.table.Table objects.
+"""Read LIGO_LW documents into :class:`~glue.ligolw.table.Table` objects.
 """
 
 import inspect
@@ -46,7 +46,7 @@ GET_AS_EXCLUDE = ['get_column', 'get_table']
 
 def to_astropy_table(llwtable, apytable, copy=False, columns=None,
                      rename=None, on_attributeerror=None, get_as_columns=None):
-    """Convert a `~glue.ligolw.table.Table` to an `~astropy.tableTable`
+    """Convert a :class:`~glue.ligolw.table.Table` to an `~astropy.tableTable`
 
     This method is designed as an internal method to be attached to
     :class:`~glue.ligolw.table.Table` objects as `__astropy_table__`.
@@ -124,7 +124,7 @@ def to_astropy_table(llwtable, apytable, copy=False, columns=None,
 
 
 def to_astropy_column(llwcol, cls, copy=False, dtype=None, **kwargs):
-    """Convert a `glue.ligolw.table.Column` to `astropy.table.Column`
+    """Convert a :class:`~glue.ligolw.table.Column` to `astropy.table.Column`
 
     Parameters
     -----------
@@ -192,7 +192,7 @@ def _get_column_dtype(llwcol):
 
 
 def table_to_ligolw(table, tablename):
-    """Convert a `astropy.table.Table` to a :class:`~glue.ligolw.table.Table`
+    """Convert a `astropy.table.Table` to a :class:`glue.ligolw.table.Table`
     """
     from glue.ligolw import (lsctables, types)
     from glue.ligolw.ilwd import get_ilwdchar_class

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -390,7 +390,7 @@ class TestIoLigolw(object):
     Here we only test the utilties, rather than the read/write functions,
     which are tested extensively via other modules (e.g. test_tables.py)
     """
-    @utils.skip_missing_dependency('glue.ligolw')
+    @utils.skip_missing_dependency('glue.ligolw.lsctables')  # check for LAL
     def test_open_xmldoc(self):
         from glue.ligolw.ligolw import (Document, LIGO_LW)
         assert isinstance(io_ligolw.open_xmldoc(tempfile.mktemp()), Document)
@@ -411,7 +411,7 @@ class TestIoLigolw(object):
         with pytest.raises(ValueError):
             io_ligolw.get_ligolw_element(Document())
 
-    @utils.skip_missing_dependency('glue.ligolw')
+    @utils.skip_missing_dependency('glue.ligolw.lsctables')  # check for LAL
     def test_list_tables(self):
         from glue.ligolw import lsctables
         from glue.ligolw.ligolw import (Document, LIGO_LW)

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -31,7 +31,8 @@ from gwpy.io import (cache as io_cache,
                      datafind as io_datafind,
                      gwf as io_gwf,
                      kerberos as io_kerberos,
-                     nds2 as io_nds2)
+                     nds2 as io_nds2,
+                     ligolw as io_ligolw)
 from gwpy.segments import (Segment, SegmentList)
 
 import utils
@@ -375,6 +376,58 @@ class TestIoGwf(object):
         assert io_gwf.channel_in_frame('L1:LDAS-STRAIN', TEST_GWF_FILE) is True
         assert io_gwf.channel_in_frame('X1:NOT-IN_FRAME',
                                        TEST_GWF_FILE) is False
+
+
+# -- gwpy.io.ligolw -----------------------------------------------------------
+
+class TestIoLigolw(object):
+    """Tests for :mod:`gwpy.io.ligolw`
+
+    Here we only test the utilties, rather than the read/write functions,
+    which are tested extensively via other modules (e.g. test_tables.py)
+    """
+    @utils.skip_missing_dependency('glue.ligolw')
+    def test_open_xmldoc(self):
+        from glue.ligolw.ligolw import (Document, LIGO_LW)
+        assert isinstance(io_ligolw.open_xmldoc(tempfile.mktemp()), Document)
+        with tempfile.TemporaryFile() as f:
+            xmldoc = Document()
+            xmldoc.appendChild(LIGO_LW())
+            xmldoc.write(f)
+            f.seek(0)
+            assert isinstance(io_ligolw.open_xmldoc(f), Document)
+
+    @utils.skip_missing_dependency('glue.ligolw')
+    def test_get_ligolw_element(self):
+        from glue.ligolw.ligolw import (Document, LIGO_LW)
+        xmldoc = Document()
+        llw = xmldoc.appendChild(LIGO_LW())
+        assert io_ligolw.get_ligolw_element(llw) is llw
+        assert io_ligolw.get_ligolw_element(xmldoc) is llw
+        with pytest.raises(ValueError):
+            io_ligolw.get_ligolw_element(Document())
+
+    @utils.skip_missing_dependency('glue.ligolw')
+    def test_list_tables(self):
+        from glue.ligolw import lsctables
+        from glue.ligolw.ligolw import (Document, LIGO_LW)
+
+        # build dummy document with two tables
+        xmldoc = Document()
+        llw = xmldoc.appendChild(LIGO_LW())
+        tables = [lsctables.New(lsctables.ProcessTable),
+                  lsctables.New(lsctables.SnglRingdownTable)]
+        names = [t.TableName(t.Name) for t in tables]
+        [llw.appendChild(t) for t in tables]  # add tables to xmldoc
+
+        # check that tables are listed properly
+        assert io_ligolw.list_tables(xmldoc) == names
+
+        # check that we can list from files
+        with tempfile.NamedTemporaryFile() as f:
+            xmldoc.write(f)
+            f.seek(0)
+            assert io_ligolw.list_tables(f) == names
 
 
 # -- gwpy.io.datafind ---------------------------------------------------------

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -24,6 +24,7 @@ import shutil
 import tempfile
 
 from six import PY2
+from six.moves import StringIO
 
 import pytest
 
@@ -118,27 +119,35 @@ class TestTable(object):
         table = self.create(
             100, ['peak_time', 'peak_time_ns', 'snr', 'central_freq'],
             ['i4', 'i4', 'f4', 'f4'])
-        with tempfile.NamedTemporaryFile(suffix=ext) as f:
-            table.write(f, format='ligolw.sngl_burst')
-
+        with tempfile.NamedTemporaryFile(suffix='.{}'.format(ext), delete=False) as f:
             def _read(*args, **kwargs):
-                kwargs.setdefault('format', 'ligolw.sngl_burst')
+                kwargs.setdefault('format', 'ligolw')
+                kwargs.setdefault('tablename', 'sngl_burst')
                 return self.TABLE.read(f, *args, **kwargs)
+
+            def _write(*args, **kwargs):
+                kwargs.setdefault('format', 'ligolw')
+                kwargs.setdefault('tablename', 'sngl_burst')
+                return table.write(f.name, *args, **kwargs)
+
+            # check simple write (using open file descriptor, not file path)
+            table.write(f, format='ligolw', tablename='sngl_burst')
 
             # check simple read
             t2 = _read()
             utils.assert_table_equal(table, t2, almost_equal=True)
+            assert t2.meta.get('tablename', None) == 'sngl_burst'
 
-            # check read with get_as_columns
-            t3 = _read(get_as_columns=True, on_attributeerror='ignore')
+            # check accessing get_xxx columns works
+            t3 = _read(columns=['peak_time', 'peak_time_ns', 'peak'])
             assert 'peak' in t3.columns
             utils.assert_array_equal(
                 t3['peak'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
 
             # check reading multiple tables works
             try:
-                t3 = self.TABLE.read([f.name, f.name],
-                                     format='ligolw.sngl_burst')
+                t3 = self.TABLE.read([f.name, f.name], format='ligolw',
+                                     tablename='sngl_burst')
             except NameError as e:
                 if not PY2:  # ligolw not patched for python3 just yet
                     pytest.xfail(str(e))
@@ -147,12 +156,12 @@ class TestTable(object):
 
             # check writing to existing file raises IOError
             with pytest.raises(IOError) as exc:
-                table.write(f.name, format='ligolw.sngl_burst')
+                _write()
             assert str(exc.value) == 'File exists: %s' % f.name
 
             # check overwrite=True, append=False rewrites table
             try:
-                table.write(f.name, format='ligolw.sngl_burst', overwrite=True)
+                _write(overwrite=True)
             except TypeError as e:
                 # ligolw is not python3-compatbile, so skip if it fails
                 if not PY2 and (
@@ -163,30 +172,42 @@ class TestTable(object):
             utils.assert_table_equal(t2, t3)
 
             # check append=True duplicates table
-            table.write(f.name, format='ligolw.sngl_burst', append=True)
+            _write(append=True)
             t3 = _read()
             utils.assert_table_equal(vstack((t2, t2)), t3)
 
             # check overwrite=True, append=True rewrites table
-            table.write(f.name, format='ligolw.sngl_burst',
-                        append=True, overwrite=True)
+            _write(append=True, overwrite=True)
             t3 = _read()
             utils.assert_table_equal(t2, t3)
 
             # write another table and check we can still get back the first
             insp = self.create(10, ['end_time', 'snr', 'chisq_dof'])
-            insp.write(f.name, format='ligolw.sngl_inspiral', append=True)
+            insp.write(f.name, format='ligolw', tablename='sngl_inspiral',
+                       append=True)
             t3 = _read()
             utils.assert_table_equal(t2, t3)
 
             # write another table with append=False and check the first table
             # is gone
-            insp.write(f.name, format='ligolw.sngl_inspiral', append=False,
-                       overwrite=True)
+            insp.write(f.name, format='ligolw', tablename='sngl_inspiral',
+                       append=False, overwrite=True)
             with pytest.raises(ValueError) as exc:
                 _read()
             assert str(exc.value) == ('document must contain exactly '
                                       'one sngl_burst table')
+
+            # -- deprecations
+            # check deprecations print warnings where expected
+
+            with pytest.warns(DeprecationWarning):
+                table.write(f.name, format='ligolw.sngl_burst', overwrite=True)
+            with pytest.warns(DeprecationWarning):
+                _read(format='ligolw.sngl_burst')
+            with pytest.warns(DeprecationWarning):
+                _read(get_as_columns=True)
+            with pytest.warns(DeprecationWarning):
+                _read(on_attributeerror='anything')
 
     @utils.skip_missing_dependency('root_numpy')
     def test_read_write_root(self, table):


### PR DESCRIPTION
This PR simplifies the LIGO_LW interface, mainly by deprecating the table-dependent format registrations, in favour of a single format ``ligolw`` where I/O routines now accept (expect?) a ``tablename=`` keyword argument.

In the most common form, the following example:

```python
EventTable.read('events.xml', format='ligolw.sngl_burst')
```

should be updated to

```python
EventTable.read('events.xml', format='ligolw', tablename='sngl_burst')
```

This change allows for a simpler implementation of the interface, and also native discovery of ``LIGO_LW``-format files by their content, not by the file name.

The documentation has been updated to match the new syntax.