### PR TITLE
Fixed bug in writing TimeSeriesDict with HDF5

### DIFF
--- a/gwpy/timeseries/io/hdf5.py
+++ b/gwpy/timeseries/io/hdf5.py
@@ -97,6 +97,7 @@ def write_hdf5_dict(tsdict, h5f, group=None, **kwargs):
         h5g = h5f
 
     # write each timeseries
+    kwargs.setdefault('format', 'hdf5')
     for key, series in tsdict.items():
         series.write(h5g, path=str(key), **kwargs)
 

--- a/gwpy/timeseries/io/wav.py
+++ b/gwpy/timeseries/io/wav.py
@@ -115,7 +115,7 @@ def is_wav(origin, filepath, fileobj, *args, **kwargs):
     else:
         try:
             wave.open(args[0])
-        except wave.Error:
+        except (wave.Error, AttributeError):
             return False
         else:
             return True


### PR DESCRIPTION
This PR fixes #627 by patching `gwpy.timeseries.io.wav` to catch errors identifying wav-format files. I also patched this a second time by explicitly setting `format='hdf5'` for the `TimeSeries.write` calls inside of `TimeSeriesDict.write` for `format='hdf5'`.