### PR TITLE
Added empty contextmanager utility

### DIFF
--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -32,7 +32,6 @@ def gprint(*values, **kwargs):  # pylint: disable=missing-docstring
     file_ = kwargs['file']
     print(*values, **kwargs)
     file_.flush()
-
 gprint.__doc__ = print.__doc__
 
 

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -21,8 +21,23 @@
 
 from __future__ import print_function
 
+from contextlib import contextmanager
 from sys import stdout
 
-from .misc import *
-
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+def gprint(*values, **kwargs):  # pylint: disable=missing-docstring
+    kwargs.setdefault('file', stdout)
+    file_ = kwargs['file']
+    print(*values, **kwargs)
+    file_.flush()
+
+gprint.__doc__ = print.__doc__
+
+
+@contextmanager
+def null_context():
+    """Null context manager
+    """
+    yield

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -32,6 +32,8 @@ def gprint(*values, **kwargs):  # pylint: disable=missing-docstring
     file_ = kwargs['file']
     print(*values, **kwargs)
     file_.flush()
+
+
 gprint.__doc__ = print.__doc__
 
 


### PR DESCRIPTION
This PR adds a new submodule `gwpy.utils.misc` that provides `null_context`, an empty `contextmanager` useful in a `with` statement where a context is optional (i.e. in progress bars for verbose `utils.mp`).