### PR TITLE
Improvements to LOSC data fetching

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1214,6 +1214,57 @@ class TestStateTimeSeriesDict(TestTimeSeriesBaseDict):
         return NotImplemented
 
 
+# -- Bits ---------------------------------------------------------------------
+
+class TestBits(object):
+    TEST_CLASS = Bits
+
+    @pytest.mark.parametrize('in_, out', [
+        # list
+        (['bit 0', 'bit 1', 'bit 2', None, 'bit 3', ''],
+         ['bit 0', 'bit 1', 'bit 2', None, 'bit 3', None]),
+        # dict
+        ({1: 'bit 1', 4: 'bit 4', '6': 'bit 6'},
+         [None, 'bit 1', None, None, 'bit 4', None, 'bit 6']),
+    ])
+    def test_init(self, in_, out):
+        bits = self.TEST_CLASS(in_)
+        assert bits == out
+        assert bits.channel is None
+        assert bits.epoch is None
+        assert bits.description == {bit: None for bit in bits if
+                                    bit is not None}
+
+        bits = self.TEST_CLASS(in_, channel='L1:Test', epoch=0)
+        assert bits.epoch == Time(0, format='gps')
+        assert bits.channel == Channel('L1:Test')
+
+    def test_str(self):
+        bits = self.TEST_CLASS(['a', 'b', None, 'c'])
+        assert str(bits) == (
+            "Bits(0: a\n"
+            "     1: b\n"
+            "     3: c,\n"
+            "     channel=None,\n"
+            "     epoch=None)")
+
+    def test_repr(self):
+        bits = self.TEST_CLASS(['a', 'b', None, 'c'])
+        assert repr(bits) == (
+            "<Bits(0: 'a'\n"
+            "      1: 'b'\n"
+            "      3: 'c',\n"
+            "      channel=None,\n"
+            "      epoch=None)>")
+
+    def test_array(self):
+        bits = self.TEST_CLASS(['a', 'b', None, 'c'])
+        utils.assert_array_equal(
+            numpy.asarray(bits),
+            ['a', 'b', '', 'c'],
+        )
+
+
 # -- StateVector---------------------------------------------------------------
 
 class TestStateVector(TestTimeSeriesBase):

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1380,7 +1380,8 @@ class TestStateVector(TestTimeSeriesBase):
 
     @pytest.mark.parametrize('format', [
         pytest.param('hdf5', marks=utils.skip_missing_dependency('h5py')),
-        pytest.param('gwf', marks=utils.skip_missing_dependency('lalframe')),
+        pytest.param(  # only frameCPP actually reads units properly
+            'gwf', marks=utils.skip_missing_dependency('LDAStools.frameCPP')),
     ])
     def test_fetch_open_data(self, format):
         try:

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -696,7 +696,7 @@ class TestTimeSeries(TestTimeSeriesBase):
     def test_fetch_open_data(self, losc, format):
         try:
             ts = self.TEST_CLASS.fetch_open_data(
-                LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format)
+                LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, verbose=True)
         except URLError as e:
             pytest.skip(str(e))
         utils.assert_quantity_sub_equal(ts, losc, exclude=['name', 'unit'])

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -316,6 +316,45 @@ class TimeSeriesBase(Series):
         **kwargs
             any other keyword arguments are passed to the `TimeSeries.read`
             method that parses the file that was downloaded
+
+        Examples
+        --------
+        >>> from gwpy.timeseries import (TimeSeries, StateVector)
+        >>> print(TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
+        TimeSeries([  2.17704028e-19,  2.08763900e-19,  2.39681183e-19,
+                    ...,   3.55365541e-20,  6.33533516e-20,
+                      7.58121195e-20]
+                   unit: Unit(dimensionless),
+                   t0: 1126259446.0 s,
+                   dt: 0.000244140625 s,
+                   name: Strain,
+                   channel: None)
+        >>> print(StateVector.fetch_open_data('H1', 1126259446, 1126259478)
+        StateVector([127,127,127,127,127,127,127,127,127,127,127,127,
+                     127,127,127,127,127,127,127,127,127,127,127,127,
+                     127,127,127,127,127,127,127,127]
+                    unit: Unit(dimensionless),
+                    t0: 1126259446.0 s,
+                    dt: 1.0 s,
+                    name: Data quality,
+                    channel: None,
+                    bits: Bits(0: data present
+                               1: passes cbc CAT1 test
+                               2: passes cbc CAT2 test
+                               3: passes cbc CAT3 test
+                               4: passes burst CAT1 test
+                               5: passes burst CAT2 test
+                               6: passes burst CAT3 test,
+                               channel=None,
+                               epoch=1126259446.0))
+
+        For the `StateVector`, the naming of the bits will be
+        ``format``-dependent, because they are recorded differently by LOSC
+        in different formats.
+
+        Notes
+        -----
+        `StateVector` data are not available in ``txt.gz`` format.
         """
         from .io.losc import fetch_losc_data
         return fetch_losc_data(ifo, start, end, sample_rate=sample_rate,

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -122,7 +122,7 @@ class TimeSeriesBase(Series):
         allow passing of sub-classes by the array generator
     """
     _default_xunit = units.second
-    _print_slots = ['t0', 'dt', 'name', 'channel']
+    _print_slots = ('t0', 'dt', 'name', 'channel')
     DictClass = None
 
     def __new__(cls, data, unit=None, t0=None, dt=None, sample_rate=None,

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -62,12 +62,13 @@ __all__ = ['TimeSeriesBase', 'ArrayTimeSeries', 'TimeSeriesBaseDict']
 
 ASTROPY_2_0 = astropy_version >= '2.0'
 
-_UFUNC_STRING = {'less': '<',
-                 'less_equal': '<=',
-                 'equal': '==',
-                 'greater_equal': '>=',
-                 'greater': '>',
-                }
+_UFUNC_STRING = {
+    'less': '<',
+    'less_equal': '<=',
+    'equal': '==',
+    'greater_equal': '>=',
+    'greater': '>',
+}
 
 
 def _format_time(gps):
@@ -892,8 +893,8 @@ class TimeSeriesBaseDict(OrderedDict):
                         for c in channels)
             err = "Cannot find all relevant data on any known server."
             if not verbose:
-                err += (" Try again using the verbose=True keyword argument to "
-                        "see detailed failures.")
+                err += (" Try again using the verbose=True keyword argument "
+                        " to see detailed failures.")
             raise RuntimeError(err)
 
         # -- at this point we have an open connection, so perform fetch

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -272,7 +272,7 @@ class TimeSeriesBase(Series):
     @classmethod
     def fetch_open_data(cls, ifo, start, end, sample_rate=4096,
                         format=None, host='https://losc.ligo.org',
-                        verbose=False, **kwargs):
+                        verbose=False, cache=False, **kwargs):
         """Fetch open-access data from the LIGO Open Science Center
 
         Parameters
@@ -289,32 +289,38 @@ class TimeSeriesBase(Series):
             GPS end time of required data, defaults to end of data found;
             any input parseable by `~gwpy.time.to_gps` is fine
 
-        sample_rate : `float`, optional, default: `4096`
-            the sample rate of desired data. Most data are stored
+        sample_rate : `float`, optional,
+            the sample rate of desired data; most data are stored
             by LOSC at 4096 Hz, however there may be event-related
-            data releases with a 16384 Hz rate
+            data releases with a 16384 Hz rate, default: `4096`
 
         format : `str`, optional
-            the data format to download and parse, defaults to 'txt.gz'
-            which requires no extra packages. Other options include
+            the data format to download and parse, defaults to the most
+            efficient option based on third-party libraries available;
+            one of:
 
+            - ``'txt.gz'`` - requires `numpy`
             - ``'hdf5'`` - requires |h5py|_
             - ``'gwf'`` - requires |LDAStools.frameCPP|_
+
+        host : `str`, optional
+            HTTP host name of LOSC server to access
 
         verbose : `bool`, optional, default: `False`
             print verbose output while fetching data
 
-        host : `str`, optional
-            HTTP host name of LOSC server to access
+        cache : `bool`, optional
+            save/read a local copy of the remote URL, default: `False`;
+            useful if the same remote data are to be accessed multiple times
 
         **kwargs
             any other keyword arguments are passed to the `TimeSeries.read`
             method that parses the file that was downloaded
         """
         from .io.losc import fetch_losc_data
-        return fetch_losc_data(ifo, start, end, cls=cls,
-                               sample_rate=sample_rate, format=format,
-                               host=host, verbose=verbose, **kwargs)
+        return fetch_losc_data(ifo, start, end, sample_rate=sample_rate,
+                               format=format, verbose=verbose, cache=cache,
+                               host=host, cls=cls, **kwargs)
 
     @classmethod
     def find(cls, channel, start, end, frametype=None,

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -124,6 +124,38 @@ def import_gwf_library(library, package=__package__):
         raise
 
 
+def get_default_gwf_api():
+    """Return the preferred GWF library
+
+    Examples
+    --------
+    If you have |LDAStools.frameCPP|_ installed:
+
+    >>> from gwpy.timeseries.io.gwf import get_default_gwf_api
+    >>> get_default_gwf_api()
+    'framecpp'
+
+    Or, if you don't have |lalframe|_:
+
+    >>> get_default_gwf_api()
+    'lalframe'
+
+    Otherwise:
+
+    >>> get_default_gwf_api()
+    ImportError: no GWF API available, please install a third-party GWF library (framecpp, lalframe) and try again
+    """
+    for lib in APIS:
+        try:
+            import_gwf_library(lib)
+        except ImportError as e:
+            continue
+        else:
+            return lib
+    raise ImportError("no GWF API available, please install a third-party GWF "
+                      "library ({}) and try again".format(', '.join(APIS)))
+
+
 # -- generic I/O methods ------------------------------------------------------
 
 def register_gwf_api(library):
@@ -360,30 +392,13 @@ def register_gwf_format(container):
     container : `Series`, `dict`
         series class or series dict class to register
     """
-    formats = get_formats(data_class=container)
     def read_(*args, **kwargs):
-        for fmt in formats:
-            if fmt['Format'].startswith('gwf.'):
-                kwargs['format'] = fmt['Format']
-                try:
-                    return container.read(*args, **kwargs)
-                except ImportError:
-                    continue
-        raise ImportError("No GWF API available with which to read these "
-                          "data. Please install one of the third-party GWF "
-                          "libraries and try again")
+        kwargs['format'] = 'gwf.{}'.format(get_default_gwf_api())
+        return container.read(*args, **kwargs)
 
     def write_(*args, **kwargs):
-        for fmt in formats:
-            if fmt['Format'].startswith('gwf.'):
-                kwargs['format'] = fmt['Format']
-                try:
-                    return container.write(*args, **kwargs)
-                except ImportError:
-                    continue
-        raise ImportError("No GWF API available with which to write these "
-                          "data. Please install one of the third-party GWF "
-                          "libraries and try again")
+        kwargs['format'] = 'gwf.{}'.format(get_default_gwf_api())
+        return container.write(*args, **kwargs)
 
     register_identifier('gwf', container, identify_gwf)
     register_reader('gwf', container, read_)

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -103,7 +103,7 @@ def _read_framefile(framefile, channels, start=None, end=None, ctype=None,
         end = 0
 
     # open file
-    stream = frameCPP.IFrameFStream(framefile)
+    stream = frameCPP.IFrameFStream(str(framefile))
 
     # get number of frames in file
     try:

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -67,22 +67,26 @@ def open_data_source(source):
     if isinstance(source, GlueCacheEntry):
         source = source.path
 
-    # read single file
-    if isinstance(source, string_types) and source.endswith('.gwf'):
-        return lalframe.FrStreamOpen(*os.path.split(source))
     # read cache file
-    elif (isinstance(source, string_types) and
+    if (isinstance(source, string_types) and
           source.endswith(('.lcf', '.cache'))):
         return lalframe.FrStreamCacheOpen(lal.CacheImport(source))
+
     # read glue cache object
-    elif isinstance(source, GlueCache):
+    if isinstance(source, GlueCache):
         cache = lal.Cache()
         for entry in source:
             cache = lal.CacheMerge(
                 cache, lal.CacheGlob(*os.path.split(entry.path)))
         return lalframe.FrStreamCacheOpen(cache)
-    elif isinstance(source, lal.Cache):
+
+    # read lal cache object
+    if isinstance(source, lal.Cache):
         return lalframe.FrStreamCacheOpen(source)
+
+    # read single file
+    if isinstance(source, string_types):
+        return lalframe.FrStreamOpen(*os.path.split(source))
 
     raise ValueError("Don't know how to open data source of type %r"
                      % type(source))

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -412,7 +412,7 @@ class StateVector(TimeSeriesBase):
 
     """
     _metadata_slots = TimeSeriesBase._metadata_slots + ('bits',)
-    _print_slots = TimeSeriesBase._print_slots + ('bits',)
+    _print_slots = TimeSeriesBase._print_slots + ('_bits',)
 
     def __new__(cls, data, bits=None, t0=None, dt=None, sample_rate=None,
                 times=None, channel=None, name=None, **kwargs):

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -249,13 +249,25 @@ class Bits(list):
         (bit, desc) `dict` of longer descriptions for each bit
     """
     def __init__(self, bits, channel=None, epoch=None, description=None):
-        list.__init__(self, [b or None for b in bits])
+        # handle dict of (index, bitname) pairs
+        if isinstance(bits, dict):
+            n = max(map(int, bits.keys())) + 1
+            list.__init__(self, [None] * n)
+            for key, val in bits.items():
+                self[int(key)] = val
+        # otherwise just parse a list of bitnames
+        else:
+            list.__init__(self, [b or None for b in bits])
+
+        # populate metadata
         if channel is not None:
             self.channel = channel
         if epoch is not None:
             self.epoch = epoch
         self.description = description
-        for i, bit in enumerate(bits):
+
+        # rebuild descriptions
+        for i, bit in enumerate(self):
             if bit is None or bit in self.description:
                 continue
             elif channel:

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -707,44 +707,6 @@ class StateVector(TimeSeriesBase):
         return new
 
     @classmethod
-    def fetch_open_data(cls, ifo, start, end, format='hdf5',
-                        host='https://losc.ligo.org', verbose=False):
-        """Fetch open-access data from the LIGO Open Science Center
-
-        Parameters
-        ----------
-        ifo : `str`
-            the two-character prefix of the IFO in which you are interested,
-            e.g. `'L1'`
-
-        start : `~gwpy.time.LIGOTimeGPS`, `float`, `str`, optional
-            GPS start time of required data, defaults to start of data found;
-            any input parseable by `~gwpy.time.to_gps` is fine
-
-        end : `~gwpy.time.LIGOTimeGPS`, `float`, `str`, optional
-            GPS end time of required data, defaults to end of data found;
-            any input parseable by `~gwpy.time.to_gps` is fine
-
-        format : `str`, optional
-            the data format to download and parse, defaults to ``'hdf5'``
-            which relies upon |h5py|_
-
-        host : `str`, optional
-            HTTP host name of LOSC server to access
-
-        verbose : `bool`, optional, default: `False`
-            print verbose output while fetching data
-
-        Returns
-        -------
-        state : `~gwpy.timeseries.StateVector`
-            the data-quality statevector recorded by LOSC for this period
-        """
-        from .io.losc import fetch_losc_data
-        return fetch_losc_data(ifo, start, end, format=format, cls=cls,
-                               host=host, verbose=verbose)
-
-    @classmethod
     def get(cls, channel, start, end, bits=None, **kwargs):
         """Get data for this channel from frames or NDS
 

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -412,6 +412,7 @@ class StateVector(TimeSeriesBase):
 
     """
     _metadata_slots = TimeSeriesBase._metadata_slots + ('bits',)
+    _print_slots = TimeSeriesBase._print_slots + ('bits',)
 
     def __new__(cls, data, bits=None, t0=None, dt=None, sample_rate=None,
                 times=None, channel=None, name=None, **kwargs):

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -236,7 +236,7 @@ class Array(Quantity):
                 val = getattr(self, key)
             except (AttributeError, KeyError):
                 val = None
-            mindent = ' ' * (len(key) + 1)
+            mindent = ' ' * (len(key) + 2)
             rval = str(val).replace('\n', '\n%s' % (indent+mindent))
             metadatarepr.append('%s: %s' % (key.strip('_'), rval))
         metadata = (',\n%s' % indent).join(metadatarepr)


### PR DESCRIPTION
This PR combines a few different improvements related to `TimeSeries.fetch_open_data`, namely

- use astropy progress bar for `verbose=True`
- enable astropy download caching with `cache=True`
- fixed errors when `format='gwf'`
- improved unit tests for both `TimeSeries` and `StateVector`