### PR TITLE
Don't use fancy dependencies if not supported by setuptools

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -34,21 +34,6 @@ apt-get -yq install \
     python-git \
     python-jinja2 \
 
-# install setuptools from jessie-backports
-if [ `get_debian_version` -eq 8 ]; then
-    # enable backports
-    apt-cache policy | grep "jessie-backports/main" &> /dev/null || \
-        {
-         echo "deb http://ftp.debian.org/debian jessie-backports main" \
-         > /etc/apt/sources.list.d/backports.list;
-         apt-get update -yqq;
-        }
-    # install setuptools
-    apt-get -yq install -t jessie-backports \
-        python-setuptools \
-        python3-setuptools
-fi
-
 # get versions
 GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
 GWPY_RELEASE=${GWPY_VERSION%%+*}

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -38,6 +38,11 @@ apt-get -yq install \
 GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
 GWPY_RELEASE=${GWPY_VERSION%%+*}
 
+# upgrade setuptools for development builds only to prevent version munging
+if [[ "${GWPY_VERSION}" == *"+"* ]]; then
+    pip install "setuptools>=25"
+fi
+
 # prepare the tarball (sdist generates debian/changelog)
 python setup.py sdist
 

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -28,6 +28,11 @@ yum -y install rpm-build git2u python-jinja2 ${PY_PREFIX}-jinja2
 
 GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
 
+# upgrade setuptools for development builds only to prevent version munging
+if [[ "${GWPY_VERSION}" == *"+"* ]]; then
+    pip install "setuptools>=25"
+fi
+
 # build the RPM
 python setup.py bdist_rpm
 

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -28,9 +28,6 @@ yum -y install rpm-build git2u python-jinja2 ${PY_PREFIX}-jinja2
 
 GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
 
-# update setuptools for bdist_rpm
-pip install "setuptools>=25"
-
 # build the RPM
 python setup.py bdist_rpm
 

--- a/debian/control
+++ b/debian/control
@@ -11,8 +11,8 @@ Build-Depends: debhelper (>= 9),
                dh-python,
                python-all,
                python3-all,
-               python-setuptools (>= 33.0),
-               python3-setuptools (>= 33.0),
+               python-setuptools,
+               python3-setuptools,
 
 # -- python-gwpy --------------------------------------------------------------
 

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -6,7 +6,7 @@
 
 Name:           python-%{srcname}
 Version:        {{ version }}
-Release:        1
+Release:        1%{?dist}
 Summary:        {{ description }}
 
 License:        {{ license }}

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@
 from __future__ import print_function
 
 import sys
+from distutils.version import LooseVersion
 
 from setuptools import (setup, find_packages,
                         __version__ as setuptools_version)
@@ -52,7 +53,7 @@ install_requires = [
 ]
 
 # exclude matplotlib 2.1.x (see matplotlib/matplotlib#10003) if possible
-if setuptools_version >= '25':  # exclude matplotlib 2.1.x
+if LooseVersion(setuptools_version) >= '25':  # exclude matplotlib 2.1.x
     install_requires[2] += ',!=2.1.*'
 
 # test for LAL

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ from __future__ import print_function
 
 import sys
 
-from setuptools import (setup, find_packages)
+from setuptools import (setup, find_packages,
+                        __version__ as setuptools_version)
 
 import versioneer
 from setup_utils import (CMDCLASS, get_setup_requires, get_scripts)
@@ -43,12 +44,16 @@ setup_requires = get_setup_requires()
 install_requires = [
     'numpy>=1.7.1',
     'scipy>=0.12.1',
-    'matplotlib>=1.2.0,!=2.1.*',
+    'matplotlib>=1.2.0',
     'astropy>=1.1.1',
     'six>=1.5',
     'lscsoft-glue>=1.55.2',
     'python-dateutil',
 ]
+
+# exclude matplotlib 2.1.x (see matplotlib/matplotlib#10003) if possible
+if setuptools_version >= '25':  # exclude matplotlib 2.1.x
+    install_requires[2] += ',!=2.1.*'
 
 # test for LAL
 try:


### PR DESCRIPTION
This PR modifies `setup.py` to only use fancy dependency specification for matplotlib if the version of setuptools will support it. This should simplify the build for debian and RHEL packages.