### PR TITLE
Fixed duplicate pypi deployment by excluding docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,7 @@ deploy:
     password: ${PYPI_PASSWD}
     distributions: bdist_wheel
     on:
+      condition: -z "${DOCKER_IMAGE}"
       branch: master
       tags: true
       python: '3.6'


### PR DESCRIPTION
This PR fixes (attempts to fix) a bug in the pypi deployment configuration on travis-ci where _all_ python2.7 builds attempt to upload a tarball to pypi.python.org. The trick, hopefully, is to add the condition `-z "${DOCKER_IMAGE}"` to only deploy for non-docker builds.