### PR TITLE
Handle object dtypes in EventTable.event_rate

### DIFF
--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -286,6 +286,8 @@ class EventTable(Table):
         """
         from gwpy.timeseries import TimeSeries
         times = self[timecolumn]
+        if times.dtype is numpy.dtype('O'):  # cast to ufunc-compatible type
+            times = times.astype('float64', copy=False)
         if not start:
             start = times.min()
         if not end:

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -328,6 +328,15 @@ class TestEventTable(TestTable):
         assert isinstance(rate, TimeSeries)
         assert rate.sample_rate == 1 * units.Hz
 
+        # repeat with object dtype
+        try:
+            from lal import LIGOTimeGPS
+        except ImportError:
+            return
+        lgps = map(LIGOTimeGPS, table['time'])
+        t2 = type(table)(data=[lgps], names=['time'])
+        rate2 = t2.event_rate(1, start=table['time'].min())
+        utils.assert_quantity_sub_equal(rate, rate2)
 
     def test_binned_event_rates(self, table):
         rates = table.binned_event_rates(100, 'snr', [10, 100],


### PR DESCRIPTION
This PR fixes a corner-case issue in `EventTable.event_rate` when `numpy.histogram` can't handle `numpy.object_` dtypes. The fix is to cast these to `float64` on-the-fly.