### PR TITLE
Use .copy() to ensure data ownership when creating Array

### DIFF
--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -102,10 +102,10 @@ class TestArray(object):
         array = self.create()
         utils.assert_array_equal(array.value, self.data)
 
-        # test that copies ensures owndata
-        a = self.TEST_CLASS([1, 2, 3, 4], copy=True)
-        assert a.flags.owndata
-        assert self.TEST_CLASS(a, copy=True).flags.owndata
+        # test that copy=True ensures owndata
+        a = self.create(copy=False)
+        assert self.create(copy=False).flags.owndata is False
+        assert self.create(copy=True).flags.owndata is True
 
         # return array for subclasses to use
         return array

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -101,6 +101,13 @@ class TestArray(object):
         # test with some data
         array = self.create()
         utils.assert_array_equal(array.value, self.data)
+
+        # test that copies ensures owndata
+        a = self.TEST_CLASS([1, 2, 3, 4], copy=True)
+        assert a.flags.owndata
+        assert self.TEST_CLASS(a, copy=True).flags.owndata
+
+        # return array for subclasses to use
         return array
 
     def test_unit(self, array):

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -331,15 +331,16 @@ class TestTimeSeriesBaseDict(object):
         new = type(instance)()
         for key in instance:
             a = instance[key]
-            new[key] = type(a)([1, 2, 3, 4, 5], x0=a.xspan[1], dx=a.dx,
-                               dtype=a.dtype)
+            new[key] = type(a)([1, 2, 3, 4, 5], x0=a.xspan[1]+a.dx.value,
+                               dx=a.dx, dtype=a.dtype)
         # check error
         with pytest.raises(ValueError):
             instance.append(new)
+
         # check padding works (don't validate too much, that is tested
         # elsewhere)
         b = instance.copy()
-        b.append(new, pad=0)
+        b.append(new, pad=0, gap='pad')
 
     def test_prepend(self, instance):
         # test appending from empty (with and without copy)

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -105,7 +105,7 @@ class Array(Quantity):
 
     def __new__(cls, value, unit=None,  # Quantity attrs
                 name=None, epoch=None, channel=None,  # new attrs
-                dtype=None, copy=False, subok=True,  # ndarray attrs
+                dtype=None, copy=True, subok=True,  # ndarray attrs
                 order=None, ndmin=0):
         """Create a new `Array`
         """
@@ -119,8 +119,13 @@ class Array(Quantity):
 
         # create new array
         new = super(Array, cls).__new__(cls, value, unit=unit, dtype=dtype,
-                                        copy=copy, order=order, subok=subok,
+                                        copy=False, order=order, subok=subok,
                                         ndmin=ndmin)
+
+        # explicitly copy here to get ownership of the data,
+        # see (astropy/astropy#7244)
+        if copy:
+            new = new.copy()
 
         # set new attributes
         if name is not None:


### PR DESCRIPTION
This PR modifies `Array.__new__` to explicitly call `Array.copy()` for `Array(..., copy=True)`.

See astropy/astropy#7244. Fixes #446.