### PR TITLE
Updated usage of glue.lal for glue-1.58.1

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -94,7 +94,6 @@ def open_cache(*args, **kwargs):  # pylint: disable=missing-docstring
     warnings.warn("gwpy.io.cache.open_cache was renamed read_cache",
                   DeprecationWarning)
     return read_cache(*args, **kwargs)
-open_cache.__doc__ = read_cache.__doc__
 
 
 def write_cache(cache, fobj):

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -29,13 +29,14 @@ from gzip import GzipFile
 from six import string_types
 from six.moves import StringIO
 
+from glue.lal import Cache
+
 try:
-    from glue.lal import Cache
-except ImportError:  # no lal
-    HAS_CACHE = False
-else:
-    HAS_CACHE = True
     from lal.utils import CacheEntry
+except ImportError:  # no lal
+    HAS_CACHEENTRY = False
+else:
+    HAS_CACHEENTRY = True
     Cache.entry_class = CacheEntry
 
 from ..time import LIGOTimeGPS
@@ -75,8 +76,6 @@ def read_cache(lcf, coltype=LIGOTimeGPS):
         a cache object, representing each line in the file as a
         :class:`~lal.utils.CacheEntry`
     """
-    from glue.lal import Cache  # pylint: disable=redefined-outer-name
-
     # open file
     if not isinstance(lcf, FILE_LIKE):
         with open(lcf, 'r') as fobj:
@@ -147,7 +146,7 @@ def is_cache(cache):
             if not c:  # return empty file as False
                 return False
             return True
-    elif HAS_CACHE and isinstance(cache, Cache):
+    elif isinstance(cache, Cache):
         return True
     return False
 
@@ -208,7 +207,7 @@ def file_name(fobj):
         return fobj
     if isinstance(fobj, FILE_LIKE) and not isinstance(fobj, StringIO):
         return fobj.name
-    if HAS_CACHE and isinstance(fobj, CacheEntry):
+    if HAS_CACHEENTRY and isinstance(fobj, CacheEntry):
         return fobj.path
     raise ValueError("Cannot parse file name for %r" % fobj)
 
@@ -299,8 +298,6 @@ def find_contiguous(*caches):
     caches : `iter` of :class:`~glue.lal.Cache`
         an interable yielding each contiguous cache
     """
-    from glue.lal import Cache  # pylint: disable=redefined-outer-name
-
     try:
         flat = flatten(*caches)
     except IndexError:

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -105,7 +105,7 @@ def read_ligolw_dict(source, flags=None, gpstype=LIGOTimeGPS, coalesce=False):
 def read_ligolw_flag(source, flag=None, **kwargs):
     """Read a single `DataQualityFlag` from a LIGO_LW XML file
     """
-    return read_ligolw_dict(source, flags=flag, **kwargs).values()[0]
+    return list(read_ligolw_dict(source, flags=flag, **kwargs).values())[0]
 
 
 # -- write --------------------------------------------------------------------

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -35,6 +35,8 @@ import numpy
 
 import pytest
 
+from glue.lal import Cache
+
 from gwpy.io import (cache as io_cache,
                      datafind as io_datafind,
                      gwf as io_gwf,
@@ -203,7 +205,6 @@ class TestIoCache(object):
             from lal.utils import CacheEntry
         except ImportError as e:
             pytest.skip(str(e))
-        from glue.lal import Cache
 
         segs = SegmentList()
         cache = Cache()
@@ -239,7 +240,7 @@ class TestIoCache(object):
             c3 = io_cache.read_cache(f.name)
             assert cache == c3
 
-    @utils.skip_missing_dependency('glue.lal')
+    @utils.skip_missing_dependency('lal.utils')
     def test_is_cache(self):
         # sanity check
         assert io_cache.is_cache(None) is False

--- a/gwpy/tests/test_time.py
+++ b/gwpy/tests/test_time.py
@@ -28,6 +28,8 @@ from freezegun import freeze_time
 from astropy.time import Time
 from astropy.units import (UnitConversionError, Quantity)
 
+from glue.lal import LIGOTimeGPS as GlueGPS
+
 from gwpy import time
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -100,10 +102,6 @@ def test_tconvert():
     # from GPS using LAL LIGOTimeGPS
     assert time.tconvert(time.LIGOTimeGPS(1126259462.391)) == (
         datetime(2015, 9, 14, 9, 50, 45, 391000))
-    try:
-        from glue.lal import LIGOTimeGPS as GlueGPS
-    except ImportError:
-        pass
     else:
         assert time.tconvert(GlueGPS(1126259462.391)) == (
             datetime(2015, 9, 14, 9, 50, 45, 391000))

--- a/gwpy/tests/test_time.py
+++ b/gwpy/tests/test_time.py
@@ -102,9 +102,8 @@ def test_tconvert():
     # from GPS using LAL LIGOTimeGPS
     assert time.tconvert(time.LIGOTimeGPS(1126259462.391)) == (
         datetime(2015, 9, 14, 9, 50, 45, 391000))
-    else:
-        assert time.tconvert(GlueGPS(1126259462.391)) == (
-            datetime(2015, 9, 14, 9, 50, 45, 391000))
+    assert time.tconvert(GlueGPS(1126259462.391)) == (
+        datetime(2015, 9, 14, 9, 50, 45, 391000))
 
     # to GPS
     assert time.tconvert(datetime(2015, 9, 14, 9, 50, 45, 391000)) == (

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -633,8 +633,7 @@ class TestTimeSeries(TestTimeSeriesBase):
                     type(array).read(f, array.name, format=api)
 
             # check reading from cache
-             self.create(name='TEST', t0=array.span[1],
-                             dt=array.dx)
+            self.create(name='TEST', t0=array.span[1], dt=array.dx)
             suffix = '-%d-%d.gwf' % (a2.t0.value, a2.duration.value)
             with tempfile.NamedTemporaryFile(prefix='GWpy-',
                                              suffix=suffix) as f2:

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -46,6 +46,8 @@ use('agg')  # nopep8
 from astropy import units
 from astropy.io.registry import (get_reader, register_reader)
 
+from glue.lal import Cache
+
 from gwpy.detector import Channel
 from gwpy.time import (Time, LIGOTimeGPS)
 from gwpy.timeseries import (TimeSeriesBase, TimeSeriesBaseDict,
@@ -631,22 +633,17 @@ class TestTimeSeries(TestTimeSeriesBase):
                     type(array).read(f, array.name, format=api)
 
             # check reading from cache
-            try:
-                from glue.lal import Cache
-            except ImportError:
-                pass
-            else:
-                a2 = self.create(name='TEST', t0=array.span[1],
-                                 dt=array.dx)
-                suffix = '-%d-%d.gwf' % (a2.t0.value, a2.duration.value)
-                with tempfile.NamedTemporaryFile(prefix='GWpy-',
-                                                 suffix=suffix) as f2:
-                    a2.write(f2.name)
-                    cache = Cache.from_urls([f.name, f2.name], coltype=int)
-                    comb = type(array).read(cache, 'TEST', format=fmt, nproc=2)
-                    utils.assert_quantity_sub_equal(
-                        comb, array.append(a2, inplace=False),
-                        exclude=['channel'])
+             self.create(name='TEST', t0=array.span[1],
+                             dt=array.dx)
+            suffix = '-%d-%d.gwf' % (a2.t0.value, a2.duration.value)
+            with tempfile.NamedTemporaryFile(prefix='GWpy-',
+                                             suffix=suffix) as f2:
+                a2.write(f2.name)
+                cache = Cache.from_urls([f.name, f2.name], coltype=int)
+                comb = type(array).read(cache, 'TEST', format=fmt, nproc=2)
+                utils.assert_quantity_sub_equal(
+                    comb, array.append(a2, inplace=False),
+                    exclude=['channel'])
 
     @utils.skip_missing_dependency('h5py')
     @pytest.mark.parametrize('ext', ('hdf5', 'h5'))

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -633,7 +633,7 @@ class TestTimeSeries(TestTimeSeriesBase):
                     type(array).read(f, array.name, format=api)
 
             # check reading from cache
-            self.create(name='TEST', t0=array.span[1], dt=array.dx)
+            a2 = self.create(name='TEST', t0=array.span[1], dt=array.dx)
             suffix = '-%d-%d.gwf' % (a2.t0.value, a2.duration.value)
             with tempfile.NamedTemporaryFile(prefix='GWpy-',
                                              suffix=suffix) as f2:

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -40,12 +40,7 @@ import numpy
 
 from astropy.io.registry import (get_formats, get_reader, get_writer)
 
-try:
-    from glue.lal import Cache
-except ImportError:  # no lal
-    HAS_CACHE = False
-else:
-    HAS_CACHE = True
+from glue.lal import Cache
 
 from ....segments import Segment
 from ....time import to_gps
@@ -255,7 +250,7 @@ def register_gwf_api(library):
                     source.name.endswith(('.lcf', '.cache'))):
             source = read_cache_file(source)
         # separate cache into contiguous segments
-        if HAS_CACHE and isinstance(source, Cache):
+        if isinstance(source, Cache):
             if start is not None and end is not None:
                 source = source.sieve(segment=Segment(start, end))
             source = list(find_contiguous(source))

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -27,6 +27,7 @@ import operator
 from collections import OrderedDict
 
 from six import string_types
+from six.moves import reduce
 
 import numpy
 


### PR DESCRIPTION
This PR updates usage of `glue.lal` and `lal.utils` throughout gwpy now that (as of lscsoft-glue-1.58.1) `glue.lal` no longer explicitly depends on LAL.