### PR TITLE
Minor improvements to astro.range

### DIFF
--- a/docs/astro/index.rst
+++ b/docs/astro/index.rst
@@ -1,0 +1,27 @@
+.. currentmodule:: gwpy.astro
+
+.. _gwpy-astro:
+
+#######################
+Astrophysical modelling
+#######################
+
+Currently the only methods available from `gwpy.astro` are concerned with calculating sensitive distance.
+
+.. _gwpy-astro-range:
+
+==================
+Sensitive distance
+==================
+
+The sensitive distance (sometimes called 'range', or 'horizon') is a measure of how far out into the universe a gravitational-wave source can be and still be detectable by a gravitational-wave detector 
+
+`gwpy.astro` provides methods to calculate the distance to simple models of inspiral and burst signals:
+
+.. autosummary::
+   :toctree: ../api
+
+   burst_range
+   burst_range_spectrum
+   inspiral_range
+   inspiral_range_psd

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,6 +70,7 @@ Working with data
 
    detector/channel
    time/index
+   astro/index
 
 .. ----------------------------------------------------------------
 .. other sections (not directly linked, but need for cross-linking)

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -29,7 +29,6 @@ from astropy import (units, constants)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-# pylint: disable=no-member
 
 
 def inspiral_range_psd(psd, snr=8, mass1=1.4, mass2=1.4, horizon=False):
@@ -39,16 +38,22 @@ def inspiral_range_psd(psd, snr=8, mass1=1.4, mass2=1.4, horizon=False):
     ----------
     psd : `~gwpy.frequencyseries.FrequencySeries`
         the instrumental power-spectral-density data
+
     snr : `float`, optional
-        the signal-to-noise ratio for which to calculate range
+        the signal-to-noise ratio for which to calculate range,
+        default: `8`
+
     mass1 : `float`, `~astropy.units.Quantity`, optional
         the mass (`float` assumed in solar masses) of the first binary
-        component
+        component, default: `1.4`
+
     mass2 : `float`, `~astropy.units.Quantity`, optional
         the mass (`float` assumed in solar masses) of the second binary
+        component, default: `1.4`
+
     horizon : `bool`, optional
         if `True`, return the maximal 'horizon' sensitive distance, otherwise
-        return the angle-averaged range
+        return the angle-averaged range, default: `False`
 
     Returns
     -------
@@ -60,8 +65,10 @@ def inspiral_range_psd(psd, snr=8, mass1=1.4, mass2=1.4, horizon=False):
     mass2 = units.Quantity(mass2, 'solMass').to('kg')
     mtotal = mass1 + mass2
     mchirp = (mass1 * mass2) ** (3/5.) / mtotal ** (1/5.)
+
     # compute ISCO
     fisco = (constants.c ** 3 / (constants.G * 6**1.5 * pi * mtotal)).to('Hz')
+
     # calculate integral pre-factor
     prefactor = (
         (1.77**2 * 5 * constants.c ** (1/3.) *
@@ -75,6 +82,7 @@ def inspiral_range_psd(psd, snr=8, mass1=1.4, mass2=1.4, horizon=False):
     integrand.override_unit(units.Unit('Mpc^2 / Hz'))
     # restrict to ISCO
     integrand = integrand[psd.frequencies.value < fisco.value]
+
     # normalize and return
     if integrand.f0.value == 0.0:
         integrand[0] = 0.0
@@ -97,21 +105,29 @@ def inspiral_range(psd, snr=8, mass1=1.4, mass2=1.4, fmin=0, fmax=None,
     ----------
     psd : `~gwpy.frequencyseries.FrequencySeries`
         the instrumental power-spectral-density data
+
     snr : `float`, optional
-        the signal-to-noise ratio for which to calculate range
+        the signal-to-noise ratio for which to calculate range,
+        default: `8`
+
     mass1 : `float`, `~astropy.units.Quantity`, optional
         the mass (`float` assumed in solar masses) of the first binary
-        component
+        component, default: `1.4`
+
     mass2 : `float`, `~astropy.units.Quantity`, optional
         the mass (`float` assumed in solar masses) of the second binary
+        component, default: `1.4`
+
     fmin : `float`, optional
-        the lower frequency cut-off of the integral
+        the lower frequency cut-off of the integral, default: `psd.df`
+
     fmax : `float`, optional
-        the maximum frequency limit of the integral, if not given or `None`,
-        the innermost stable circular orbit (ISCO) frequency is used
+        the maximum frequency limit of the integral, defaults to
+        innermost stable circular orbit (ISCO) frequency
+
     horizon : `bool`, optional
         if `True`, return the maximal 'horizon' sensitive distance, otherwise
-        return the angle-averaged range
+        return the angle-averaged range, default: `False`
 
     Returns
     -------
@@ -154,13 +170,14 @@ def burst_range_spectrum(psd, snr=8, energy=1e-2, unit='Mpc'):
     ----------
     psd : `~gwpy.frequencyseries.FrequencySeries`
         the instrumental power-spectral-density data
+
     snr : `float`, optional
-        the signal-to-noise ratio for which to calculate range
+        the signal-to-noise ratio for which to calculate range,
+        default: `8`
+
     energy : `float`, optional
-        the relative energy output of the GW burst, defaults to 1e-2 for
-        a GRB-like burst
-    unit : `str`, `~astropy.units.Unit`
-        desired unit of the returned `~astropy.units.Quantity`
+        the relative energy output of the GW burst,
+        default: `0.01` (GRB-like burst)
 
     Returns
     -------
@@ -177,6 +194,7 @@ def burst_range_spectrum(psd, snr=8, energy=1e-2, unit='Mpc'):
     # rescale 0 Hertz (which has 0 range always)
     if rspec.f0.value == 0.0:
         rspec[0] = 0.0
+
     return rspec
 
 
@@ -187,15 +205,20 @@ def burst_range(psd, snr=8, energy=1e-2, fmin=100, fmax=500, unit='Mpc'):
     ----------
     psd : `~gwpy.frequencyseries.FrequencySeries`
         the instrumental power-spectral-density data
+
     snr : `float`, optional
         the signal-to-noise ratio for which to calculate range
+
     energy : `float`, optional
         the relative energy output of the GW burst, defaults to 1e-2 for
         a GRB-like burst
+
     fmin : `float`, optional
         the lower frequency cutoff of the burst range integral
+
     fmax : `float, optional
         the upper frequency cutoff of the burst range integral
+
     unit : `str`, `~astropy.units.Unit`
         desired unit of the returned `~astropy.units.Quantity`
 

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -198,7 +198,7 @@ def burst_range_spectrum(psd, snr=8, energy=1e-2):
     # calculate frequency dependent range in parsecs
     a = (constants.G * energy * constants.M_sun * 0.4 /
          (pi**2 * constants.c))**(1/2.)
-    dspec = a / (snr * psd ** (1/2.) * psd.frequencies)
+    dspec = psd ** (-1/2.) * a / (snr * psd.frequencies)
 
     # convert to output unit
     rspec = dspec.to('Mpc')

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -43,7 +43,7 @@ def _preformat_psd(func):
 
 @_preformat_psd
 def inspiral_range_psd(psd, snr=8, mass1=1.4, mass2=1.4, horizon=False):
-    """Compute the inspiral sensitive distance PSD for the given GW strain PSD
+    """Compute the inspiral sensitive distance PSD from a GW strain PSD
 
     Parameters
     ----------
@@ -103,7 +103,7 @@ def inspiral_range_psd(psd, snr=8, mass1=1.4, mass2=1.4, horizon=False):
 
 def inspiral_range(psd, snr=8, mass1=1.4, mass2=1.4, fmin=None, fmax=None,
                    horizon=False):
-    """Calculate the inspiral sensitive distance for the given PSD
+    """Calculate the inspiral sensitive distance from a GW strain PSD
 
     The method returns the distance (in megaparsecs) to which an compact
     binary inspiral with the given component masses would be detectable
@@ -143,6 +143,21 @@ def inspiral_range(psd, snr=8, mass1=1.4, mass2=1.4, fmin=None, fmax=None,
     -------
     range : `~astropy.units.Quantity`
         the calculated inspiral range [Mpc]
+
+    Examples
+    --------
+    Grab some data for LIGO-Livingston around GW150914 and generate a PSD
+
+    >>> from gwpy.timeseries import TimeSeries
+    >>> hoft = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
+    >>> hoff = hoft.psd(fftlength=4)
+
+    Now we can calculate the :func:`inspiral_range`:
+
+    >>> from gwpy.astro import inspiral_range
+    >>> r = inspiral_range(hoff, fmin=30)
+    >>> print(r)
+    70.4612102889 Mpc
     """
     mass1 = units.Quantity(mass1, 'solMass').to('kg')
     mass2 = units.Quantity(mass2, 'solMass').to('kg')
@@ -175,7 +190,7 @@ def inspiral_range(psd, snr=8, mass1=1.4, mass2=1.4, fmin=None, fmax=None,
 
 @_preformat_psd
 def burst_range_spectrum(psd, snr=8, energy=1e-2):
-    """Calculate the frequency-dependent GW burst range for the given PSD
+    """Calculate the frequency-dependent GW burst range from a strain PSD
 
     Parameters
     ----------
@@ -211,7 +226,7 @@ def burst_range_spectrum(psd, snr=8, energy=1e-2):
 
 
 def burst_range(psd, snr=8, energy=1e-2, fmin=100, fmax=500):
-    """Calculate the integrated GRB-like burst range for the given PSD
+    """Calculate the integrated GRB-like GW burst range from a strain PSD
 
     Parameters
     ----------
@@ -219,22 +234,40 @@ def burst_range(psd, snr=8, energy=1e-2, fmin=100, fmax=500):
         the instrumental power-spectral-density data
 
     snr : `float`, optional
-        the signal-to-noise ratio for which to calculate range
+        the signal-to-noise ratio for which to calculate range,
+        default: `8`
 
     energy : `float`, optional
         the relative energy output of the GW burst, defaults to 1e-2 for
         a GRB-like burst
 
     fmin : `float`, optional
-        the lower frequency cutoff of the burst range integral
+        the lower frequency cutoff of the burst range integral,
+        default: `100 Hz`
 
     fmax : `float, optional
-        the upper frequency cutoff of the burst range integral
+        the upper frequency cutoff of the burst range integral,
+        default: `500 Hz`
 
     Returns
     -------
     range : `~astropy.units.Quantity`
         the GRB-like-burst sensitive range [Mpc (default)]
+
+    Examples
+    --------
+    Grab some data for LIGO-Livingston around GW150914 and generate a PSD
+
+    >>> from gwpy.timeseries import TimeSeries
+    >>> hoft = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
+    >>> hoff = hoft.psd(fftlength=4)
+
+    Now we can calculate the :func:`burst_range`:
+
+    >>> from gwpy.astro import burst_range
+    >>> r = burst_range(hoff, fmin=30)
+    >>> print(r)
+    42.5055584195 Mpc
     """
     freqs = psd.frequencies.value
     # restrict integral

--- a/gwpy/tests/test_astro.py
+++ b/gwpy/tests/test_astro.py
@@ -84,7 +84,7 @@ def psd():
 def test_inspiral_range_psd(psd):
     """Test for :func:`gwpy.astro.inspiral_range_psd`
     """
-    r = astro.inspiral_range_psd(psd)
+    r = astro.inspiral_range_psd(psd[1:])  # avoid DC
     assert isinstance(r, FrequencySeries)
     utils.assert_quantity_almost_equal(r.max(),
                                        TEST_RESULTS['inspiral_range_psd'])
@@ -100,13 +100,13 @@ def test_inspiral_range(psd):
 def test_burst_range(psd):
     """Test for :func:`gwpy.astro.burst_range`
     """
-    r = astro.burst_range(psd[psd.frequencies.value < 1000])
+    r = astro.burst_range(psd.crop(None, 1000)[1:])
     utils.assert_quantity_almost_equal(r, TEST_RESULTS['burst_range'])
 
 
 def test_burst_range_spectrum(psd):
     """Test for :func:`gwpy.astro.burst_range_spectrum`
     """
-    r = astro.burst_range_spectrum(psd[psd.frequencies.value < 1000])
+    r = astro.burst_range_spectrum(psd.crop(None, 1000)[1:])
     utils.assert_quantity_almost_equal(r.max(),
                                        TEST_RESULTS['burst_range_spectrum'])


### PR DESCRIPTION
This PR makes some internal improvements to astro.range

- preformat PSDs to ensure unit=1/Hz
- use proper `Quantity` operations throughout to make sure units get handled properly
- don't pass 0 Hz from PSD in testing, always ends up with a `RuntimeWarning` (which it should, its just annoying)
- removed `unit` kwarg from all `astro.range` methods, its unnecessary