### PR TITLE
Added skip decorator for missing h5py in Spectrogram tests

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -58,9 +58,11 @@ dpkg --install ${GWPY_DEB} || { \
 }
 
 # install system-level extras for the correct python version
-apt-get -yq --ignore-missing install \
+for pckg in \
     ${PY_PREFIX}-nds2-client \
     ldas-tools-framecpp-${PY_PREFIX} \
     lalframe-${PY_PREFIX} \
     ${PY_PREFIX}-h5py \
-|| true
+; do
+    apt-get -yqq install $pckg || true
+done

--- a/gwpy/tests/test_spectrogram.py
+++ b/gwpy/tests/test_spectrogram.py
@@ -187,6 +187,7 @@ class TestSpectrogram(TestArray2D):
         with pytest.raises(TypeError):
             array.filter(lti, blah=1)
 
+    @utils.skip_missing_dependency('h5py')
     def test_read_write_hdf5(self):
         array = self.create(name='X1:TEST')
         utils.test_read_write(array, 'hdf5', write_kw={'overwrite': True})


### PR DESCRIPTION
This PR fixes a test that fails when `h5py` is missing by adding a decorator to skip that test in that situation (since `h5py` is optional).