### PR TITLE
Improvements to internal parse_filter method

### DIFF
--- a/gwpy/plotter/filter.py
+++ b/gwpy/plotter/filter.py
@@ -25,7 +25,7 @@ import numpy
 
 from scipy import signal
 
-from matplotlib.ticker import MultipleLocator
+from matplotlib.ticker import MaxNLocator
 
 from astropy.units import Quantity
 
@@ -136,8 +136,10 @@ class BodePlot(Plot):
         self.paxes.set_ylabel('Phase [deg]')
         self.maxes.set_xscale('log')
         self.paxes.set_xscale('log')
-        self.paxes.yaxis.set_major_locator(MultipleLocator(base=90))
-        self.paxes.set_ylim(-185, 185)
+        self.paxes.yaxis.set_major_locator(
+            MaxNLocator(nbins='auto', steps=[4.5, 9]))
+        self.paxes.yaxis.set_minor_locator(
+            MaxNLocator(nbins=20, steps=[4.5, 9]))
         if title:
             self.maxes.set_title(title)
 

--- a/gwpy/plotter/filter.py
+++ b/gwpy/plotter/filter.py
@@ -136,8 +136,12 @@ class BodePlot(Plot):
         self.paxes.set_ylabel('Phase [deg]')
         self.maxes.set_xscale('log')
         self.paxes.set_xscale('log')
-        self.paxes.yaxis.set_major_locator(
-            MaxNLocator(nbins='auto', steps=[4.5, 9]))
+        try:
+            self.paxes.yaxis.set_major_locator(
+                MaxNLocator(nbins='auto', steps=[4.5, 9]))
+        except ValueError:  # matplotlib < 2.0
+            self.paxes.yaxis.set_major_locator(
+                MaxNLocator(nbins=9, steps=[4.5, 9]))
         self.paxes.yaxis.set_minor_locator(
             MaxNLocator(nbins=20, steps=[4.5, 9]))
         if title:

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -61,15 +61,15 @@ def _design_iir(wp, ws, sample_rate, gpass, gstop,
     nyq = sample_rate / 2.
     wp = numpy.atleast_1d(wp)
     ws = numpy.atleast_1d(ws)
-    if analog:
+    if analog:  # convert Hz to rad/s
         wp *= TWO_PI
         ws *= TWO_PI
-    else:
+    else:  # convert Hz to half-cycles / sample
         wp /= nyq
         ws /= nyq
     z, p, k = signal.iirdesign(wp, ws, gpass, gstop, analog=analog,
                                ftype=ftype, output='zpk')
-    if analog:
+    if analog:  # convert back to Hz
         z /= -TWO_PI
         p /= -TWO_PI
     if output == 'zpk':

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -241,7 +241,7 @@ def parse_filter(args, analog=False, sample_rate=None):
     if isinstance(args, LinearTimeInvariant):
         lti = args
     else:
-        lti = signal.dlti(*args)
+        lti = signal.lti(*args)
 
     # convert to zpk format
     try:

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -232,9 +232,9 @@ def parse_filter(args, analog=False, sample_rate=None):
 
     # parse FIR filter
     if isinstance(args, numpy.ndarray) and args.ndim == 1:  # fir
-        b, a = args, 1.
+        b, a = args, [1.]
         if analog:
-            b, a = signal.bilinear(b, a)
+            return 'ba', signal.bilinear(b, a)
         return 'ba', (b, a)
 
     # parse IIR filter

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -72,6 +72,7 @@ def _design_iir(wp, ws, sample_rate, gpass, gstop,
     if analog:  # convert back to Hz
         z /= -TWO_PI
         p /= -TWO_PI
+        k *= TWO_PI ** z.size / -TWO_PI ** p.size
     if output == 'zpk':
         return z, p, k
     elif output == 'ba':

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -196,8 +196,8 @@ def bilinear_zpk(zeros, poles, gain, fs=1.0, unit='Hz'):
     return dzeros, dpoles, dgain
 
 
-def parse_digital_lti(args, analog=False, sample_rate=None):
-    """Parse arbitrary input args as an LTI filter definition
+def parse_filter(args, analog=False, sample_rate=None):
+    """Parse arbitrary input args into a TF or ZPK filter definition
 
     Parameters
     ----------
@@ -214,8 +214,11 @@ def parse_digital_lti(args, analog=False, sample_rate=None):
 
     Returns
     -------
-    lti : `~scipy.signal.ZerosPolesGain`, `~scipy.signal.lti`
-        a formatted LTI filter in ZPK format
+    ftype : `str`
+        either ``'ba'`` or ``'zpk'``
+    filt : `tuple`
+        the filter components for the returned `ftype`, either a 2-tuple
+        for with transfer function components, or a 3-tuple for ZPK
     """
     if analog and not sample_rate:
         raise ValueError("Must give sample_rate frequency to convert "
@@ -228,72 +231,29 @@ def parse_digital_lti(args, analog=False, sample_rate=None):
 
     # parse FIR filter
     if isinstance(args, numpy.ndarray) and args.ndim == 1:  # fir
+        b, a = args, 1.
         if analog:
-            raise ValueError("Filtering with analog FIR filters is "
-                             "not supported")
-        try:
-            return signal.lti(args, [1.])
-        except ValueError as exc:
-            if str(exc).startswith('Improper transfer function'):
-                exc.args = ('{} scipy >= 0.16 is required to represent FIR '
-                            'filters as LTI.'.format(str(exc)),)
-            raise
+            b, a = signal.bilinear(b, a)
+        return 'ba', (b, a)
 
     # parse IIR filter
     if isinstance(args, LinearTimeInvariant):
         lti = args
     else:
-        lti = signal.lti(*args)
+        lti = signal.dlti(*args)
 
-    if analog:
-        lti = signal.lti(
-            *bilinear_zpk(lti.zeros, lti.poles, lti.gain, fs=sample_rate))
-
+    # convert to zpk format
     try:
-        return lti.to_zpk()
+        lti = lti.to_zpk()
     except AttributeError:  # scipy < 0.18, doesn't matter
-        return lti
+        pass
 
-
-def with_digital_lti(func):
-    """Decorate a function to pre-format a filter as a digital LTI system
-
-    This decorator interprets all positional arguments as a single
-    filter definition (c.f. `scipy.signal.lti`), and strips the following
-    keyword arguments
-
-    - ``analog`` : whether the input filter is digital or not
-    - ``sample_rate`` : the sampling rate at which to convert from analog
-
-    ``func`` should then be written to accept a single positional argument
-    as a `scipy.signal.ZerosPolesGain` with digital coefficients.
-    All other keyword arguments will be passed through untouched.
-    """
-    @wraps(func)
-    def decorated_func(self, *filt, **kwargs):
-        """Parse `args` to `scipy.signal.lti`, and pass to underlying function
-        """
-        # parse kwargs
-        analog = kwargs.pop('analog', False)
-        sample_rate = kwargs.pop('sample_rate', None)
-
-        if analog and not sample_rate:
-            # try and parse sample_rate from class instance
-            if hasattr(self, 'df'):
-                # FrequencySeries or Spectrogram
-                sample_rate = 2 * (
-                    self.f0 + (self.shape[-1] - 1) * self.df).to('Hz').value
-            elif hasattr(self, 'sample_rate'):
-                # TimeSeries
-                sample_rate = self.sample_rate.to('Hz').value
-
-        # parse filter as LTI
-        lti = parse_digital_lti(filt, analog=analog, sample_rate=sample_rate)
-
-        # call original function with ZerosPolesGain
-        return func(self, lti, **kwargs)
-
-    return decorated_func
+    # convert to digital components
+    if analog:
+        return 'zpk', bilinear_zpk(lti.zeros, lti.poles, lti.gain,
+                                   fs=sample_rate)
+    # return zpk
+    return 'zpk', (lti.zeros, lti.poles, lti.gain)
 
 
 # -- user methods -------------------------------------------------------------

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -919,7 +919,6 @@ class TestBodePlot(PlottingTestBase):
         assert paxes.get_xlabel() == 'Frequency [Hz]'
         assert paxes.get_yscale() == 'linear'
         assert paxes.get_ylabel() == 'Phase [deg]'
-        assert paxes.get_ylim() == (-185, 185)
 
     def test_add_filter(self):
         # test method 1

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -130,6 +130,14 @@ class TestSignalFilterDesign(object):
             filter_design.concatenate_zpks(zpk1, zpk2),
             ([1, 2, 3, 1, 2, 3, 4], [4, 5, 6, 5, 6, 7, 8], 100))
 
+    def test_parse_filter(self):
+        fir = numpy.arange(10)
+        assert filter_design.parse_filter(fir) == ('ba', (fir, 1.))
+        zpk = ([1, 2, 3], [4, 5, 6], 1.)
+        parsed = filter_design.parse_filter(zpk)
+        assert parsed[0] == 'zpk'
+        utils.assert_zpk_equal(parsed[1], zpk)
+
 
 # -- gwpy.signal.window -------------------------------------------------------
 

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -132,7 +132,7 @@ class TestSignalFilterDesign(object):
 
     def test_parse_filter(self):
         fir = numpy.arange(10)
-        assert filter_design.parse_filter(fir) == ('ba', (fir, 1.))
+        assert filter_design.parse_filter(fir) == ('ba', (fir, [1.]))
         zpk = ([1, 2, 3], [4, 5, 6], 1.)
         parsed = filter_design.parse_filter(zpk)
         assert parsed[0] == 'zpk'

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1051,32 +1051,19 @@ class TimeSeries(TimeSeriesBase):
         filtfilt = kwargs.pop('filtfilt', False)
 
         # parse filter
-        sos = None
-        try:
-            lti = filter_design.parse_digital_lti(
+        form, filt = filter_design.parse_filter(
                 filt, analog=kwargs.pop('analog', False),
-                sample_rate=self.sample_rate.to('Hz').value)
-        except ValueError:
-            if (len(filt) == 1 and isinstance(filt[0], numpy.ndarray) and
-                    filt[0].ndim == 1):  # FIR
-                a = [1.]
-                b = filt[0]
-        else:
-            # determine FIR or IIR
+                sample_rate=self.sample_rate.to('Hz').value,
+        )
+        if form == 'zpk':
             try:
-                if lti.den.shape == (1,) and lti.den[0] == (1.):  # FIR
-                    a = lti.den
-                    b = lti.num
-                else:
-                    raise AttributeError  # push into IIR parser
-            except AttributeError:  # IIR
-                # if here, we know that ``lti`` is a ZPK-compatible IIR filter
-                # so, try and convert to SOS
-                try:
-                    sos = signal.zpk2sos(lti.zeros, lti.poles, lti.gain)
-                except AttributeError:  # scipy < 0.16, no SOS filtering
-                    a = lti.den
-                    b = lti.num
+                sos = signal.zpk2sos(*filt)
+            except AttributeError:  # scipy < 0.16, no SOS filtering
+                sos = None
+                b, a = filt
+        else:
+            sos = None
+            b, a = filt
 
         # perform filter
         kwargs.setdefault('axis', 0)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1060,7 +1060,7 @@ class TimeSeries(TimeSeriesBase):
                 sos = signal.zpk2sos(*filt)
             except AttributeError:  # scipy < 0.16, no SOS filtering
                 sos = None
-                b, a = filt
+                b, a = signal.zpk2tf(*filt)
         else:
             sos = None
             b, a = filt


### PR DESCRIPTION
This PR reworks `gwpy.signal.filter_design.parse_filter` (renamed from `parse_digital_lti`) to make it simpler. The return is now just the filter type (`'ba'` or `'zpk'`) and the filter components. The main improvement here is that FIR filters aren't shoe-horned through `scipy.signal.lti` so we don't get annoying warnings about bad filter coefficients.

A small set of other improvements are included, but have no impact on the API.