### PR TITLE
Added event_gps method to gwpy.io.losc

### DIFF
--- a/gwpy/io/losc.py
+++ b/gwpy/io/losc.py
@@ -134,6 +134,25 @@ def fetch_run_json(run, detector, gpsstart, gpsend, host=LOSC_URL):
 
 # -- utilities ----------------------------------------------------------------
 
+def event_gps(event, host=LOSC_URL):
+    """Returns the GPS time of an open-data event
+
+    Parameters
+    ----------
+    event : `str`
+        the name of the event to query
+
+    host : `str`, optional
+        the URL of the LOSC host to query, defaults to losc.ligo.org
+
+    Returns
+    -------
+    gps : `float`
+        the GPS time of this event
+    """
+    return fetch_event_json(event, host=host)['GPS']
+
+
 def event_segment(event, host=LOSC_URL, **match):
     """Returns the GPS segment covered by a LOSC event dataset
 

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -729,3 +729,10 @@ class TestIoLosc(object):
         except (URLError, SSLError) as exc:
             pytest.skip(str(exc))
         assert sets == result
+
+    def test_event_gps(self):
+        try:
+            gps = io_losc.event_gps('GW170817')
+        except (URLError, SSLError) as exc:
+            pytest.skip(str(exc))
+        assert gps == 1187008882.43


### PR DESCRIPTION
This PR adds a new `event_gps()` method to `gwpy.io.losc` to return just the GPS time of an event, as recorded by LOSC.

This is useful to build GPS segments for use with `TimeSeries.fetch_open_data` and friends.