### PR TITLE
Improved default server selection in DataQualityFlag.query*

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -400,10 +400,9 @@ class DataQualityFlag(object):
             filled appropriately.
         """
         url = kwargs.get('url', DEFAULT_SEGMENT_SERVER)
-        if 'dqsegdb' in url or re.match('https://[a-z1-9-]+.ligo.org', url):
-            return cls.query_dqsegdb(flag, *args, **kwargs)
-        else:
+        if urlparse(url).netloc.startswith('geosegdb.'):  # only DB2 server
             return cls.query_segdb(flag, *args, **kwargs)
+        return cls.query_dqsegdb(flag, *args, **kwargs)
 
     @classmethod
     def query_segdb(cls, flag, *args, **kwargs):

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -31,6 +31,7 @@ from __future__ import absolute_import
 import datetime
 import json
 import operator
+import os
 import re
 import warnings
 from io import StringIO
@@ -60,6 +61,9 @@ re_IFO_TAG_VERSION = re.compile(
     r"\A(?P<ifo>[A-Z]\d):(?P<tag>[^/]+):(?P<version>\d+)\Z")
 re_IFO_TAG = re.compile(r"\A(?P<ifo>[A-Z]\d):(?P<tag>[^/]+)\Z")
 re_TAG_VERSION = re.compile(r"\A(?P<tag>[^/]+):(?P<version>\d+)\Z")
+
+DEFAULT_SEGMENT_SERVER = os.getenv('DEFAULT_SEGMENT_SERVER',
+                                   'https://segments.ligo.org')
 
 
 class DataQualityFlag(object):
@@ -378,8 +382,9 @@ class DataQualityFlag(object):
             defining a number of summary segments
 
         url : `str`, optional
-            URL of the segment database,
-            default: ``'https://segments.ligo.org'``
+            URL of the segment database, defaults to
+            ``$DEFAULT_SEGMENT_SERVER`` environment variable, or
+            ``'https://segments.ligo.org'``
 
         See Also
         --------
@@ -394,7 +399,7 @@ class DataQualityFlag(object):
             A new `DataQualityFlag`, with the `known` and `active` lists
             filled appropriately.
         """
-        url = kwargs.get('url', 'https://segments.ligo.org')
+        url = kwargs.get('url', DEFAULT_SEGMENT_SERVER)
         if 'dqsegdb' in url or re.match('https://[a-z1-9-]+.ligo.org', url):
             return cls.query_dqsegdb(flag, *args, **kwargs)
         else:
@@ -414,8 +419,10 @@ class DataQualityFlag(object):
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments
 
-        url : `str`, optional, default: ``'https://segments.ligo.org'``
-            URL of the segment database
+        url : `str`, optional
+            URL of the segment database, defaults to
+            ``$DEFAULT_SEGMENT_SERVER`` environment variable, or
+            ``'https://segments.ligo.org'``
 
         Returns
         -------
@@ -464,8 +471,10 @@ class DataQualityFlag(object):
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments
 
-        url : `str`, optional, default: ``'https://segments.ligo.org'``
-            URL of the segment database
+        url : `str`, optional
+            URL of the segment database, defaults to
+            ``$DEFAULT_SEGMENT_SERVER`` environment variable, or
+            ``'https://segments.ligo.org'``
 
         Returns
         -------
@@ -486,7 +495,7 @@ class DataQualityFlag(object):
 
         # get server
         protocol, server = kwargs.pop(
-            'url', 'https://segments.ligo.org').split('://', 1)
+            'url', DEFAULT_SEGMENT_SERVER).split('://', 1)
 
         # parse flag
         out = cls(name=flag)
@@ -662,7 +671,7 @@ class DataQualityFlag(object):
         -----"""
         return io_registry.write(self, target, *args, **kwargs)
 
-    def populate(self, source='https://segments.ligo.org', segments=None,
+    def populate(self, source=DEFAULT_SEGMENT_SERVER, segments=None,
                  pad=True, **kwargs):
         """Query the segment database for this flag's active segments.
 
@@ -1030,8 +1039,10 @@ class DataQualityDict(OrderedDict):
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments
 
-        url : `str`, optional, default: ``'https://segments.ligo.org'``
-            URL of the segment database
+        url : `str`, optional
+            URL of the segment database, defaults to
+            ``$DEFAULT_SEGMENT_SERVER`` environment variable, or
+            ``'https://segments.ligo.org'``
 
         See Also
         --------
@@ -1046,7 +1057,7 @@ class DataQualityDict(OrderedDict):
             A new `DataQualityFlag`, with the `known` and `active` lists
             filled appropriately.
         """
-        url = kwargs.get('url', 'https://segments.ligo.org')
+        url = kwargs.get('url', DEFAULT_SEGMENT_SERVER)
         if 'dqsegdb' in url or re.match('https://[a-z1-9-]+.ligo.org', url):
             return cls.query_dqsegdb(flag, *args, **kwargs)
         return cls.query_segdb(flag, *args, **kwargs)
@@ -1063,8 +1074,10 @@ class DataQualityDict(OrderedDict):
             Either, two `float`-like numbers indicating the
             GPS [start, stop) interval, or a `SegmentList`
             defining a number of summary segments.
-        url : `str`, optional, default: ``'https://segments.ligo.org'``
-            URL of the segment database.
+        url : `str`, optional
+            URL of the segment database, defaults to
+            ``$DEFAULT_SEGMENT_SERVER`` environment variable, or
+            ``'https://segments.ligo.org'``
 
         Returns
         -------
@@ -1084,7 +1097,7 @@ class DataQualityDict(OrderedDict):
             raise ValueError("DataQualityDict.query_segdb must be called with "
                              "a list of flag names, and either GPS start and "
                              "stop times, or a SegmentList of query segments")
-        url = kwargs.pop('url', 'https://segments.ligo.org')
+        url = kwargs.pop('url', DEFAULT_SEGMENT_SERVER)
         if kwargs.pop('on_error', None) is not None:
             warnings.warn("DataQualityDict.query_segdb doesn't accept the "
                           "on_error keyword argument")
@@ -1166,8 +1179,10 @@ class DataQualityDict(OrderedDict):
             - `'warn'`: print a warning
             - `'ignore'`: move onto the next flag as if nothing happened
 
-        url : `str`, optional, default: ``'https://segments.ligo.org'``
-            URL of the segment database.
+        url : `str`, optional
+            URL of the segment database, defaults to
+            ``$DEFAULT_SEGMENT_SERVER`` environment variable, or
+            ``'https://segments.ligo.org'``
 
         Returns
         -------
@@ -1466,7 +1481,7 @@ class DataQualityDict(OrderedDict):
         -----"""
         return io_registry.write(self, target, *args, **kwargs)
 
-    def populate(self, source='https://segments.ligo.org',
+    def populate(self, source=DEFAULT_SEGMENT_SERVER,
                  segments=None, pad=True, on_error='raise', **kwargs):
         """Query the segment database for each flag's active segments.
 

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -596,7 +596,8 @@ class TestDataQualityFlag(object):
                 RESULT = QUERY_RESULT[QUERY_FLAGS[0]].copy().coalesce()
             else:
                 result = query_segdb(self.TEST_CLASS.query, QUERY_FLAGS[0],
-                                     0, 10, url='https://segdb.does.not.exist')
+                                     0, 10,
+                                     url='https://geosegdb.does.not.exist')
                 RESULT = QUERY_RESULT[QUERY_FLAGS[0]]
         except ImportError as e:
             pytest.skip(str(e))


### PR DESCRIPTION
This PR improves the default server and method logic in `gwpy.segments.flag` for the `DataQualityFlag` and `DataQualityDict` objects.

- fixes #664 by matching only `geosegdb` to `query_segdb()`
- fixes #665 by using `DEFAULT_SEGMENT_SERVER` for default query URL