### PR TITLE
Fixed missing return for gwpy.io.datafind._find_latest_frame

### DIFF
--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -282,7 +282,7 @@ def _find_latest_frame(connection, ifo, frametype, gpstime=None,
     else:
         if not os.access(frame.path, os.R_OK):
             raise IOError("Latest frame file for {}-{} is unreadable: "
-                               "{}".format(ifo, frametype, frame.path))
+                          "{}".format(ifo, frametype, frame.path))
         if not allow_tape and on_tape(frame.path):
             raise IOError("Latest frame file for {}-{} is on tape "
                           "(pass allow_tape=True to force): "


### PR DESCRIPTION
This PR fixes a missing `return` for the specific case of a file returned from a datafind 'latest' query that wasn't readable, or was on tape.