### PR TITLE
Added disclaimer to dev docs [ci skip]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.linkcode',
+    'sphinx.ext.ifconfig',
     'sphinx_automodapi.automodapi',
     'numpydoc',
     'matplotlib.sphinxext.plot_directive',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,16 @@
 
 .. title:: Docs
 
+.. ifconfig:: '+' in release
+
+   .. warning::
+
+      You are viewing documentation for a development build of GWpy.
+      This version may include unstable code, or breaking changes relative
+      the most recent stable release.
+      To view the documentation for the latest stable release of GWpy, please
+      `click here <../stable/>`_.
+
 GWpy is a collaboration-driven `Python <http://www.python.org>`_ package
 providing tools for studying data from ground-based gravitational-wave
 detectors.


### PR DESCRIPTION
This PR adds a sphinx dependency on `ifconfig` to support a disclaimer reminding viewers of the development documentation `/latest` that things might not be 100% stable.