### PR TITLE
Added explicit float casting of times in LOSC JSON metadata 

### DIFF
--- a/gwpy/io/losc.py
+++ b/gwpy/io/losc.py
@@ -170,8 +170,8 @@ def get_event_segment(event, host=LOSC_URL, **match):
     for fmeta in jdata['strain']:
         if match and not any(match[key] != fmeta[key] for key in match):
             continue
-        start = fmeta['GPSstart']
-        end = start + fmeta['duration']
+        start = float(fmeta['GPSstart'])
+        end = start + float(fmeta['duration'])
         fseg = Segment(start, end)
         if seg is None:
             seg = fseg


### PR DESCRIPTION
This PR adds an explicit `float()` call in `gwpy.io.losc.get_event_segment` in case the timing in LOSC JSON metadata is stored as a string, instead of an integer (or float).