### PR TITLE
Added python3.5 CI build with --pre

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
             - texlive-fonts-recommended
             - dvipng
             - libhdf5-serial-dev
-    - env: PIP_FLAGS="--pre"
+    - env: PIP_FLAGS="--upgrade --pre"
       python: 3.5
       addons:
         apt:
@@ -85,18 +85,6 @@ matrix:
 
   allow_failures:
     - env: PIP_FLAGS="--upgrade --pre"
-      python: '3.5'
-      addons:
-        apt:
-          packages:
-            - gcc
-            - gfortran
-            - libblas-dev
-            - liblapack-dev
-            - texlive-latex-extra
-            - texlive-fonts-recommended
-            - dvipng
-            - libhdf5-serial-dev
     - env: DOCKER_IMAGE="ligo/software:jessie"
       python: '3.4'
     - env: DOCKER_IMAGE="ligo/software:stretch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,19 @@ matrix:
             - texlive-fonts-recommended
             - dvipng
             - libhdf5-serial-dev
+    - env: PIP_FLAGS="--pre"
+      python: 3.5
+      addons:
+        apt:
+          packages:
+            - gcc
+            - gfortran
+            - libblas-dev
+            - liblapack-dev
+            - texlive-latex-extra
+            - texlive-fonts-recommended
+            - dvipng
+            - libhdf5-serial-dev
 
     # debian 8 build
     - env: DOCKER_IMAGE="ligo/software:jessie"
@@ -71,6 +84,8 @@ matrix:
         - docker
 
   allow_failures:
+    - env: PIP_FLAGS="--upgrade --pre"
+      python: '3.5'
     - env: DOCKER_IMAGE="ligo/software:jessie"
       python: '3.4'
     - env: DOCKER_IMAGE="ligo/software:stretch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,17 @@ matrix:
   allow_failures:
     - env: PIP_FLAGS="--upgrade --pre"
       python: '3.5'
+      addons:
+        apt:
+          packages:
+            - gcc
+            - gfortran
+            - libblas-dev
+            - liblapack-dev
+            - texlive-latex-extra
+            - texlive-fonts-recommended
+            - dvipng
+            - libhdf5-serial-dev
     - env: DOCKER_IMAGE="ligo/software:jessie"
       python: '3.4'
     - env: DOCKER_IMAGE="ligo/software:stretch"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -31,7 +31,7 @@ get_environment
 # install for this OS
 if [ -z ${DOCKER_IMAGE} ]; then  # simple
     ${PIP} install .
-    ${PIP} install -r requirements-dev.txt
+    ${PIP} install -r requirements-dev.txt ${PIP_FLAGS}
     return 0
 fi
 


### PR DESCRIPTION
This PR adds another job to the CI configuration that uses the `--pre` option to `pip install` to test against pre-releases of the dependencies.