### PR TITLE
Updated tests to match updated LOSC JSON metadata for GW150914

### DIFF
--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -705,9 +705,9 @@ class TestIoLosc(object):
         assert sorted(list(jdata.keys())) == ['events', 'runs']
         assert jdata['events']['GW150914'] == {
             'DQbits': 7,
-            'GPStime': 1126259462.0,
+            'GPStime': 1126259462.4,
             'INJbits': 5,
-            'UTCtime': u'2015-09-14T09:50:45',
+            'UTCtime': u'2015-09-14T09:50:45.400000',
             'detectors': [u'L1', u'H1'],
             'frametype': u'%s_HOFT_C02',
         }


### PR DESCRIPTION
This PR fixes an out-of-date test, broken by an upstream change in the LOSC JSON metadata for GW150914.