### PR TITLE
Install suggested packages for gwpy

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -77,7 +77,7 @@ dpkg --install ${GWPY_DEB} || { \
 # install system-level extras for the correct python version
 for pckg in \
     ${PY_PREFIX}-nds2-client \
-    ${PY_PREFIX}-dqsegdb \
+    ${PY_PREFIX}-dqsegdb ${PY_PREFIX}-m2crypto \
     ${PY_PREFIX}-sqlalchemy \
     ${PY_PREFIX}-pandas \
     ${PY_PREFIX}-psycopg2 \

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -77,6 +77,11 @@ dpkg --install ${GWPY_DEB} || { \
 # install system-level extras for the correct python version
 for pckg in \
     ${PY_PREFIX}-nds2-client \
+    ${PY_PREFIX}-dqsegdb \
+    ${PY_PREFIX}-sqlalchemy \
+    ${PY_PREFIX}-pandas \
+    ${PY_PREFIX}-psycopg2 \
+    ${PY_PREFIX}-pymysql \
     ldas-tools-framecpp-${PY_PREFIX} \
     lalframe-${PY_PREFIX} \
     ${PY_PREFIX}-h5py \


### PR DESCRIPTION
This PR adds an option to install 'Suggests' packages in debian CI builds. This should hopefully extend the test suite coverage a wee bit.