### PR TITLE
Fixed bugs in identifying failed tests in travis CI

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -24,15 +24,12 @@ cd ${GWPY_PATH}
 
 . ci/lib.sh
 
-set -ex
-
 get_environment
 
 # install for this OS
 if [ -z ${DOCKER_IMAGE} ]; then  # simple
     ${PIP} install .
     ${PIP} install -r requirements-dev.txt
-    set +ex
     return 0
 fi
 
@@ -49,5 +46,3 @@ echo "GWpy installed to `${PYTHON} -c 'import gwpy; print(gwpy.__file__)'`"
 echo
 echo "------------------------------------------------------------------------"
 cd -
-
-set +ex

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -24,8 +24,7 @@ cd ${GWPY_PATH}
 
 . ci/lib.sh
 
-set -e
-set -x
+set -ex
 
 get_environment
 
@@ -33,6 +32,7 @@ get_environment
 if [ -z ${DOCKER_IMAGE} ]; then  # simple
     ${PIP} install .
     ${PIP} install -r requirements-dev.txt
+    set +ex
     return 0
 fi
 
@@ -50,5 +50,4 @@ echo
 echo "------------------------------------------------------------------------"
 cd -
 
-set +e
-set +x
+set +ex

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -34,11 +34,10 @@ export GWPY_PATH
 ci_run() {
     # run a command normally, or in docker, depending on environment
     if [ -z "${DOCKER_IMAGE}" ]; then  # execute function normally
-        eval "$@" || return 1
+        bash -lec "$@"
     else  # execute function in docker container
-        docker exec -it ${DOCKER_IMAGE##*:} bash -lc "eval \"$@\"" || return 1
+        docker exec -it ${DOCKER_IMAGE##*:} bash -lec "$@"
     fi
-    return 0
 }
 
 # -- in-container helpers -----------------------------------------------------

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -22,9 +22,9 @@
 
 cd ${GWPY_PATH}
 
-. ci/lib.sh
+set -e
 
-set -ex
+. ci/lib.sh
 
 get_environment  # sets PIP variables etc
 
@@ -41,4 +41,4 @@ ${PIP} install lscsoft-glue
 # run tests
 coverage run ./setup.py test --addopts gwpy/tests/
 
-set +ex
+set +e

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -24,8 +24,7 @@ cd ${GWPY_PATH}
 
 . ci/lib.sh
 
-set -x
-set -e
+set -ex
 
 get_environment  # sets PIP variables etc
 
@@ -42,5 +41,4 @@ ${PIP} install lscsoft-glue
 # run tests
 coverage run ./setup.py test --addopts gwpy/tests/
 
-set +e
-set +x
+set +ex

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -126,6 +126,7 @@ class TestFrequencySeries(TestSeries):
         a2 = self.TEST_CLASS.from_lal(lalts)
         assert a2.unit is units.dimensionless_unscaled
 
+    @utils.skip_missing_dependency('lal')
     @utils.skip_missing_dependency('pycbc')
     def test_to_from_pycbc(self, array):
         from pycbc.types import FrequencySeries as PyCBCFrequencySeries

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -394,7 +394,7 @@ class TestIoLigolw(object):
     def test_open_xmldoc(self):
         from glue.ligolw.ligolw import (Document, LIGO_LW)
         assert isinstance(io_ligolw.open_xmldoc(tempfile.mktemp()), Document)
-        with tempfile.TemporaryFile() as f:
+        with tempfile.TemporaryFile(mode='w') as f:
             xmldoc = Document()
             xmldoc.appendChild(LIGO_LW())
             xmldoc.write(f)
@@ -428,7 +428,7 @@ class TestIoLigolw(object):
         assert io_ligolw.list_tables(xmldoc) == names
 
         # check that we can list from files
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(mode='w') as f:
             xmldoc.write(f)
             f.seek(0)
             assert io_ligolw.list_tables(f) == names

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -538,6 +538,7 @@ class TestDataQualityFlag(object):
         assert f.name == 'X1:TEST-FLAG'
         assert f.version is None
 
+    @utils.skip_missing_dependency('lal')
     @utils.skip_missing_dependency('dqsegdb')
     def test_populate(self):
         name = QUERY_FLAGS[0]
@@ -857,6 +858,7 @@ class TestDataQualityDict(object):
         assert isinstance(result, self.TEST_CLASS)
         utils.assert_dict_equal(result, QUERY_RESULT, utils.assert_flag_equal)
 
+    @utils.skip_missing_dependency('lal')
     @utils.skip_missing_dependency('dqsegdb')
     def test_populate(self):
         def fake():

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -228,6 +228,7 @@ class TestTimeSeriesBase(TestSeries):
         a2 = self.TEST_CLASS.from_lal(lalts)
         assert a2.unit is units.dimensionless_unscaled
 
+    @utils.skip_missing_dependency('lal')
     @utils.skip_missing_dependency('pycbc')
     def test_to_from_pycbc(self, array):
         from pycbc.types import TimeSeries as PyCBCTimeSeries


### PR DESCRIPTION
This PR fixes a bug in the TravisCI configuration introduced by #552 whereby a failing pytest run wouldn't be picked up by Travis itself.