### PR TITLE
Use python 3.6 for pre-release CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
             - libhdf5-serial-dev
 
     - env: PIP_FLAGS="--upgrade --pre --quiet"
-      python: 'nightly'
+      python: '3.6'
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 matrix:
   include:
     # simple build
-    - python: 2.7
+    - python: '2.7'
       addons:
         apt:
           packages:
@@ -21,7 +21,7 @@ matrix:
             - texlive-fonts-recommended
             - dvipng
             - libhdf5-serial-dev
-    - python: 3.4
+    - python: '3.4'
       addons:
         apt:
           packages:
@@ -33,7 +33,7 @@ matrix:
             - texlive-fonts-recommended
             - dvipng
             - libhdf5-serial-dev
-    - python: 3.5
+    - python: '3.5'
       addons:
         apt:
           packages:
@@ -45,7 +45,7 @@ matrix:
             - texlive-fonts-recommended
             - dvipng
             - libhdf5-serial-dev
-    - python: 3.6
+    - python: '3.6'
       addons:
         apt:
           packages:

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -40,8 +40,11 @@ else  # simple pip build
 fi
 
 # install python extras
+${PIP} install --upgrade pip
 ${PIP} install --quiet ${PIP_FLAGS} "setuptools>=25"
 ${PIP} install -r requirements-dev.txt --quiet ${PIP_FLAGS}
+
+set +x
 
 cd /tmp
 _gwpyloc=`${PYTHON} -c 'import gwpy; print(gwpy.__file__)'`
@@ -51,3 +54,7 @@ echo "GWpy installed to $_gwpyloc"
 echo
 echo "------------------------------------------------------------------------"
 cd - 1> /dev/null
+
+echo "Dependencies:"
+echo "-------------"
+${PYTHON} -m pip list installed --format=columns


### PR DESCRIPTION
This PR modifies `.travis.yml` to use `python: '3.6'` for the `pip install --pre` CI job. Scipy doesn't seem to want to build on `python: 'nightly'` and the purpose of this job is to find breaking changes in dependencies, not necessary the python standard library.