### PR TITLE
Added documentation page for citations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ pip-delete-this-directory.txt
 /docs/*.inv
 /docs/api/
 /docs/cli/*.png
+/docs/citing.rst
 
 # OS/editor files
 *.swp

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -54,7 +54,7 @@ clean:
 apidoc:
 	sphinx-apidoc -o _generated ../gwpy
 
-html: cli-examples examples lal.tag lalframe.tag
+html: cli-examples examples lal.tag lalframe.tag citing.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
@@ -248,3 +248,6 @@ $(CLIEXAMPLEDIR)/cli-spg-01.png: $(CLIEXAMPLEDIR)
 
 %.tag:
 	-wget --no-check-certificate http://software.ligo.org/docs/lalsuite/$*/$*.tag -O $@ --quiet
+
+citing.rst: zenodo-citations.py
+	python $< 597016 > $@

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ First steps
 
    What is GWpy? <overview>
    How do I install GWpy? <install/index>
+   Citing GWpy <citing>
 
 Working with data
 ~~~~~~~~~~~~~~~~~

--- a/docs/zenodo-citations.py
+++ b/docs/zenodo-citations.py
@@ -35,8 +35,10 @@ if args.output_file:
 else:
     f = sys.stdout
 
+
 def _print(*args):
     return print(*args, file=f)
+
 
 with f:
     _print("""
@@ -44,10 +46,13 @@ with f:
 Citing GWpy
 ###########
 
-If you have used GWpy as part of a project that leads to a scientific publication, please acknowledge this by citing the DOI for the version of GWpy that you have used.
+If you have used GWpy as part of a project that leads to a scientific
+publication, please acknowledge this by citing the DOI for the version of
+GWpy that you have used.
 
 Each of the DOIs below resolves a Zenodo record for that version.
-See the _Export_ section on each page for formatted citations in a number of common styles.
+See the _Export_ section on each page for formatted citations in a number
+of common styles.
 
 The list below includes only the {hits} most recent releases of GWpy.
 For older versions, please `click here <{weburl}>`__.
@@ -60,6 +65,6 @@ For older versions, please `click here <{weburl}>`__.
         _print('-' * len(version))
         _print('')
         _print('.. image:: {badge}\n'
-              '   :target: {doi}'.format(**hit['links']))
+               '   :target: {doi}'.format(**hit['links']))
         if i < args.hits - 1:
             _print('')

--- a/docs/zenodo-citations.py
+++ b/docs/zenodo-citations.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import requests
+import sys
+
+parser = argparse.ArgumentParser(
+    description=__doc__,
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('id', type=int, help='Zenodo ID for package')
+parser.add_argument('-u', '--url', default='https://zenodo.org/',
+                    help='%(metavar)s to query')
+parser.add_argument('-n', '--hits', default=10, type=int,
+                    help='number of versions to display')
+parser.add_argument('-p', '--tag-prefix', default='v',
+                    help='prefix for git version tags')
+parser.add_argument('-o', '--output-file', help='output file path')
+args = parser.parse_args()
+
+# query for metadata
+url = ('{url}/api/records/?'
+       'page=1&'
+       'size={hits}&'
+       'q=conceptrecid:"{id}"&'
+       'sort=-version&'
+       'all_versions=True'.format(**vars(args)))
+metadata = requests.get(url).json()
+
+weburl = url.replace('api/records/', 'search').replace('page=1', 'page=2')
+
+if args.output_file:
+    f = open(args.output_file, 'w')
+else:
+    f = sys.stdout
+
+def _print(*args):
+    return print(*args, file=f)
+
+with f:
+    _print("""
+###########
+Citing GWpy
+###########
+
+If you have used GWpy as part of a project that leads to a scientific publication, please acknowledge this by citing the DOI for the version of GWpy that you have used.
+
+Each of the DOIs below resolves a Zenodo record for that version.
+See the _Export_ section on each page for formatted citations in a number of common styles.
+
+The list below includes only the {hits} most recent releases of GWpy.
+For older versions, please `click here <{weburl}>`__.
+""".format(hits=args.hits, weburl=weburl).lstrip())
+
+    for i, hit in enumerate(metadata['hits']['hits']):
+        version = hit['metadata']['version'].strip(args.tag_prefix)
+        _print('-' * len(version))
+        _print(version)
+        _print('-' * len(version))
+        _print('')
+        _print('.. image:: {badge}\n'
+              '   :target: {doi}'.format(**hit['links']))
+        if i < args.hits - 1:
+            _print('')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,7 @@ numpydoc
 sphinx-bootstrap-theme >= 0.6
 sphinxcontrib-programoutput
 sphinx-automodapi
+requests
 
 # tests
 pytest >= 3.1

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ extras_require = {
     'segments': ['dqsegdb'],
     'hacr': ['pymysql'],
     'docs': ['sphinx>=1.6.1', 'numpydoc', 'sphinx-bootstrap-theme>=0.6',
-             'sphinxcontrib-programoutput', 'sphinx-automodapi'],
+             'sphinxcontrib-programoutput', 'sphinx-automodapi',
+             'requests'],
 }
 
 # define 'all' as the intersection of all extras


### PR DESCRIPTION
This PR adds the `/docs/zenodo-citations.py` script to auto-generate a page of DOIs to help people who want to cite GWpy.