### PR TITLE
Install package with PIP_FLAGS in CI

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -36,7 +36,7 @@ elif [[ ${DOCKER_IMAGE} =~ :el[0-9]+$ ]]; then  # SLX
 elif [ -n "${DOCKER_IMAGE}" ]; then  # debian
     . ci/install-debian.sh
 else  # simple pip build
-    ${PIP} install .
+    ${PIP} install . ${PIP_FLAGS}
     ${PIP} install -r requirements-dev.txt ${PIP_FLAGS}
 fi
 

--- a/gwpy/tests/test_spectrogram.py
+++ b/gwpy/tests/test_spectrogram.py
@@ -187,6 +187,7 @@ class TestSpectrogram(TestArray2D):
         with pytest.raises(TypeError):
             array.filter(lti, blah=1)
 
+    @utils.skip_missing_dependency('h5py')
     def test_read_write_hdf5(self):
         array = self.create(name='X1:TEST')
         utils.test_read_write(array, 'hdf5', write_kw={'overwrite': True})


### PR DESCRIPTION
This PR works around a problem with the python `'nightly'` CI build reaching the 10,000 line log error. The fix is to apply the `PIP_FLAGS` environment setting to the 

```
pip install .
```

command, mainly so that the `--quiet` flag gets applied.