### PR TITLE
Simplified gwpy.utils.lal module for lal>=6.14.0

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,7 @@
 ; vim: set syntax=dosini :
 
 [basic]
-good-names = _,i,j,k,q,x,y,ax
+good-names = _,i,j,k,q,u,x,y,ax
 
 [messages control]
 disable = import-error, superfluous-parens

--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Depends: ${misc:Depends},
          python-scipy (>= 0.12.0),
          python-astropy (>= 1.1.1),
          python-matplotlib (>= 1.2.0),
-         lal-python,
+         lal-python (>= 6.14.0),
          python-glue (>= 1.55.2)
 Recommends: python-h5py (>= 1.3)
 Suggests: python-pymysql,
@@ -54,7 +54,7 @@ Depends: ${misc:Depends},
          python3-scipy (>= 0.12.0),
          python3-astropy (>= 1.1.1),
          python3-matplotlib (>= 1.2.0),
-         lal-python3,
+         lal-python3 (>= 6.14.0),
          python3-glue (>= 1.55.2)
 Recommends: python3-h5py (>= 1.3)
 Suggests: python3-pymysql,

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -33,7 +33,7 @@ Requires:       numpy
 Requires:       scipy
 Requires:       python-matplotlib
 Requires:       python-astropy
-Requires:       lal-python
+Requires:       lal-python >= 6.14.0
 Requires:       glue
 
 %{?python_provide:%python_provide python2-%{srcname}}
@@ -52,7 +52,7 @@ Requires:       python%{python3_pkgversion}-numpy
 Requires:       python%{python3_pkgversion}-scipy
 Requires:       python%{python3_pkgversion}-matplotlib
 Requires:       python%{python3_pkgversion}-astropy
-Requires:       lal-python%{python3_pkgversion}
+Requires:       lal-python%{python3_pkgversion} >= 6.14.0
 Requires:       python%{python3_pkgversion}-glue
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -157,29 +157,6 @@ def test_detector_units(name):
     assert units.Unit(name)
 
 
-@utils.skip_missing_dependency('lal')
-def test_lal_units():
-    import lal
-    from gwpy.utils.lal import (to_lal_unit as to_, from_lal_unit as from_)
-
-    # test to LAL
-    lalu = to_('meter')
-    assert lalu == lal.MeterUnit
-
-    # test from LAL
-    a = from_(lalu)
-    assert a == units.meter
-
-    # test compound
-    assert from_(to_('N')) == units.Newton
-
-    # test error
-    with pytest.raises(ValueError):
-        to_('blah')
-    with pytest.raises(TypeError):
-        from_('blah')
-
-
 # -----------------------------------------------------------------------------
 #
 #   gwpy.detector.channel

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -245,7 +245,7 @@ class TestTimeSeriesBase(TestSeries):
             lalts = array.to_lal()
         assert lalts.sampleUnits == lal.DimensionlessUnit
         a2 = self.TEST_CLASS.from_lal(lalts)
-        assert a2.unit is units.dimensionless_unscaled
+        assert a2.unit == units.dimensionless_unscaled
 
     @utils.skip_missing_dependency('lal')
     @utils.skip_missing_dependency('pycbc')

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1037,7 +1037,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         # test overlap
         if window == 'hann':
             sg2 = _spectrogram(1, fftlength=0.5, overlap=.25)
-            utils.assert_quantity_sub_equal(sg, sg2)
+            utils.assert_quantity_sub_equal(sg, sg2, almost_equal=True)
 
         # test multiprocessing
         sg2 = _spectrogram(1, fftlength=0.5, nproc=2)

--- a/gwpy/tests/test_utils.py
+++ b/gwpy/tests/test_utils.py
@@ -25,8 +25,14 @@ from six import PY2
 
 import pytest
 
+import numpy
+
+from astropy import units
+
 from gwpy.utils import shell
 from gwpy.utils import deps  # deprecated
+
+import utils
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -89,3 +95,56 @@ def test_compat_ordereddict():
         from gwpy.utils.compat import OrderedDict as CompatOrderedDict
     from collections import OrderedDict
     assert CompatOrderedDict is OrderedDict
+
+
+# -- gwpy.utils.lal -----------------------------------------------------------
+
+@utils.skip_missing_dependency('lal')
+class TestUtilsLal(object):
+    """Tests of :mod:`gwpy.utils.lal`
+    """
+    import lal
+    from gwpy.utils import lal as utils_lal
+
+    def test_to_lal_type_str(self):
+        assert self.utils_lal.to_lal_type_str(float) == 'REAL8'
+        assert self.utils_lal.to_lal_type_str(
+            numpy.dtype('float64')) == 'REAL8'
+        assert self.utils_lal.to_lal_type_str(11) == 'REAL8'
+        with pytest.raises(ValueError):
+            self.utils_lal.to_lal_type_str('blah')
+        with pytest.raises(ValueError):
+            self.utils_lal.to_lal_type_str(numpy.int8)
+        with pytest.raises(ValueError):
+            self.utils_lal.to_lal_type_str(20)
+
+    def test_find_typed_function(self):
+        assert self.utils_lal.find_typed_function(
+            'REAL8', 'Create', 'Sequence') is self.lal.CreateREAL8Sequence
+
+        try:
+            import lalframe
+        except ImportError:  # no lalframe
+            pass
+        else:
+            self.utils_lal.find_typed_function(
+                'REAL4', 'FrStreamRead', 'TimeSeries',
+                module=lalframe) is lalframe.FrStreamReadREAL4TimeSeries
+
+    def test_to_lal_unit(self):
+        assert self.utils_lal.to_lal_unit('m') == self.lal.MeterUnit
+        assert self.utils_lal.to_lal_unit('Farad') == self.lal.Unit(
+            'm^-2 kg^-1 s^4 A^2')
+        with pytest.raises(ValueError):
+            self.utils_lal.to_lal_unit('rad/s')
+
+    def test_from_lal_unit(self):
+        assert self.utils_lal.from_lal_unit(
+            self.lal.MeterUnit / self.lal.SecondUnit) == (
+            units.Unit('m/s'))
+        assert self.utils_lal.from_lal_unit(self.lal.StrainUnit) == (
+            units.Unit('strain'))
+
+    def test_to_lal_ligotimegps(self):
+        assert self.utils_lal.to_lal_ligotimegps(123.456) == (
+            self.lal.LIGOTimeGPS(123, 456000000))

--- a/gwpy/tests/test_utils.py
+++ b/gwpy/tests/test_utils.py
@@ -20,6 +20,7 @@
 """
 
 import subprocess
+from importlib import import_module
 
 from six import PY2
 
@@ -103,8 +104,9 @@ def test_compat_ordereddict():
 class TestUtilsLal(object):
     """Tests of :mod:`gwpy.utils.lal`
     """
-    import lal
-    from gwpy.utils import lal as utils_lal
+    def setup_class(self):
+        self.lal = import_module('lal')
+        self.utils_lal = import_module('gwpy.utils.lal')
 
     def test_to_lal_type_str(self):
         assert self.utils_lal.to_lal_type_str(float) == 'REAL8'

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -652,16 +652,19 @@ class TimeSeriesBase(Series):
         """Convert this `TimeSeries` into a LAL TimeSeries.
         """
         import lal
-        from ..utils.lal import (LAL_TYPE_STR_FROM_NUMPY, to_lal_unit)
-        typestr = LAL_TYPE_STR_FROM_NUMPY[self.dtype.type]
+        from ..utils.lal import (find_typed_function, to_lal_unit)
+
+        # map unit
         try:
             unit = to_lal_unit(self.unit)
-        except ValueError as exc:
-            warnings.warn("%s, defaulting to lal.DimensionlessUnit" % str(exc))
+        except ValueError as e:
+            warnings.warn("%s, defaulting to lal.DimensionlessUnit" % str(e))
             unit = lal.DimensionlessUnit
-        create = getattr(lal, 'Create%sTimeSeries' % typestr.upper())
+
+        # create TimeSeries
+        create = find_typed_function(self.dtype, 'Create', 'TimeSeries')
         lalts = create(self.name, lal.LIGOTimeGPS(self.epoch.gps), 0,
-                       self.dt.value, unit, self.size)
+                       self.dt.value, unit, self.shape[0])
         lalts.data.data = self.value
         return lalts
 

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -153,8 +153,8 @@ def read(source, channels, start=None, end=None, series_class=TimeSeries):
 
 def _read_channel(stream, channel, start, duration):
     dtype = lalframe.FrStreamGetTimeSeriesType(channel, stream)
-    typestr = lalutils.LAL_TYPE_STR[dtype]
-    reader = getattr(lalframe, 'FrStreamRead%sTimeSeries' % typestr)
+    reader = lalutils.find_typed_function(dtype, 'FrStreamRead', 'TimeSeries',
+                                          module=lalframe)
     return reader(stream, channel, start, duration, 0)
 
 
@@ -187,9 +187,8 @@ def write(tsdict, outfile, start=None, end=None,
         lalseries = series.to_lal()
 
         # find adder
-        laltype = lalutils.LAL_TYPE_FROM_NUMPY[series.dtype.type]
-        typestr = lalutils.LAL_TYPE_STR[laltype]
-        add_ = getattr(lalframe, 'FrameAdd%sTimeSeriesProcData' % typestr)
+        add_ = lalutils.find_typed_function(
+            series.dtype, 'FrameAdd', 'TimeSeriesProcData', module=lalframe)
 
         # add time series to frame
         add_(frame, lalseries)

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -17,6 +17,8 @@
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """Utilies for interacting with the LIGO Algorithm Library.
+
+This module requires lal >= 6.14.0
 """
 
 from __future__ import absolute_import
@@ -32,86 +34,130 @@ from astropy import units
 import lal
 
 from ..time import to_gps
+# import gwpy.detector.units to register other units now
 from ..detector import units as gwpy_units  # pylint: disable=unused-import
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+# -- type matching ------------------------------------------------------------
+
 # LAL type enum
-try:
-    LAL_TYPE_STR = {lal.LAL_I2_TYPE_CODE: 'INT2',
-                    lal.LAL_I4_TYPE_CODE: 'INT4',
-                    lal.LAL_I8_TYPE_CODE: 'INT8',
-                    lal.LAL_U2_TYPE_CODE: 'UINT2',
-                    lal.LAL_U4_TYPE_CODE: 'UINT4',
-                    lal.LAL_U8_TYPE_CODE: 'UINT8',
-                    lal.LAL_S_TYPE_CODE: 'REAL4',
-                    lal.LAL_D_TYPE_CODE: 'REAL8',
-                    lal.LAL_C_TYPE_CODE: 'COMPLEX8',
-                    lal.LAL_Z_TYPE_CODE: 'COMPLEX16'}
-except AttributeError:
-    LAL_TYPE_STR = {lal.I2_TYPE_CODE: 'INT2',
-                    lal.I4_TYPE_CODE: 'INT4',
-                    lal.I8_TYPE_CODE: 'INT8',
-                    lal.U2_TYPE_CODE: 'UINT2',
-                    lal.U4_TYPE_CODE: 'UINT4',
-                    lal.U8_TYPE_CODE: 'UINT8',
-                    lal.S_TYPE_CODE: 'REAL4',
-                    lal.D_TYPE_CODE: 'REAL8',
-                    lal.C_TYPE_CODE: 'COMPLEX8',
-                    lal.Z_TYPE_CODE: 'COMPLEX16'}
+LAL_TYPE_STR = {
+    lal.I2_TYPE_CODE: 'INT2',
+    lal.I4_TYPE_CODE: 'INT4',
+    lal.I8_TYPE_CODE: 'INT8',
+    lal.U2_TYPE_CODE: 'UINT2',
+    lal.U4_TYPE_CODE: 'UINT4',
+    lal.U8_TYPE_CODE: 'UINT8',
+    lal.S_TYPE_CODE: 'REAL4',
+    lal.D_TYPE_CODE: 'REAL8',
+    lal.C_TYPE_CODE: 'COMPLEX8',
+    lal.Z_TYPE_CODE: 'COMPLEX16',
+}
 
-LAL_TYPE_FROM_STR = dict((v, k) for k, v in LAL_TYPE_STR.items())
+LAL_TYPE_FROM_STR = {v: k for k, v in LAL_TYPE_STR.items()}
 
-# map numpy dtypes to LAL type codes
-try:
-    LAL_TYPE_FROM_NUMPY = {numpy.int16: lal.LAL_I2_TYPE_CODE,
-                           numpy.int32: lal.LAL_I4_TYPE_CODE,
-                           numpy.int64: lal.LAL_I8_TYPE_CODE,
-                           numpy.uint16: lal.LAL_U2_TYPE_CODE,
-                           numpy.uint32: lal.LAL_U4_TYPE_CODE,
-                           numpy.uint64: lal.LAL_U8_TYPE_CODE,
-                           numpy.float32: lal.LAL_S_TYPE_CODE,
-                           numpy.float64: lal.LAL_D_TYPE_CODE,
-                           numpy.complex64: lal.LAL_C_TYPE_CODE,
-                           numpy.complex128: lal.LAL_Z_TYPE_CODE}
-except AttributeError:
-    LAL_TYPE_FROM_NUMPY = {numpy.int16: lal.I2_TYPE_CODE,
-                           numpy.int32: lal.I4_TYPE_CODE,
-                           numpy.int64: lal.I8_TYPE_CODE,
-                           numpy.uint16: lal.U2_TYPE_CODE,
-                           numpy.uint32: lal.U4_TYPE_CODE,
-                           numpy.uint64: lal.U8_TYPE_CODE,
-                           numpy.float32: lal.S_TYPE_CODE,
-                           numpy.float64: lal.D_TYPE_CODE,
-                           numpy.complex64: lal.C_TYPE_CODE,
-                           numpy.complex128: lal.Z_TYPE_CODE}
+LAL_TYPE_FROM_NUMPY = {
+    numpy.int16: lal.I2_TYPE_CODE,
+    numpy.int32: lal.I4_TYPE_CODE,
+    numpy.int64: lal.I8_TYPE_CODE,
+    numpy.uint16: lal.U2_TYPE_CODE,
+    numpy.uint32: lal.U4_TYPE_CODE,
+    numpy.uint64: lal.U8_TYPE_CODE,
+    numpy.float32: lal.S_TYPE_CODE,
+    numpy.float64: lal.D_TYPE_CODE,
+    numpy.complex64: lal.C_TYPE_CODE,
+    numpy.complex128: lal.Z_TYPE_CODE,
+}
 
-LAL_TYPE_STR_FROM_NUMPY = dict((key, LAL_TYPE_STR[value]) for (key, value) in
-                               LAL_TYPE_FROM_NUMPY.items())
+LAL_TYPE_STR_FROM_NUMPY = {k: LAL_TYPE_STR[v] for
+                           (k, v) in LAL_TYPE_FROM_NUMPY.items()}
 
-try:
-    LAL_UNIT_INDEX = [lal.lalMeterUnit,
-                      lal.lalKiloGramUnit,
-                      lal.lalSecondUnit,
-                      lal.lalAmpereUnit,
-                      lal.lalKelvinUnit,
-                      lal.lalStrainUnit,
-                      lal.lalADCCountUnit]
-except AttributeError:
-    LAL_UNIT_INDEX = [lal.MeterUnit,
-                      lal.KiloGramUnit,
-                      lal.SecondUnit,
-                      lal.AmpereUnit,
-                      lal.KelvinUnit,
-                      lal.StrainUnit,
-                      lal.ADCCountUnit]
-    lal_unit_to_str = str
-    LAL_UNIT_FROM_ASTROPY = dict((units.Unit(lal_unit_to_str(u)), u) for
-                                 u in LAL_UNIT_INDEX)
-else:
-    lal_unit_to_str = lal.UnitToString
-    LAL_UNIT_FROM_ASTROPY = dict((units.Unit(lal_unit_to_str(u)), u) for
-                                 u in LAL_UNIT_INDEX)
+
+def to_lal_type_str(pytype):
+    """Convert the input python type to a LAL type string
+
+    Examples
+    --------
+    To convert a python type:
+
+    >>> from gwpy.utils.lal import to_lal_type_str
+    >>> to_lal_type_str(float)
+    'REAL8'
+
+    To convert a `numpy.dtype`:
+
+    >>> import numpy
+    >>> to_lal_type_str(numpy.dtype('uint32'))
+    'UINT4'
+
+    To convert a LAL type code:
+
+    >>> to_lal_type_str(11)
+    'REAL8'
+
+    Raises
+    ------
+    KeyError
+        if the input doesn't map to a LAL type string
+    """
+    # noop
+    if pytype in LAL_TYPE_FROM_STR:
+        return pytype
+
+    # convert type code
+    if pytype in LAL_TYPE_STR:
+        return LAL_TYPE_STR[pytype]
+
+    # convert python type
+    try:
+        dtype = numpy.dtype(pytype)
+        return LAL_TYPE_STR_FROM_NUMPY[dtype.type]
+    except (TypeError, KeyError):
+        raise ValueError("Failed to map {!r} to LAL type string")
+
+
+def find_typed_function(pytype, prefix, suffix, module=lal):
+    """Returns the lal method for the correct type
+
+    Parameters
+    ----------
+    pytype : `type`, `numpy.dtype`
+        the python type, or dtype, to map
+
+    prefix : `str`
+        the function name prefix (before the type tag)
+
+    suffix : `str`
+        the function name suffix (after the type tag)
+
+    Raises
+    ------
+    AttributeError
+        if the function is not found
+
+    Examples
+    --------
+    >>> from gwpy.utils.lal import find_typed_function
+    >>> find_typed_function(float, 'Create', 'Sequence')
+    <built-in function CreateREAL8Sequence>
+    """
+    laltype = to_lal_type_str(pytype)
+    return getattr(module, '{0}{1}{2}'.format(prefix, laltype, suffix))
+
+
+# -- units --------------------------------------------------------------------
+
+LAL_UNIT_INDEX = [
+    lal.MeterUnit,
+    lal.KiloGramUnit,
+    lal.SecondUnit,
+    lal.AmpereUnit,
+    lal.KelvinUnit,
+    lal.StrainUnit,
+    lal.ADCCountUnit,
+]
+LAL_UNIT_FROM_ASTROPY = {units.Unit(str(u)): u for u in LAL_UNIT_INDEX}
 
 
 def to_lal_unit(aunit):

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -23,6 +23,7 @@ This module requires lal >= 6.14.0
 
 from __future__ import absolute_import
 
+import operator
 from collections import OrderedDict
 
 from six import string_types
@@ -227,23 +228,9 @@ def from_lal_unit(lunit):
     ValueError
         if Astropy doesn't understand the base units for the input
     """
-    try:
-        lunit = lal.Unit(lunit)
-    except RuntimeError:
-        raise TypeError("Cannot convert %r to lal.Unit" % lunit)
-    aunit = units.Unit("")
-    for power, lalbase in zip(lunit.unitNumerator, LAL_UNIT_INDEX):
-        # if not used, continue
-        if not power:
-            continue
-        # convert to astropy unit
-        try:
-            u = units.Unit(lal_unit_to_str(lalbase))
-        except ValueError:
-            raise ValueError("Astropy has no unit corresponding to %r"
-                             % lalbase)
-        aunit *= u ** power
-    return aunit
+    return reduce(operator.mul, (
+        units.Unit(str(LAL_UNIT_INDEX[i])) ** exp for
+        i, exp in enumerate(lunit.unitNumerator)))
 
 
 def to_lal_ligotimegps(gps):


### PR DESCRIPTION
This PR removes support for lal < 6.14.0 by simplifying the `gwpy.utils.lal` module. 6.14.0 was released in 2015, so is probably new enough.

Additionally this PR provides a few new methods to simplify mapping python types to LAL type strings (e.g. `float` -> `'REAL8'`).

Finally, I added tests of the functions in `gwpy.utils.lal`.