### PR TITLE
Fixed missing kwarg in TimeSeries.spectrogram

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -946,11 +946,16 @@ class TestTimeSeries(TestTimeSeriesBase):
         utils.assert_quantity_sub_equal(sg, sg2)
 
         # test a couple of methods
-        with pytest.warns(UserWarning):
-            sg = losc.spectrogram(0.5, fftlength=0.25, method='welch')
-        assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
-        assert sg.df == 4 * units.Hertz
-        assert sg.dt == 0.5 * units.second
+        try:
+            with pytest.warns(UserWarning):
+                sg = losc.spectrogram(0.5, fftlength=0.25, method='welch')
+        except TypeError:  # old pycbc doesn't accept window as array
+            pass
+        else:
+            assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
+            assert sg.df == 4 * units.Hertz
+            assert sg.dt == 0.5 * units.second
+
         sg = losc.spectrogram(0.5, fftlength=0.25, method='scipy-bartlett')
         assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
         assert sg.df == 4 * units.Hertz

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -434,7 +434,7 @@ class TimeSeries(TimeSeriesBase):
         # calculate PSD using UI method
         return fft_ui.average_spectrogram(self, method_func, stride,
                                           fftlength=fftlength, overlap=overlap,
-                                          **kwargs)
+                                          window=window, **kwargs)
 
     def spectrogram2(self, fftlength, overlap=0, **kwargs):
         """Calculate the non-averaged power `Spectrogram` of this `TimeSeries`


### PR DESCRIPTION
This PR fixes a critical bug in `TimeSeries.spectrogram` whereby the `window` kwarg wasn't being used at all.