### PR TITLE
Fixed error raising in io.datafind.find_best_frametype

### DIFF
--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -300,13 +300,15 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
             break
 
     # raise exception if nothing found
-    if not match:
-        msg = "Cannot locate channel(s) in any known frametype"
+    missing = set(channels) - set(match.keys())
+    if missing:
+        msg = "Cannot locate the following channel(s) in any known frametype"
         if gpstime:
             msg += " at GPS=%d" % gpstime
+        msg += ":\n    {}".format('\n    '.join(missing))
         if not allow_tape:
-            msg += (" [those files on tape have not been checked, use "
-                    "allow_tape=True to perform a complete search]")
+            msg += ("\n[files on tape have not been checked, use "
+                    "allow_tape=True for a complete search]")
         raise ValueError(msg)
 
     # if matching all types, rank based on coverage, tape, and TOC size

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -529,28 +529,28 @@ class TestIoDatafind(object):
                                               allow_tape=True) == 'GW100916'
             assert io_datafind.find_frametype('L1:LDAS-STRAIN',
                                               return_all=True) == ['GW100916']
+
             # test missing channel raises sensible error
             with pytest.raises(ValueError) as exc:
                 io_datafind.find_frametype('X1:TEST', allow_tape=True)
-            assert str(exc.value) == ('Cannot locate channel(s) in any known '
-                                      'frametype')
+            assert str(exc.value) == (
+                'Cannot locate the following channel(s) '
+                'in any known frametype:\n    X1:TEST')
+
             # test malformed channel name raises sensible error
             with pytest.raises(ValueError) as exc:
                 io_datafind.find_frametype('bad channel name')
             assert str(exc.value) == ('Cannot parse interferometer prefix '
                                       'from channel name \'bad channel name\','
                                       ' cannot proceed with find()')
+
             # test trend sorting ends up with an error
             with pytest.raises(ValueError) as exc:
                 io_datafind.find_frametype('X1:TEST.rms,s-trend',
                                            allow_tape=True)
-            assert str(exc.value) == ('Cannot locate channel(s) '
-                                      'in any known frametype')
             with pytest.raises(ValueError):
                 io_datafind.find_frametype('X1:TEST.rms,m-trend',
                                            allow_tape=True)
-            assert str(exc.value) == ('Cannot locate channel(s) '
-                                      'in any known frametype')
 
     def test_find_best_frametype(self, connection):
         """Test :func:`gwpy.io.datafind.find_best_frametype


### PR DESCRIPTION
This PR fixes a broken error state in `gwpy.io.datafind.find_best_frametype` where only if _all_ channels were not matched would a `ValueError` be raised.

Now, if _any_ channel is not matched to a frametype, an error is raised.