### PR TITLE
Fixed bug in parsing table filters with unicode names

### DIFF
--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -25,6 +25,7 @@ import re
 from tokenize import generate_tokens
 from collections import OrderedDict
 
+from six import string_types
 from six.moves import StringIO
 
 import numpy
@@ -193,10 +194,10 @@ def parse_column_filters(*definitions):
 def _flatten(container):
     """Flatten arbitrary nested list of filters into a 1-D list
     """
-    if isinstance(container, str):
+    if isinstance(container, string_types):
         container = [container]
     for elem in container:
-        if isinstance(elem, str) or is_filter_tuple(elem):
+        if isinstance(elem, string_types) or is_filter_tuple(elem):
             yield elem
         else:
             for elem2 in _flatten(elem):
@@ -207,7 +208,9 @@ def is_filter_tuple(tup):
     """Return whether a `tuple` matches the format for a column filter
     """
     return isinstance(tup, (tuple, list)) and (
-        len(tup) == 3 and isinstance(tup[0], str) and callable(tup[1]))
+        len(tup) == 3 and
+        isinstance(tup[0], string_types) and
+        callable(tup[1]))
 
 
 # -- filter -------------------------------------------------------------------

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -318,6 +318,9 @@ class TestEventTable(TestTable):
         utils.assert_table_equal(
             midf, table.filter('frequency > 100').filter('frequency < 1000'))
 
+        # check unicode parsing (PY2)
+        loud2 = table.filter(u'snr > 100')
+
     def test_filter_in_segmentlist(self, table):
         print(table)
         # check filtering on segments works


### PR DESCRIPTION
This PR fixes a bug in `gwpy.table.filter` whereby `unicode` names were not being parsed properly. The fix is to use `six.string_types` to accept `str` and `unicode` throughout.