### PR TITLE
Added support for reading FrequencySeries from LIGO_LW Array elements

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ Working with data
 **Working with frequency-domain data**
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    spectrum/index
    spectrogram/index

--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -56,6 +56,16 @@ In this example we expand upon plotting a :class:`~gwpy.timeseries.TimeSeries`, 
 
 where the result is an average spectrum calculated using the `Welch method <https://en.wikipedia.org/wiki/Welch_method>`_.
 
+=====================================
+Reading/writing frequency-domain data
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+
+   io
+
+
 .. _gwpy-frequencyseries-plot:
 
 ============================

--- a/docs/spectrum/io.rst
+++ b/docs/spectrum/io.rst
@@ -1,0 +1,105 @@
+.. currentmodule:: gwpy.frequencyseries
+
+.. _gwpy-frequencyseries-io:
+
+#########################################
+Reading and writing frequency-domain data
+#########################################
+
+The `FrequencySeries` object includes :meth:`~FrequencySeries.read` and :meth:`~FrequencySeries.write` methods to enable reading from and writing to files respectively.
+For example, to read from an ASCII file containing frequency and amplitude columns::
+
+    >>> data = FrequencySeries.read('my-data.txt')
+
+The ``format`` keyword argument can be used to manually identify the input file-format, but is not required where the file extension is sufficiently well understood.
+
+The :meth:`~FrequencySeries.read` and :meth:`~FrequencySeries.write` methods take different arguments and keywords based on the input/output file format, see the following sections for details on reading/writing for each of the built-in formats.
+Those formats are:
+
+- :ref:`gwpy-frequencyseries-io-ascii`
+- :ref:`gwpy-frequencyseries-io-hdf5`
+- :ref:`gwpy-frequencyseries-io-ligolw`
+
+.. _gwpy-frequencyseries-io-ascii:
+
+=====
+ASCII
+=====
+
+GWpy supports writing `FrequencySeries` data to ASCII in a two-column ``frequency`` and ``amplitude`` format.
+
+Reading
+-------
+
+To read a `FrequencySeries` from ASCII::
+
+   >>> t = FrequencySeries.read('data.txt')
+
+See :func:`numpy.loadtxt` for keyword argument options.
+
+Writing
+-------
+
+To write a `FrequencySeries` to ASCII::
+
+   >>> t.write('data.txt')
+
+See :func:`numpy.savetxt` for keyword argument options.
+
+
+.. _gwpy-frequencyseries-io-hdf5:
+
+====
+HDF5
+====
+
+**Additional dependencies:** |h5py|_
+
+GWpy allows storing data in HDF5 format files, using a custom specification for storage of metadata.
+
+Reading
+-------
+
+To read `FrequencySeries` data held in HDF5 files pass the filename (or filenames) or the source, and the path of the data inside the HDF5 file::
+
+   >>> data = FrequencySeries.read('data.h5', 'psd')
+
+Writing
+-------
+
+Data held in a `FrequencySeries` can be written to an HDF5 file via::
+
+   >>> data.write('output.hdf', 'psd')
+
+If the target file already exists, an :class:`~exceptions.IOError` will be raised, use ``overwrite=True`` to force a new file to be written.
+
+To add a `FrequencySeries` to an existing file, use ``append=True``::
+
+    >>> data.write('output.h5', 'psd2', append=True)
+
+To replace an dataset in an existing file, while preserving other data, use *both* ``append=True`` and ``overwrite=True``::
+
+    >>> data.write('output.h5', 'psd', append=True, overwrite=True)
+
+
+.. _gwpy-frequencyseries-io-ligolw:
+
+===============
+``LIGO_LW`` XML
+===============
+
+**Additional dependencies:** :mod:`glue.ligolw`
+
+Alongside storing :ref:`tabular data <gwpy-table-io-ligolw>`, the ``LIGO_LW`` XML format allows storing array data.
+
+Reading
+-------
+
+A `FrequencySeries` can be read from LIGO_LW XML by passing the file path and the ``Name`` of the containing ``<LIGO_LW>`` element:
+
+   >>> data = FrequencySeries.read('data.xml', 'psd')
+
+Writing
+-------
+
+Writing `FrequencySeries` to LIGO_LW XML files is not supported.

--- a/gwpy/frequencyseries/io/ligolw.py
+++ b/gwpy/frequencyseries/io/ligolw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2017)
 #
 # This file is part of GWpy.
 #
@@ -16,13 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Input/Output routines for gwpy.frequencyseries
+"""LIGO_LW I/O registrations for gwpy.frequencyseries objects
 """
 
-from . import (  # pylint: disable=unused-import
-    ascii,
-    hdf5,
-    ligolw,
-)
+from ...io import registry as io_registry
+from ...io.ligolw import is_ligolw
+from ...types.io.ligolw import read_series
+from .. import FrequencySeries
 
-__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+# -- registration -------------------------------------------------------------
+
+io_registry.register_reader('ligolw', FrequencySeries, read_series)
+io_registry.register_identifier('ligolw', FrequencySeries, is_ligolw)

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -447,8 +447,12 @@ def is_ligolw(origin, filepath, fileobj, *args, **kwargs):
         try:
             line1 = fileobj.readline().lower()
             line2 = fileobj.readline().lower()
-            return (line1.startswith(XML_SIGNATURE) and
-                    line2.startswith(LIGOLW_SIGNATURE))
+            try:
+                return (line1.startswith(XML_SIGNATURE) and
+                        line2.startswith(LIGOLW_SIGNATURE))
+            except TypeError:  # bytes vs str
+                return (line1.startswith(XML_SIGNATURE.decode('utf-8')) and
+                        line2.startswith(LIGOLW_SIGNATURE.decode('utf-8')))
         finally:
             fileobj.seek(loc)
     try:

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -206,6 +206,7 @@ class TestFrequencySeries(TestSeries):
             assert_equal=utils.assert_quantity_sub_equal,
             assert_kw={'exclude': ['name', 'channel', 'unit', 'epoch']})
 
+    @utils.skip_missing_dependency('glue.ligolw.utils.ligolw_add')
     def test_read_ligolw(self):
         with tempfile.NamedTemporaryFile() as fobj:
             fobj.write(LIGO_LW_ARRAY)

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -208,7 +208,7 @@ class TestFrequencySeries(TestSeries):
 
     @utils.skip_missing_dependency('glue.ligolw.utils.ligolw_add')
     def test_read_ligolw(self):
-        with tempfile.NamedTemporaryFile() as fobj:
+        with tempfile.NamedTemporaryFile(mode='w+') as fobj:
             fobj.write(LIGO_LW_ARRAY)
             array = FrequencySeries.read(fobj, 'psd',
                                          match={'channel': 'X1:TEST-CHANNEL_1'})

--- a/gwpy/types/io/ligolw.py
+++ b/gwpy/types/io/ligolw.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read/write series in LIGO_LW-XML
+"""
+
+from .. import Series
+from ...io.ligolw import read_ligolw
+from ...time import to_gps
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+
+def series_contenthandler():
+    """Build a `~xml.sax.handlers.ContentHandler` to read a LIGO_LW <Array>
+    """
+    from glue.ligolw import (
+        ligolw,
+        array as ligolw_array,
+        param as ligolw_param
+    )
+
+    @ligolw_array.use_in
+    @ligolw_param.use_in
+    class ArrayContentHandler(ligolw.LIGOLWContentHandler):
+        """`~xml.sax.handlers.ContentHandler` to read a LIGO_LW <Array>
+        """
+        pass
+
+    return ArrayContentHandler
+
+
+def read_series(source, name, match=None):
+    """Read a `Series` from LIGO_LW-XML
+
+    Parameters
+    ----------
+    source : `file`, `str`, :class:`~glue.ligolw.ligolw.Document`
+        file path or open LIGO_LW-format XML file
+
+    name : `str`
+        name of the relevant `LIGO_LW` element to read
+
+    match : `dict`, optional
+        dict of (key, value) `Param` pairs to match correct LIGO_LW element,
+        this is useful if a single file contains multiple `LIGO_LW` elements
+        with the same name
+    """
+    from glue.ligolw.ligolw import (LIGO_LW, Time, Array, Dim)
+    from glue.ligolw.param import get_param
+
+    # read document
+    xmldoc = read_ligolw(source, contenthandler=series_contenthandler())
+
+    # parse match dict
+    if match is None:
+        match = dict()
+
+    def _is_match(elem):
+        try:
+            if elem.Name != name:
+                return False
+        except AttributeError:  # Name is not set
+            return False
+        for key, value in match.items():
+            try:
+                if get_param(elem, key).pcdata != value:
+                    return False
+            except ValueError:  # no Param with this Name
+                return False
+        return True
+
+    # parse out correct element
+    matches = filter(_is_match, xmldoc.getElementsByTagName(LIGO_LW.tagName))
+    try:
+        elem, = matches
+    except ValueError as exc:
+        if not matches:
+            exc.args = ("no LIGO_LW elements found matching request",)
+        else:
+            exc.args = ('multiple LIGO_LW elements found matching request, '
+                        'please consider using `match=` to select the '
+                        'correct element',)
+        raise
+
+    # get data
+    array, = elem.getElementsByTagName(Array.tagName)
+
+    # parse dimensions
+    dims = array.getElementsByTagName(Dim.tagName)
+    xdim = dims[0]
+    x0 = xdim.Start
+    dx = xdim.Scale
+    xunit = xdim.Unit
+    try:
+        ndim = dims[1].n
+    except IndexError:
+        pass
+    else:
+        if ndim > 2:
+            raise ValueError("Cannot parse LIGO_LW Array with {} "
+                             "dimensions".format(ndim))
+
+    # parse metadata
+    array_kw = {
+        'name': array.Name,
+        'unit': array.Unit,
+        'xunit': xunit,
+    }
+    try:
+        array_kw['epoch'] = to_gps(
+            elem.getElementsByTagName(Time.tagName)[0].pcdata)
+    except IndexError:
+        pass
+    for key in ('channel',):
+        try:
+            array_kw[key] = get_param(elem, key)
+        except ValueError:
+            pass
+
+    # build Series
+    try:
+        xindex, value = array.array
+    except ValueError:  # not two dimensions stored
+        return Series(array.array[0], x0=x0, dx=dx, **array_kw)
+    return Series(value, xindex=xindex, **array_kw)


### PR DESCRIPTION
This PR adds support (including implementation, tests, and documentation) for reading a `FrequencySeries` from a `<LIGO_LW>` element containing an `<Array>`. This is used in the LSC for uploading PSDs to GraceDB (by at least one search).