### PR TITLE
Added test of signal.fft.get_default_fft_api

### DIFF
--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -35,7 +35,8 @@ except ImportError:
     pass
 
 from gwpy.signal import (filter_design, window)
-from gwpy.signal.fft import (lal as fft_lal, utils as fft_utils,
+from gwpy.signal.fft import (get_default_fft_api,
+                             lal as fft_lal, utils as fft_utils,
                              registry as fft_registry, ui as fft_ui)
 from gwpy.timeseries import TimeSeries
 
@@ -163,6 +164,21 @@ class TestSignalWindow(object):
             window.recommended_overlap('kaiser')
         assert str(exc.value) == ('no recommended overlap for \'kaiser\' '
                                   'window')
+
+
+# -- gwpy.signal.fft ----------------------------------------------------------
+
+class TestSignalFft(object):
+
+    def test_get_default_fft_api(self):
+        api = get_default_fft_api()
+        for lib in ('pycbc.psd', 'lal', 'scipy'):
+            try:
+                import_module(lib)
+            except ImportError:
+                continue
+            assert api == lib
+            return
 
 
 # -- gwpy.signal.fft.registry -------------------------------------------------


### PR DESCRIPTION
This PR adds a new unit test for `gwpy.signal.fft.get_default_fft_api()`. I couldn't think of an elegant test, so the test essentially reproduces the functional code to check that it worked. Changes are I didn't mess it up twice.