### PR TITLE
Added documentation notes about quoting strings in table filters [ci skip]

### DIFF
--- a/docs/table/filter.rst
+++ b/docs/table/filter.rst
@@ -79,6 +79,13 @@ Filters can be trivially chained (either in `str` form, or functional form)::
     -------- ------------- ---- ---- ---- -------- -------
     GW170814 1186741861.53 30.5 25.3 18.0      540     HLV
 
+=======
+Gotchas
+=======
+
+The parser used to intrepet simple filters doesn't recognised strings containing alpha-numeric characters as single words, meaning things like LIGO data channel names will get parsed incorrectly if not quoted.
+So, if in doubt, always pass a string in quotes; the quotes will get removed internally by the parser anyway. E.g., use ``channel = "X1:TEST"`` and not ``channel = X1:TEST``.
+
 ================
 Built-in filters
 ================

--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -125,12 +125,21 @@ def parse_column_filter(definition):
         if any parsed operator string cannnot be mapped to a function from
         the `operator` module
 
+    Notes
+    -----
+    Strings that contain non-alphanumeric characters (e.g. hyphen `-`) should
+    be quoted inside the filter definition, to prevent such characters
+    being interpreted as operators, e.g. ``channel = X1:TEST`` should always
+    be passed as ``channel = "X1:TEST"``.
+
     Examples
     --------
     >>> parse_column_filter("frequency>10")
     [('frequency', <function operator.gt>, 10.)]
     >>> parse_column_filter("50 < snr < 100")
     [('snr', <function operator.gt>, 50.), ('snr', <function operator.lt>, 100.)]
+    >>> parse_column_filter("channel = "H1:TEST")
+    [('channel', <function operator.eq>, 'H1:TEST')]
     """  # nopep8
     # parse definition into parts
     parts = list(generate_tokens(StringIO(definition.strip()).readline))


### PR DESCRIPTION
This PR improves the documentation for `gwpy.table.filter` by adding some documentation notes about the importance of quoting strings, especially if they may contain non-alpha-numeric characters (e.g. LIGO channel names).