### PR TITLE
Optimised (minimised) use of decimal.Decimal in GPSTransform

### DIFF
--- a/gwpy/plotter/gps.py
+++ b/gwpy/plotter/gps.py
@@ -163,7 +163,7 @@ class GPSTransformBase(GPSMixin, Transform):
     def transform(self, values):
         # format ticks using decimal for precision display
         if isinstance(values, (Number, Decimal)):
-            return self._transform_decimal(values, self.epoch, self.scale)
+            return self._transform_decimal(values, self.epoch or 0, self.scale)
         return super(GPSTransformBase, self).transform(values)
 
     def transform_non_affine(self, values):

--- a/gwpy/plotter/gps.py
+++ b/gwpy/plotter/gps.py
@@ -188,9 +188,11 @@ class GPSTransformBase(GPSMixin, Transform):
         # otherwise do things carefully (and slowly) with Decimals
         # -- ideally this only gets called for transforming tick positions
         flat = values.flatten()
-        _trans = lambda x: self._transform_decimal(x, epoch, scale)
-        return numpy.asarray(
-            list(map(_trans, flat))).reshape(values.shape)
+
+        def _trans(x):
+            return self._transform_decimal(x, epoch, scale)
+
+        return numpy.asarray(list(map(_trans, flat))).reshape(values.shape)
 
     @staticmethod
     def _transform(value, epoch, scale):


### PR DESCRIPTION
This PR implements a slight optimisation of the use of `decimal.Decimal in `plotter.gps`. The `GPSTransform` uses `decimal.Decimal` via `str` to guarantee precision when converting to/from 19-sigfig GPS times, but we need to do this only when absolutely necessary, because it's very slow.