### PR TITLE
Added CI jobs to test simple build against python 3.4 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
             - dvipng
             - libhdf5-serial-dev
 
-    - env: PIP_FLAGS="--upgrade --pre"
+    - env: PIP_FLAGS="--upgrade --pre --quiet"
       python: 'nightly'
       addons:
         apt:
@@ -115,7 +115,7 @@ matrix:
       sudo: required
 
   allow_failures:
-    - env: PIP_FLAGS="--upgrade --pre"
+    - env: PIP_FLAGS="--upgrade --pre --quiet"
     - env: DOCKER_IMAGE="ligo/software:jessie"
       python: '3.4'
     - env: DOCKER_IMAGE="ligo/software:stretch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,18 @@ matrix:
             - texlive-fonts-recommended
             - dvipng
             - libhdf5-serial-dev
+    - python: 3.4
+      addons:
+        apt:
+          packages:
+            - gcc
+            - gfortran
+            - libblas-dev
+            - liblapack-dev
+            - texlive-latex-extra
+            - texlive-fonts-recommended
+            - dvipng
+            - libhdf5-serial-dev
     - python: 3.5
       addons:
         apt:
@@ -33,8 +45,21 @@ matrix:
             - texlive-fonts-recommended
             - dvipng
             - libhdf5-serial-dev
+    - python: 3.6
+      addons:
+        apt:
+          packages:
+            - gcc
+            - gfortran
+            - libblas-dev
+            - liblapack-dev
+            - texlive-latex-extra
+            - texlive-fonts-recommended
+            - dvipng
+            - libhdf5-serial-dev
+
     - env: PIP_FLAGS="--upgrade --pre"
-      python: 3.5
+      python: 'nightly'
       addons:
         apt:
           packages:

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -34,7 +34,7 @@ export GWPY_PATH
 ci_run() {
     # run a command normally, or in docker, depending on environment
     if [ -z "${DOCKER_IMAGE}" ]; then  # execute function normally
-        bash -lec "$@"
+        bash -ec "$@"
     else  # execute function in docker container
         docker exec -it ${DOCKER_IMAGE##*:} bash -lec "$@"
     fi

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -97,8 +97,6 @@ install_package() {
 get_python_version() {
     if [ -n "${PYTHON_VERSION}" ]; then
         :
-    elif [ -n "${TRAVIS_PYTHON_VERSION}" ]; then
-        PYTHON_VERSION=${TRAVIS_PYTHON_VERSION}
     else
         PYTHON_VERSION=`python -c
             'import sys; print(".".join(map(str, sys.version_info[:2])))'`

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -95,11 +95,8 @@ install_package() {
 }
 
 get_python_version() {
-    if [ -n "${PYTHON_VERSION}" ]; then
-        :
-    else
-        PYTHON_VERSION=`python -c
-            'import sys; print(".".join(map(str, sys.version_info[:2])))'`
+    if [ -z ${PYTHON_VERSION} ]; then
+        PYTHON_VERSION=`python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'`
     fi
     export PYTHON_VERSION
     echo ${PYTHON_VERSION}

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,12 @@ setup(
 
     # classifiers
     classifiers=[
+        'Development Status :: 4 - Beta',
         'Programming Language :: Python',
-        'Development Status :: 3 - Alpha',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Intended Audience :: Science/Research',
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This PR extends the travis CI configuration to include simple builds against python 3.4 and 3.6, and adds classifiers in `setup.py` to display the compatible python versions.