### PR TITLE
Fixed bugs and inconsistencies in crop() methods

### DIFF
--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -543,12 +543,12 @@ class Spectrogram(Array2D):
         if low is None:
             idx0 = None
         else:
-            idx0 = int((low.value - self.f0.value) // self.df.value)
+            idx0 = int(float(low.value - self.f0.value) // self.df.value)
         # find high index
         if high is None:
             idx1 = None
         else:
-            idx1 = int((high.value - self.f0.value) // self.df.value)
+            idx1 = int(float(high.value - self.f0.value) // self.df.value)
         # crop
         if copy:
             return self[:, idx0:idx1].copy()

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -808,12 +808,12 @@ class Series(Array):
         if start is None:
             idx0 = None
         else:
-            idx0 = int(float(start - self.xspan[0]) / self.dx.value)
+            idx0 = int(float(start - self.xspan[0]) // self.dx.value)
         # find end index
         if end is None:
             idx1 = None
         else:
-            idx1 = int(float(end - self.xspan[0]) / self.dx.value)
+            idx1 = int(float(end - self.xspan[0]) // self.dx.value)
             if idx1 >= self.size:
                 idx1 = None
         # crop


### PR DESCRIPTION
This PR fixes inconsistensies and bugs in the `Series.crop` and `Spectrogram.crop_frequencies` methods that meant (a) the behaviour was wrong, and (b) the behaviour was different between these methods.