### PR TITLE
Improved error handling in TestGravitySpyTable

### DIFF
--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -22,9 +22,11 @@
 import os.path
 import shutil
 import tempfile
+from ssl import SSLError
 
 from six import PY2
 from six.moves import StringIO
+from six.moves.urllib.error import URLError
 
 import pytest
 
@@ -524,11 +526,9 @@ class TestGravitySpyTable(TestEventTable):
     TABLE = GravitySpyTable
 
     def test_search(self):
-        from ssl import SSLError
-
         try:
             t2 = self.TABLE.search(uniqueID="8FHTgA8MEu", howmany=1)
-        except SSLError as e:
+        except (URLError, SSLError) as e:
             pytest.skip(str(e))
 
         import json


### PR DESCRIPTION
This PR improves the error handling in the tests of `GravitySpyTable.search` by catching `URLError` as well as `SSLError` (see, e.g, [this failure](https://travis-ci.org/gwpy/gwpy/jobs/342725747)).

cc: @scottcoughlin2014