### PR TITLE
Updated expected LOSC timeline results to handle upstream change

### DIFF
--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -672,8 +672,8 @@ class TestDataQualityFlag(object):
         assert segs.label == 'H1_DATA'
         utils.assert_segmentlist_equal(segs.known, [(946339215, 946368015)])
         utils.assert_segmentlist_equal(segs.active, [
-            (946340946, 946351800),
-            (946356479, 946360620),
+            (946340946, 946351799),
+            (946356479, 946360619),
             (946362652, 946368015),
         ])
 


### PR DESCRIPTION
This PR fixes the expected results from `DataQualityFlag.fetch_open_data` to accommodate an upstream bug-fix to the LOSC timeline segments. This should serve as a reminder that this test should use `mock`, and not rely on an actualy download from losc.ligo.org.