### PR TITLE
Fixed warnings in parse_unit if parse_strict='silent'

### DIFF
--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -47,6 +47,7 @@ class GWpyFormat(Generic):
     name = 'gwpy'
     re_closest_unit = re.compile(r'Did you mean (.*)\?\Z')
     re_closest_unit_delim = re.compile('(, | or )')
+    warn = True
 
     @classmethod
     def _get_unit(cls, t):
@@ -77,10 +78,11 @@ class GWpyFormat(Generic):
             elif sname.lower() in alts:
                 alt = sname.lower()
             else:
-                warnings.warn('{0} Mathematical operations using this unit '
-                              'should work, but conversions to other units '
-                              'will not.'.format(str(exc).rstrip(' ')),
-                              category=units.UnitsWarning)
+                if cls.warn:
+                    warnings.warn('{0} Mathematical operations using this unit '
+                                  'should work, but conversions to other units '
+                                  'will not.'.format(str(exc).rstrip(' ')),
+                                  category=units.UnitsWarning)
                 try:  # return previously created unit
                     return UNRECOGNIZED_UNITS[name]
                 except KeyError:  # or create new one now
@@ -120,9 +122,16 @@ def parse_unit(name, parse_strict='warn', format='gwpy'):
         return None
 
     # pylint: disable=unexpected-keyword-arg
-    if parse_strict in ('raise',):
-        return units.Unit(name, parse_strict=parse_strict)
-    return units.Unit(name, parse_strict=parse_strict, format=format)
+    try:
+        return units.Unit(name, parse_strict='raise')
+    except ValueError as exc:
+        if parse_strict == 'raise' or not 'did not parse as unit' in str(exc):
+            raise
+        # try again using out own lenient parser
+        GWpyFormat.warn = parse_strict != 'silent'  # don't warn if 'silent'
+        return units.Unit(name, parse_strict='silent', format=format)
+    finally:
+        GWpyFormat.warn = True
 
 
 # -- custom units -------------------------------------------------------------

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -79,10 +79,11 @@ class GWpyFormat(Generic):
                 alt = sname.lower()
             else:
                 if cls.warn:
-                    warnings.warn('{0} Mathematical operations using this unit '
-                                  'should work, but conversions to other units '
-                                  'will not.'.format(str(exc).rstrip(' ')),
-                                  category=units.UnitsWarning)
+                    warnings.warn(
+                        '{0} Mathematical operations using this unit should '
+                        'work, but conversions to other units will '
+                        'not.'.format(str(exc).rstrip(' ')),
+                        category=units.UnitsWarning)
                 try:  # return previously created unit
                     return UNRECOGNIZED_UNITS[name]
                 except KeyError:  # or create new one now
@@ -125,7 +126,7 @@ def parse_unit(name, parse_strict='warn', format='gwpy'):
     try:
         return units.Unit(name, parse_strict='raise')
     except ValueError as exc:
-        if parse_strict == 'raise' or not 'did not parse as unit' in str(exc):
+        if parse_strict == 'raise' or 'did not parse as unit' not in str(exc):
             raise
         # try again using out own lenient parser
         GWpyFormat.warn = parse_strict != 'silent'  # don't warn if 'silent'

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -136,7 +136,7 @@ def test_parse_unit_strict():
     assert str(u) == 'metre'
 
     # assert that a newly-created unit only gets created once
-    u2 = parse_unit('metre', parse_strict='ignore')
+    u2 = parse_unit('metre', parse_strict='silent')
     assert u2 is u  # same object
     assert u == u2  # compare as equal (just in case)
 


### PR DESCRIPTION
This PR fixes an issue in `gwpy.detector.units.parse_unit` with `parse_strict='silent'` by adding a class attribute that controls whether warnings should be emitted. It's a bit clunky, but it works.