### PR TITLE
Added verbose output to gwpy.io.mp.read_multi

### DIFF
--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -61,6 +61,8 @@ def read_multi(flatten, cls, source, *args, **kwargs):
     **kwargs
         keyword arguments to pass to the reader
     """
+    verbose = kwargs.pop('verbose', False)
+
     # parse input as a list of files
     try:  # try and map to a list of file-like objects
         files = file_list(source)
@@ -101,9 +103,14 @@ def read_multi(flatten, cls, source, *args, **kwargs):
                 return fobj, exc.getException()  # pylint: disable=no-member
             return fobj, exc
 
+    # format verbosity
+    if verbose is True:
+        verbose = 'Reading ({}):'.format(kwargs['format'])
+
     # read files
     output = mp_utils.multiprocess_with_queues(
-        nproc, _read_single_file, files, raise_exceptions=False)
+        nproc, _read_single_file, files, raise_exceptions=False,
+        verbose=verbose)
 
     # raise exceptions (from multiprocessing, single process raises inline)
     for fobj, exc in output:

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -560,6 +560,9 @@ class DataQualityFlag(object):
             require segment start and stop times match printed duration,
             only valid for ``format='segwizard'``.
 
+        verbose : `bool`, optional, default: `False`
+            print a progress bar showing read status
+
         Returns
         -------
         dqflag : `DataQualityFlag`

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -560,6 +560,9 @@ class DataQualityFlag(object):
             require segment start and stop times match printed duration,
             only valid for ``format='segwizard'``.
 
+        nproc : `int`, optional, default: 1
+            number of CPUs to use for parallel reading of multiple files
+
         verbose : `bool`, optional, default: `False`
             print a progress bar showing read status
 
@@ -1174,6 +1177,12 @@ class DataQualityDict(OrderedDict):
 
         coalesce : `bool`, optional, default: `True`
             coalesce all `SegmentLists` before returning.
+
+        nproc : `int`, optional, default: 1
+            number of CPUs to use for parallel reading of multiple files
+
+        verbose : `bool`, optional, default: `False`
+            print a progress bar showing read status
 
         Returns
         -------

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -105,6 +105,9 @@ class EventTable(Table):
         nproc : `int`, optional, default: 1
             number of CPUs to use for parallel file reading
 
+        verbose : `bool`, optional, default: `False`
+            print a progress bar showing read status
+
         .. note::
 
            Keyword arguments other than those listed here may be required

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -103,10 +103,10 @@ class EventTable(Table):
             ``['snr > 5', 'frequency < 1000']``
 
         nproc : `int`, optional, default: 1
-            number of CPUs to use for parallel file reading
+            number of CPUs to use for parallel reading of multiple files
 
-        verbose : `bool`, optional, default: `False`
-            print a progress bar showing read status
+        verbose : `bool`, optional
+            print a progress bar showing read status, default: `False`
 
         .. note::
 

--- a/gwpy/utils/mp.py
+++ b/gwpy/utils/mp.py
@@ -102,6 +102,8 @@ def multiprocess_with_queues(nproc, func, inputs, raise_exceptions=False,
     stream = sys.stdout if verbose else StringIO()
     if verbose is True:
         verbose = 'Processing:'
+    elif not verbose:
+        verbose = ''
 
     bar = _MultiProgressBarOrSpinner(total, verbose, file=stream)
 


### PR DESCRIPTION
This PR implements a multiprocess-friendly `ProgressBar` mainly for the `gwpy.io.mp.read_multi` I/O utility method. With this enable (`verbose=True`) you should get something like this: 

```
Reading (ligolw):
|==========================================| 1.8k/1.8k (100.00%)      1m48s
```

All kudos go to whomsoever added this to Astropy.