### PR TITLE
Updated dependencies to avoid matplotlib 2.1.x due to bug in mlab.cohere()

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,11 +6,11 @@ pykerberos
 pyRXP
 
 # extras
-h5py>=1.3
+h5py >= 1.3
 pymysql
 dqsegdb
 https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
-pycbc; python_version == '2.7'
+pycbc ; python_version == '2.7'
 git+https://github.com/duncanmmacleod/ligo.org.git
 sqlalchemy
 psycopg2
@@ -23,9 +23,9 @@ sphinx-bootstrap-theme
 sphinxcontrib-programoutput
 
 # tests
-pytest>=3.1
+pytest >= 3.1
 coveralls
-mock; python_version < '3'
+mock ; python_version < '3'
 freezegun
 sqlparse
 bs4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # GWpy core requirements
 #           [use requirements-dev.txt for a full development environment
 #            including docs and testing dependencies]
-six>=1.5
+six >= 1.5
 python-dateutil
-enum34; python_version < '3'
-numpy>=1.7.1
-scipy>=0.12.0
-astropy>=1.1.1
-matplotlib>=1.2.0, !=2.1.*
-lscsoft-glue>=1.55.2
+enum34 ; python_version < '3'
+numpy >= 1.7.1
+scipy >= 0.12.0
+astropy >= 1.1.1
+matplotlib >= 1.2.0, != 2.1.*
+lscsoft-glue >= 1.55.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ enum34; python_version < '3'
 numpy>=1.7.1
 scipy>=0.12.0
 astropy>=1.1.1
-matplotlib>=1.2.0
+matplotlib>=1.2.0, !=2.1.*
 lscsoft-glue>=1.55.2

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_requires = get_setup_requires()
 install_requires = [
     'numpy>=1.7.1',
     'scipy>=0.12.1',
-    'matplotlib>=1.2.0',
+    'matplotlib>=1.2.0,!=2.1.*',
     'astropy>=1.1.1',
     'six>=1.5',
     'lscsoft-glue>=1.55.2',


### PR DESCRIPTION
This PR updates the dependencies (`setup.py` and `requirements.txt`) to avoid installing matplotlib 2.1.x, see matplotlib/matplotlib#10003.