### PR TITLE
Updated Build-Requires in debian/control

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -21,10 +21,13 @@
 #
 
 # enable backports for jessie
-if [[ `cat /etc/debian_version` == "8."* ]];
+if [[ `cat /etc/debian_version` == "8."* ]]; then
     apt-cache policy | grep "jessie-backports/main" &> /dev/null || \
-        echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list
-    yum update -yqq
+        {
+         echo "deb http://ftp.debian.org/debian jessie-backports main" \
+         > /etc/apt/sources.list.d/backports.list;
+         apt-get update -yqq;
+        }
 fi
 
 # install pip for system python

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -20,16 +20,6 @@
 # Build Debian package
 #
 
-# enable backports for jessie
-if [ `get_debian_version` -eq 8 ]; then
-    apt-cache policy | grep "jessie-backports/main" &> /dev/null || \
-        {
-         echo "deb http://ftp.debian.org/debian jessie-backports main" \
-         > /etc/apt/sources.list.d/backports.list;
-         apt-get update -yqq;
-        }
-fi
-
 # install pip for system python
 apt-get -yq install python-pip
 
@@ -42,12 +32,18 @@ apt-get -yq install \
     python-setuptools \
     python3-setuptools \
     python-git \
-    python3-git \
     python-jinja2 \
-    python3-jinja2
 
 # install setuptools from jessie-backports
 if [ `get_debian_version` -eq 8 ]; then
+    # enable backports
+    apt-cache policy | grep "jessie-backports/main" &> /dev/null || \
+        {
+         echo "deb http://ftp.debian.org/debian jessie-backports main" \
+         > /etc/apt/sources.list.d/backports.list;
+         apt-get update -yqq;
+        }
+    # install setuptools
     apt-get -yq install -t jessie-backports \
         python-setuptools \
         python3-setuptools

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -20,15 +20,18 @@
 # Build Debian package
 #
 
-# install build dependencies
+# install build dependencies (should match debian/control)
 apt-get -yq install \
     debhelper \
     dh-python \
     python-all \
+    python3-all \
     python-setuptools \
-    python-pip \
+    python3-setuptools \
     python-git \
-    python-jinja2
+    python3-git \
+    python-jinja2 \
+    python3-jinja2
 
 # needed to prevent version number munging with versioneer
 pip install "setuptools>33"

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -27,6 +27,9 @@ if [[ `cat /etc/debian_version` == "8."* ]];
     yum update -yqq
 fi
 
+# install pip for system python
+apt-get -yq install python-pip
+
 # install build dependencies (should match debian/control)
 apt-get -yq install \
     debhelper \

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -20,6 +20,13 @@
 # Build Debian package
 #
 
+# enable backports for jessie
+if [[ `cat /etc/debian_version` == "8."* ]];
+    apt-cache policy | grep "jessie-backports/main" &> /dev/null || \
+        echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list
+    yum update -yqq
+fi
+
 # install build dependencies (should match debian/control)
 apt-get -yq install \
     debhelper \

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -21,7 +21,7 @@
 #
 
 # enable backports for jessie
-if [[ `cat /etc/debian_version` == "8."* ]]; then
+if [ `get_debian_version` -eq 8 ]; then
     apt-cache policy | grep "jessie-backports/main" &> /dev/null || \
         {
          echo "deb http://ftp.debian.org/debian jessie-backports main" \
@@ -47,7 +47,7 @@ apt-get -yq install \
     python3-jinja2
 
 # install setuptools from jessie-backports
-if [[ `cat /etc/debian_version` == "8."* ]]; then
+if [ `get_debian_version` -eq 8 ]; then
     apt-get -yq install -t jessie-backports \
         python-setuptools \
         python3-setuptools

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -46,8 +46,12 @@ apt-get -yq install \
     python-jinja2 \
     python3-jinja2
 
-# needed to prevent version number munging with versioneer
-pip install "setuptools>33"
+# install setuptools from jessie-backports
+if [[ `cat /etc/debian_version` == "8."* ]]; then
+    apt-get -yq install -t jessie-backports \
+        python-setuptools \
+        python3-setuptools
+fi
 
 # get versions
 GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -51,6 +51,10 @@ get_os_type() {
     fi
 }
 
+get_debian_version() {
+    cat /etc/debian_version | cut -d\. -f1
+}
+
 get_package_manager() {
     local ostype=`get_os_type`
     if [ $ostype == macos ]; then

--- a/debian/control
+++ b/debian/control
@@ -13,10 +13,6 @@ Build-Depends: debhelper (>= 9),
                python3-all,
                python-setuptools (>= 33.0),
                python3-setuptools (>= 33.0),
-               python-git,
-               python3-git,
-               python-jinja2,
-               python3-jinja2
 
 # -- python-gwpy --------------------------------------------------------------
 

--- a/debian/control
+++ b/debian/control
@@ -1,13 +1,24 @@
+# -- gwpy source package ------------------------------------------------------
+
 Source: gwpy
 Maintainer: Duncan Macleod <duncan.macleod@ligo.org>
 Section: python
 Priority: optional
-Build-Depends: python-setuptools (>= 0.6b3),
-               python-all (>= 2.6.6-3),
-               debhelper (>= 7.4.3)
 Standards-Version: 3.9.1
 X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.4
+Build-Depends: debhbelper (>= 9),
+               dh-python,
+               python-all,
+               python3-all,
+               python-setuptools (>= 33.0),
+               python3-setuptools (>= 33.0),
+               python-git,
+               python3-git,
+               python-jinja2,
+               python3-jinja2
+
+# -- python-gwpy --------------------------------------------------------------
 
 Package: python-gwpy
 Architecture: all
@@ -34,6 +45,8 @@ Description: A python package for gravitational-wave astrophysics
            package providing tools for studying data from ground-based
            gravitational-wave detectors.
  .
+
+# -- python3-gwpy -------------------------------------------------------------
 
 Package: python3-gwpy
 Architecture: all

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Priority: optional
 Standards-Version: 3.9.1
 X-Python-Version: >= 2.7
 X-Python3-Version: >= 3.4
-Build-Depends: debhbelper (>= 9),
+Build-Depends: debhelper (>= 9),
                dh-python,
                python-all,
                python3-all,


### PR DESCRIPTION
This PR updates the `Build-Requires` list in `debian/control` to match what is actually required, and updated ci instructions to duplicate build-requires list, which should prevent further `setuptools` incompatibility issues.