### PR TITLE
Install python2 and python3 packages during CI for debian and rhel

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -59,8 +59,13 @@ tar -xf ../gwpy_${GWPY_RELEASE}.orig.tar.gz --strip-components=1
 dpkg-buildpackage -us -uc
 popd
 
-# print and install the deb
-for PREF in python python3; do
+if [ ${PY_XY} -lt 30 ]; then  # install python2 only
+    PREFICES="python"
+else  # install both 2 and 3
+    PREFICES="python python3"
+fi
+for PREF in ${PREFICES}; do
+    # print and install the deb
     GWPY_DEB="dist/${PREF}-gwpy_${GWPY_RELEASE}-1_all.deb"
     echo "-------------------------------------------------------"
     dpkg --info ${GWPY_DEB}

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -60,14 +60,16 @@ dpkg-buildpackage -us -uc
 popd
 
 # print and install the deb
-GWPY_DEB="dist/${PY_PREFIX}-gwpy_${GWPY_RELEASE}-1_all.deb"
-echo "-------------------------------------------------------"
-dpkg --info ${GWPY_DEB}
-echo "-------------------------------------------------------"
-dpkg --install ${GWPY_DEB} || { \
-    apt-get -y -f install;  # install dependencies and package
-    dpkg --install ${GWPY_DEB};  # shouldn't fail
-}
+for PREF in python python3; do
+    GWPY_DEB="dist/${PREF}-gwpy_${GWPY_RELEASE}-1_all.deb"
+    echo "-------------------------------------------------------"
+    dpkg --info ${GWPY_DEB}
+    echo "-------------------------------------------------------"
+    dpkg --install ${GWPY_DEB} || { \
+        apt-get -y -f install;  # install dependencies and package
+        dpkg --install ${GWPY_DEB};  # shouldn't fail
+    }
+done
 
 # install system-level extras for the correct python version
 for pckg in \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -39,13 +39,9 @@ pip install "GitPython>=2.1.8"
 # build the RPM
 python setup.py bdist_rpm
 
-# install the rpm
-if [ ${PY_XY} -lt 30 ]; then
-    GWPY_RPM="dist/python2-gwpy-*.noarch.rpm"
-else
-    GWPY_RPM="dist/${PY_PREFIX}-gwpy-*.noarch.rpm"
-fi
-yum -y --nogpgcheck localinstall ${GWPY_RPM}
+# install the rpms
+GWPY_RPMS="dist/python*-gwpy-*.noarch.rpm"
+yum -y --nogpgcheck localinstall ${GWPY_RPMS}
 
 # install system-level extras
 yum -y install \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -39,9 +39,13 @@ pip install "GitPython>=2.1.8"
 # build the RPM
 python setup.py bdist_rpm
 
-# install the rpms
-GWPY_RPMS="dist/python*-gwpy-*.noarch.rpm"
-yum -y --nogpgcheck localinstall ${GWPY_RPMS}
+# install the rpm
+if [ ${PY_XY} -lt 30 ]; then
+    GWPY_RPM="dist/python2-gwpy-*.noarch.rpm"  # install python2 only
+else
+    GWPY_RPM="dist/python*-gwpy-*.noarch.rpm"  # install both 2 and 3
+fi
+yum -y --nogpgcheck localinstall ${GWPY_RPM}
 
 # install system-level extras
 yum -y install \


### PR DESCRIPTION
This PR modifies the CI builds for debian and RHEL linux to install both of the python2 and python3 packages at the same time, mainly to test for conflicts between them.