### PR TITLE
Added debian/source/ to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include versioneer.py
 include gwpy.spec
 include gwpy/_version.py
 include debian/*
+include debian/source/*


### PR DESCRIPTION
This PR fixes a problem with the `sdist` for debian builds by explicitly adding `include debian/source/*` to `MANIFEST.in.