### PR TITLE
Improved filtering definitions and parsing

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,6 @@
+pycodestyle:
+  exclude:
+    - docs/conf.py
+    - ez_setup.py
+    - versioneer.py
+    - gwpy/_version.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@
 import sys
 import inspect
 import os.path
+import re
 
 from matplotlib import use
 use('agg')
@@ -152,6 +153,16 @@ numpydoc_show_class_members = False
 
 # auto-insert plot directive in examples
 numpydoc_use_plots = True
+
+# try and update the plot detection to include .show() calls
+try:  # requires numpydoc >= 0.8
+    from numpydoc import docscrape_sphinx
+    parts = re.split('[\(\)|]', docscrape_sphinx.IMPORT_MATPLOTLIB_RE)[1:-1]
+except AttributeError:
+    pass
+else:
+    parts.extend(('fig.show()', 'plot.show()'))
+    docscrape_sphinx.IMPORT_MATPLOTLIB_RE = r'\b({})\b'.format('|'.join(parts))
 
 # -- inhertiance_diagram ------------------------
 

--- a/docs/signal/index.rst
+++ b/docs/signal/index.rst
@@ -6,7 +6,7 @@
 Signal processing
 #################
 
-In a wide-array of applications, the original `TimeSeries` recorded from a digital system must be manipulated in order to extract the greatest amount of information.
+In a wide-array of applications, the original data recorded from a digital system must be manipulated in order to extract the greatest amount of information.
 GWpy provides a suite of functions to simplify and extend the excellent digital signal processing suite in :mod:`scipy.signal`.
 
 ===============
@@ -14,6 +14,7 @@ Fourier methods
 ===============
 
 The `TimeSeries` object comes with a number of Fourier methods to calculate a `~gwpy.frequencyseries.FrequencySeries` or `~gwpy.spectrogram.Spectrogram` by calculating and averaging FFTs.
+
 See :ref:`gwpy-signal-fft` for more details.
 
 =====================
@@ -30,8 +31,10 @@ Available methods include:
    TimeSeries.lowpass
    TimeSeries.bandpass
    TimeSeries.zpk
-   TimeSeries.filter
    TimeSeries.whiten
+   TimeSeries.filter
+
+Each of the above methods eventually calls out to :meth:`TimeSeries.filter` to apply a digital linear filter, normally via cascaded second-order-sections (requires `scipy >= 0.16`).
 
 For a worked example of how to filter LIGO data to discover a gravitational-wave signal, see the example :ref:`gwpy-example-signal-gw150914`.
 
@@ -65,11 +68,11 @@ The :mod:`gwpy.signal` provides a number of filter design methods which, when co
 .. autosummary::
    :nosignatures:
 
-   ~gwpy.signal.lowpass
-   ~gwpy.signal.highpass
-   ~gwpy.signal.bandpass
-   ~gwpy.signal.notch
-   ~gwpy.signal.contatenate_zpks
+   ~gwpy.signal.filter_design.lowpass
+   ~gwpy.signal.filter_design.highpass
+   ~gwpy.signal.filter_design.bandpass
+   ~gwpy.signal.filter_design.notch
+   ~gwpy.signal.filter_design.concatenate_zpks
 
 Each of these will return filter coefficients that can be passed directly into `~TimeSeries.zpk` (default for analogue filters) or `~TimeSeries.filter` (default for digital filters).
 
@@ -91,23 +94,16 @@ For a worked example of how to compare channels like this, see the example :ref:
 Reference/API
 =============
 
-The :mod:`gwpy.signal` module provides the following methods:
+--------------------------------
+:mod:`gwpy.signal.filter_design`
+--------------------------------
 
-.. autosummary::
-   :nosignatures:
+.. automethod:: gwpy.signal.filter_design.bandpass
 
-   bandpass
-   lowpass
-   highpass
-   notch
-   concatenate_zpks
+.. automethod:: gwpy.signal.filter_design.lowpass
 
-.. automethod:: gwpy.signal.bandpass
+.. automethod:: gwpy.signal.filter_design.highpass
 
-.. automethod:: gwpy.signal.lowpass
+.. automethod:: gwpy.signal.filter_design.notch
 
-.. automethod:: gwpy.signal.highpass
-
-.. automethod:: gwpy.signal.notch
-
-.. automethod:: gwpy.signal.concatenate_zpks
+.. automethod:: gwpy.signal.filter_design.concatenate_zpks

--- a/gwpy/frequencyseries/_fdcommon.py
+++ b/gwpy/frequencyseries/_fdcommon.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Common utilities for frequency-domain operations
+
+This module holds code used by both the `FrequencySeries` and `Spectrogram`.
+"""
+
+import numpy
+
+from scipy import signal
+
+from ..signal.filter_design import with_digital_lti
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+
+@with_digital_lti
+def fdfilter(data, *filt, **kwargs):
+    """Filter a frequency-domain data object
+
+    See Also
+    --------
+    gwpy.frequencyseries.FrequencySeries.filter
+    gwpy.spectrogram.Spectrogram.filter
+    """
+    # parse keyword args
+    inplace = kwargs.pop('inplace', False)
+    if kwargs:
+        raise TypeError("filter() got an unexpected keyword argument '%s'"
+                        % list(kwargs.keys())[0])
+
+    # decorator formats filt as (digital) signal.lti
+    lti = filt[0]
+
+    # generate frequency response
+    freqs = data.frequencies.value.copy()
+    fresp = numpy.nan_to_num(abs(lti.freqresp(w=freqs)[1]))
+
+    # apply to array
+    if inplace:
+        data *= fresp
+        return data
+    new = data * fresp
+    return new

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -231,7 +231,13 @@ def parse_digital_lti(args, analog=False, sample_rate=None):
         if analog:
             raise ValueError("Filtering with analog FIR filters is "
                              "not supported")
-        return signal.lti(args, [1.])
+        try:
+            return signal.lti(args, [1.])
+        except ValueError as exc:
+            if str(exc).startswith('Improper transfer function'):
+                exc.args = ('{} scipy >= 0.16 is required to represent FIR '
+                            'filters as LTI.'.format(str(exc)),)
+            raise
 
     # parse IIR filter
     if isinstance(args, LinearTimeInvariant):

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -21,15 +21,20 @@
 
 from __future__ import division
 import operator
+from functools import wraps
 from math import (pi, log10)
 
 from six.moves import reduce
 
-from numpy import (atleast_1d, concatenate, ndarray)
+import numpy
 
 from scipy import signal
+try:
+    from scipy.signal.ltisys import LinearTimeInvariant
+except ImportError:  # scipy < 0.18
+    from scipy.signal import lti as LinearTimeInvariant
 
-from astropy.units import Quantity
+from astropy.units import (Unit, Quantity)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __all__ = ['lowpass', 'highpass', 'bandpass', 'notch', 'concatenate_zpks']
@@ -54,8 +59,8 @@ def _design_iir(wp, ws, sample_rate, gpass, gstop,
                 analog=False, ftype='cheby1', output='zpk'):
     # pylint: disable=invalid-name
     nyq = sample_rate / 2.
-    wp = atleast_1d(wp)
-    ws = atleast_1d(ws)
+    wp = numpy.atleast_1d(wp)
+    ws = numpy.atleast_1d(ws)
     if analog:
         wp *= TWO_PI
         ws *= TWO_PI
@@ -79,8 +84,8 @@ def _design_iir(wp, ws, sample_rate, gpass, gstop,
 
 def _design_fir(wp, ws, sample_rate, gpass, gstop, window='hamming', **kwargs):
     # pylint: disable=invalid-name
-    wp = atleast_1d(wp)
-    ws = atleast_1d(ws)
+    wp = numpy.atleast_1d(wp)
+    ws = numpy.atleast_1d(ws)
     tw = abs(wp[0] - ws[0])
     nt = num_taps(sample_rate, tw, gpass, gstop)
     if wp[0] > ws[0]:
@@ -136,9 +141,154 @@ def is_zpk(zpktup):
     return (
         isinstance(zpktup, (tuple, list)) and
         len(zpktup) == 3 and
-        isinstance(zpktup[0], (list, tuple, ndarray)) and
-        isinstance(zpktup[1], (list, tuple, ndarray)) and
+        isinstance(zpktup[0], (list, tuple, numpy.ndarray)) and
+        isinstance(zpktup[1], (list, tuple, numpy.ndarray)) and
         isinstance(zpktup[2], float))
+
+
+def bilinear_zpk(zeros, poles, gain, fs=1.0, unit='Hz'):
+    """Convert an analogue ZPK filter to digital using a bilinear transform
+
+    Parameters
+    ----------
+    zeros : array-like
+        list of zeros
+
+    poles : array-like
+        list of poles
+
+    gain : `float`
+        filter gain
+
+    fs : `float`, `~astropy.units.Quantity`
+        sampling rate at which to evaluate bilinear transform, default: 1.
+
+    unit : `str`, `~astropy.units.Unit`
+        unit of inputs, one or 'Hz' or 'rad/s', default: ``'Hz'``
+
+    Returns
+    -------
+    zpk : `tuple`
+        digital version of input zpk
+    """
+    zeros = numpy.array(zeros, dtype=float, copy=False)
+    zeros = zeros[numpy.isfinite(zeros)]
+    poles = numpy.array(poles, dtype=float, copy=False)
+    gain = gain
+
+    # convert from Hz to rad/s if needed
+    unit = Unit(unit)
+    if unit == Unit('Hz'):
+        zeros *= -2 * pi
+        poles *= -2 * pi
+    elif unit != Unit('rad/s'):
+        raise ValueError("zpk can only be given with unit='Hz' "
+                         "or 'rad/s'")
+
+    # convert to Z-domain via bilinear transform
+    fs = 2 * Quantity(fs, 'Hz').value
+    dpoles = (1 + poles/fs) / (1 - poles/fs)
+    dzeros = (1 + zeros/fs) / (1 - zeros/fs)
+    dzeros = numpy.concatenate((
+        dzeros, -numpy.ones(len(dpoles) - len(dzeros)),
+    ))
+    dgain = gain * numpy.prod(fs - zeros)/numpy.prod(fs - poles)
+    return dzeros, dpoles, dgain
+
+
+def parse_digital_lti(args, analog=False, sample_rate=None):
+    """Parse arbitrary input args as an LTI filter definition
+
+    Parameters
+    ----------
+    args : `tuple`, `~scipy.signal.lti`
+        filter definition, normally just captured positional ``*args``
+        from a function call
+
+    analog : `bool`, optional
+        `True` if filter definition has analogue coefficients
+
+    sample_rate : `float`, optional
+        sampling frequency at which to convert analogue filter to digital
+        via bilinear transform, required if ``analog=True``
+
+    Returns
+    -------
+    lti : `~scipy.signal.ZerosPolesGain`, `~scipy.signal.lti`
+        a formatted LTI filter in ZPK format
+    """
+    if analog and not sample_rate:
+        raise ValueError("Must give sample_rate frequency to convert "
+                         "analog filter to digital")
+
+    # unpack filter
+    if isinstance(args, tuple) and len(args) == 1:
+        # either packed defintion ((z, p, k)) or simple definition (lti,)
+        args = args[0]
+
+    # parse FIR filter
+    if isinstance(args, numpy.ndarray) and args.ndim == 1:  # fir
+        if analog:
+            raise ValueError("Filtering with analog FIR filters is "
+                             "not supported")
+        return signal.lti(args, [1.])
+
+    # parse IIR filter
+    if isinstance(args, LinearTimeInvariant):
+        lti = args
+    else:
+        lti = signal.lti(*args)
+
+    if analog:
+        lti = signal.lti(
+            *bilinear_zpk(lti.zeros, lti.poles, lti.gain, fs=sample_rate))
+
+    try:
+        return lti.to_zpk()
+    except AttributeError:  # scipy < 0.18, doesn't matter
+        return lti
+
+
+def with_digital_lti(func):
+    """Decorate a function to pre-format a filter as a digital LTI system
+
+    This decorator interprets all positional arguments as a single
+    filter definition (c.f. `scipy.signal.lti`), and strips the following
+    keyword arguments
+
+    - ``analog`` : whether the input filter is digital or not
+    - ``sample_rate`` : the sampling rate at which to convert from analog
+
+    ``func`` should then be written to accept a single positional argument
+    as a `scipy.signal.ZerosPolesGain` with digital coefficients.
+    All other keyword arguments will be passed through untouched.
+    """
+    @wraps(func)
+    def decorated_func(self, *filt, **kwargs):
+        """Parse `args` to `scipy.signal.lti`, and pass to underlying function
+        """
+        # parse kwargs
+        analog = kwargs.pop('analog', False)
+        sample_rate = kwargs.pop('sample_rate', None)
+
+        if analog and not sample_rate:
+            # try and parse sample_rate from class instance
+            if hasattr(self, 'df'):
+                # FrequencySeries or Spectrogram
+                sample_rate = 2 * (
+                    self.f0 + (self.shape[-1] - 1) * self.df).to('Hz').value
+            elif hasattr(self, 'sample_rate'):
+                # TimeSeries
+                sample_rate = self.sample_rate.to('Hz').value
+
+        # parse filter as LTI
+        lti = parse_digital_lti(filt, analog=analog, sample_rate=sample_rate)
+
+        # call original function with ZerosPolesGain
+        return func(self, lti, **kwargs)
+
+    return decorated_func
+
 
 # -- user methods -------------------------------------------------------------
 
@@ -185,21 +335,14 @@ def lowpass(frequency, sample_rate, fstop=None, gpass=2, gstop=30, type='iir',
     --------
     To create a low-pass filter at 1000 Hz for 4096 Hz-sampled data:
 
-    .. plot::
-       :context: reset
-
-       from gwpy.signal import lowpass
-       zpk = lowpass(1000, 4096)
+    >>> from gwpy.signal.filter_design import lowpass
+    >>> lp = lowpass(1000, 4096)
 
     To view the filter, you can use the `~gwpy.plotter.BodePlot`:
 
-    .. plot::
-       :context:
-
-       from gwpy.plotter import BodePlot
-       plot = BodePlot(zpk, sample_rate=4096)
-       plot.show()
-
+    >>> from gwpy.plotter import BodePlot
+    >>> plot = BodePlot(lp, sample_rate=4096)
+    >>> plot.show()
     """
     sample_rate = _as_float(sample_rate)
     frequency = _as_float(frequency)
@@ -254,21 +397,14 @@ def highpass(frequency, sample_rate, fstop=None, gpass=2, gstop=30, type='iir',
     --------
     To create a high-pass filter at 100 Hz for 4096 Hz-sampled data:
 
-    .. plot::
-       :context: reset
-
-       from gwpy.signal import highpass
-       zpk = highpass(100, 4096)
+    >>> from gwpy.signal.filter_design import highpass
+    >>> hp = highpass(100, 4096)
 
     To view the filter, you can use the `~gwpy.plotter.BodePlot`:
 
-    .. plot::
-       :context:
-
-       from gwpy.plotter import BodePlot
-       plot = BodePlot(zpk, sample_rate=4096)
-       plot.show()
-
+    >>> from gwpy.plotter import BodePlot
+    >>> plot = BodePlot(hp, sample_rate=4096)
+    >>> plot.show()
     """
     sample_rate = _as_float(sample_rate)
     frequency = _as_float(frequency)
@@ -327,20 +463,14 @@ def bandpass(flow, fhigh, sample_rate, fstop=None, gpass=2, gstop=30,
     --------
     To create a band-pass filter for 100-1000 Hz for 4096 Hz-sampled data:
 
-    .. plot::
-       :context: reset
-
-       from gwpy.signal import bandpass
-       zpk = bandpass(100, 1000, 4096)
+    >>> from gwpy.signal.filter_design import bandpass
+    >>> bp = bandpass(100, 1000, 4096)
 
     To view the filter, you can use the `~gwpy.plotter.BodePlot`:
 
-    .. plot::
-       :context:
-
-       from gwpy.plotter import BodePlot
-       plot = BodePlot(zpk, sample_rate=4096)
-       plot.show()
+    >>> from gwpy.plotter import BodePlot
+    >>> plot = BodePlot(bp, sample_rate=4096)
+    >>> plot.show()
     """
     sample_rate = _as_float(sample_rate)
     flow = _as_float(flow)
@@ -390,20 +520,14 @@ def notch(frequency, sample_rate, type='iir', **kwargs):
     --------
     To create a low-pass filter at 1000 Hz for 4096 Hz-sampled data:
 
-    .. plot::
-       :context: reset
-
-       from gwpy.signal import notch
-       n = notch(100, 4096)
+    >>> from gwpy.signal.filter_design import notch
+    >>> n = notch(100, 4096)
 
     To view the filter, you can use the `~gwpy.plotter.BodePlot`:
 
-    .. plot::
-       :context:
-
-       from gwpy.plotter import BodePlot
-       plot = BodePlot(n, sample_rate=4096)
-       plot.show()
+    >>> from gwpy.plotter import BodePlot
+    >>> plot = BodePlot(n, sample_rate=4096)
+    >>> plot.show()
     """
     frequency = Quantity(frequency, 'Hz').value
     sample_rate = Quantity(sample_rate, 'Hz').value
@@ -445,19 +569,21 @@ def concatenate_zpks(*zpks):
 
     Examples
     --------
-    .. plot::
-       :context: reset
+    Create a lowpass and a highpass filter, and combine them:
 
-       from gwpy.signal import (highpass, lowpass, concatenate_zpks)
-       hp = highpass(100, 4096)
-       lp = lowpass(1000, 4096)
-       zpk = concatenate_zpks(hp, lp)
+    >>> from gwpy.signal.filter_design import (
+    ...     highpass, lowpass, concatenate_zpks)
+    >>> hp = highpass(100, 4096)
+    >>> lp = lowpass(1000, 4096)
+    >>> zpk = concatenate_zpks(hp, lp)
 
-       from gwpy.plotter import BodePlot
-       plot = BodePlot(zpk, sample_rate=4096)
-       plot.show()
+    Plot the filter:
+
+    >>> from gwpy.plotter import BodePlot
+    >>> plot = BodePlot(zpk, sample_rate=4096)
+    >>> plot.show()
     """
     zeros, poles, gains = zip(*zpks)
-    return (concatenate(zeros),
-            concatenate(poles),
+    return (numpy.concatenate(zeros),
+            numpy.concatenate(poles),
             reduce(operator.mul, gains, 1))

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -35,6 +35,7 @@ from ..types import (Array2D, Series)
 from ..timeseries import (TimeSeries, TimeSeriesList)
 from ..timeseries.core import _format_time
 from ..frequencyseries import FrequencySeries
+from ..frequencyseries._fdcommon import fdfilter
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org"
 
@@ -386,17 +387,23 @@ class Spectrogram(Array2D):
                                frequencies=(hasattr(self, '_frequencies') and
                                             self.frequencies or None))
 
-    def zpk(self, zeros, poles, gain):
+    def zpk(self, zeros, poles, gain, analog=True):
         """Filter this `Spectrogram` by applying a zero-pole-gain filter
 
         Parameters
         ----------
         zeros : `array-like`
             list of zero frequencies (in Hertz)
+
         poles : `array-like`
             list of pole frequencies (in Hertz)
+
         gain : `float`
             DC gain of filter
+
+        analog : `bool`, optional
+            type of ZPK being applied, if `analog=True` all parameters
+            will be converted in the Z-domain for digital filtering
 
         Returns
         -------
@@ -415,73 +422,42 @@ class Spectrogram(Array2D):
 
             >>> data2 = data.zpk([100]*5, [1]*5, 1e-10)
         """
-        return self.filter(zeros, poles, gain)
+        return self.filter(zeros, poles, gain, analog=analog)
 
     def filter(self, *filt, **kwargs):
         """Apply the given filter to this `Spectrogram`.
-
-        Recognised filter arguments are converted into the standard
-        ``(numerator, denominator)`` representation before being applied
-        to this `Spectrogram`.
-
-        .. note::
-
-           Unlike the related
-           :meth:`TimeSeries.filter <gwpy.timeseries.TimeSeries.filter>`
-           method, here all frequency information (e.g. frequencies of
-           poles or zeros in a ZPK) is assumed to be in Hertz.
 
         Parameters
         ----------
         *filt
             one of:
 
-            - `scipy.signal.lti`
+            - :class:`scipy.signal.lti`
             - ``(numerator, denominator)`` polynomials
             - ``(zeros, poles, gain)``
             - ``(A, B, C, D)`` 'state-space' representation
 
+        analog : `bool`, optional
+            if `True`, filter definition will be converted from Hertz
+            to Z-domain digital representation, default: `False`
+
+        inplace : `bool`, optional
+            if `True`, this array will be overwritten with the filtered
+            version, default: `False`
+
         Returns
         -------
         result : `Spectrogram`
-            the filtered version of the input `Spectrogram`
-
-        See also
-        --------
-        FrequencySeries.zpk
-            for information on filtering in zero-pole-gain format
-        scipy.signal.zpk2tf
-            for details on converting ``(zeros, poles, gain)`` into
-            transfer function format
-        scipy.signal.ss2tf
-            for details on converting ``(A, B, C, D)`` to transfer function
-            format
-        scipy.signal.freqs
-            for details on the filtering calculation
+            the filtered version of the input `Spectrogram`,
+            if ``inplace=True`` was given, this is just a reference to
+            the modified input array
 
         Raises
         ------
         ValueError
-            If ``filt`` arguments cannot be interpreted properly
+            if ``filt`` arguments cannot be interpreted properly
         """
-        # parse filter
-        if len(filt) == 1 and isinstance(filt[0], signal.lti):
-            filt = filt[0]
-        else:
-            # pylint: disable=no-value-for-parameter
-            filt = signal.lti(*filt)
-        # parse keyword args
-        inplace = kwargs.pop('inplace', False)
-        if kwargs:
-            raise TypeError("Spectrogram.filter() got an unexpected keyword "
-                            "argument '%s'" % list(kwargs.keys())[0])
-        freqs = self.frequencies.value.copy()
-        fresp = numpy.nan_to_num(abs(filt.freqresp(w=freqs)[1]))
-        if inplace:
-            self *= fresp
-            return self
-        new = self * fresp
-        return new
+        return fdfilter(self, *filt, **kwargs)
 
     def variance(self, bins=None, low=None, high=None, nbins=500,
                  log=False, norm=False, density=False):

--- a/gwpy/tests/test_spectrogram.py
+++ b/gwpy/tests/test_spectrogram.py
@@ -164,7 +164,8 @@ class TestSpectrogram(TestArray2D):
 
     def test_zpk(self, array):
         zpk = [], [1], 1
-        utils.assert_quantity_sub_equal(array.zpk(*zpk), array.filter(*zpk))
+        utils.assert_quantity_sub_equal(
+            array.zpk(*zpk), array.filter(*zpk, analog=True))
 
     def test_filter(self):
         array = self.create(t0=0, dt=1/1024., f0=0, df=1)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1062,6 +1062,16 @@ class TestTimeSeries(TestTimeSeriesBase):
         detrended = losc.detrend()
         assert numpy.isclose(detrended.value.mean(), 0.0)
 
+    def test_filter(self, losc):
+        zpk = [], [], 1
+        fts = losc.filter(zpk, analog=True)
+        utils.assert_quantity_sub_equal(losc, fts)
+
+    def test_zpk(self, losc):
+        zpk = [10, 10], [1, 1], 100
+        utils.assert_quantity_sub_equal(
+            losc.zpk(*zpk), losc.filter(*zpk, analog=True))
+
     def test_notch(self, losc):
         # test notch runs end-to-end
         notched = losc.notch(60)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -366,10 +366,7 @@ class TestTimeSeriesBaseDict(object):
     def test_resample(self, instance):
         if self.ENTRY_CLASS is TimeSeriesBase:  # currently only for subclasses
             return NotImplemented
-        if issubclass(self.ENTRY_CLASS, TimeSeries):
-            a = instance.resample(.5, ftype='iir')
-        else:
-            a = instance.resample(.5)
+        a = instance.resample(.5)
         for key in a:
             assert a[key].dx == 1/.5 * a[key].xunit
 

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -366,7 +366,7 @@ class TestTimeSeriesBaseDict(object):
     def test_resample(self, instance):
         if self.ENTRY_CLASS is TimeSeriesBase:  # currently only for subclasses
             return NotImplemented
-        a = instance.resample(.5)
+        a = instance.resample(.5, ftype='iir')
         for key in a:
             assert a[key].dx == 1/.5 * a[key].xunit
 

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -366,7 +366,10 @@ class TestTimeSeriesBaseDict(object):
     def test_resample(self, instance):
         if self.ENTRY_CLASS is TimeSeriesBase:  # currently only for subclasses
             return NotImplemented
-        a = instance.resample(.5, ftype='iir')
+        if issubclass(self.ENTRY_CLASS, TimeSeries):
+            a = instance.resample(.5, ftype='iir')
+        else:
+            a = instance.resample(.5)
         for key in a:
             assert a[key].dx == 1/.5 * a[key].xunit
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1127,20 +1127,21 @@ class TimeSeries(TimeSeriesBase):
         # parse keyword arguments
         filtfilt = kwargs.pop('filtfilt', False)
 
+        # parse filter
+        sos = None
         try:
             lti = filter_design.parse_digital_lti(
                 filt, analog=kwargs.pop('analog', False),
                 sample_rate=self.sample_rate.to('Hz').value)
         except ValueError:
             if (len(filt) == 1 and isinstance(filt[0], numpy.ndarray) and
-                filt[0].ndim == 1):  # FIR
+                    filt[0].ndim == 1):  # FIR
                 a = [1.]
                 b = filt[0]
         else:
             # determine FIR or IIR
             try:
                 if lti.den.shape == (1,) and lti.den[0] == (1.):  # FIR
-                    sos = None
                     a = lti.den
                     b = lti.num
                 else:
@@ -1151,7 +1152,6 @@ class TimeSeries(TimeSeriesBase):
                 try:
                     sos = signal.zpk2sos(lti.zeros, lti.poles, lti.gain)
                 except AttributeError:  # scipy < 0.16, no SOS filtering
-                    sos = None
                     a = lti.den
                     b = lti.num
 


### PR DESCRIPTION
This PR improves the way FIR and IIR filters are passed to filtering functions, and normalises duplicated code into the relevant modules. Summary is:

- new common methods under `signal.filter_design` for parsing filter arguments, and converting analog ZPK to digital, used by `<Array>.filter` instance methods
- added common frequency-domain methods module as `frequencyseries._fdcommon`, which now feeds `FrequencySeries.filter` and `TimeSeries.filter`
- improved documentation of methods and functions