### PR TITLE
Reinstated timeseries.io.cache module for multiprocessing cache reading

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -140,7 +140,8 @@ def is_cache(cache):
     if isinstance(cache, string_types + FILE_LIKE):
         try:
             c = read_cache(cache)
-        except TypeError:  # failed to parse cache
+        except (TypeError, ValueError, UnicodeDecodeError):
+            # failed to parse cache
             return False
         else:
             if not c:  # return empty file as False

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -123,6 +123,34 @@ def write_cache(cache, fobj):
             fobj.write(line.encode('utf-8'))
 
 
+def is_cache(cache):
+    """Returns `True` if ``cache`` is a readable cache file or object
+
+    Parameters
+    ----------
+    cache : `str`, `file`, :class:`~glue.lal.Cache`
+        object to detect as cache
+
+    Returns
+    -------
+    iscache : `bool`
+        `True` if the input object is a cache, or a file in LAL cache format,
+        otherwise `False`
+    """
+    if isinstance(cache, string_types + FILE_LIKE):
+        try:
+            c = read_cache(cache)
+        except TypeError:  # failed to parse cache
+            return False
+        else:
+            if not c:  # return empty file as False
+                return False
+            return True
+    elif HAS_CACHE and isinstance(cache, Cache):
+        return True
+    return False
+
+
 # -- cache manipulation -------------------------------------------------------
 
 def file_list(flist):

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -140,7 +140,7 @@ def is_cache(cache):
     if isinstance(cache, string_types + FILE_LIKE):
         try:
             c = read_cache(cache)
-        except (TypeError, ValueError, UnicodeDecodeError):
+        except (TypeError, ValueError, UnicodeDecodeError, ImportError):
             # failed to parse cache
             return False
         else:

--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -27,11 +27,11 @@ from xml.sax import SAXException
 
 from six import string_types
 
-from astropy.io.registry import (_get_valid_format as get_format,
-                                 read as io_read)
+from astropy.io.registry import (read as io_read)
 from astropy.utils.data import get_readable_fileobj
 
 from .cache import (FILE_LIKE, file_list)
+from .registry import get_read_format
 from ..utils import mp as mp_utils
 
 
@@ -70,23 +70,8 @@ def read_multi(flatten, cls, source, *args, **kwargs):
         files = [source]
 
     # determine input format (so we don't have to do it multiple times)
-    # -- this is basically harvested from astropy.io.registry.read()
     if kwargs.get('format', None) is None:
-        ctx = None
-        if isinstance(source, FILE_LIKE):
-            fileobj = source
-        else:
-            try:
-                ctx = get_readable_fileobj(files[0], encoding='binary')
-                fileobj = ctx.__enter__()  # pylint: disable=no-member
-            except IOError:
-                raise
-            except Exception:  # pylint: disable=broad-except
-                fileobj = None
-        kwargs['format'] = get_format(
-            'read', cls, files[0], fileobj, args, kwargs)
-        if ctx is not None:
-            ctx.__exit__(*sys.exc_info())  # pylint: disable=no-member
+        kwargs['format'] = get_read_format(cls, files[0], args, kwargs)
 
     # calculate maximum number of processes
     nproc = min(kwargs.pop('nproc', 1), len(files))

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -270,8 +270,7 @@ def average_spectrogram(timeseries, method_func, stride, *args, **kwargs):
                                              raise_exceptions=True)
 
     # recombobulate PSDs into a spectrogram
-    return Spectrogram.from_spectra(*psds, epoch=epoch, dt=stride,
-                                    channel=timeseries.channel)
+    return Spectrogram.from_spectra(*psds, epoch=epoch, dt=stride)
 
 
 @set_fft_params
@@ -336,8 +335,8 @@ def spectrogram(timeseries, method_func, **kwargs):
         timeseries.unit, scaling=kwargs.get('scaling', 'density'))
     out = Spectrogram(numpy.empty((numtimes, numfreqs), dtype=timeseries.dtype),
                       copy=False, dt=nstride * timeseries.dt, t0=timeseries.t0,
-                      channel=timeseries.channel, unit=unit, f0=0,
-                      df=sampling/nfft)
+                      f0=0, df=sampling/nfft, unit=unit,
+                      name=timeseries.name, channel=timeseries.channel)
 
     # normalize over-dense grid
     density = nfft // nstride

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -351,6 +351,7 @@ class Spectrogram(Array2D):
         if not all(s.df == spec1.df for s in spectra):
             raise ValueError("Cannot stack spectra with different df")
         kwargs.setdefault('name', spec1.name)
+        kwargs.setdefault('channel', spec1.channel)
         kwargs.setdefault('epoch', spec1.epoch)
         kwargs.setdefault('f0', spec1.f0)
         kwargs.setdefault('df', spec1.df)

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -28,6 +28,8 @@ import sys
 
 from six import PY2
 
+import numpy
+
 import pytest
 
 from gwpy.io import (cache as io_cache,
@@ -249,6 +251,27 @@ class TestIoCache(object):
             f.seek(0)
             assert io_cache.is_cache(f) is True
             assert io_cache.is_cache(f.name) is True
+
+        # check ASCII file gets returned as False
+        a = numpy.array([[1, 2], [3, 4]])
+        with tempfile.TemporaryFile() as f:
+            numpy.savetxt(f, a)
+            f.seek(0)
+            assert io_cache.is_cache(f) is False
+
+        # check HDF5 file gets returned as False
+        try:
+            import h5py
+        except ImportError:
+            pass
+        else:
+            fp = tempfile.mktemp()
+            try:
+                h5py.File(fp, 'w').close()
+                assert io_cache.is_cache(fp) is False
+            finally:
+                if os.path.isfile(fp):
+                    os.remove(fp)
 
     def test_file_list(self):
         cache = self.make_cache()[0]

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -228,6 +228,28 @@ class TestIoCache(object):
             c3 = io_cache.read_cache(f.name)
             assert cache == c3
 
+    @utils.skip_missing_dependency('glue.lal')
+    def test_is_cache(self):
+        # sanity check
+        assert io_cache.is_cache(None) is False
+
+        # make sure Cache is returned as True
+        cache = io_cache.Cache()
+        assert io_cache.is_cache(cache) is True
+
+        # check file(path) is return as True if parsed as Cache
+        cache.append(io_cache.CacheEntry.from_T050017('/tmp/A-B-12345-6.txt'))
+        with tempfile.NamedTemporaryFile() as f:
+            # empty file should return False
+            assert io_cache.is_cache(f) is False
+            assert io_cache.is_cache(f.name) is False
+
+            # cache file should return True
+            io_cache.write_cache(cache, f)
+            f.seek(0)
+            assert io_cache.is_cache(f) is True
+            assert io_cache.is_cache(f.name) is True
+
     def test_file_list(self):
         cache = self.make_cache()[0]
 

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -53,7 +53,7 @@ from astropy.io import registry as io_registry
 
 from ..types import (Array2D, Series)
 from ..detector import (Channel, ChannelList)
-from ..io import datafind
+from ..io import (datafind, cache as io_cache)
 from ..io.mp import read_multi as io_read_multi
 from ..time import (Time, LIGOTimeGPS, to_gps)
 from ..utils import gprint
@@ -283,6 +283,14 @@ class TimeSeriesBase(Series):
 
         Notes
         -----"""
+        # if reading a cache, use specialised processor
+        if io_cache.is_cache(source):
+            from .io.cache import read_from_cache
+            kwargs['target'] = cls
+            return read_from_cache(source, *args, **kwargs)
+
+        # -- otherwise --------------------------
+
         gap = kwargs.pop('gap', 'raise')
         pad = kwargs.pop('pad', 0.)
 
@@ -820,6 +828,14 @@ class TimeSeriesBaseDict(OrderedDict):
 
         Notes
         -----"""
+        # if reading a cache, use specialised processor
+        if io_cache.is_cache(source):
+            from .io.cache import read_from_cache
+            kwargs['target'] = cls
+            return read_from_cache(source, *args, **kwargs)
+
+        # -- otherwise --------------------------
+
         gap = kwargs.pop('gap', 'raise')
         pad = kwargs.pop('pad', 0.)
 

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Multi-processed I/O utilities for `TimeSeries`
+"""
+
+from math import ceil
+
+from six import string_types
+
+from astropy.io.registry import read as io_read
+
+from ...io.registry import get_read_format
+from ...io.cache import (read_cache, cache_segments, FILE_LIKE)
+from ...segments import (Segment, SegmentList)
+from ...utils.mp import multiprocess_with_queues
+from ..core import TimeSeriesBaseList
+from ..timeseries import TimeSeries
+from ..statevector import (StateVector, StateVectorDict)
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+
+def read_from_cache(cache, channel, start=None, end=None, resample=None,
+                    gap=None, pad=None, nproc=1, format=None, verbose=False,
+                    **kwargs):
+    """Read a `TimeSeries` from a cache of data files using multiprocessing
+
+    The inner-workings are agnostic of data-type, but can only handle a
+    single data type at a time.
+
+    Parameters
+    ----------
+    cache : :class:`glue.lal.Cache`, `str`
+        cache of GWF frame files, or path to a LAL-format cache file
+        on disk
+
+    channel : :class:`~gwpy.detector.channel.Channel`, `str`
+        data channel to read from frames
+
+    start : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
+        start GPS time of desired data
+
+    end : `Time`, `~gwpy.time.LIGOTimeGPS`, optional
+        end GPS time of desired data
+
+    resample : `float`, optional
+        rate (samples per second) to resample
+
+    format : `str`, optional
+        name of data file format, e.g. ``gwf`` or ``hdf``.
+
+    nproc : `int`, default: ``1``
+        maximum number of independent frame reading processes, default
+        is set to single-process file reading.
+
+    gap : `str`, optional
+        how to handle gaps in the cache, one of
+        - 'ignore': do nothing, let the undelying reader method handle it
+        - 'warn': do nothing except print a warning to the screen
+        - 'raise': raise an exception upon finding a gap (default)
+        - 'pad': insert a value to fill the gaps
+
+    pad : `float`, optional
+        value with which to fill gaps in the source data, only used if
+        gap is not given, or `gap='pad'` is given
+
+    Notes
+    -----
+    The number of independent processes spawned by this function can be
+    calculated as ``min(maxprocesses, len(cache)//minprocesssize)``.
+
+    Returns
+    -------
+    data : `~gwpy.timeseries.TimeSeries`
+        a new `TimeSeries` containing the data read from disk
+    """
+    cls = kwargs.pop('target', TimeSeries)
+
+    # open cache file
+    if isinstance(cache, FILE_LIKE + string_types):
+        cache = read_cache(cache)
+    cache = type(cache)(cache)
+    cache.sort(key=lambda e: e.segment)
+
+    # get input format
+    if kwargs.get('format', None) is None:
+        kwargs['format'] = get_read_format(cls, cache[0].path, (), {})
+
+    # handle resampling as an overlap for TimeSeries
+    if not resample or cls in (StateVector, StateVectorDict):
+        overlap = 0
+    else:
+        overlap = 4
+
+    # get timing
+    if start is None:  # start time of earliest file
+        start = cache[0].segment[0]
+    if end is None:  # end time of latest file
+        end = cache[-1].segment[-1]
+    span = Segment(start, end)
+    cache = cache.sieve(segment=span.protract(overlap))
+    cspan = Segment(cache[0].segment[0], cache[-1].segment[1])
+
+    # define segments for multiprocessing
+    segs = get_mp_cache_segments(cache, nproc, span, overlap=overlap)
+
+    # define reader for each segment
+    def _read_segment(segment):
+        try:
+            if segment[0] is None:
+                pseg = segment
+                subcache = cache
+            else:
+                pseg = segment.protract(overlap) & cspan  # processing segment
+                subcache = cache.sieve(segment=pseg)
+            data = io_read(cls, subcache, channel, start=pseg[0], end=pseg[1],
+                           **kwargs)
+            if resample:
+                data = data.resample(resample)
+            if overlap:  # crop out the overlap introduced for resampling
+                return data.crop(*segment)
+            return data
+        except Exception as exc:  # pylint: disable=broad-except
+            if nproc == 1:  # raise now
+                raise
+            return exc  # will be raised after multiprocessing closes
+
+    # multi-process
+    chunks = multiprocess_with_queues(nproc, _read_segment, segs,
+                                      raise_exceptions=True, verbose=verbose)
+
+    # flatten dicts
+    if issubclass(cls, dict):
+        out = cls()
+        while chunks:
+            new = chunks.pop(0)
+            out.append(new, gap=gap, pad=pad)
+            del new
+        return out
+
+    # flatten series
+    list_ = TimeSeriesBaseList(*chunks)
+    return list_.join(pad=pad, gap=gap)
+
+
+def get_mp_cache_segments(cache, nproc, span, overlap=0):
+    """Determine segments in which to multiprocess a cache
+    """
+    # no data
+    if not cache:
+        nproc = 1
+        return [(None, None)]
+
+    # single process
+    if nproc == 1:
+        return SegmentList([span])
+
+    # actual multiprocessing
+    numf = len(cache)
+    nproc = min(nproc, numf)
+    fperproc = int(ceil(numf / nproc))
+    segs = SegmentList()
+    # loop over data segments
+    for seg in cache_segments(cache) & SegmentList([span]):
+        subcache = cache.sieve(segment=(seg.protract(overlap) & span))
+        numf2 = len(subcache)
+        # if seg is small, process in one
+        if numf2 <= fperproc:
+            segs.append(seg)
+        # otherwise split into chunks
+        else:
+            j = numf2 / fperproc  # nproc to use here
+            dur = ceil(abs(seg) / j)  # time to include in proc
+            start, end = seg
+            while start + dur <= end:
+                segs.append(Segment(start, start + dur))
+                start += dur
+    return segs

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -38,7 +38,7 @@ from six import string_types
 
 import numpy
 
-from astropy.io.registry import get_formats
+from astropy.io.registry import (get_formats, get_reader, get_writer)
 
 try:
     from glue.lal import Cache
@@ -384,17 +384,12 @@ def register_gwf_format(container):
     container : `Series`, `dict`
         series class or series dict class to register
     """
-    def read_(*args, **kwargs):
-        kwargs['format'] = 'gwf.{}'.format(get_default_gwf_api())
-        return container.read(*args, **kwargs)
-
-    def write_(*args, **kwargs):
-        kwargs['format'] = 'gwf.{}'.format(get_default_gwf_api())
-        return container.write(*args, **kwargs)
-
+    fmt = 'gwf.{}'.format(get_default_gwf_api())
+    reader = get_reader(fmt, container)
+    writer = get_writer(fmt, container)
     register_identifier('gwf', container, identify_gwf)
-    register_reader('gwf', container, read_)
-    register_writer('gwf', container, write_)
+    register_reader('gwf', container, reader)
+    register_writer('gwf', container, writer)
 
 
 # -- DEPRECATED - register old format name ------------------------------------
@@ -419,22 +414,22 @@ def register_library_format(container, library):
         name of frame library
     """
     fmt = 'gwf.%s' % library
+    reader = get_reader(fmt, container)
+    writer = get_writer(fmt, container)
 
     def read_(*args, **kwargs):
         warnings.warn("Reading with format=%r is deprecated and will be "
                       "disabled in an upcoming release, please use "
                       "format=%r instead" % (library, fmt),
                       DeprecationWarning)
-        kwargs['format'] = fmt
-        return container.read(*args, **kwargs)
+        return reader(*args, **kwargs)
 
     def write_(*args, **kwargs):
         warnings.warn("Writing with format=%r is deprecated and will be "
                       "disabled in an upcoming release, please use "
                       "format=%r instead" % (library, fmt),
                       DeprecationWarning)
-        kwargs['format'] = fmt
-        return container.write(*args, **kwargs)
+        return writer(*args, **kwargs)
 
     register_reader(library, container, read_)
     register_writer(library, container, write_)

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -384,12 +384,19 @@ def register_gwf_format(container):
     container : `Series`, `dict`
         series class or series dict class to register
     """
-    fmt = 'gwf.{}'.format(get_default_gwf_api())
-    reader = get_reader(fmt, container)
-    writer = get_writer(fmt, container)
+    def read_(*args, **kwargs):
+        fmt = 'gwf.{}'.format(get_default_gwf_api())
+        reader = get_reader(fmt, container)
+        return reader(*args, **kwargs)
+
+    def write_(*args, **kwargs):
+        fmt = 'gwf.{}'.format(get_default_gwf_api())
+        writer = get_writer(fmt, container)
+        return writer(*args, **kwargs)
+
     register_identifier('gwf', container, identify_gwf)
-    register_reader('gwf', container, reader)
-    register_writer('gwf', container, writer)
+    register_reader('gwf', container, read_)
+    register_writer('gwf', container, write_)
 
 
 # -- DEPRECATED - register old format name ------------------------------------

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -157,8 +157,8 @@ class TimeSeries(TimeSeriesBase):
             nfft = self.size
         dft = npfft.rfft(self.value, n=nfft) / nfft
         dft[1:] *= 2.0
-        new = FrequencySeries(dft, epoch=self.epoch, channel=self.channel,
-                              unit=self.unit)
+        new = FrequencySeries(dft, epoch=self.epoch, unit=self.unit,
+                              name=self.name, channel=self.channel)
         try:
             new.frequencies = npfft.rfftfreq(nfft, d=self.dx.value)
         except AttributeError:

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -161,8 +161,14 @@ class Array2D(Series):
                 new = new.view(self._columnclass)
                 new.dx = self.dy
                 new.x0 = self.y0
+                new.__metadata_finalize__(self)
+                try:
+                    new.xindex = self._yindex
+                except AttributeError:
+                    pass
             else:
                 new = new.view(self._rowclass)
+                new.__metadata_finalize__(self)
         # unwrap a Spectrogram
         else:
             new = new.view(type(self))


### PR DESCRIPTION
This PR reinstates an improved version of  `gwpy.timeseries.io.cache`, which provides an efficient reader of `TimeSeries` data from cache files - at least more efficient than a simple `map` from `gwpy.io.mp`.