### PR TITLE
Fixed bug in auto-discovery of LIGO_LW columns for 'time'

### DIFF
--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -120,7 +120,8 @@ class TestTable(object):
         table = self.create(
             100, ['peak_time', 'peak_time_ns', 'snr', 'central_freq'],
             ['i4', 'i4', 'f4', 'f4'])
-        with tempfile.NamedTemporaryFile(suffix='.{}'.format(ext), delete=False) as f:
+        with tempfile.NamedTemporaryFile(suffix='.{}'.format(ext),
+                                         delete=False) as f:
             def _read(*args, **kwargs):
                 kwargs.setdefault('format', 'ligolw')
                 kwargs.setdefault('tablename', 'sngl_burst')

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -145,6 +145,12 @@ class TestTable(object):
             utils.assert_array_equal(
                 t3['peak'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
 
+            # check auto-discovery of 'time' columns works
+            t3 = _read(columns=['time'])
+            assert 'time' in t3.columns
+            utils.assert_array_equal(
+                t3['time'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
+
             # check reading multiple tables works
             try:
                 t3 = self.TABLE.read([f.name, f.name], format='ligolw',


### PR DESCRIPTION
This PR fixes a bug in `table.io.ligolw` where the auto-discovery of the real columns for 'time' was broken probably by #550.