### PR TITLE
Improved docstring for Spectrogram.plot

### DIFF
--- a/gwpy/plotter/timeseries.py
+++ b/gwpy/plotter/timeseries.py
@@ -284,19 +284,22 @@ class TimeSeriesAxes(Axes):
 
         **kwargs
             any other keyword arguments acceptable for
-            :meth:`~matplotlib.Axes.imshow` (if ``imshow=True``),
-            or :meth:`~matplotlib.Axes.pcolormesh` (``imshow=False``)
+            :meth:`~matplotlib.axes.Axes.imshow` (if ``imshow=True``),
+            or :meth:`~matplotlib.axes.Axes.pcolormesh` (``imshow=False``)
 
         Returns
         -------
-        layer : `~matplotlib.collections.QuadMesh`, `~matplotlib.images.Image`
+        layer : `matplotlib.collections.QuadMesh`, `matplotlib.image.AxesImage`
             the layer for this spectrogram
 
         See Also
         --------
         matplotlib.axes.Axes.imshow
+            for a full description of acceptable ``*args`` and ``**kwargs``
+            for ``imshow=True``
         matplotlib.axes.Axes.pcolormesh
             for a full description of acceptable ``*args`` and ``**kwargs``
+            for ``imshow=False``
         """
         # rescue grid settings
         grid = (self.xaxis._gridOnMajor, self.xaxis._gridOnMinor,

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -317,6 +317,29 @@ class Spectrogram(Array2D):
 
     def plot(self, **kwargs):
         """Plot the data for this `Spectrogram`
+
+        Parameters
+        ----------
+        **kwargs
+            all keyword arguments are passed along to underlying
+            functions, see below for references
+
+        Returns
+        -------
+        plot : `~gwpy.plotter.SpectrogramPlot`
+            the `Plot` containing the data
+
+        See Also
+        --------
+        matplotlib.pyplot.figure
+            for documentation of keyword arguments used to create the
+            figure
+        matplotlib.figure.Figure.add_subplot
+            for documentation of keyword arguments used to create the
+            axes
+        gwpy.plotter.TimeSeriesAxes.plot_spectrogram
+            for documentation of keyword arguments used in rendering the
+            `Spectrogram` data
         """
         from ..plotter import SpectrogramPlot
         return SpectrogramPlot(self, **kwargs)


### PR DESCRIPTION
This PR improves the docstrings for `Spectrogram.plot` and `TimeSeriesAxes.plot_spectrogram`.

Fixes #462.