### PR TITLE
Added interface to pycbc.psd routines

### DIFF
--- a/docs/signal/fft.rst
+++ b/docs/signal/fft.rst
@@ -6,29 +6,56 @@ FFT routines for GWpy
 
 The Fourier transform (and the associated digital FFT algorithm) is the most
 common way of investigating the frequency-domain content of a time-domain signal.
-GWpy provides wrappers of average spectrum methods from :mod:`scipy.signal`, and |lal|_ to simplify calculating a `~gwpy.frequencyseries.FrequencySeries` from a `~gwpy.timeseries.TimeSeries`.
+GWpy provides wrappers of average spectrum methods from :mod:`scipy.signal`, |lal|_, and :mod:`pycbc.psd` to simplify calculating a `~gwpy.frequencyseries.FrequencySeries` from a `~gwpy.timeseries.TimeSeries`.
 
-The `gwpy.signal.fft` sub-package provides the following PSD averaging methods:
+The `gwpy.signal.fft` sub-package provides the following FFT averaging methods:
 
-.. autosummary::
-   :toctree: ../api
-   :nosignatures:
-
-   gwpy.signal.fft.scipy.welch
-   gwpy.signal.fft.scipy.bartlett
-   gwpy.signal.fft.lal.welch
-   gwpy.signal.fft.lal.bartlett
-   gwpy.signal.fft.lal.median
-   gwpy.signal.fft.lal.median_mean
+=======================  ===================================
+      Method name                     Function
+=======================  ===================================
+      ``'pycbc_welch'``  `gwpy.signal.fft.pycbc.welch`
+   ``'pycbc_bartlett'``  `gwpy.signal.fft.pycbc.bartlett`
+     ``'pycbc_median'``  `gwpy.signal.fft.pycbc.median`
+``'pycbc_median_mean'``  `gwpy.signal.fft.pycbc.median_mean`
+        ``'lal_welch'``  `gwpy.signal.fft.lal.welch`
+     ``'lal_bartlett'``  `gwpy.signal.fft.lal.bartlett`
+       ``'lal_median'``  `gwpy.signal.fft.lal.median`
+  ``'lal_median_mean'``  `gwpy.signal.fft.lal.median_mean`
+      ``'scipy_welch'``  `gwpy.signal.fft.scipy.welch`
+   ``'scipy_bartlett'``  `gwpy.signal.fft.scipy.bartlett`
+=======================  ===================================
 
 Each of these can be specified by passing the function name as the ``method`` keyword argument to any of the relevant `~gwpy.timeseries.TimeSeries` instance methods, e.g::
 
    >>> ts = TimeSeries(...)
-   >>> psd = ts.psd(..., method='welch', ...)
+   >>> psd = ts.psd(..., method='pycbc_welch', ...)
+
+Additionally, short versions the following registrations map to the first registered instance of that name in the registry:
+
+=======================  ===================================
+      Method name                     Function
+=======================  ===================================
+            ``'welch'``  `gwpy.signal.fft.pycbc.welch`
+         ``'bartlett'``  `gwpy.signal.fft.pycbc.bartlett`
+           ``'median'``  `gwpy.signal.fft.pycbc.median`
+      ``'median_mean'``  `gwpy.signal.fft.pycbc.median_mean`
+=======================  ===================================
 
 .. note::
 
-   Since `welch` and `bartlett` are defined in both the `scipy` and `lal`
-   sub-modules, the LAL versions are registered as ``'lal-welch'`` and
-   ``'lal-bartlett'``, so to use them, pass ``method='lal-welch'`` to the
-   relevant `~gwpy.timeseries.TimeSeries` method.
+   The simple names (e.g. ``'welch'``) are mapped at runtime, meaning if
+   you don't have `pycbc` on your system, the registrations will map to
+   |lal|_ or `scipy` instead. These are provided only for convenience, so
+   if you want to be able to reproduce your results on any system,
+   use the full API-specific name when using :meth:`TimeSeries.psd`
+   and friends.
+
+
+.. note::
+
+   You can check which FFT library will be used via the
+   :func:`gwpy.signal.fft.get_default_fft_api` method, e.g::
+
+      >>> from gwpy.signal.fft import get_default_fft_api
+      >>> get_default_fft_api()
+      'pycbc'

--- a/gwpy/signal/fft/__init__.py
+++ b/gwpy/signal/fft/__init__.py
@@ -36,9 +36,10 @@ To add another API from scratch, copy the format of the `gwpy.signal.fft.scipy`
 module.
 """
 
-from . import (  # pylint: disable=unused-import
+from . import (
     scipy,
     lal,
+    pycbc,
 )
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/signal/fft/__init__.py
+++ b/gwpy/signal/fft/__init__.py
@@ -33,13 +33,46 @@ function into the sub-module and call
 to register it.
 
 To add another API from scratch, copy the format of the `gwpy.signal.fft.scipy`
-module.
+module, and then add it to the import below. The imports are ordered by
+preference (after `basic`).
 """
 
+from importlib import import_module
+
 from . import (
-    scipy,
+    basic,
+    pycbc,  # <- PyCBC is preferred (better optimisation)
     lal,
-    pycbc,
+    scipy,
 )
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def get_default_fft_api():
+    """Return the preferred FFT-API library
+
+    This is referenced to set the default methods for
+    `~gwpy.timeseries.TimeSeries` methods (amongst others)
+
+    Examples
+    --------
+    If you have :mod:`pycbc` installed:
+
+    >>> from gwpy.signal.fft import get_default_fft_api
+    >>> get_default_fft_api()
+    'pycbc'
+
+    If you just have a basic installation (from `pip install gwpy`):
+
+    >>> get_default_fft_api()
+    'scipy'
+    """
+    for lib in ('pycbc', 'lal',):
+        try:
+            import_module(lib)
+        except ImportError:
+            pass
+        else:
+            return lib
+    return 'scipy'

--- a/gwpy/signal/fft/basic.py
+++ b/gwpy/signal/fft/basic.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Simple registrations for the FFT registry
+
+`scipy.signal` doesn't provide alternatives to a simple mean average, so
+this method maps the names of the other averages to an actual method provided
+by one of the other FFT-API libraries (e.g. `pycbc`).
+"""
+
+import warnings
+from functools import wraps
+
+from . import registry as fft_registry
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def map_fft_method(func):
+    name = func.__name__
+
+    @wraps(func)
+    def mapped_method(*args, **kwargs):
+        for (scaling, regname) in ((k, v) for k in fft_registry.METHODS for
+                                    v in fft_registry.METHODS[k]):
+            if regname.endswith('_{}'.format(name)):
+                api_func = fft_registry.METHODS[scaling][regname]
+                try:
+                    return api_func(*args, **kwargs)
+                except ImportError:
+                    pass
+                finally:
+                    warnings.warn('no FFT method registered as {!r}, '
+                                  'using {!r}, please consider specifying '
+                                  'this directly in the future'.format(
+                                      name, regname))
+        raise RuntimeError("no underlying API method available for FFT method "
+                           "{!r}, consider installing one of the extra "
+                           "FFT-API libraries, see the online docs for full "
+                           "details".format(name))
+
+    return mapped_method
+
+
+@map_fft_method
+def welch(timeseries, segmentlength, noverlap=None, **kwargs):
+    """Calculate a PSD of this `TimeSeries using a mean average of FFTs
+
+    This method is dynamically linked at runtime to an underlying method
+    provided by a third-party library.
+
+    Parameters
+    ----------
+    timeseries : `~gwpy.timeseries.TimeSeries`
+        input `TimeSeries` data.
+
+    segmentlength : `int`
+        number of samples in single average.
+
+    noverlap : `int`
+        number of samples to overlap between segments, defaults to 50%.
+
+    Returns
+    -------
+    spectrum : `~gwpy.frequencyseries.FrequencySeries`
+        average power `FrequencySeries`
+    """
+    pass
+
+
+@map_fft_method
+def bartlett(timeseries, segmentlength, **kwargs):
+    pass
+bartlett.__doc__ = welch.__doc__.replace('mean average',
+                                         'zero-overlap mean average')
+
+
+@map_fft_method
+def median(timeseries, segmentlength, noverlap=None, **kwargs):
+    pass
+median.__doc__ = welch.__doc__.replace('mean average', 'median average')
+
+
+@map_fft_method
+def median_mean(timeseries, segmentlength, noverlap=None, **kwargs):
+    pass
+median_mean.__doc__ = welch.__doc__.replace('mean average',
+                                            'median-mean average')
+
+
+for func in (welch, bartlett, median, median_mean,):
+    fft_registry.register_method(func, scaling='density')

--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -375,9 +375,6 @@ def median_mean(timeseries, segmentlength, noverlap=None,
 
 
 # register LAL methods without overriding scipy method
-for func in [welch, bartlett, median, median_mean]:
-    try:
-        fft_registry.register_method(func, scaling='density')
-    except KeyError:  # already exists from scipy
-        fft_registry.register_method(func, name='lal-%s' % func.__name__,
-                                     scaling='density')
+for func in (welch, bartlett, median, median_mean,):
+    fft_registry.register_method(func, name='lal-{}'.format(func.__name__),
+                                 scaling='density')

--- a/gwpy/signal/fft/pycbc.py
+++ b/gwpy/signal/fft/pycbc.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""GWpy API to the pycbc.psd FFT routines
+"""
+
+from __future__ import absolute_import
+
+import numpy
+
+import scipy.signal
+
+from ...frequencyseries import FrequencySeries
+from .utils import scale_timeseries_unit
+from . import registry as fft_registry
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def welch(timeseries, segmentlength, noverlap=None, **kwargs):
+    """Calculate a PSD using Welch's method with a mean average
+
+    Parameters
+    ----------
+    timeseries : `~gwpy.timeseries.TimeSeries`
+        input `TimeSeries` data.
+
+    segmentlength : `int`
+        number of samples in single average.
+
+    noverlap : `int`
+        number of samples to overlap between segments, defaults to 50%.
+
+    **kwargs
+        other keyword arguments to pass to :func:`pycbc.psd.welch`
+
+    Returns
+    -------
+    spectrum : `~gwpy.frequencyseries.FrequencySeries`
+        average power `FrequencySeries`
+
+    See also
+    --------
+    pycbc.psd.welch
+    """
+    from pycbc.psd import welch as pycbc_welch
+
+    # default to 'standard' welch
+    kwargs.setdefault('avg_method', 'mean')
+
+    # generate pycbc FrequencySeries
+    fseries = pycbc_welch(timeseries.to_pycbc(), seg_len=segmentlength,
+                          seg_stride=noverlap, **kwargs)
+
+    # return GWpy FrequencySeries
+    return FrequencySeries.from_pycbc(fseries)
+
+
+def median(*args, **kwargs):
+    kwargs['avg_method'] = 'median'
+    return welch(*args, **kwargs)
+median.__doc__ = welch.__doc__.replace('mean average', 'median average')
+
+
+def median_mean(*args, **kwargs):
+    kwargs['avg_method'] = 'median-mean'
+    return welch(*args, **kwargs)
+median_mean.__doc__ = welch.__doc__.replace('mean average',
+                                            'median-mean average')
+
+
+# register new functions
+for func in (welch, median, median_mean):
+    try:
+        fft_registry.register_method(func, scaling='density')
+    except KeyError:
+        pass  # name already registered from another API
+    finally:
+        fft_registry.register_method(func, scaling='density',
+                                     name='pycbc-{}'.format(func.__name__))

--- a/gwpy/signal/fft/registry.py
+++ b/gwpy/signal/fft/registry.py
@@ -79,7 +79,7 @@ def get_method(name, scaling='density'):
     try:
         return methods[name]
     except KeyError as exc:
-        exc.args = ("No FFT method (scaling=%r) registered with name %r"
+        exc.args = ("no FFT method (scaling=%r) registered with name %r"
                     % (scaling, name),)
         raise
 
@@ -112,7 +112,6 @@ def update_doc(obj, scaling='density'):
     for method in METHODS[scaling]:
         func = METHODS[scaling][method]
         rows.append((method, '`%s.%s`' % (func.__module__, func.__name__)))
-    rows.sort(key=lambda x: x[1])
     format_str = Table(rows=rows, names=['Method name', 'Function']).pformat(
         max_lines=-1, max_width=80, align=('>', '<'))
     format_str[1] = format_str[1].replace('-', '=')

--- a/gwpy/signal/fft/scipy.py
+++ b/gwpy/signal/fft/scipy.py
@@ -32,6 +32,8 @@ from . import registry as fft_registry
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+# -- density scaling methods --------------------------------------------------
+
 def welch(timeseries, segmentlength, noverlap=None, **kwargs):
     """Calculate a PSD of this `TimeSeries` using Welch's method.
 
@@ -67,8 +69,6 @@ def welch(timeseries, segmentlength, noverlap=None, **kwargs):
                            name=timeseries.name, epoch=timeseries.epoch,
                            channel=timeseries.channel)
 
-fft_registry.register_method(welch, scaling='density')
-
 
 def bartlett(timeseries, segmentlength, **kwargs):
     """Calculate a PSD of this `TimeSeries` using Bartlett's method
@@ -96,8 +96,14 @@ def bartlett(timeseries, segmentlength, **kwargs):
     kwargs.pop('noverlap', None)
     return welch(timeseries, segmentlength, noverlap=0, **kwargs)
 
-fft_registry.register_method(bartlett, scaling='density')
 
+# register
+for func in (welch, bartlett,):
+    fft_registry.register_method(func, name='scipy-{}'.format(func.__name__),
+                                 scaling='density')
+
+
+# -- other scaling methods ----------------------------------------------------
 
 def rayleigh(timeseries, segmentlength, noverlap=0):
     """Calculate a Rayleigh statistic spectrum
@@ -135,8 +141,6 @@ def rayleigh(timeseries, segmentlength, noverlap=0):
                            df=timeseries.sample_rate.value/segmentlength,
                            channel=timeseries.channel,
                            name='Rayleigh spectrum of %s' % timeseries.name)
-
-fft_registry.register_method(rayleigh, scaling='other')
 
 
 def csd(timeseries, other, segmentlength, noverlap=None, **kwargs):
@@ -186,4 +190,8 @@ def csd(timeseries, other, segmentlength, noverlap=None, **kwargs):
         name=str(timeseries.name)+'---'+str(other.name),
         epoch=timeseries.epoch, channel=timeseries.channel)
 
-fft_registry.register_method(csd, scaling='other')
+
+# register
+for func in (rayleigh, csd,):
+    fft_registry.register_method(func, name='scipy-{}'.format(func.__name__),
+                                 scaling='other')

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -19,6 +19,8 @@
 """Unit test for signal module
 """
 
+from importlib import import_module
+
 import pytest
 
 import numpy
@@ -203,25 +205,24 @@ class TestSignalFftRegistry(object):
             -----"""
             pass
 
+        # update docs
         fft_registry.update_doc(fake_caller)
-        assert fake_caller.__doc__ == """Test method
 
-            Notes
-            -----
-            The available methods are:
-            
-            ============ =================================
-            Method name               Function            
-            ============ =================================
-            lal_bartlett `gwpy.signal.fft.lal.bartlett`   
-             median_mean `gwpy.signal.fft.lal.median_mean`
-                  median `gwpy.signal.fft.lal.median`     
-               lal_welch `gwpy.signal.fft.lal.welch`      
-                bartlett `gwpy.signal.fft.scipy.bartlett` 
-                   welch `gwpy.signal.fft.scipy.welch`    
-            ============ =================================
-            
-            See :ref:`gwpy-signal-fft` for more details"""  # nopep8
+        # simple tests
+        doc = fake_caller.__doc__
+        assert '            The available methods are:' in doc
+        assert 'scipy_welch `gwpy.signal.fft.scipy.welch`' in doc
+
+    @pytest.mark.parametrize('library', ['basic', 'pycbc', 'lal', 'scipy'])
+    def test_register_library(self, library):
+        apilib = import_module('gwpy.signal.fft.{}'.format(library))
+        regname = library == 'basic' and str else ('%s_{}' % library).format
+        for method in ('welch', 'bartlett', 'median', 'median_mean'):
+            if method == 'median' and library == 'scipy':
+                break
+            assert (
+                fft_registry.get_method(regname(method)) is
+                getattr(apilib, method))
 
 
 # -- gwpy.signal.fft.ui -------------------------------------------------------


### PR DESCRIPTION
This PR adds support for using PyCBC routines to calculate a PSD using the `pycbc.psd` module. The authors of that have gone to great lengths to optimise the FFT operations, so we may as well make the most of it.