### PR TITLE
Fixed bugs in TimeSeries FFT methods and improved tests

### DIFF
--- a/gwpy/signal/fft/basic.py
+++ b/gwpy/signal/fft/basic.py
@@ -80,25 +80,25 @@ def welch(timeseries, segmentlength, noverlap=None, **kwargs):
     spectrum : `~gwpy.frequencyseries.FrequencySeries`
         average power `FrequencySeries`
     """
-    pass
+    pass  # pragma: nocover
 
 
 @map_fft_method
 def bartlett(timeseries, segmentlength, **kwargs):
-    pass
+    pass  # pragma: nocover
 bartlett.__doc__ = welch.__doc__.replace('mean average',
                                          'zero-overlap mean average')
 
 
 @map_fft_method
 def median(timeseries, segmentlength, noverlap=None, **kwargs):
-    pass
+    pass  # pragma: nocover
 median.__doc__ = welch.__doc__.replace('mean average', 'median average')
 
 
 @map_fft_method
 def median_mean(timeseries, segmentlength, noverlap=None, **kwargs):
-    pass
+    pass  # pragma: nocover
 median_mean.__doc__ = welch.__doc__.replace('mean average',
                                             'median-mean average')
 

--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -237,6 +237,7 @@ def _lal_spectrum(timeseries, segmentlength, noverlap=None, method='welch',
 
     # format and return
     spec = FrequencySeries.from_lal(lalfs)
+    spec.name = timeseries.name
     spec.channel = timeseries.channel
     spec.override_unit(scale_timeseries_unit(
         timeseries.unit, scaling='density'))

--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -87,7 +87,7 @@ def generate_fft_plan(length, level=None, dtype='float64', forward=True):
         return LAL_FFTPLANS[key]
 
 
-def generate_window(length, window=('kaiser', 24), dtype='float64'):
+def generate_window(length, window=None, dtype='float64'):
     """Generate a time-domain window for use in a LAL FFT
 
     Parameters
@@ -110,6 +110,9 @@ def generate_window(length, window=('kaiser', 24), dtype='float64'):
     """
     import lal
     from ...utils.lal import LAL_TYPE_STR_FROM_NUMPY
+
+    if window is None:
+        window = ('kaiser', 24)
 
     # generate key for caching window
     laltype = LAL_TYPE_STR_FROM_NUMPY[numpy.dtype(dtype).type]

--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -132,6 +132,21 @@ def generate_window(length, window=('kaiser', 24), dtype='float64'):
         return LAL_WINDOWS[key]
 
 
+def window_from_array(array):
+    """Convert a `numpy.ndarray` into a LAL `Window` object
+    """
+    import lal
+    from ...utils.lal import LAL_TYPE_STR_FROM_NUMPY
+    laltype = LAL_TYPE_STR_FROM_NUMPY[array.dtype.type]
+
+    # create sequence
+    seq = getattr(lal, 'Create{}Sequence'.format(laltype))(array.size)
+    seq.data = array
+
+    # create window from sequence
+    return getattr(lal, 'Create{}WindowFromSequence'.format(laltype))(seq)
+
+
 # -- spectrumm methods ------------------------------------------------------
 
 def _lal_spectrum(timeseries, segmentlength, noverlap=None, method='welch',
@@ -177,6 +192,9 @@ def _lal_spectrum(timeseries, segmentlength, noverlap=None, method='welch',
     elif isinstance(window, (tuple, str)):
         window = generate_window(segmentlength, window=window,
                                  dtype=timeseries.dtype)
+    elif isinstance(window, numpy.ndarray):
+        window = window_from_array(window)
+
     # get FFT plan
     if plan is None:
         plan = generate_fft_plan(segmentlength, dtype=timeseries.dtype)

--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -227,17 +227,12 @@ def _lal_spectrum(timeseries, segmentlength, noverlap=None, method='welch',
     lalfs = create(timeseries.name, lal.LIGOTimeGPS(timeseries.epoch.gps), 0,
                    1 / segmentlength, unit, int(segmentlength // 2 + 1))
 
-    # calculate medianmean spectrum
-    if re.match(r'median-mean\Z', method, re.I):
-        spec_func = getattr(lal, "%sAverageSpectrumMedianMean" % laltypestr)
-    elif re.match(r'median\Z', method, re.I):
-        spec_func = getattr(lal, "%sAverageSpectrumMedian" % laltypestr)
-    elif re.match(r'welch\Z', method, re.I):
-        spec_func = getattr(lal, "%sAverageSpectrumWelch" % laltypestr)
-    else:
-        raise NotImplementedError("Unrecognised LAL spectrum method %r"
-                                  % method)
+    # find LAL method (e.g. median-mean -> lal.REAL8AverageSpectrumMedianMean)
+    methodname = ''.join(map(str.title, re.split('[-_]', method)))
+    spec_func = getattr(
+        lal, '{}AverageSpectrum{}'.format(laltypestr, methodname))
 
+    # calculate spectrum
     spec_func(lalfs, timeseries.to_lal(), segmentlength, stride, window, plan)
 
     # format and return

--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -31,6 +31,7 @@ import warnings
 import numpy
 
 from ...frequencyseries import FrequencySeries
+from ..window import canonical_name
 from .utils import scale_timeseries_unit
 from . import registry as fft_registry
 
@@ -121,14 +122,13 @@ def generate_window(length, window=('kaiser', 24), dtype='float64'):
     except KeyError:
         # parse window as name and arguments, e.g. ('kaiser', 24)
         if isinstance(window, (list, tuple)):
-            args = window[1:]
-            window = str(window[0])
+            window, beta = window
         else:
-            args = []
-        window = window.title() if window.islower() else window
+            beta = 0
+        window = canonical_name(window)
         # create window
-        create = getattr(lal, 'Create%s%sWindow' % (window, laltype))
-        LAL_WINDOWS[key] = create(length, *args)
+        create = getattr(lal, 'CreateNamed{}Window'.format(laltype))
+        LAL_WINDOWS[key] = create(window, beta, length)
         return LAL_WINDOWS[key]
 
 

--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -170,10 +170,10 @@ def _lal_spectrum(timeseries, segmentlength, noverlap=None, method='welch',
     noverlap : `int`
         number of samples to overlap between segments, defaults to 50%.
 
-    window : `tuple`, `str`, optional
-        window parameters to apply to timeseries prior to FFT
+    window : `lal.REAL8Window`, optional
+        window to apply to timeseries prior to FFT
 
-    plan : `REAL8FFTPlan`, optional
+    plan : `lal.REAL8FFTPlan`, optional
         LAL FFT plan to use when generating average spectrum
 
     Returns
@@ -192,11 +192,6 @@ def _lal_spectrum(timeseries, segmentlength, noverlap=None, method='welch',
     # get window
     if window is None:
         window = generate_window(segmentlength, dtype=timeseries.dtype)
-    elif isinstance(window, (tuple, str)):
-        window = generate_window(segmentlength, window=window,
-                                 dtype=timeseries.dtype)
-    elif isinstance(window, numpy.ndarray):
-        window = window_from_array(window)
 
     # get FFT plan
     if plan is None:

--- a/gwpy/signal/fft/pycbc.py
+++ b/gwpy/signal/fft/pycbc.py
@@ -76,6 +76,7 @@ def welch(timeseries, segmentlength, noverlap=None, scheme=None, **kwargs):
 
     # return GWpy FrequencySeries
     fseries = FrequencySeries.from_pycbc(pycbc_fseries, copy=False)
+    fseries.name = timeseries.name
     fseries.override_unit(scale_timeseries_unit(
         timeseries.unit, scaling='density'))
     return fseries

--- a/gwpy/signal/fft/registry.py
+++ b/gwpy/signal/fft/registry.py
@@ -89,10 +89,6 @@ def update_doc(obj, scaling='density'):
     """
     header = 'The available methods are:'
 
-    # if __doc__ isn't a string, bail-out now
-    if not isinstance(obj.__doc__, string_types):
-        return
-
     # remove the old format list
     lines = obj.__doc__.splitlines()
     try:
@@ -120,8 +116,6 @@ def update_doc(obj, scaling='density'):
     format_str.extend(['', 'See :ref:`gwpy-signal-fft` for more details'])
 
     lines.extend([' ' * indent + line for line in [header, ''] + format_str])
+
     # and overwrite the docstring
-    try:
-        obj.__doc__ = '\n'.join(lines)
-    except AttributeError:
-        obj.__func__.__doc__ = '\n'.join(lines)
+    obj.__doc__ = '\n'.join(lines)

--- a/gwpy/signal/fft/scipy.py
+++ b/gwpy/signal/fft/scipy.py
@@ -193,9 +193,6 @@ def csd(timeseries, other, segmentlength, noverlap=None, **kwargs):
 
 # register
 for func in (rayleigh, csd,):
-    try:
-        fft_registry.register_method(func, scaling='other')
-    except KeyError:
-        pass
+    fft_registry.register_method(func, scaling='other')
     fft_registry.register_method(func, name='scipy-{}'.format(func.__name__),
                                  scaling='other')

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -81,6 +81,10 @@ def normalize_fft_params(series, kwargs=None, library=None):
     If a ``window`` is given, the ``noverlap`` parameter will be set to the
     recommended overlap for that window type, if ``overlap`` is not given.
 
+    If a ``window`` is given as a `str`, it will be converted to a
+    `numpy.ndarray` containing the correct window (of the correct length),
+    or a `lal.REAL8Window`-type object for `lal` library methods.
+
     Parameters
     ----------
     series : `gwpy.timeseries.TimeSeries`
@@ -100,9 +104,10 @@ def normalize_fft_params(series, kwargs=None, library=None):
     >>> from gwpy.signal.fft.ui import normalize_fft_params
     >>> normalize_fft_params(TimeSeries(normal(size=1024), sample_rate=256))
     {'nfft': 1024, 'noverlap': 0}
-    >>> normalize_fft_params(TimeSeries(normal(size=1024), sample_rate=256), {'window': 'hann'})
-    {'window': array([  0.00000000e+00,   9.41235870e-06,   3.76490804e-05, ...,
-         8.47091021e-05,   3.76490804e-05,   9.41235870e-06]), 'noverlap': 0, 'nfft': 1024}
+    >>> normalize_fft_params(TimeSeries(normal(size=1024), sample_rate=256),
+    ...                      {'window': 'hann'})
+    {'window': array([  0.00000000e+00,   9.41235870e-06, ...,
+         3.76490804e-05,   9.41235870e-06]), 'noverlap': 0, 'nfft': 1024}
     """
     if kwargs is None:
         kwargs = dict()

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -214,11 +214,12 @@ def psdn(timeseries, method_func, *args, **kwargs):
     # unpack tuple of timeseries for cross spectrum
     try:
         timeseries, other = timeseries
-        return method_func(timeseries, other, kwargs.pop('nfft'),
-                           *args, **kwargs)
     # or just calculate PSD
     except ValueError:
         return method_func(timeseries, kwargs.pop('nfft'), *args, **kwargs)
+    else:
+        return method_func(timeseries, other, kwargs.pop('nfft'),
+                           *args, **kwargs)
 
 
 def average_spectrogram(timeseries, method_func, stride, *args, **kwargs):

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -153,13 +153,12 @@ def _normalize_overlap(overlap, window, nfft, samp):
 def _normalize_window(window, nfft, library, dtype):
     if isinstance(window, string_types):
         window = canonical_name(window)
-    if library == 'lal':
-        if isinstance(window, numpy.ndarray):
-            from .lal import window_from_array
-            return window_from_array(window)
-        else:
-            from .lal import generate_window
-            return generate_window(nfft, window=window, dtype=dtype)
+    if library == 'lal' and isinstance(window, numpy.ndarray):
+        from .lal import window_from_array
+        return window_from_array(window)
+    elif library == 'lal':
+        from .lal import generate_window
+        return generate_window(nfft, window=window, dtype=dtype)
     elif isinstance(window, string_types + (tuple,)):
         return get_window(window, nfft)
 

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -151,15 +151,15 @@ def _normalize_overlap(overlap, window, nfft, samp):
 
 
 def _normalize_window(window, nfft, library, dtype):
-    if isinstance(window, string_types):
-        window = canonical_name(window)
     if library == 'lal' and isinstance(window, numpy.ndarray):
         from .lal import window_from_array
         return window_from_array(window)
-    elif library == 'lal':
+    if library == 'lal':
         from .lal import generate_window
         return generate_window(nfft, window=window, dtype=dtype)
-    elif isinstance(window, string_types + (tuple,)):
+    if isinstance(window, string_types):
+        window = canonical_name(window)
+    if isinstance(window, string_types + (tuple,)):
         return get_window(window, nfft)
 
 

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -142,7 +142,7 @@ def normalize_fft_params(series, kwargs=None, library=None):
         kwargs['window'] = window
 
     # create FFT plan for LAL
-    if library == 'lal' and kwargs.get('plan', None):
+    if library == 'lal' and kwargs.get('plan', None) is None:
         from .lal import generate_fft_plan
         kwargs['plan'] = generate_fft_plan(nfft, dtype=series.dtype)
 

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -101,7 +101,8 @@ def normalize_fft_params(series, kwargs=None, library=None):
     >>> normalize_fft_params(TimeSeries(normal(size=1024), sample_rate=256))
     {'nfft': 1024, 'noverlap': 0}
     >>> normalize_fft_params(TimeSeries(normal(size=1024), sample_rate=256), {'window': 'hann'})
-    {'nfft': 1024, 'noverlap': 0, 'window': 'hann'}
+    {'window': array([  0.00000000e+00,   9.41235870e-06,   3.76490804e-05, ...,
+         8.47091021e-05,   3.76490804e-05,   9.41235870e-06]), 'noverlap': 0, 'nfft': 1024}
     """
     if kwargs is None:
         kwargs = dict()

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -269,7 +269,11 @@ class TestSignalFftUI(object):
         ftp = fft_ui.normalize_fft_params(
             TimeSeries(numpy.zeros(1024), sample_rate=256),
             {'window': 'hann'})
-        assert ftp == {'nfft': 1024, 'noverlap': 512, 'window': 'hann'}
+        win = signal.get_window('hann', 1024)
+        assert ftp.pop('nfft') == 1024
+        assert ftp.pop('noverlap') == 512
+        utils.assert_array_equal(ftp.pop('window'), win)
+        assert not ftp
 
 
 # -- gwpy.signal.fft.utils ----------------------------------------------------

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -316,7 +316,7 @@ class TestSignalFftLal(object):
         assert isinstance(w, lal.REAL4Window)
         assert w.sum == 32.31817089602309
         # test errors
-        with pytest.raises(AttributeError):
+        with pytest.raises(ValueError)
             fft_lal.generate_window(128, 'unknown')
         with pytest.raises(AttributeError):
             fft_lal.generate_window(128, dtype=int)

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -36,7 +36,11 @@ except ImportError:
 
 from gwpy.signal import (filter_design, window)
 from gwpy.signal.fft import (get_default_fft_api,
-                             lal as fft_lal, utils as fft_utils,
+                             basic as fft_basic,
+                             scipy as fft_scipy,
+                             lal as fft_lal,
+                             pycbc as fft_pycbc,
+                             utils as fft_utils,
                              registry as fft_registry, ui as fft_ui)
 from gwpy.timeseries import TimeSeries
 
@@ -274,6 +278,24 @@ class TestSignalFftUI(object):
         assert ftp.pop('noverlap') == 512
         utils.assert_array_equal(ftp.pop('window'), win)
         assert not ftp
+
+    def test_chunk_timeseries(self):
+        """Test :func:`gwpy.signal.fft.ui._chunk_timeseries`
+        """
+        a = TimeSeries(numpy.arange(400))
+        chunks = list(fft_ui._chunk_timeseries(a, 100, 50))
+        assert chunks == [
+            a[:150], a[75:225], a[175:325], a[275:400],
+        ]
+
+    def test_fft_library(self):
+        """Test :func:`gwpy.signal.fft.ui._fft_library`
+        """
+        assert fft_ui._fft_library(fft_lal.welch) == 'lal'
+        assert fft_ui._fft_library(fft_scipy.welch) == 'scipy'
+        assert fft_ui._fft_library(fft_pycbc.welch) == 'pycbc'
+        assert fft_ui._fft_library(fft_basic.welch) == (
+            get_default_fft_api().split('.', 1)[0])
 
 
 # -- gwpy.signal.fft.utils ----------------------------------------------------

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -319,6 +319,29 @@ class TestSignalFftUtils(object):
         assert scale_(None) == units.Unit('Hz^-1')
 
 
+# -- gwpy.signal.fft.basic ----------------------------------------------------
+
+class TestSignalFftBasic(object):
+    def test_map_fft_method(self):
+        """Test :func:`gwpy.signal.fft.basic.map_fft_method`
+        """
+        # check that defining a new method that doesn't map to a
+        # library method raises an exception
+        @fft_basic.map_fft_method
+        def blah(*args, **kwargs):
+            pass
+
+        with pytest.raises(RuntimeError) as exc:
+             blah()
+        assert str(exc.value).startswith('no underlying API method')
+
+        # check that if we only have scipy, we get the same error for
+        # median-mean
+        if get_default_fft_api() == 'scipy':
+            with pytest.raises(RuntimeError):
+                fft_basic.median_mean(None, None)
+
+
 # -- gwpy.signal.fft.lal ------------------------------------------------------
 
 @utils.skip_missing_dependency('lal')

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -316,7 +316,7 @@ class TestSignalFftLal(object):
         assert isinstance(w, lal.REAL4Window)
         assert w.sum == 32.31817089602309
         # test errors
-        with pytest.raises(ValueError)
+        with pytest.raises(ValueError):
             fft_lal.generate_window(128, 'unknown')
         with pytest.raises(AttributeError):
             fft_lal.generate_window(128, dtype=int)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1012,7 +1012,8 @@ class TestTimeSeries(TestTimeSeriesBase):
                 psd = losc[:n].psd(fftlength=1, overlap=overlap,
                                    method=method, window=win)
             # FIXME: epoch should not be excluded here (probably)
-            utils.assert_quantity_sub_equal(sg[0], psd, exclude=['epoch'])
+            utils.assert_quantity_sub_equal(sg[0], psd, exclude=['epoch'],
+                                            almost_equal=True)
 
         # test fftlength
         sg = _spectrogram(1, fftlength=0.5)
@@ -1028,10 +1029,7 @@ class TestTimeSeries(TestTimeSeriesBase):
 
         # test multiprocessing
         sg2 = _spectrogram(1, fftlength=0.5, nproc=2)
-        try:
-            utils.assert_quantity_sub_equal(sg, sg2)
-        except AssertionError:  # old numpy?
-            utils.assert_quantity_sub_equal(sg, sg2, almost_equal=True)
+        utils.assert_quantity_sub_equal(sg, sg2, almost_equal=True)
 
         # check that `cross` keyword gets deprecated properly
         # TODO: removed before 1.0 release
@@ -1044,7 +1042,8 @@ class TestTimeSeries(TestTimeSeriesBase):
             assert '`cross` keyword argument has been deprecated' in \
                 wng[0].message.args[0]
             utils.assert_quantity_sub_equal(
-                out, losc.csd_spectrogram(losc, 0.5, fftlength=.25))
+                out, losc.csd_spectrogram(losc, 0.5, fftlength=.25),
+                almost_equal=True)
 
     def test_spectrogram2(self, losc):
         # test defaults

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -893,8 +893,14 @@ class TestTimeSeries(TestTimeSeriesBase):
 
             # generate PSD
             with warnctx:
-                return losc.psd(fftlength=fftlength, overlap=overlap,
-                                method=method, window=_window)
+                try:
+                    return losc.psd(fftlength=fftlength, overlap=overlap,
+                                    method=method, window=_window)
+                except TypeError as exc:
+                    # catch pycbc window as array error
+                    if str(exc).startswith('unhashable type'):
+                        pytest.skip(str(exc))
+                    raise
 
         # test basic
         if method.endswith('median_mean'):
@@ -967,7 +973,13 @@ class TestTimeSeries(TestTimeSeriesBase):
                 w = window
             kwargs.setdefault('window', w)
             with ctx():
-                return losc.spectrogram(*args, **kwargs)
+                try:
+                    return losc.spectrogram(*args, **kwargs)
+                except TypeError as exc:
+                    # catch pycbc window as array error
+                    if str(exc).startswith('unhashable type'):
+                        pytest.skip(str(exc))
+                    raise
 
         # test defaults
         sg = _spectrogram(1)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1028,7 +1028,10 @@ class TestTimeSeries(TestTimeSeriesBase):
 
         # test multiprocessing
         sg2 = _spectrogram(1, fftlength=0.5, nproc=2)
-        utils.assert_quantity_sub_equal(sg, sg2)
+        try:
+            utils.assert_quantity_sub_equal(sg, sg2)
+        except AssertionError:  # old numpy?
+            utils.assert_quantity_sub_equal(sg, sg2, almost_equal=True)
 
         # check that `cross` keyword gets deprecated properly
         # TODO: removed before 1.0 release

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -851,7 +851,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         # check that basic methods always post a warning telling the user
         # to be more specific
         with pytest.warns(UserWarning):
-            fs = losc.psd(1, method=method)
+            fs = losc.psd(1, method=method, window=None)
 
         # and check that the basic parameters are sane
         assert fs.size == losc.sample_rate.value // 2 + 1

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -19,9 +19,11 @@
 """Unit test for timeseries module
 """
 
+import importlib
 import os
 import pytest
 import tempfile
+from itertools import (chain, product)
 
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import URLError
@@ -844,57 +846,77 @@ class TestTimeSeries(TestTimeSeriesBase):
 
         fs = losc.average_fft(fftlength=0.4, overlap=0.2)
 
-    def test_psd_simple(self, losc):
-        # test all defaults
-        fs = losc.psd()
-        assert isinstance(fs, FrequencySeries)
-        assert fs.size == losc.size // 2 + 1
-        assert fs.f0 == 0 * units.Hz
-        assert fs.df == 1 / losc.duration
-        assert fs.channel is losc.channel
-        assert fs.unit == losc.unit ** 2 / units.Hz
-
-        # test fftlength
-        fs = losc.psd(fftlength=0.5)
-        assert fs.size == 0.5 * losc.sample_rate.value // 2 + 1
-        assert fs.df == 2 * units.Hz
-
-        # test overlap
-        fs = losc.psd(fftlength=0.4, overlap=0.2)
-
-        # test default overlap
-        fs2 = losc.psd(fftlength=.4)
-        utils.assert_quantity_sub_equal(fs, fs2)
-
-    @pytest.mark.parametrize('library', (
-        pytest.param('pycbc',
-                     marks=utils.skip_missing_dependency('pycbc.psd')),
-        pytest.param('lal', marks=utils.skip_missing_dependency('lal')),
+    @pytest.mark.parametrize('library, method', chain(
+        product([None], ['welch', 'bartlett']),
+        product(['scipy'], ['welch', 'bartlett']),
+        product(['pycbc'], ['welch', 'bartlett', 'median', 'median_mean']),
+        product(['lal'], ['welch', 'bartlett', 'median', 'median_mean']),
     ))
     @pytest.mark.parametrize(
-        'method', ('welch', 'bartlett', 'median', 'median_mean'),
+        'window', (None, 'hann', ('kaiser', 24), 'array'),
     )
-    def test_psd_library(self, losc, library, method):
-        method = '{}_{}'.format(library, method)
+    def test_psd(self, losc, library, method, window):
+        if library:
+            try:
+                importlib.import_module(library)
+            except ImportError as exc:
+                pytest.skip(str(exc))
 
-        def _psd():
-            if method == 'lal_median_mean':
+            method = '{}_{}'.format(library, method)
+
+        def _psd(fftlength, overlap, **kwargs):
+            # check number of segments for LAL median-mean
+            if fftlength is None:
+                nfft = losc.size
+            else:
+                nfft = int(fftlength * losc.sample_rate.value)
+            if overlap is None:
+                noverlap = int(nfft/2.)
+            else:
+                noverlap = int(overlap * losc.sample_rate.value)
+            nstep = nfft - noverlap
+            req = (int((losc.size - nfft) / nstep) * nstep + nfft)
+            if method == 'lal_median_mean' and req != losc.size:
                 # LAL should warn about the data being the wrong length
+                warnctx = pytest.warns(UserWarning)
+            elif library is None and method is not None:
+                # not specifying library should print warning
                 warnctx = pytest.warns(UserWarning)
             else:
                 warnctx = null_context()
-            with warnctx:
-                return losc.psd(fftlength=.5, overlap=.25, method=method)
 
-        # check simple
-        psd = _psd()
-        assert isinstance(psd, FrequencySeries)
-        assert psd.f0 == 0 * units.Hz
+            # create window of the correct length
+            if window == 'array':
+                _window = signal.get_window('hamming', nfft)
+            else:
+                _window = window
+
+            # generate PSD
+            with warnctx:
+                return losc.psd(fftlength=fftlength, overlap=overlap,
+                                method=method, window=_window)
+
+        # test basic
+        if method.endswith('median_mean'):
+            ctx = pytest.raises(ValueError)
+        else:
+            ctx = null_context()
+        with ctx:
+            fs = _psd(None, None)
+            assert fs.size == losc.size // 2 + 1
+            assert fs.f0 == 0 * units.Hz
+            assert fs.df == 1 / losc.duration
+            assert fs.channel is losc.channel
+            assert fs.unit == losc.unit ** 2 / units.Hz
+
+        # test fftlength maps to yindex
+        psd = _psd(.5, None)
+        assert psd.size == 0.5 * losc.sample_rate.value // 2 + 1
         assert psd.df == 2 * units.Hz
 
-        # check window selection
-        if library != 'pycbc':
-            _psd()
+        # test default overlap
+        if library is None and method == 'welch' and window == 'hann':
+            utils.assert_quantity_sub_equal(psd, _psd(.5, .25))
 
     def test_asd(self, losc):
         fs = losc.asd()
@@ -914,11 +936,42 @@ class TestTimeSeries(TestTimeSeriesBase):
         # test overlap
         losc.csd(losc, fftlength=0.4, overlap=0.2)
 
-    def test_spectrogram(self, losc):
+    @pytest.mark.parametrize('library, method', chain(
+        product([None], ['welch', 'bartlett']),
+        product(['scipy'], ['welch', 'bartlett']),
+        product(['pycbc'], ['welch', 'bartlett', 'median', 'median_mean']),
+        product(['lal'], ['welch', 'bartlett', 'median', 'median_mean']),
+    ))
+    @pytest.mark.parametrize(
+        'window', (None, 'hann', ('kaiser', 24), 'array'),
+    )
+    def test_spectrogram(self, losc, library, method, window):
+        if library:
+            try:
+                importlib.import_module(library)
+            except ImportError as exc:
+                pytest.skip(str(exc))
+            method = '{}_{}'.format(library, method)
+            ctx = null_context
+        else:
+            ctx = lambda: pytest.warns(UserWarning)
+
+        def _spectrogram(*args, **kwargs):
+            kwargs.setdefault('method', method)
+            if window == 'array':
+                nfft = int(losc.sample_rate.value * (
+                    kwargs.get('fftlength', args[0]) or args[0]))
+                w = signal.get_window('hamming', nfft)
+            else:
+                w = window
+            kwargs.setdefault('window', w)
+            with ctx():
+                return losc.spectrogram(*args, **kwargs)
+
         # test defaults
-        sg = losc.spectrogram(1)  # defaults to 50% overlap for 'hann' window
+        sg = _spectrogram(1)
         assert isinstance(sg, Spectrogram)
-        assert sg.shape == (4, losc.sample_rate.value // 2 + 1)
+        assert sg.shape == (abs(losc.span), losc.sample_rate.value // 2 + 1)
         assert sg.f0 == 0 * units.Hz
         assert sg.df == 1 * units.Hz
         assert sg.channel is losc.channel
@@ -927,56 +980,56 @@ class TestTimeSeries(TestTimeSeriesBase):
         assert sg.span == losc.span
 
         # check the same result as PSD
-        psd = losc[:int(losc.sample_rate.value)].psd()
+        with ctx():
+            if window == 'array':
+                win = signal.get_window('hamming', int(losc.sample_rate.value))
+            else:
+                win = window
+            n = int(losc.sample_rate.value)
+            overlap = 0
+            if window in {'hann'}:
+                overlap = .5
+                n += int(overlap * losc.sample_rate.value)
+            psd = losc[:n].psd(fftlength=1, overlap=overlap,
+                               method=method, window=win)
         # FIXME: epoch should not be excluded here (probably)
         utils.assert_quantity_sub_equal(sg[0], psd, exclude=['epoch'])
 
         # test fftlength
-        sg = losc.spectrogram(1, fftlength=0.5)
-        assert sg.shape == (4, 0.5 * losc.sample_rate.value // 2 + 1)
+        sg = _spectrogram(1, fftlength=0.5)
+        assert sg.shape == (abs(losc.span),
+                            0.5 * losc.sample_rate.value // 2 + 1)
         assert sg.df == 2 * units.Hertz
         assert sg.dt == 1 * units.second
+
         # test overlap
-        sg = losc.spectrogram(0.5, fftlength=0.25, overlap=0.125)
-        assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
-        assert sg.df == 4 * units.Hertz
-        assert sg.dt == 0.5 * units.second
+        if window == 'hann':
+            sg2 = _spectrogram(1, fftlength=0.5, overlap=.25)
+            utils.assert_quantity_sub_equal(sg, sg2)
+
         # test multiprocessing
-        sg2 = losc.spectrogram(0.5, fftlength=0.25, overlap=0.125, nproc=2)
+        sg2 = _spectrogram(1, fftlength=0.5, nproc=2)
         utils.assert_quantity_sub_equal(sg, sg2)
-
-        # test a couple of methods
-        try:
-            with pytest.warns(UserWarning):
-                sg = losc.spectrogram(0.5, fftlength=0.25, method='welch')
-        except TypeError:  # old pycbc doesn't accept window as array
-            pass
-        else:
-            assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
-            assert sg.df == 4 * units.Hertz
-            assert sg.dt == 0.5 * units.second
-
-        sg = losc.spectrogram(0.5, fftlength=0.25, method='scipy-bartlett')
-        assert sg.shape == (8, 0.25 * losc.sample_rate.value // 2 + 1)
-        assert sg.df == 4 * units.Hertz
-        assert sg.dt == 0.5 * units.second
 
         # check that `cross` keyword gets deprecated properly
         # TODO: removed before 1.0 release
-        with pytest.warns(DeprecationWarning) as wng:
-            try:
-                out = losc.spectrogram(0.5, fftlength=.25, cross=losc)
-            except AttributeError:
-                return  # scipy is too old
-        assert '`cross` keyword argument has been deprecated' in \
-            wng[0].message.args[0]
-        utils.assert_quantity_sub_equal(
-            out, losc.csd_spectrogram(losc, 0.5, fftlength=.25))
+        if method == 'scipy_welch' and window is None:
+            with pytest.warns(DeprecationWarning) as wng:
+                try:
+                    out = _spectrogram(0.5, fftlength=.25, cross=losc)
+                except AttributeError:
+                    return  # scipy is too old
+            assert '`cross` keyword argument has been deprecated' in \
+                wng[0].message.args[0]
+            utils.assert_quantity_sub_equal(
+                out, losc.csd_spectrogram(losc, 0.5, fftlength=.25))
 
     def test_spectrogram2(self, losc):
         # test defaults
         sg = losc.spectrogram2(1)
-        utils.assert_quantity_sub_equal(sg, losc.spectrogram(1))
+        utils.assert_quantity_sub_equal(
+            sg, losc.spectrogram(1, fftlength=1, overlap=0,
+                                 method='scipy-welch', window='boxcar'))
 
         # test fftlength
         sg = losc.spectrogram2(0.5)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -849,7 +849,7 @@ class TestTimeSeries(TestTimeSeriesBase):
     @pytest.mark.parametrize('library, method', chain(
         product([None], ['welch', 'bartlett']),
         product(['scipy'], ['welch', 'bartlett']),
-        product(['pycbc'], ['welch', 'bartlett', 'median', 'median_mean']),
+        product(['pycbc.psd'], ['welch', 'bartlett', 'median', 'median_mean']),
         product(['lal'], ['welch', 'bartlett', 'median', 'median_mean']),
     ))
     @pytest.mark.parametrize(
@@ -861,7 +861,7 @@ class TestTimeSeries(TestTimeSeriesBase):
                 importlib.import_module(library)
             except ImportError as exc:
                 pytest.skip(str(exc))
-
+            library = library.split('.', 1)[0]
             method = '{}_{}'.format(library, method)
 
         def _psd(fftlength, overlap, **kwargs):
@@ -939,7 +939,7 @@ class TestTimeSeries(TestTimeSeriesBase):
     @pytest.mark.parametrize('library, method', chain(
         product([None], ['welch', 'bartlett']),
         product(['scipy'], ['welch', 'bartlett']),
-        product(['pycbc'], ['welch', 'bartlett', 'median', 'median_mean']),
+        product(['pycbc.psd'], ['welch', 'bartlett', 'median', 'median_mean']),
         product(['lal'], ['welch', 'bartlett', 'median', 'median_mean']),
     ))
     @pytest.mark.parametrize(
@@ -951,6 +951,7 @@ class TestTimeSeries(TestTimeSeriesBase):
                 importlib.import_module(library)
             except ImportError as exc:
                 pytest.skip(str(exc))
+            library = library.split('.', 1)[0]
             method = '{}_{}'.format(library, method)
             ctx = null_context
         else:

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -368,7 +368,7 @@ class TimeSeries(TimeSeriesBase):
                           overlap=overlap, window=window, **kwargs)
 
     @_update_doc_with_fft_methods
-    def spectrogram(self, stride, fftlength=None, overlap=0,
+    def spectrogram(self, stride, fftlength=None, overlap=None,
                     window='hann', method='scipy-welch', nproc=1, **kwargs):
         """Calculate the average power spectrogram of this `TimeSeries`
         using the specified average spectrum method.


### PR DESCRIPTION
This PR fixes at least one bug in the `gwpy.signal.fft` methods for the `TimeSeries` class, and improves the tests of some of those methods.