### PR TITLE
Fixed CI failure caused by shallow clone on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,9 @@ matrix:
   fast_finish: true
 
 before_install:
+  # force unshallow clone (for full history)
+  - git fetch --unshallow
+
   # set up utilities
   - . ./ci/lib.sh
 


### PR DESCRIPTION
This PR adds a fix for the CI failures caused by a shallow clone on travis. This caused versioneer failures that escalated to a `dpkg-buildpackage` failure on debian images.
  