### PR TITLE
Deprecated unnecessary gwpy.utils.compat module

### DIFF
--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -66,6 +66,7 @@ For example,
 """
 
 import re
+from collections import OrderedDict
 try:
     import configparser
 except ImportError:
@@ -78,7 +79,6 @@ from numpy import inf
 from ...io import registry
 from ...io.utils import identify_factory
 from ...io.cache import (file_list, FILE_LIKE)
-from ...utils.compat import OrderedDict
 from .. import (Channel, ChannelList)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/detector/io/omega.py
+++ b/gwpy/detector/io/omega.py
@@ -23,11 +23,11 @@ from __future__ import print_function
 
 import sys
 import os
+from collections import OrderedDict
 
 from astropy.io import registry
 
 from ...io.cache import FILE_LIKE
-from ...utils.compat import OrderedDict
 from .. import (Channel, ChannelList)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -28,6 +28,7 @@ import os
 import re
 import sys
 import warnings
+from collections import OrderedDict
 from functools import wraps
 
 from six.moves import reduce
@@ -43,7 +44,6 @@ else:
 
 from ..time import to_gps
 from .kerberos import kinit
-from ..utils.compat import OrderedDict
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -34,6 +34,7 @@ import operator
 import re
 import warnings
 from io import StringIO
+from collections import OrderedDict
 from copy import (copy as shallowcopy, deepcopy)
 from math import (floor, ceil)
 from threading import Thread
@@ -51,7 +52,6 @@ from astropy.utils.data import get_readable_fileobj
 
 from ..io.mp import read_multi as io_read_multi
 from ..time import to_gps, LIGOTimeGPS
-from ..utils.compat import OrderedDict
 from .segments import Segment, SegmentList
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"

--- a/gwpy/signal/fft/registry.py
+++ b/gwpy/signal/fft/registry.py
@@ -20,10 +20,9 @@
 """
 
 import re
+from collections import OrderedDict
 
 from six import string_types
-
-from ...utils.compat import OrderedDict
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 

--- a/gwpy/tests/test_utils.py
+++ b/gwpy/tests/test_utils.py
@@ -82,3 +82,10 @@ def test_with_import():
     # FIXME: this should really test the message
     with pytest.raises(ImportError) as exc:
         with_import_tester()
+
+
+def test_compat_ordereddict():
+    with pytest.warns(DeprecationWarning):
+        from gwpy.utils.compat import OrderedDict as CompatOrderedDict
+    from collections import OrderedDict
+    assert CompatOrderedDict is OrderedDict

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -42,6 +42,7 @@ from __future__ import (division, print_function)
 import os
 import sys
 import warnings
+from collections import OrderedDict
 from math import ceil
 
 import numpy
@@ -54,7 +55,6 @@ from ..detector import (Channel, ChannelList)
 from ..io import datafind
 from ..time import (Time, LIGOTimeGPS, to_gps)
 from ..utils import gprint
-from ..utils.compat import OrderedDict
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/utils/compat.py
+++ b/gwpy/utils/compat.py
@@ -19,12 +19,11 @@
 """Python version compatibilities
 """
 
-from __future__ import print_function
+import warnings
+warnings.warn('The gwpy.utils.compat module has been deprecated and will '
+              'be removed in an upcoming release, all objects provided '
+              'by this module can be found in other libraries.')
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-# OrderedDict isn't bundled with python < 2.7
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+from collections import OrderedDict  # pylint: disable=unused-import

--- a/gwpy/utils/compat.py
+++ b/gwpy/utils/compat.py
@@ -22,7 +22,8 @@
 import warnings
 warnings.warn('The gwpy.utils.compat module has been deprecated and will '
               'be removed in an upcoming release, all objects provided '
-              'by this module can be found in other libraries.')
+              'by this module can be found in other libraries.',
+              DeprecationWarning)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 


### PR DESCRIPTION
This PR deprecates (but doesn't remove) the `gwpy.utils.compat` module which so far only provided an import for `OrderedDict`. Since we don't support python2.6 anymore, we don't need it.