### PR TITLE
Modified debian/rules to not install bin scripts for python3

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,7 @@ override_dh_auto_install:
 	done
 	for py in $(PY3VERS); do \
 		$$py setup.py install --root=debian/python3-gwpy --no-compile -O0 --install-layout=deb; \
+		$(RM) debian/python3-gwpy/usr/bin/*; \
 	done
 
 override_dh_python2:


### PR DESCRIPTION
This PR modifies `debian/rules` to delete `bin/*` during packaging to prevent conflicts between the python2 and python3 versions of the binaries (`gwpy-plot`).