### PR TITLE
 Separate release/development badges on README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,21 @@
 <img src="https://gwpy.github.io/images/gwpy_1200.png" alt="GWpy logo" width="400" />
 
+### Release status
 [![PyPI version](https://badge.fury.io/py/gwpy.svg)](http://badge.fury.io/py/gwpy) 
 [![DOI](https://zenodo.org/badge/9979119.svg)](https://zenodo.org/badge/latestdoi/9979119) 
 [![License](https://img.shields.io/pypi/l/gwpy.svg)](https://choosealicense.com/licenses/gpl-3.0/)
+[![Research software impact](http://depsy.org/api/package/pypi/gwpy/badge.svg)](http://depsy.org/package/python/gwpy) 
 
 [![Build Status](https://travis-ci.org/gwpy/gwpy.svg?branch=master)](https://travis-ci.org/gwpy/gwpy) 
-[![Coverage Status](https://coveralls.io/repos/gwpy/gwpy/badge.svg)](https://coveralls.io/r/gwpy/gwpy) 
-[![Research software impact](http://depsy.org/api/package/pypi/gwpy/badge.svg)](http://depsy.org/package/python/gwpy) 
-[![Maintainability](https//api.codeclimate.com/v1/badges/2cf14445b3e070133745/maintainability)](https://codeclimate.com/github/gwpy/gwpy/maintainability)
+[![Coverage Status](https://coveralls.io/repos/github/gwpy/gwpy/badge.svg?branch=master)](https://coveralls.io/github/gwpy/gwpy?branch=master)
 [![Code Health](https://landscape.io/github/gwpy/gwpy/master/landscape.svg?style=flat)](https://landscape.io/github/gwpy/gwpy/master) 
+
+
+
+### Development status
+[![Build Status](https://travis-ci.org/gwpy/gwpy.svg?branch=develop)](https://travis-ci.org/gwpy/gwpy) 
+[![Coverage Status](https://coveralls.io/repos/github/gwpy/gwpy/badge.svg?branch=develop)](https://coveralls.io/github/gwpy/gwpy?branch=master)
+[![Code Health](https://landscape.io/github/gwpy/gwpy/develop/landscape.svg?style=flat)](https://landscape.io/github/gwpy/gwpy/develop) 
 
 [https://gwpy.github.io](https://gwpy.github.io)
 


### PR DESCRIPTION
This PR separates the project status badges into release (`master`) and development (`develop`) groups, so that people can see progress between releases.