### PR TITLE
Use PEP-508 to specify dependencies

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -24,9 +24,9 @@ cd ${GWPY_PATH}
 
 . ci/lib.sh
 
-set -x && trap 'set +x' RETURN
-
 get_environment
+
+set -x
 
 # install for this OS
 if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then  # macports

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -41,7 +41,7 @@ fi
 
 # install python extras
 ${PIP} install --upgrade pip
-${PIP} install --quiet ${PIP_FLAGS} "setuptools>=25"
+${PIP} install --quiet ${PIP_FLAGS} "setuptools>=36.2"
 ${PIP} install -r requirements-dev.txt --quiet ${PIP_FLAGS}
 
 set +x

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -112,36 +112,31 @@ get_environment() {
     IFS='.' read PY_MAJOR_VERSION PY_MINOR_VERSION <<< "$pyversion"
     PY_XY="${PY_MAJOR_VERSION}${PY_MINOR_VERSION}"
     PYTHON=python$pyversion
+    PIP="${PYTHON} -m pip"
     case "$pkger" in
         "port")
             PY_DIST=python${PY_XY}
             PY_PREFIX=py${PY_XY}
-            PIP=pip-$pyversion
             ;;
         "apt-get")
             if [ ${PY_MAJOR_VERSION} == 2 ]; then
                 PY_DIST=python
                 PY_PREFIX=python
-                PIP=pip
             else
                 PY_DIST=python${PY_MAJOR_VERSION}
                 PY_PREFIX=python${PY_MAJOR_VERSION}
-                PIP=pip${PY_MAJOR_VERSION}
             fi
             ;;
         "yum")
             if [ ${PY_MAJOR_VERSION} == 2 ]; then
                 PY_DIST=python
                 PY_PREFIX=python
-                PIP=pip
             elif [ ${PY_XY} -eq 34 ]; then
                 PY_DIST=python${PY_XY}
                 PY_PREFIX=python${PY_XY}
-                PIP=pip${PY_MAJOR_VERSION}
             else
                 PY_DIST=python${PY_XY}u
                 PY_PREFIX=python${PY_XY}u
-                PIP=pip$pyversion
             fi
             ;;
     esac

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ python-dateutil
 enum34 ; python_version < '3'
 numpy >= 1.7.1
 scipy >= 0.12.0
-astropy >= 1.1.1
-matplotlib >= 1.2.0, != 2.1.*
+astropy >= 1.1.1, < 3.0.0 ; python_version < '3'
+astropy >= 1.1.1 ; python_version >= '3'
+matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
 lscsoft-glue >= 1.55.2

--- a/setup.py
+++ b/setup.py
@@ -36,31 +36,43 @@ from setup_utils import (CMDCLASS, get_setup_requires, get_scripts)
 
 __version__ = versioneer.get_version()
 
+PEP_508 = LooseVersion(setuptools_version) >= '36.2'
+
 # -- dependencies -------------------------------------------------------------
 
 # build dependencies
 setup_requires = get_setup_requires()
 
-# package dependencies
-install_requires = [
-    'numpy>=1.7.1',
-    'scipy>=0.12.1',
-    'matplotlib>=1.2.0',
-    'astropy>=1.1.1',
-    'six>=1.5',
-    'lscsoft-glue>=1.55.2',
-    'python-dateutil',
-]
+# runtime dependencies
+dependencies = {
+    'six': '>= 1.5',
+    'python-dateutil': None,
+    'numpy': '>= 1.7.1',
+    'scipy': '>= 0.12.1',
+    'matplotlib': '>= 1.2.0',
+    'astropy': '>= 1.1.1',
+    'lscsoft-glue': '>= 1.55.2',
+}
 
-# exclude matplotlib 2.1.x (see matplotlib/matplotlib#10003) if possible
-if LooseVersion(setuptools_version) >= '25':  # exclude matplotlib 2.1.x
-    install_requires[2] += ',!=2.1.*'
+# include fancy dependencies
+if PEP_508:
+    # exclude astropy >= 3.0 on python2.7
+    dependencies['astropy '] = "{} ; python_version >= '3'".format(
+        dependencies['astropy'])
+    dependencies['astropy'] += " ; python_version < '3'"
+
+    # exclude matplotlib 2.1.[01] (see matplotlib/matplotlib#10003)
+    dependencies['matplotlib'] += ', !=2.1.0, !=2.1.1'
+
+# unwrap dependencies into simple list
+install_requires = ['{0} {1}'.format(pkg.strip(), ver or '') for
+                    pkg, ver in dependencies.items()]
 
 # test for LAL
 try:
     import lal  # pylint: disable=unused-import
 except ImportError as e:
-    install_requires.append('ligotimegps>=1.2.1')
+    install_requires.append('ligotimegps >= 1.2.1')
 
 # enum34 required for python < 3.4
 try:


### PR DESCRIPTION
This PR updates `setup.py` and `requirements.txt` to use [PEP-508](https://www.python.org/dev/peps/pep-0508/) for fancy dependency specification, allowing the following specifications:

- astropy<3 for python<3
- matplotlib!=2.1.[01] (broken)

`enum34` is still specified using a `try/except` so that systems with old versions of `setuptools` still get the correct basic requirements.