### PR TITLE
Bump required GitPython for setup

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -29,7 +29,7 @@ set -x && trap 'set +x' RETURN
 get_environment
 
 # install for this OS
-if [ ${TRAVIS_OS_NAME} == "osx" ]; then  # macports
+if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then  # macports
     . ci/install-macos.sh
 elif [[ ${DOCKER_IMAGE} =~ :el[0-9]+$ ]]; then  # SLX
     . ci/install-el.sh

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -99,7 +99,8 @@ class changelog(Command):
         return ("{} ({}-1) unstable; urgency=low\n\n"
                 "  * {}\n\n"
                 " -- {} <{}>  {} {:+05d}\n".format(
-                    name, version, message, tagger.name, tagger.email, dstr, tz))
+                    name, version, message,
+                    tagger.name, tagger.email, dstr, tz))
 
     def get_git_tags(self):
         import git
@@ -207,7 +208,8 @@ class sdist(orig_sdist):
 
 
 CMDCLASS['sdist'] = sdist
-SETUP_REQUIRES['sdist'] = SETUP_REQUIRES['changelog'] + SETUP_REQUIRES['bdist_rpm']
+SETUP_REQUIRES['sdist'] = (SETUP_REQUIRES['changelog'] +
+                           SETUP_REQUIRES['bdist_rpm'])
 
 
 class clean(orig_clean):

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -125,7 +125,7 @@ class changelog(Command):
 
 
 CMDCLASS['changelog'] = changelog
-SETUP_REQUIRES['changelog'] = ('GitPython',)
+SETUP_REQUIRES['changelog'] = ('GitPython>=2.1.8',)
 
 orig_bdist_rpm = CMDCLASS.pop('bdist_rpm', _bdist_rpm)
 DEFAULT_SPEC_TEMPLATE = os.path.join('etc', 'spec.template')


### PR DESCRIPTION
This PR fixes the broken build (see [travis-ci/315512380](https://travis-ci.org/gwpy/gwpy/builds/315512380)): GitPython 2.1.8 is required to operate alongside git 2.15 [[ref]].

[ref]: https://github.com/gitpython-developers/GitPython/issues/687#issuecomment-350780349