### PR TITLE
Added option to cast ligolw types to numpy when reading Tables

### DIFF
--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -121,6 +121,17 @@ These 'columns' can be requested directly, providing the :class:`glue.ligolw.tab
 
       >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['snr', 'q'], ligolw_columns=['snr', 'duration', 'central_freq'])
 
+By default, the returned `Table` or `EventTable` uses the dtypes returned by the :mod:`glue.ligolw` library, and functions therein, which often end up as `numpy.object_` arrays in the table.
+To force all columns to have real `numpy` data types, use the ``use_numpy_dtypes=True`` keyword, which will cast (known) custom object types to a standard `numpy.dtype`, e.g::
+
+   >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['peak'], ligolw_columns=['peak_time', 'peak_time_ns'])
+   >>> print(type(t[0]['peak']))
+   <type 'lal.LIGOTimeGPS'>
+   >>> t = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst', columns=['peak'], ligolw_columns=['peak_time', 'peak_time_ns'], use_numpy_dtypes=True)
+   >>> print(type(t[0]['peak']))
+   <type 'numpy.float64'>
+
+
 Writing
 -------
 

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -33,6 +33,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 XML_SIGNATURE = b'<?xml'
 LIGOLW_SIGNATURE = b'<!doctype ligo_lw'
+LIGOLW_ELEMENT = b'<ligo_lw>'
 
 
 # -- content handling ---------------------------------------------------------
@@ -449,10 +450,11 @@ def is_ligolw(origin, filepath, fileobj, *args, **kwargs):
             line2 = fileobj.readline().lower()
             try:
                 return (line1.startswith(XML_SIGNATURE) and
-                        line2.startswith(LIGOLW_SIGNATURE))
+                        line2.startswith((LIGOLW_SIGNATURE, LIGOLW_ELEMENT)))
             except TypeError:  # bytes vs str
                 return (line1.startswith(XML_SIGNATURE.decode('utf-8')) and
-                        line2.startswith(LIGOLW_SIGNATURE.decode('utf-8')))
+                        line2.startswith(LIGOLW_SIGNATURE.decode('utf-8'),
+                                         LIGOLW_ELEMENT.decode('utf-8')))
         finally:
             fileobj.seek(loc)
     try:

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -27,7 +27,7 @@ from astropy.io import registry as io_registry
 
 from ...time import LIGOTimeGPS
 from ...io.ligolw import (is_xml, build_content_handler, read_ligolw,
-                          write_tables)
+                          write_tables, patch_ligotimegps)
 from ...segments import (DataQualityFlag, DataQualityDict)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -90,8 +90,9 @@ def read_ligolw_dict(source, flags=None, gpstype=LIGOTimeGPS, coalesce=False):
               table_ in (SegmentDefTable, SegmentSumTable, SegmentTable)]
 
     # parse tables
-    out = DataQualityDict.from_ligolw_tables(*tables, names=flags,
-                                             gpstype=gpstype)
+    with patch_ligotimegps():
+        out = DataQualityDict.from_ligolw_tables(*tables, names=flags,
+                                                 gpstype=gpstype)
 
     # coalesce
     if coalesce:

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -30,7 +30,7 @@ import pytest
 
 import sqlparse
 
-from numpy import (random, isclose)
+from numpy import (random, isclose, dtype)
 
 from matplotlib import use, rc_context
 use('agg')  # nopep8
@@ -148,8 +148,16 @@ class TestTable(object):
                 t3['peak'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
 
             # check auto-discovery of 'time' columns works
+            from glue.ligolw.lsctables import LIGOTimeGPS
             t3 = _read(columns=['time'])
             assert 'time' in t3.columns
+            assert isinstance(t3[0]['time'], LIGOTimeGPS)
+            utils.assert_array_equal(
+                t3['time'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
+
+            # check numpy type casting works
+            t3 = _read(columns=['time'], use_numpy_dtypes=True)
+            assert t3['time'].dtype == dtype('float64')
             utils.assert_array_equal(
                 t3['time'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
 


### PR DESCRIPTION
This PR implements a new keyword argument `use_numpy_dtypes` when reading `LIGO_LW`-format XML files into a `Table`. This casts known custom object types to numpy types to prevent `numpy.object_` dtypes in the returned table (since e.g. HDF5 can't write them).