### PR TITLE
Index should return elements as Quantity, not Index

### DIFF
--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -31,7 +31,7 @@ import numpy
 from astropy import units
 from astropy.time import Time
 
-from gwpy.types import (Array, Series, Array2D)
+from gwpy.types import (Array, Series, Array2D, Index)
 from gwpy.detector import Channel
 from gwpy.segments import Segment
 from gwpy.time import LIGOTimeGPS
@@ -717,3 +717,26 @@ class TestArray2D(TestSeries):
 
     def test_pad(self):
         return NotImplemented
+
+
+class TestIndex(object):
+    TEST_CLASS = Index
+
+    def test_is_regular(self):
+        a = self.TEST_CLASS([1, 2, 3, 4, 5, 6], 's')
+        assert a.is_regular()
+        assert a[::-1].is_regular()
+
+        b = self.TEST_CLASS([1, 2, 4, 5, 7, 8, 9])
+        assert not b.is_regular()
+
+    def test_regular(self):
+        a = self.TEST_CLASS([1, 2, 3, 4, 5, 6], 's')
+        assert a.regular
+        assert a.regular is a.info.meta['regular']
+
+    def test_getitem(self):
+        a = self.TEST_CLASS([1, 2, 3, 4, 5, 6], 'Hz')
+        assert type(a[0]) is units.Quantity
+        assert a[0] == 1 * units.Hz
+        assert isinstance(a[:2], type(a))

--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -47,3 +47,9 @@ class Index(Quantity):
         if self.size <= 1:
             return False
         return numpy.isclose(numpy.diff(self.value, n=2), 0).all()
+
+    def __getitem__(self, key):
+        item = super(Index, self).__getitem__(key)
+        if item.isscalar:
+            return item.view(Quantity)
+        return item


### PR DESCRIPTION
This PR patches `Index.__getitem__` to return scalar items as a `Quantity`, rather than a 0-dimensional `Index`, mainly because that doesn't really make sense.

A test case for the `Index` object has also been added.