### PR TITLE
Added support for imshow in plotting spectrograms

### DIFF
--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -284,16 +284,18 @@ class TimeSeriesAxes(Axes):
 
         **kwargs
             any other keyword arguments acceptable for
-            :meth:`~matplotlib.Axes.plot`
+            :meth:`~matplotlib.Axes.imshow` (if ``imshow=True``),
+            or :meth:`~matplotlib.Axes.pcolormesh` (``imshow=False``)
 
         Returns
         -------
-        Line2D
-            the `~matplotlib.lines.Line2D` for this line layer
+        layer : `~matplotlib.collections.QuadMesh`, `~matplotlib.images.Image`
+            the layer for this spectrogram
 
         See Also
         --------
-        matplotlib.axes.Axes.plot
+        matplotlib.axes.Axes.imshow
+        matplotlib.axes.Axes.pcolormesh
             for a full description of acceptable ``*args`` and ``**kwargs``
         """
         # rescue grid settings

--- a/gwpy/plotter/utils.py
+++ b/gwpy/plotter/utils.py
@@ -40,9 +40,13 @@ LINE_PARAMS = [
     'linewidth', 'linestyle', 'color', 'label', 'alpha', 'rasterized',
 ]
 COLLECTION_PARAMS = [
-    'cmap', 'vmin', 'vmax', 'marker', 's', 'norm', 'rasterized', 'imshow',
+    'cmap', 'vmin', 'vmax', 'marker', 's', 'norm', 'rasterized',
 ]
-ARTIST_PARAMS = set(LINE_PARAMS + COLLECTION_PARAMS)
+IMAGE_PARAMS = [
+    'imshow', 'cmap', 'vmin', 'vmax', 'norm', 'rasterized', 'extent',
+    'origin', 'interpolation', 'aspect',
+]
+ARTIST_PARAMS = set(LINE_PARAMS + COLLECTION_PARAMS + IMAGE_PARAMS)
 LEGEND_PARAMS = [
     'loc', 'borderaxespad', 'ncol',
 ]

--- a/gwpy/plotter/utils.py
+++ b/gwpy/plotter/utils.py
@@ -40,7 +40,7 @@ LINE_PARAMS = [
     'linewidth', 'linestyle', 'color', 'label', 'alpha', 'rasterized',
 ]
 COLLECTION_PARAMS = [
-    'cmap', 'vmin', 'vmax', 'marker', 's', 'norm', 'rasterized',
+    'cmap', 'vmin', 'vmax', 'marker', 's', 'norm', 'rasterized', 'imshow',
 ]
 ARTIST_PARAMS = set(LINE_PARAMS + COLLECTION_PARAMS)
 LEGEND_PARAMS = [

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -579,7 +579,7 @@ class TestTimeSeriesAxes(TimeSeriesMixin, TestAxes):
     def test_plot_spectrogram(self):
         fig, ax = self.new()
         # check method
-        ax.plot_spectrogram(self.sg)
+        ax.plot_spectrogram(self.sg, imshow=False)
         coll = ax.collections[0]
         nptest.assert_array_equal(coll.get_array(), self.sg.value.T.flatten())
         # check GPS axis is set ok

--- a/gwpy/tests/test_spectrogram.py
+++ b/gwpy/tests/test_spectrogram.py
@@ -151,13 +151,17 @@ class TestSpectrogram(TestArray2D):
         with pytest.warns(UserWarning):
             array.crop_frequencies(array.yspan[0], array.yspan[1]+1)
 
-    def test_plot(self, array):
+    @pytest.mark.parametrize('imshow', (True, False))
+    def test_plot(self, array, imshow):
         with rc_context(rc={'text.usetex': False}):
-            plot = array.plot()
+            plot = array.plot(imshow=imshow)
             assert isinstance(plot, TimeSeriesPlot)
             assert isinstance(plot.gca(), TimeSeriesAxes)
             assert plot.gca().lines == []
-            assert len(plot.gca().collections) == 1
+            if imshow:
+                assert len(plot.gca().images) == 1
+            else:
+                assert len(plot.gca().collections) == 1
             with tempfile.NamedTemporaryFile(suffix='.png') as f:
                 plot.save(f.name)
             plot.close()


### PR DESCRIPTION
This PR enables using `imshow()` for rendering a `Spectrogram` via `TimeSeriesAxes.plot_spectrogram`. matplotlib 2.0 finally fixed the problem of images on a log axes, so we can use it for spectrograms! It is not the default option whenever mpl >= 2.0 is present.

Fixes #172.