### PR TITLE
Fixed a lot of warnings in the test

### DIFF
--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -512,10 +512,6 @@ def minute_trend_times(start, end):
     mend : `int`
         ``end`` rounded up to nearest multiple of 60
     """
-    warnings.warn("Requested at least one minute trend, but "
-                  "start and stop GPS times are not modulo "
-                  "60-seconds (from GPS epoch). Times will be "
-                  "expanded outwards to compensate")
     if start % 60:
         start = int(start) // 60 * 60
     if end % 60:

--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -165,8 +165,13 @@ class Plot(figure.Figure):
     def close(self):
         """Close the plot and release its memory.
         """
-        for ax in self.axes:
+        for ax in self.axes[::-1]:
+            # avoid matplotlib/matplotlib#9970
+            ax.set_xscale('linear')
+            ax.set_yscale('linear')
+            # clear the axes
             ax.cla()
+        # close the figure
         pyplot.close(self)
 
     # -- colour bars ----------------------------

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -589,7 +589,7 @@ class TestArray2D(TestSeries):
     def setup_class(cls, dtype=None):
         numpy.random.seed(SEED)
         cls.data = (numpy.random.random(100)
-                    * 1e5).astype(dtype=dtype).reshape((10, 10))
+                    * 1e5).astype(dtype=dtype).reshape((20, 5))
         cls.datasq = cls.data ** 2
 
     # -- test properties ------------------------
@@ -623,7 +623,7 @@ class TestArray2D(TestSeries):
         assert array.dy == units.Quantity(5, 'm')
 
     def test_yindex(self):
-        y = numpy.linspace(0, 100, num=self.data.shape[0])
+        y = numpy.linspace(0, 100, num=self.data.shape[1])
 
         # test simple
         series = self.create(yindex=y)
@@ -633,8 +633,8 @@ class TestArray2D(TestSeries):
         # test deleter
         del series.yindex
         del series.yindex
-        y1 = series.y0.value + series.shape[0] * series.dy.value
-        y_default = numpy.linspace(series.y0.value, y1, num=series.shape[0],
+        y1 = series.y0.value + series.shape[1] * series.dy.value
+        y_default = numpy.linspace(series.y0.value, y1, num=series.shape[1],
                                    endpoint=False)
         utils.assert_quantity_equal(
             series.yindex,
@@ -677,10 +677,10 @@ class TestArray2D(TestSeries):
     def test_yspan(self):
         # test normal
         series = self.create(y0=1, dy=1)
-        assert series.yspan == (1, 1 + 1 * series.shape[0])
+        assert series.yspan == (1, 1 + 1 * series.shape[1])
         assert isinstance(series.yspan, Segment)
         # test from irregular yindex
-        y = numpy.logspace(0, 2, num=self.data.shape[0])
+        y = numpy.logspace(0, 2, num=self.data.shape[1])
         series = self.create(yindex=y)
         assert series.yspan == (y[0], y[-1] + y[-1] - y[-2])
 
@@ -709,11 +709,11 @@ class TestArray2D(TestSeries):
             array.is_compatible(a2)
 
     def test_value_at(self, array):
-        assert array.value_at(2, 5) == self.data[2][5] * array.unit
+        assert array.value_at(2, 3) == self.data[2][3] * array.unit
         assert array.value_at(5 * array.xunit, 2 * array.yunit) == (
             self.data[5][2] * array.unit)
         with pytest.raises(IndexError):
-            array.value_at(1.6, 5.8)
+            array.value_at(1.6, 4.8)
 
     def test_pad(self):
         return NotImplemented

--- a/gwpy/tests/test_cli.py
+++ b/gwpy/tests/test_cli.py
@@ -23,6 +23,7 @@ import os
 import tempfile
 import importlib
 import argparse
+import warnings
 
 import pytest
 
@@ -38,6 +39,9 @@ import mocks
 from mocks import mock
 import utils
 
+warnings.filterwarnings(
+    'ignore', category=UserWarning, message=".*non-GUI backend.*")
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 _, TEMP_PLOT_FILE = tempfile.mkstemp(prefix='GWPY-UNITTEST_', suffix='.png')
@@ -46,7 +50,8 @@ _, TEMP_PLOT_FILE = tempfile.mkstemp(prefix='GWPY-UNITTEST_', suffix='.png')
 class CliTestBase(object):
     PRODUCT_NAME = 'gwpy.cli.cliproduct.CliProduct'
     ACTION = None
-    TEST_ARGS = ['--chan', 'X1:TEST-CHANNEL', '--start', '1000000000']
+    TEST_ARGS = ['--chan', 'X1:TEST-CHANNEL', '--start', '1000000000',
+                 '--nds2-server', 'nds.test.gwpy']
 
     @classmethod
     def setup_class(cls):

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -293,7 +293,7 @@ class TestSpectralVariance(TestArray2D):
 
     def test_plot(self, array):
         with rc_context(rc={'text.usetex': False}):
-            plot = array.plot()
+            plot = array.plot(yscale='linear')
             assert isinstance(plot, FrequencySeriesPlot)
             assert isinstance(plot.gca(), FrequencySeriesAxes)
             assert len(plot.gca().collections) == 1

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -152,6 +152,11 @@ class TestIoNds2(object):
                        ('nds.ligo-la.caltech.edu', 31200),
                        ('nds.ligo.caltech.edu', 31200)]
 
+        # test warnings for unknown IFO
+        with pytest.warns(UserWarning):
+            hro = io_nds2.host_resolution_order('X1')
+            assert hro == [('nds.ligo.caltech.edu', 31200)]
+
     @utils.skip_missing_dependency('nds2')
     def test_connect(self):
         """Test :func:`gwpy.io.connect`

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -20,6 +20,7 @@
 """
 
 import tempfile
+import warnings
 
 import pytest
 
@@ -60,6 +61,10 @@ from gwpy.plotter.tex import (float_to_latex, label_to_latex,
 from gwpy.plotter.table import get_column_string
 
 import utils
+
+# ignore matplotlib complaining about GUIs
+warnings.filterwarnings(
+    'ignore', category=UserWarning, message=".*non-GUI backend.*")
 
 # design ZPK for BodePlot test
 ZPK = [100], [1], 1e-2

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -149,14 +149,16 @@ class TestTable(object):
 
             # check auto-discovery of 'time' columns works
             from glue.ligolw.lsctables import LIGOTimeGPS
-            t3 = _read(columns=['time'])
+            with pytest.warns(DeprecationWarning):
+                t3 = _read(columns=['time'])
             assert 'time' in t3.columns
             assert isinstance(t3[0]['time'], LIGOTimeGPS)
             utils.assert_array_equal(
                 t3['time'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
 
             # check numpy type casting works
-            t3 = _read(columns=['time'], use_numpy_dtypes=True)
+            with pytest.warns(DeprecationWarning):
+                t3 = _read(columns=['time'], use_numpy_dtypes=True)
             assert t3['time'].dtype == dtype('float64')
             utils.assert_array_equal(
                 t3['time'], table['peak_time'] + table['peak_time_ns'] * 1e-9)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -713,16 +713,16 @@ class TestTimeSeries(TestTimeSeriesBase):
 
     @utils.skip_missing_dependency('nds2')
     def test_fetch(self):
-        ts = self.create(name='X1:TEST', t0=1000000000, unit='m')
+        ts = self.create(name='L1:TEST', t0=1000000000, unit='m')
         nds_buffer = mocks.nds2_buffer_from_timeseries(ts)
         nds_connection = mocks.nds2_connection(buffers=[nds_buffer])
         with mock.patch('nds2.connection') as mock_connection, \
                 mock.patch('nds2.buffer', nds_buffer):
             mock_connection.return_value = nds_connection
             # use verbose=True to hit more lines
-            ts2 = self.TEST_CLASS.fetch('X1:TEST', *ts.span, verbose=True)
+            ts2 = self.TEST_CLASS.fetch('L1:TEST', *ts.span, verbose=True)
             # check open connection works
-            ts2 = self.TEST_CLASS.fetch('X1:TEST', *ts.span, verbose=True,
+            ts2 = self.TEST_CLASS.fetch('L1:TEST', *ts.span, verbose=True,
                                         connection=nds_connection)
         utils.assert_quantity_sub_equal(ts, ts2, exclude=['channel'])
 

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -57,6 +57,7 @@ from gwpy.frequencyseries import (FrequencySeries, SpectralVariance)
 from gwpy.types import Array2D
 from gwpy.spectrogram import Spectrogram
 from gwpy.plotter import (TimeSeriesPlot, SegmentPlot)
+from gwpy.utils.misc import null_context
 
 import mocks
 import utils
@@ -867,15 +868,24 @@ class TestTimeSeries(TestTimeSeriesBase):
     def test_psd_library(self, losc, library, method):
         method = '{}_{}'.format(library, method)
 
+        def _psd():
+            if method == 'lal_median_mean':
+                # LAL should warn about the data being the wrong length
+                warnctx = pytest.warns(UserWarning)
+            else:
+                warnctx = null_context()
+            with warnctx:
+                return losc.psd(fftlength=.5, overlap=.25, method=method)
+
         # check simple
-        psd = losc.psd(fftlength=.5, overlap=.25, method=method)
+        psd = _psd()
         assert isinstance(psd, FrequencySeries)
         assert psd.f0 == 0 * units.Hz
         assert psd.df == 2 * units.Hz
 
         # check window selection
         if library != 'pycbc':
-            losc.psd(fftlength=.5, method=method, window='hamming')
+            _psd()
 
     def test_asd(self, losc):
         fs = losc.asd()
@@ -925,31 +935,17 @@ class TestTimeSeries(TestTimeSeriesBase):
         # test multiprocessing
         sg2 = losc.spectrogram(0.5, fftlength=0.25, overlap=0.125, nproc=2)
         utils.assert_quantity_sub_equal(sg, sg2)
-        # test methods
-        sg = losc.spectrogram(0.5, fftlength=0.25, method='welch')
+
+        # test a couple of methods
+        with pytest.warns(UserWarning):
+            sg = losc.spectrogram(0.5, fftlength=0.25, method='welch')
         assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
         assert sg.df == 4 * units.Hertz
         assert sg.dt == 0.5 * units.second
-        sg = losc.spectrogram(0.5, fftlength=0.25, method='bartlett')
+        sg = losc.spectrogram(0.5, fftlength=0.25, method='scipy-bartlett')
         assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
         assert sg.df == 4 * units.Hertz
         assert sg.dt == 0.5 * units.second
-        try:
-            sg = losc.spectrogram(0.5, fftlength=0.25, method='lal-welch')
-        except ImportError:
-            pass
-        else:
-            assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
-            assert sg.df == 4 * units.Hertz
-            assert sg.dt == 0.5 * units.second
-            sg = losc.spectrogram(0.5, fftlength=0.25, method='median-mean')
-            assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
-            assert sg.df == 4 * units.Hertz
-            assert sg.dt == 0.5 * units.second
-            sg = losc.spectrogram(0.5, fftlength=0.25, method='median')
-            assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
-            assert sg.df == 4 * units.Hertz
-            assert sg.dt == 0.5 * units.second
 
         # check that `cross` keyword gets deprecated properly
         # TODO: removed before 1.0 release

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -572,7 +572,7 @@ class Series(Array):
                      % (self.dtype, other.dtype))
         return True
 
-    def append(self, other, gap='raise', inplace=True, pad=0.0, resize=True):
+    def append(self, other, gap='raise', inplace=True, pad=0, resize=True):
         """Connect another series onto the end of the current one.
 
         Parameters
@@ -628,7 +628,7 @@ class Series(Array):
                             type(self).__name__, self.xspan, other.xspan))
                 gapshape = list(self.shape)
                 gapshape[0] = int(ngap)
-                padding = numpy.ones(gapshape, dtype=self.dtype) * pad
+                padding = (numpy.ones(gapshape) * pad).astype(self.dtype)
                 self.append(padding, inplace=True, resize=resize)
             elif gap == 'ignore':
                 pass
@@ -707,7 +707,7 @@ class Series(Array):
                 self.x0 = self.xindex[0]
         return self
 
-    def prepend(self, other, gap='raise', inplace=True, pad=0.0, resize=True):
+    def prepend(self, other, gap='raise', inplace=True, pad=0, resize=True):
         """Connect another series onto the start of the current one.
 
         Parameters


### PR DESCRIPTION
This PR catches a lot of warnings emitted from the test suite, either by catching them appropriately with `pytest.warns` (which also acts as a test that the warning gets emitted when it should), or by modifying the test or module code to not produce the warning in the first place.

This should clean up the test output, and make finding problems easier in the future, especially when scanning the warning dump.