### PR TITLE
Added --quiet flag to pip install for dev to prevent travis errors

### DIFF
--- a/ci/docker-install.sh
+++ b/ci/docker-install.sh
@@ -33,7 +33,7 @@ sudo apt-get update
 sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 # download container
-travis_retry sudo docker pull ${DOCKER_IMAGE}
+travis_retry sudo timeout 300 docker pull ${DOCKER_IMAGE}
 
 # start container
 sudo docker run \

--- a/ci/docker-install.sh
+++ b/ci/docker-install.sh
@@ -33,7 +33,7 @@ sudo apt-get update
 sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 # download container
-sudo docker pull ${DOCKER_IMAGE}
+travis_retry sudo docker pull ${DOCKER_IMAGE}
 
 # start container
 sudo docker run \

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -40,7 +40,7 @@ else  # simple pip build
 fi
 
 # install python extras
-${PIP} install -r requirements-dev.txt ${PIP_FLAGS}
+${PIP} install -r requirements-dev.txt --quiet ${PIP_FLAGS}
 
 cd /tmp
 _gwpyloc=`${PYTHON} -c 'import gwpy; print(gwpy.__file__)'`


### PR DESCRIPTION
This PR modifies the CI configuration to use `--quiet` when install the `requirements-dev.txt` file. This should hopefully prevent [annoying errors](https://travis-ci.org/gwpy/gwpy/jobs/329240853) from travis.