### PR TITLE
WIP: Attempts to debug nightly build failure with --verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
             - dvipng
             - libhdf5-serial-dev
 
-    - env: PIP_FLAGS="--upgrade --pre --verbose"
+    - env: PIP_FLAGS="--upgrade --pre"
       python: 'nightly'
       addons:
         apt:
@@ -127,7 +127,7 @@ matrix:
       sudo: required
 
   allow_failures:
-    - env: PIP_FLAGS="--upgrade --pre --verbose"
+    - env: PIP_FLAGS="--upgrade --pre"
     - env: DOCKER_IMAGE="ligo/software:jessie"
       python: '3.4'
     - env: DOCKER_IMAGE="ligo/software:stretch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
             - dvipng
             - libhdf5-serial-dev
 
-    - env: PIP_FLAGS="--upgrade --pre"
+    - env: PIP_FLAGS="--upgrade --pre --quiet"
       python: 'nightly'
       addons:
         apt:
@@ -127,7 +127,7 @@ matrix:
       sudo: required
 
   allow_failures:
-    - env: PIP_FLAGS="--upgrade --pre"
+    - env: PIP_FLAGS="--upgrade --pre --quiet"
     - env: DOCKER_IMAGE="ligo/software:jessie"
       python: '3.4'
     - env: DOCKER_IMAGE="ligo/software:stretch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ matrix:
             - dvipng
             - libhdf5-serial-dev
 
-    - env: PIP_FLAGS="--upgrade --pre --quiet"
+    - env: PIP_FLAGS="--upgrade --pre --verbose"
       python: 'nightly'
       addons:
         apt:
@@ -127,7 +127,7 @@ matrix:
       sudo: required
 
   allow_failures:
-    - env: PIP_FLAGS="--upgrade --pre --quiet"
+    - env: PIP_FLAGS="--upgrade --pre --verbose"
     - env: DOCKER_IMAGE="ligo/software:jessie"
       python: '3.4'
     - env: DOCKER_IMAGE="ligo/software:stretch"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -37,7 +37,7 @@ elif [ -n "${DOCKER_IMAGE}" ]; then  # debian
     . ci/install-debian.sh
 else  # simple pip build
     [[ ${TRAVIS_PYTHON_VERSION} == "nightly" ]] && \
-        ${PIP} install Cython ${PIP_FLAGS} --install-option="--no-cython-compile"
+        ${PIP} install Cython ${PIP_FLAGS} --upgrade --install-option="--no-cython-compile"
     ${PIP} install . ${PIP_FLAGS}
 fi
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -36,6 +36,8 @@ elif [[ ${DOCKER_IMAGE} =~ :el[0-9]+$ ]]; then  # SLX
 elif [ -n "${DOCKER_IMAGE}" ]; then  # debian
     . ci/install-debian.sh
 else  # simple pip build
+    [[ ${TRAVIS_PYTHON_VERSION} == "nightly" ]] && \
+        ${PIP} install Cython ${PIP_FLAGS} --install-option="--no-cython-compile"
     ${PIP} install . ${PIP_FLAGS}
 fi
 


### PR DESCRIPTION
This PR modifies the `python:nightly` build to print verbose output, in an attempt to debug the failures with `scipy`.