### PR TITLE
Updated setup.py port command

### DIFF
--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -41,7 +41,9 @@ sudo port -N install \
 
 # make Portfile
 cd ${GWPY_PATH}
-$PYTHON setup.py port
+GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
+$PYTHON setup.py sdist
+$PYTHON setup.py port --tarball dist/gwpy-${GWPY_VERSION}.tar.gz
 
 # create mock portfile repo and install
 PORT_REPO=`pwd`/ports

--- a/etc/Portfile.template
+++ b/etc/Portfile.template
@@ -8,7 +8,7 @@ github.setup        gwpy gwpy {{ version }} v
 name                py-gwpy
 
 categories-append   science
-maintainers         {ligo.org:duncan.macleod @duncanmmacleod}
+maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
 
 platforms           darwin
 license             GPL-3
@@ -21,14 +21,14 @@ homepage            https://gwpy.github.io
 
 master_sites        pypi:g/gwpy \
                     https://github.com/gwpy/gwpy/releases/v${version}/
-distname            gwpy-${version}
 
 checksums   rmd160  {{ rmd160 }} \
-            sha256  {{ sha256 }}
+            sha256  {{ sha256 }} \
+            size    {{ size }}
 
 # until glue is available for multiple python versions, we are stuck to
 # python 2.7
-#python.versions     27 34 35 36
+
 python.versions     27
 python.default_version 27
 

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -366,15 +366,8 @@ class port(Command):
         with temp_directory() as tmpd:
             # download dist file
             if self.tarball is None:
-                from pip.commands.download import DownloadCommand
-                dcmd = DownloadCommand()
-                rset = dcmd.run(*dcmd.parse_args([
-                    '{}=={}'.format(self.distributions.get_name(),
-                                    self.version),
-                    '--dest', tmpd, '--no-deps', '--no-binary', ':all:',
-                ]))
-                self.tarball = os.path.join(
-                    tmpd, rset.requirements['gwpy'].link.filename)
+                self.tarball = self._download(self.distribution.get_name(),
+                                              self.version, tmpd)
 
             # get checksum digests
             log.info('reading distribution tarball %r' % self.tarball)
@@ -394,6 +387,19 @@ class port(Command):
                     version=self.version, **checksum),
                     file=fport)
             log.info('portfile written to %r' % self.portfile)
+
+    @staticmethod
+    def _download(name, version, targetdir):
+        from pip.commands.download import DownloadCommand
+        dcmd = DownloadCommand()
+        rset = dcmd.run(*dcmd.parse_args([
+            '{}=={}'.format(name, version),
+            '--dest', targetdir, '--no-deps', '--no-binary', ':all:',
+        ]))
+        log.info('downloaded {}'.format(
+            rset.requirements[name].link.url_without_fragment))
+        return os.path.join(
+            targetdir, rset.requirements[name].link.filename)
 
     @staticmethod
     def _get_sha(data, algorithm=256):

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -363,18 +363,15 @@ class port(Command):
             self.version = self.distribution.get_version()
 
     def run(self):
-        # find dist file
-        name = self.distribution.get_name()
-        print(self.version)
-
         with temp_directory() as tmpd:
             # download dist file
             if self.tarball is None:
                 from pip.commands.download import DownloadCommand
                 dcmd = DownloadCommand()
                 rset = dcmd.run(*dcmd.parse_args([
-                    '{}=={}'.format(name, self.version), '--dest', tmpd,
-                    '--no-deps', '--no-binary', ':all:',
+                    '{}=={}'.format(self.distributions.get_name(),
+                                    self.version),
+                    '--dest', tmpd, '--no-deps', '--no-binary', ':all:',
                 ]))
                 self.tarball = os.path.join(
                     tmpd, rset.requirements['gwpy'].link.filename)
@@ -386,11 +383,11 @@ class port(Command):
             log.info('recovered checksums:')
             checksum = dict()
             checksum['rmd160'] = self._get_rmd160(self.tarball)
-            for algo in [1, 256]:
-                checksum['sha%d' % algo] = self._get_sha(data, algo)
+            checksum['sha256'] = self._get_sha(data)
             checksum['size'] = os.path.getsize(self.tarball)
             for key, val in checksum.iteritems():
                 log.info('    %s: %s' % (key, val))
+
             # write finished portfile to file
             with open(self.portfile, 'w') as fport:
                 print(self._template.render(


### PR DESCRIPTION
This PR updates the template `Portfile` for macports, based on discussions with the macports maintainers, and reworks the `setup.py port` command to use the tarball that exists on pypi.python.org to get the checksums, since that is what will be downloaded during `port install py-gwpy`.