### PR TITLE
Fixed problems with filtering ROOT files when reading

### DIFF
--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -173,13 +173,11 @@ def parse_column_filters(*definitions):
     """  # nopep8
     fltrs = []
     for def_ in _flatten(definitions):
-        print(type(def_), def_)
         if is_filter_tuple(def_):
             fltrs.append(def_)
         else:
             for splitdef in DELIM_REGEX.split(def_)[::2]:
                 fltrs.extend(parse_column_filter(splitdef))
-    print(fltrs)
     return fltrs
 
 

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -241,9 +241,9 @@ class TestTable(object):
             assert str(exc.value).startswith('Multiple trees found')
 
             # test selections work
-            t2 = _read(treename='test', selection='frequency > 500')
+            t2 = _read(treename='test', selection='200 < frequency < 500')
             utils.assert_table_equal(
-                t2, filter_table(table, 'frequency > 500'))
+                t2, filter_table(table, '200 < frequency < 500'))
 
         finally:
             if os.path.isdir(tempdir):

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -241,9 +241,16 @@ class TestTable(object):
             assert str(exc.value).startswith('Multiple trees found')
 
             # test selections work
-            t2 = _read(treename='test', selection='200 < frequency < 500')
+            segs = SegmentList([Segment(100, 200), Segment(400, 500)])
+            t2 = _read(treename='test',
+                       selection=['200 < frequency < 500',
+                                  ('time', filters.in_segmentlist, segs)])
             utils.assert_table_equal(
-                t2, filter_table(table, '200 < frequency < 500'))
+                t2, filter_table(table,
+                                 'frequency > 200',
+                                 'frequency < 500',
+                                 ('time', filters.in_segmentlist, segs)),
+            )
 
         finally:
             if os.path.isdir(tempdir):


### PR DESCRIPTION
This PR fixes a problem with filtering on-the-fly when reading ROOT files using `root_numpy`.

`root_numpy` has support for on-the-fly selections, but obviously can't handle gwpy-style function filters, so we need to separate out the simple filters from the function filters and perform each appropriately.

I updated the unit tests to capture this in `test_read_write_root`.