### PR TITLE
Fixed bug in RPM spec file that adds python3.4 as a dependency of python2-gwpy

### DIFF
--- a/etc/spec.template
+++ b/etc/spec.template
@@ -66,11 +66,12 @@ Requires:       python%{python3_pkgversion}-glue
 %autosetup -n %{srcname}-%{version}
 
 %build
-%py2_build
+# build python3 first
 %py3_build
+# so that the scripts come from python2
+%py2_build
 
 %install
-# install python3 first so that scripts come from python2
 %py3_install
 %py2_install
 


### PR DESCRIPTION
This PR fixes a bug in the `spec.template` file that ended up with `/usr/bin/python3.4` as a dependency of the `python2-gwpy` RPM package.

The trick is that we need to build python2 _after_ python3, so that the resulting `bin/` files have `/usr/bin/python2` in their shebang line - this gets pulled into the dependencies for the resulting `python2-gwpy` RPM package.

This also means that when we move to having `python3x-gwpy` supply the binaries, we need to switch the `%build` order back again.