### PR TITLE
gwpy-plot re-add check for need for no display matplotlib renderer

### DIFF
--- a/bin/gwpy-plot
+++ b/bin/gwpy-plot
@@ -106,6 +106,11 @@ if __name__ == '__main__':
         if len(os.getenv('HOME', '')) == 0:
             os.environ['HOME'] = '/tmp/'
 
+        # if launched from a terminal with no display
+        if len(os.getenv('DISPLAY', '')) == 0:
+            import matplotlib
+            matplotlib.use('Agg')
+
         # parse the command line
         args = parser.parse_args()
         if args.silent:


### PR DESCRIPTION
We seem to have lost a test for  no display that requires a different backend.