### PR TITLE
Updated LOSC API to handle multiple tags and versions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,9 @@
 version: "2"
 
 checks:
+  argument-count:
+    config:
+      threshold: 5
   file-lines:
     config:
       threshold: 500

--- a/gwpy/io/losc.py
+++ b/gwpy/io/losc.py
@@ -167,9 +167,7 @@ def get_event_segment(event, host=LOSC_URL, **match):
     """
     jdata = fetch_json('{}/archive/{}/json/'.format(host, event))
     seg = None
-    for fmeta in jdata['strain']:
-        if match and not any(match[key] != fmeta[key] for key in match):
-            continue
+    for fmeta in sieve_urls(jdata['strain'], **match):
         start = fmeta['GPSstart']
         end = start + fmeta['duration']
         fseg = Segment(start, end)
@@ -180,3 +178,15 @@ def get_event_segment(event, host=LOSC_URL, **match):
     if seg is None:
         raise ValueError("No files matched for event {}".format(event))
     return seg
+
+
+def sieve_urls(urllist, **match):
+    """Sieve a list of LOSC URL metadata dicts based on key, value pairs
+
+    This method simply matches keys from the ``match`` keywords with those
+    found in the JSON dicts for a file URL returned by the LOSC API.
+    """
+    for urlmeta in urllist:
+        if any(match[key] != urlmeta[key] for key in match):
+            continue
+        yield urlmeta

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -713,9 +713,13 @@ class TestTimeSeries(TestTimeSeriesBase):
             "Cannot find a LOSC dataset for %s covering [0, 1)" % LOSC_IFO)
 
         # check errors with multiple tags
-        with pytest.raises(ValueError) as exc:
-            self.TEST_CLASS.fetch_open_data(LOSC_IFO, 1187008880, 1187008884)
-        assert str(exc.value).lower().startswith('multiple losc url tags')
+        try:
+            with pytest.raises(ValueError) as exc:
+                self.TEST_CLASS.fetch_open_data(LOSC_IFO, 1187008880, 1187008884)
+            assert str(exc.value).lower().startswith('multiple losc url tags')
+            self.TEST_CLASS.fetch_open_data(LOSC_IFO, 1187008880, 1187008884, tag='CLN')
+        except URLError:
+            pass
 
     @utils.skip_missing_dependency('nds2')
     def test_fetch(self):

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -691,7 +691,6 @@ class TestTimeSeries(TestTimeSeriesBase):
 
     @pytest.mark.parametrize('format', [
         None,
-        'txt.gz',
         pytest.param('hdf5', marks=utils.skip_missing_dependency('h5py')),
     ])
     def test_fetch_open_data(self, losc, format):

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -712,6 +712,11 @@ class TestTimeSeries(TestTimeSeriesBase):
         assert str(exc.value) == (
             "Cannot find a LOSC dataset for %s covering [0, 1)" % LOSC_IFO)
 
+        # check errors with multiple tags
+        with pytest.raises(ValueError) as exc:
+            self.TEST_CLASS.fetch_open_data(LOSC_IFO, 1187008880, 1187008884)
+        assert str(exc.value).lower().startswith('multiple losc url tags')
+
     @utils.skip_missing_dependency('nds2')
     def test_fetch(self):
         ts = self.create(name='L1:TEST', t0=1000000000, unit='m')
@@ -1409,7 +1414,7 @@ class TestStateVector(TestTimeSeriesBase):
     def test_fetch_open_data(self, format):
         try:
             sv = self.TEST_CLASS.fetch_open_data(
-                LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format)
+                LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, version=1)
         except URLError as e:
             pytest.skip(str(e))
         utils.assert_quantity_sub_equal(

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -365,6 +365,7 @@ class TimeSeriesBase(Series):
 
     @classmethod
     def fetch_open_data(cls, ifo, start, end, sample_rate=4096,
+                        tag=None, version=None,
                         format=None, host='https://losc.ligo.org',
                         verbose=False, cache=False, **kwargs):
         """Fetch open-access data from the LIGO Open Science Center
@@ -387,6 +388,14 @@ class TimeSeriesBase(Series):
             the sample rate of desired data; most data are stored
             by LOSC at 4096 Hz, however there may be event-related
             data releases with a 16384 Hz rate, default: `4096`
+
+        tag : `str`, optional
+            file tag, e.g. ``'CLN'`` to select cleaned data, or ``'C00'``
+            for 'raw' calibrated data.
+
+        version : `int`, optional
+            version of files to download, defaults to highest discovered
+            version
 
         format : `str`, optional
             the data format to download and parse, defaults to the most
@@ -414,7 +423,7 @@ class TimeSeriesBase(Series):
         Examples
         --------
         >>> from gwpy.timeseries import (TimeSeries, StateVector)
-        >>> print(TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
+        >>> print(TimeSeries.fetch_open_data('H1', 1126259446, 1126259478))
         TimeSeries([  2.17704028e-19,  2.08763900e-19,  2.39681183e-19,
                     ...,   3.55365541e-20,  6.33533516e-20,
                       7.58121195e-20]
@@ -423,7 +432,7 @@ class TimeSeriesBase(Series):
                    dt: 0.000244140625 s,
                    name: Strain,
                    channel: None)
-        >>> print(StateVector.fetch_open_data('H1', 1126259446, 1126259478)
+        >>> print(StateVector.fetch_open_data('H1', 1126259446, 1126259478))
         StateVector([127,127,127,127,127,127,127,127,127,127,127,127,
                      127,127,127,127,127,127,127,127,127,127,127,127,
                      127,127,127,127,127,127,127,127]
@@ -452,7 +461,8 @@ class TimeSeriesBase(Series):
         """
         from .io.losc import fetch_losc_data
         return fetch_losc_data(ifo, start, end, sample_rate=sample_rate,
-                               format=format, verbose=verbose, cache=cache,
+                               tag=tag, version=version, format=format,
+                               verbose=verbose, cache=cache,
                                host=host, cls=cls, **kwargs)
 
     @classmethod

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -455,6 +455,25 @@ class TimeSeriesBase(Series):
         ``format``-dependent, because they are recorded differently by LOSC
         in different formats.
 
+        For events published in O2 and later, LOSC typically provides
+        multiple data sets containing the original (``'C00'``) and cleaned
+        (``'CLN'``) data.
+        To select both data sets and plot a comparison, for example:
+
+        >>> orig = TimeSeries.fetch_open_data('H1', 1187008870, 1187008896,
+        ...                                   tag='C00')
+        >>> cln = TimeSeries.fetch_open_data('H1', 1187008870, 1187008896,
+        ...                                  tag='CLN')
+        >>> origasd = orig.asd(fftlength=4, overlap=2)
+        >>> clnasd = cln.asd(fftlength=4, overlap=2)
+        >>> plot = origasd.plot(label='Un-cleaned')
+        >>> ax = plot.gca()
+        >>> ax.plot(clnasd, label='Cleaned')
+        >>> ax.set_xlim(10, 1400)
+        >>> ax.set_ylim(1e-24, 1e-20)
+        >>> ax.legend()
+        >>> plot.show()
+
         Notes
         -----
         `StateVector` data are not available in ``txt.gz`` format.

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -112,14 +112,9 @@ def _match_urls(urls, start, end, tag=None, version=None):
     for url in urls:
         reg = LOSC_URL_RE.match(os.path.basename(url)).groupdict()
 
-        # match tag
-        if tag and reg['tag'] != tag:
-            continue
-        if not tag:
-            matched_tags.add(reg['tag'])
-
-        # match version
-        if version and reg['version'] != version:
+        # match tag and version (if given)
+        if (tag and reg['tag'] != tag) or (
+                version and reg['version'] != version):
             continue
 
         # match times
@@ -130,7 +125,11 @@ def _match_urls(urls, start, end, tag=None, version=None):
         if gps + dur <= start:  # too early
             continue
 
-        # record
+        # if user didn't specify tag, record all of them
+        if not tag:
+            matched_tags.add(reg['tag'])
+
+        # record by version
         vers = int(reg['version'][1:])
         matched.setdefault(vers, [])
         matched[vers].append(url)

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -105,7 +105,7 @@ def _match_urls(urls, start, end, tag=None, version=None):
 
     # sort URLs by duration, then start time, then ...
     urls.sort(key=lambda u:
-        os.path.splitext(os.path.basename(u))[0].split('-')[::-1])
+              os.path.splitext(os.path.basename(u))[0].split('-')[::-1])
 
     # format version request
     if version and not LOSC_VERSION_RE.match(str(version)):


### PR DESCRIPTION
This PR updates the LOSC API to handle multiple dataset tags and versions. This solves the problem of separating uncleaned `'C00'` data from cleaned `'CLN' data, and also multiple versions of the same data. By default the highest discovered version is returned, while multiple tags raises a `ValueError` that lists the available tags.

`TimeSeries.fetch_open_data` documentation was updated to describe the new kwargs, and give examples of how to use them.