### PR TITLE
Added stretch-proposed docker build to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,18 @@ matrix:
       services:
         - docker
 
+    # debian 9 testing build
+    - env: DOCKER_IMAGE="ligo/software:stretch-proposed"
+      python: '2.7'
+      sudo: required
+      services:
+        - docker
+    - env: DOCKER_IMAGE="ligo/software:stretch-proposed"
+      python: '3.5'
+      sudo: required
+      services:
+        - docker
+
     # sl7 build
     - env: DOCKER_IMAGE="ligo/software:el7"
       python: '2.7'
@@ -119,6 +131,8 @@ matrix:
     - env: DOCKER_IMAGE="ligo/software:jessie"
       python: '3.4'
     - env: DOCKER_IMAGE="ligo/software:stretch"
+      python: '3.5'
+    - env: DOCKER_IMAGE="ligo/software:stretch-proposed"
       python: '3.5'
     - env: DOCKER_IMAGE="ligo/software:el7"
       python: '3.5'

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -489,8 +489,8 @@ def is_ligolw(origin, filepath, fileobj, *args, **kwargs):
                         line2.startswith((LIGOLW_SIGNATURE, LIGOLW_ELEMENT)))
             except TypeError:  # bytes vs str
                 return (line1.startswith(XML_SIGNATURE.decode('utf-8')) and
-                        line2.startswith(LIGOLW_SIGNATURE.decode('utf-8'),
-                                         LIGOLW_ELEMENT.decode('utf-8')))
+                        line2.startswith((LIGOLW_SIGNATURE.decode('utf-8'),
+                                          LIGOLW_ELEMENT.decode('utf-8'))))
         finally:
             fileobj.seek(loc)
     try:

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -348,7 +348,7 @@ class TestEventTable(TestTable):
             from lal import LIGOTimeGPS
         except ImportError:
             return
-        lgps = map(LIGOTimeGPS, table['time'])
+        lgps = list(map(LIGOTimeGPS, table['time']))
         t2 = type(table)(data=[lgps], names=['time'])
         rate2 = t2.event_rate(1, start=table['time'].min())
         utils.assert_quantity_sub_equal(rate, rate2)


### PR DESCRIPTION
This PR adds a docker build for the `ligo-software/stretch-proposed` image, which should get a bit further on python3 (according to @tpdownes).