### PR TITLE
Fixes to builds on RHEL with mock/chroot

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -43,6 +43,11 @@ if [[ "${GWPY_VERSION}" == *"+"* ]]; then
     pip install "setuptools>=25"
 fi
 
+# upgrade GitPython (required for git>=2.15.0)
+#     since we link the git clone from travis, the dependency is actually
+#     fixed to the version of git on the travis image
+pip install "GitPython>=2.1.8"
+
 # prepare the tarball (sdist generates debian/changelog)
 python setup.py sdist
 

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -33,6 +33,9 @@ if [[ "${GWPY_VERSION}" == *"+"* ]]; then
     pip install "setuptools>=25"
 fi
 
+# upgrade GitPython (required for git>=2.15.0)
+pip install "GitPython>=2.1.8"
+
 # build the RPM
 python setup.py bdist_rpm
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -40,6 +40,7 @@ else  # simple pip build
 fi
 
 # install python extras
+${PIP} install --quiet ${PIP_FLAGS} "setuptools>=25"
 ${PIP} install -r requirements-dev.txt --quiet ${PIP_FLAGS}
 
 cd /tmp

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -16,6 +16,7 @@ Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{sr
 BuildArch:      noarch
 BuildRequires:  python2-setuptools
 BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python3-rpm-macros
 
 %description
 {{ long_description }}

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -33,6 +33,7 @@ from distutils.cmd import Command
 from distutils.command.clean import (clean as orig_clean, log, remove_tree)
 from distutils.command.bdist_rpm import bdist_rpm as distutils_bdist_rpm
 from distutils.errors import DistutilsArgError
+from distutils.version import LooseVersion
 
 from setuptools.command.bdist_rpm import bdist_rpm as _bdist_rpm
 from setuptools.command.sdist import sdist as _sdist
@@ -43,6 +44,18 @@ CMDCLASS = versioneer.get_cmdclass()
 SETUP_REQUIRES = {
     'test': ['pytest_runner'],
 }
+
+# get required version of GitPython
+try:
+    gitv = subprocess.check_output('git --version', shell=True)
+except (OSError, IOError):
+    git_version = '2.15.0'
+else:
+    git_version = gitv.rstrip().split()[-1]
+if LooseVersion(git_version) >= '2.15':  # specific minimal version required
+    GIT_PYTHON = 'GitPython>=2.1.8'
+else:  # any version
+    GIT_PYTHON = 'GitPython'
 
 
 # -- custom commands ----------------------------------------------------------
@@ -126,7 +139,7 @@ class changelog(Command):
 
 
 CMDCLASS['changelog'] = changelog
-SETUP_REQUIRES['changelog'] = ('GitPython>=2.1.8',)
+SETUP_REQUIRES['changelog'] = (GIT_PYTHON,)
 
 orig_bdist_rpm = CMDCLASS.pop('bdist_rpm', _bdist_rpm)
 DEFAULT_SPEC_TEMPLATE = os.path.join('etc', 'spec.template')

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -49,6 +49,8 @@ SETUP_REQUIRES = {
 # -- utilities ----------------------------------------------------------------
 
 def in_git_clone():
+    """Returns `True` if the current directory is a git repository
+    """
     return os.path.isdir('.git')
 
 

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -69,6 +69,9 @@ def reuse_dist_file(filename):
 
 def get_gitpython_version():
     """Determine the required version of GitPython
+
+    Because of target systems running very, very old versions of setuptools,
+    we only specify the actual version we need when we need it.
     """
     # if not in git clone, it doesn't matter
     if not in_git_clone():

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -48,23 +48,27 @@ SETUP_REQUIRES = {
 
 # -- utilities ----------------------------------------------------------------
 
-def in_git_clone():
-    """Returns `True` if the current directory is a git repository
-    """
-    return os.path.isdir('.git')
-
-
 def reuse_dist_file(filename):
     """Returns `True` if a distribution file can be reused
 
     Otherwise it should be regenerated
     """
-    # if file doesn't exist, we must make it, or if we _can_ make it, do
-    if not os.path.isfile(filename) or in_git_clone():
+    # if target file doesn't exist, we must generate it
+    if not os.path.isfile(filename):
         return False
 
-    # if existing file is newer than the setup script, reuse it
-    return os.path.getmtime(filename) >= os.path.getmtime(__file__)
+    # if we can interact with git, we can regenerate it, so we may as well
+    try:
+        import git
+    except ImportError:
+        return True
+    else:
+        try:
+            git.Repo().tags
+        except (TypeError, git.GitError):
+            return True
+        else:
+            return False
 
 
 def get_gitpython_version():

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -51,6 +51,8 @@ try:
 except (OSError, IOError):
     git_version = '2.15.0'
 else:
+    if isinstance(gitv, bytes):
+        gitv = gitv.decode('utf-8')
     git_version = gitv.rstrip().split()[-1]
 if LooseVersion(git_version) >= '2.15':  # specific minimal version required
     GIT_PYTHON = 'GitPython>=2.1.8'

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -48,6 +48,19 @@ SETUP_REQUIRES = {
 
 # -- utilities ----------------------------------------------------------------
 
+def in_git_clone():
+    """Returns `True` if the current directory is a git repository
+
+    Logic is 'borrowed' from :func:`git.repo.fun.is_git_dir`
+    """
+    gitdir = '.git'
+    return os.path.isdir(gitdir) and (
+        os.path.isdir(os.path.join(gitdir, 'objects')) and
+        os.path.isdir(os.path.join(gitdir, 'refs')) and
+        os.path.exists(os.path.join(gitdir, 'HEAD'))
+    )
+
+
 def reuse_dist_file(filename):
     """Returns `True` if a distribution file can be reused
 

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -53,13 +53,13 @@ def in_git_clone():
 
 
 def reuse_dist_file(filename):
-    # if file doesn't exist, we must make it
-    if not os.path.isfile(filename):
-        return False
+    """Returns `True` if a distribution file can be reused
 
-    # if we're not in a git clone, we need to use the existing one
-    if not in_git_clone():
-        return True
+    Otherwise it should be regenerated
+    """
+    # if file doesn't exist, we must make it, or if we _can_ make it, do
+    if not os.path.isfile(filename) or in_git_clone():
+        return False
 
     # if existing file is newer than the setup script, reuse it
     return os.path.getmtime(filename) >= os.path.getmtime(__file__)

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -77,8 +77,9 @@ def get_gitpython_version():
     # otherwise, call out to get the git version
     try:
         gitv = subprocess.check_output('git --version', shell=True)
-    except (OSError, IOError):
-        git_version = '2.15.0'
+    except (OSError, IOError, subprocess.CalledProcessError):
+        # no git installation, most likely
+        git_version = '0.0.0'
     else:
         if isinstance(gitv, bytes):
             gitv = gitv.decode('utf-8')


### PR DESCRIPTION
This PR modifies the build sequence in a few ways:

- modified `setup_utils.py` to only require `GitPython >= 2.1.8` if the installed version of `git` itself is `>= 2.15.0`
- install `GitPython>=2.1.8` manually for CI builds on RHEL
- upgrade `setuptools` _after_ the package build to help installing from requirements files