### PR TITLE
Enable parsing SOS for TimeSeries.filter and friends

### DIFF
--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -240,6 +240,10 @@ def parse_filter(args, analog=False, sample_rate=None):
     # parse IIR filter
     if isinstance(args, LinearTimeInvariant):
         lti = args
+    elif (isinstance(args, numpy.ndarray) and
+              args.ndim == 2 and
+              args.shape[1] == 6):
+        lti = signal.lti(*signal.sos2zpk(args))
     else:
         lti = signal.lti(*args)
 

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -241,8 +241,7 @@ def parse_filter(args, analog=False, sample_rate=None):
     if isinstance(args, LinearTimeInvariant):
         lti = args
     elif (isinstance(args, numpy.ndarray) and
-              args.ndim == 2 and
-              args.shape[1] == 6):
+            args.ndim == 2 and args.shape[1] == 6):
         lti = signal.lti(*signal.sos2zpk(args))
     else:
         lti = signal.lti(*args)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -58,6 +58,7 @@ from gwpy.types import Array2D
 from gwpy.spectrogram import Spectrogram
 from gwpy.plotter import (TimeSeriesPlot, SegmentPlot)
 from gwpy.utils.misc import null_context
+from gwpy.signal import filter_design
 
 import mocks
 import utils
@@ -1084,6 +1085,11 @@ class TestTimeSeries(TestTimeSeriesBase):
         zpk = [], [], 1
         fts = losc.filter(zpk, analog=True)
         utils.assert_quantity_sub_equal(losc, fts)
+
+        # check SOS filters can be used directly
+        zpk = filter_design.highpass(50, sample_rate=losc.sample_rate)
+        sos = signal.zpk2sos(*zpk)
+        utils.assert_quantity_almost_equal(losc.filter(zpk), losc.filter(sos))
 
     def test_zpk(self, losc):
         zpk = [10, 10], [1, 1], 100

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1088,8 +1088,13 @@ class TestTimeSeries(TestTimeSeriesBase):
 
         # check SOS filters can be used directly
         zpk = filter_design.highpass(50, sample_rate=losc.sample_rate)
-        sos = signal.zpk2sos(*zpk)
-        utils.assert_quantity_almost_equal(losc.filter(zpk), losc.filter(sos))
+        try:
+            sos = signal.zpk2sos(*zpk)
+        except AttributeError:  # scipy < 0.16
+            pass
+        else:
+            utils.assert_quantity_almost_equal(losc.filter(zpk),
+                                               losc.filter(sos))
 
     def test_zpk(self, losc):
         zpk = [10, 10], [1, 1], 100


### PR DESCRIPTION
This PR fixes #344 by patching `gwpy.signal.filter_design.parse_filter` to handle second order sections as input, which feeds into `TimeSeries.filter`, `Spectrogram.filter`, and `BodePlot`.