### PR TITLE
Updated sphinx conf to use rst_epilog to include references.txt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,6 +108,9 @@ default_role = 'obj'
 # unit titles (such as .. function::).
 #add_module_names = True
 
+# Epilog
+rst_epilog = "\n.. include:: /references.txt"
+
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
 #show_authors = False

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -1,5 +1,3 @@
-.. include:: ../references.txt
-
 .. _gwpy-install:
 
 ############

--- a/docs/segments/dqsegdb.rst
+++ b/docs/segments/dqsegdb.rst
@@ -1,5 +1,4 @@
 .. currentmodule:: gwpy.segments
-.. include:: ../references.txt
 
 .. _gwpy-segments-dqsegdb:
 

--- a/docs/segments/index.rst
+++ b/docs/segments/index.rst
@@ -1,5 +1,4 @@
 .. currentmodule:: gwpy.segments
-.. include:: ../references.txt
 
 .. _gwpy-segments:
 

--- a/docs/segments/io.rst
+++ b/docs/segments/io.rst
@@ -1,5 +1,4 @@
 .. currentmodule:: gwpy.segments
-.. include:: ../references.txt
 
 .. _gwpy-segments-io:
 

--- a/docs/signal/fft.rst
+++ b/docs/signal/fft.rst
@@ -1,5 +1,3 @@
-.. include:: ../references.txt
-
 .. _gwpy-signal-fft:
 
 #####################

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -1,4 +1,3 @@
-.. include:: ../references.txt
 .. currentmodule:: gwpy.table
 
 .. _gwpy-table-io:

--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -1,5 +1,4 @@
 .. currentmodule:: gwpy.timeseries
-.. include:: ../references.txt
 
 .. _gwpy-timeseries-io:
 

--- a/docs/timeseries/remote-access.rst
+++ b/docs/timeseries/remote-access.rst
@@ -1,5 +1,4 @@
 .. currentmodule:: gwpy.timeseries
-.. include:: ../references.txt
 
 .. _gwpy-timeseries-remote:
 

--- a/examples/timeseries/pycbc-snr.py
+++ b/examples/timeseries/pycbc-snr.py
@@ -31,7 +31,6 @@ Using |pycbc|_ (the actual search code), we can do that.
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __currentmodule__ = 'gwpy.timeseries'
-__include__ = '../../references.txt'
 
 # First, as always, we fetch some of the public data from the LIGO Open
 # Science Center


### PR DESCRIPTION
This PR adds an `rst_epilog` to the sphinx `conf.py` so that `references.txt` is implicitly included in all pages, and removes any explicit inclusions from files.