### PR TITLE
Added workaround for IrreducibleUnit comparisons

### DIFF
--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -27,6 +27,9 @@ from astropy.units.format.generic import Generic
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
+# container for new units (so that each one only gets created once)
+UNRECOGNIZED_UNITS = {}
+
 
 # -- parser to handle any unit ------------------------------------------------
 
@@ -78,7 +81,12 @@ class GWpyFormat(Generic):
                               'should work, but conversions to other units '
                               'will not.'.format(str(exc).rstrip(' ')),
                               category=units.UnitsWarning)
-                return units.def_unit(name, doc='Unrecognized unit')
+                try:  # return previously created unit
+                    return UNRECOGNIZED_UNITS[name]
+                except KeyError:  # or create new one now
+                    u = UNRECOGNIZED_UNITS[name] = units.def_unit(
+                        name, doc='Unrecognized unit')
+                    return u
             return cls._parse_unit(alt)
 
 

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -135,6 +135,11 @@ def test_parse_unit_strict():
     assert isinstance(u, units.IrreducibleUnit)
     assert str(u) == 'metre'
 
+    # assert that a newly-created unit only gets created once
+    u2 = parse_unit('metre', parse_strict='ignore')
+    assert u2 is u  # same object
+    assert u == u2  # compare as equal (just in case)
+
 
 @pytest.mark.parametrize('name', [
     'NONE',


### PR DESCRIPTION
This PR fixes an issue with the custom `IrreducibleUnit`s that are produced by `gwpy.detector.units.parse_unit` when the unit string is not recognised. The patch is to use a `dict` to cache the new units as they are created so that each unit string only gets mapped to a new unit once, allowed for equality comparisons with units of the same name (they are now the same object).

This is required for `TimeSeries.is_compatible` and similar functions to pass on custom units.