### PR TITLE
Fixed positioning of colorbar ticks for location='top'

### DIFF
--- a/gwpy/plotter/core.py
+++ b/gwpy/plotter/core.py
@@ -328,6 +328,11 @@ class Plot(figure.Figure):
         # make colour bar
         colorbar = self.colorbar(mappable, cax=cax, ax=ax, **kwargs)
 
+        # position ticks
+        if location == 'top':
+            cax.xaxis.tick_top()
+            cax.xaxis.set_label_position('top')
+
         # set label
         if label:
             colorbar.set_label(label)


### PR DESCRIPTION
This PR fixes a bug in the tick positioning for `Plot.add_colorbar(..., location='top')`, where the colorbar X-axis wasn't automatically modified to place ticks at the top.