### PR TITLE
Fixed CI failures due to excessive warnings

### DIFF
--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -103,7 +103,7 @@ class Qtransform(CliProduct):
         self.my_ts = self.timeseries[0]
         self.title2 = ''
 
-        self.qxfrm_args['search'] = self.my_ts.dt.value * len(self.my_ts)
+        self.qxfrm_args['search'] = abs(self.my_ts.span) / 2.
         if args.qrange:
             self.qxfrm_args['qrange'] = (float(args.qrange[0]),
                                          float(args.qrange[1]))


### PR DESCRIPTION
This PR fixes the [current CI Failures](https://travis-ci.org/gwpy/gwpy/builds/327600956) by fixing an error in the usage of the `search` kwarg for `TimeSeries.q_transform`.

This param is a one-sided window duration, meaning the search is actually `[gps-search, gps+search)`, so we need to pass `duration/2.` to search the entire `TimeSeries`. Fixing this then prevents any warnings from `TimeSeries.crop`.

cc: @areeda