### PR TITLE
Added new example of FrequencySeriesAxes.plot_frequencyseries_mmm

### DIFF
--- a/examples/frequencyseries/index.rst
+++ b/examples/frequencyseries/index.rst
@@ -10,6 +10,7 @@
 
    hoff
    variance
+   percentiles
    coherence
    transfer_function
    rayleigh

--- a/examples/frequencyseries/percentiles.py
+++ b/examples/frequencyseries/percentiles.py
@@ -39,7 +39,7 @@ __currentmodule__ = 'gwpy.timeseries'
 # First, as always, we get the data using :meth:`TimeSeries.fetch_open_data`:
 
 from gwpy.timeseries import TimeSeries
-hoft = TimeSeries.fetch_open_data('H1', 1187007040, 1187009088, tag='C00', cache=True)
+hoft = TimeSeries.fetch_open_data('H1', 1187007040, 1187009088, tag='C00')
 
 # Next we calculate a :class:`~gwpy.spectrogram.Spectrogram` by calculating
 # a number of ASDs, using the :meth:`~gwpy.timeseries.TimeSeries.spectrogram2`
@@ -64,7 +64,7 @@ ax.plot_spectrum_mmm(median, min_=min_, max_=max_, color='gwpy:ligo-hanford')
 ax.set_xscale('log')
 ax.set_yscale('log')
 ax.set_xlim(10, 1500)
-ax.set_ylim(3e-24,2e-20)
+ax.set_ylim(3e-24, 2e-20)
 ax.set_ylabel(r'Strain noise [1/\rtHz]')
 ax.set_title('LIGO-Hanford strain noise variation around GW170817',
              fontsize=16)

--- a/examples/frequencyseries/percentiles.py
+++ b/examples/frequencyseries/percentiles.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>
+
+"""Plotting an averaged ASD with percentiles.
+
+As we have seen in :ref:`gwpy-example-frequencyseries-hoff`, the Amplitude
+Spectral Density (ASD) is a key indicator of frequency-domain sensitivity for
+a gravitational-wave detector.
+
+However, the ASD doesn't allow you to see how much the sensitivity varies
+over time.
+One tool for that is the :ref:`spectrogram <gwpy-spectrogram>`, while another
+is simply to show percentiles of a number of ASD measurements.
+
+In this example we calculate the median ASD over 2048-seconds surrounding
+the GW178017 event, and also the 5th and 95th percentiles of the ASD, and
+plot them on a single figure.
+"""
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__currentmodule__ = 'gwpy.timeseries'
+
+# First, as always, we get the data using :meth:`TimeSeries.fetch_open_data`:
+
+from gwpy.timeseries import TimeSeries
+hoft = TimeSeries.fetch_open_data('H1', 1187007040, 1187009088, tag='C00', cache=True)
+
+# Next we calculate a :class:`~gwpy.spectrogram.Spectrogram` by calculating
+# a number of ASDs, using the :meth:`~gwpy.timeseries.TimeSeries.spectrogram2`
+# method:
+
+sg = hoft.spectrogram2(fftlength=4, overlap=2) ** (1/2.)
+
+# From this we can trivially extract the median, 5th and 95th percentiles:
+
+median = sg.percentile(50)
+min_ = sg.percentile(5)
+max_ = sg.percentile(95)
+
+# Finally, we can make plot, using
+# :meth:`~gwpy.plotter.FrequencySeriesAxes.plot_frequencyseries_mmm` to
+# display the 5th and 95th percentiles as a shaded region around the median:
+
+from gwpy.plotter import FrequencySeriesPlot
+plot = FrequencySeriesPlot()
+ax = plot.gca()
+ax.plot_spectrum_mmm(median, min_=min_, max_=max_, color='gwpy:ligo-hanford')
+ax.set_xscale('log')
+ax.set_yscale('log')
+ax.set_xlim(10, 1500)
+ax.set_ylim(3e-24,2e-20)
+ax.set_ylabel(r'Strain noise [1/\rtHz]')
+ax.set_title('LIGO-Hanford strain noise variation around GW170817',
+             fontsize=16)
+plot.show()
+
+# Now we can see that the ASD varies by factors of a few across most of the
+# frequency band, with notable exceptions, e.g. around the 60-Hz power line
+# harmonics (60 Hz, 120 Hz, 180 Hz, ...) where the noise is very stable.


### PR DESCRIPTION
This PR adds a new example, demonstrating `FrequencySeriesAxes.plot_frequencyseries_mmm`. Closes #298.