### PR TITLE
Reworked dependency installation for OS CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ env:
 
 matrix:
   include:
-    # simple build
+    # -- simple builds --------------------------
+
     - python: '2.7'
       addons:
         apt:
@@ -72,43 +73,9 @@ matrix:
             - dvipng
             - libhdf5-serial-dev
 
-    # debian 8 build
-    - env: DOCKER_IMAGE="ligo/software:jessie"
-      python: '2.7'
-      sudo: required
-      services:
-        - docker
-    - env: DOCKER_IMAGE="ligo/software:jessie"
-      python: '3.4'
-      sudo: required
-      services:
-        - docker
+    # -- reference OS builds --------------------
 
-    # debian 9 build
-    - env: DOCKER_IMAGE="ligo/software:stretch"
-      python: '2.7'
-      sudo: required
-      services:
-        - docker
-    - env: DOCKER_IMAGE="ligo/software:stretch"
-      python: '3.5'
-      sudo: required
-      services:
-        - docker
-
-    # debian 9 testing build
-    - env: DOCKER_IMAGE="ligo/software:stretch-proposed"
-      python: '2.7'
-      sudo: required
-      services:
-        - docker
-    - env: DOCKER_IMAGE="ligo/software:stretch-proposed"
-      python: '3.5'
-      sudo: required
-      services:
-        - docker
-
-    # sl7 build
+    # EL7
     - env: DOCKER_IMAGE="ligo/software:el7"
       python: '2.7'
       sudo: required
@@ -120,22 +87,57 @@ matrix:
       services:
         - docker
 
-    # macos build
+    # debian 8
+    - env: DOCKER_IMAGE="ligo/software:jessie"
+      python: '2.7'
+      sudo: required
+      services:
+        - docker
+    - env: DOCKER_IMAGE="ligo/software:jessie"
+      python: '3.4'
+      sudo: required
+      services:
+        - docker
+
+    # debian 9
+    - env: DOCKER_IMAGE="ligo/software:stretch"
+      python: '2.7'
+      sudo: required
+      services:
+        - docker
+    - env: DOCKER_IMAGE="ligo/software:stretch"
+      python: '3.5'
+      sudo: required
+      services:
+        - docker
+
+    # macOS
     - os: osx
       env: PYTHON_VERSION='2.7'
       language: minimal
       sudo: required
 
+    # -- full build -----------------------------
+
+    - env: DOCKER_IMAGE="ligo/software:stretch" EXTRAS=true
+      python: '2.7'
+      sudo: required
+      services:
+        - docker
+    - env: DOCKER_IMAGE="ligo/software:stretch" EXTRAS=true
+      python: '3.5'
+      sudo: required
+      services:
+        - docker
+
   allow_failures:
     - env: PIP_FLAGS="--upgrade --pre --quiet"
-    - env: DOCKER_IMAGE="ligo/software:jessie"
-      python: '3.4'
-    - env: DOCKER_IMAGE="ligo/software:stretch"
-      python: '3.5'
-    - env: DOCKER_IMAGE="ligo/software:stretch-proposed"
-      python: '3.5'
     - env: DOCKER_IMAGE="ligo/software:el7"
       python: '3.4'
+    - env: DOCKER_IMAGE="ligo/software:jessie"
+      python: '3.4'
+    - env: DOCKER_IMAGE="ligo/software:stretch" EXTRAS=true
+      python: '3.5'
 
   fast_finish: true
 

--- a/ci/docker-install.sh
+++ b/ci/docker-install.sh
@@ -44,6 +44,7 @@ sudo docker run \
     --env DOCKER_IMAGE="${DOCKER_IMAGE}" \
     --env PYTHON_VERSION="${TRAVIS_PYTHON_VERSION}" \
     --env GWPY_PATH="${GWPY_PATH}" \
+    --env EXTRAS="${EXTRAS}" \
     --volume `pwd`:${GWPY_PATH}:rw \
     ${DOCKER_IMAGE}
 

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -93,7 +93,3 @@ for pckg in \
 ; do
     apt-get -yqq install $pckg || true
 done
-
-if [ ${PY_XY} -lt 30 ]; then
-    NO_ROOT_NUMPY_TMVA=1 ${PIP} install root_numpy ${PIP_FLAGS}
-fi

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -62,6 +62,3 @@ if [ ${PY_XY} -lt 30 ]; then
 else
     yum -y install ${PY_PREFIX}-root
 fi
-
-# install root_numpy
-NO_ROOT_NUMPY_TMVA=1 ${PIP} install root_numpy ${PIP_FLAGS}

--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -101,8 +101,5 @@ kill -9 $wvbpid &> /dev/null
 MPL_VERSION=$(port -q installed ${PY_PREFIX}-matplotlib | grep active | \
               awk -F '[\@\_]' '{print $2}')
 if [[ "${MPL_VERSION}" =~ 2.1.[01] ]]; then
-    sudo $PIP install "matplotlib >= 1.2.0, != 2.1.0, != 2.1.1"
+    ${PIP} install "matplotlib >= 1.2.0, != 2.1.0, != 2.1.1"
 fi
-
-# install python extras with sudo
-sudo ${PIP} install -r requirements-dev.txt ${PIP_FLAGS}

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -24,6 +24,7 @@ cd ${GWPY_PATH}
 
 . ci/lib.sh
 
+get_python_version 1> /dev/null
 get_environment
 
 set -x

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -52,7 +52,7 @@ if [ ${EXTRAS} ]; then
     # install root_numpy if pyroot is installed for this python version
     _rootpyv=`root-config --python-version 2> /dev/null || true`
     if [[ "${_rootpyv}" == "${PYTHON_VERSION}" ]]; then
-        NO_ROOT_NUMPY_TMVA=1 ${PIP} install root_numpy ${PIP_FLAGS}
+        NO_ROOT_NUMPY_TMVA=1 ${PIP} install root_numpy --quiet ${PIP_FLAGS}
     fi
 fi
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -37,12 +37,23 @@ elif [ -n "${DOCKER_IMAGE}" ]; then  # debian
     . ci/install-debian.sh
 else  # simple pip build
     ${PIP} install . ${PIP_FLAGS}
+    EXTRAS=true
 fi
 
-# install python extras
+# upgrade pip (mainly to get `pip list --format` below)
 ${PIP} install --upgrade pip
-${PIP} install --quiet ${PIP_FLAGS} "setuptools>=36.2"
-${PIP} install -r requirements-dev.txt --quiet ${PIP_FLAGS}
+
+# install python extras for full tests
+if [ ${EXTRAS} ]; then
+    ${PIP} install --quiet ${PIP_FLAGS} "setuptools>=36.2"
+    ${PIP} install -r requirements-dev.txt --quiet ${PIP_FLAGS}
+
+    # install root_numpy if pyroot is installed for this python version
+    _rootpyv=`root-config --python-version 2> /dev/null || true`
+    if [[ "${_rootpyv}" == "${PYTHON_VERSION}" ]]; then
+        NO_ROOT_NUMPY_TMVA=1 ${PIP} install root_numpy ${PIP_FLAGS}
+    fi
+fi
 
 set +x
 

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -99,7 +99,7 @@ install_package() {
 }
 
 get_python_version() {
-    if [ -z ${PYTHON_VERSION} ]; then
+    if [ -z "${PYTHON_VERSION}" ]; then
         PYTHON_VERSION=`python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'`
     fi
     export PYTHON_VERSION

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -117,6 +117,7 @@ get_environment() {
         "port")
             PY_DIST=python${PY_XY}
             PY_PREFIX=py${PY_XY}
+            PIP="sudo ${PIP}"
             ;;
         "apt-get")
             if [ ${PY_MAJOR_VERSION} == 2 ]; then

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -606,11 +606,6 @@ class TestDataQualityFlag(object):
         utils.assert_segmentlist_equal(result.known, RESULT.known)
         utils.assert_segmentlist_equal(result.active, RESULT.active)
 
-        with pytest.raises(TypeError):
-            self.TEST_CLASS.query(QUERY_FLAGS[0], 1, 2, 3)
-        with pytest.raises(TypeError):
-            self.TEST_CLASS.query(QUERY_FLAGS[0], (1, 2, 3))
-
     def test_query_segdb(self):
         result = query_segdb(self.TEST_CLASS.query_segdb,
                              QUERY_FLAGS[0], 0, 10)
@@ -627,6 +622,11 @@ class TestDataQualityFlag(object):
         result2 = query_segdb(self.TEST_CLASS.query_segdb,
                               QUERY_FLAGS[0], SegmentList([(0, 10)]))
         utils.assert_flag_equal(result, result2)
+
+        with pytest.raises(TypeError):
+            self.TEST_CLASS.query(QUERY_FLAGS[0], 1, 2, 3)
+        with pytest.raises(TypeError):
+            self.TEST_CLASS.query(QUERY_FLAGS[0], (1, 2, 3))
 
     @pytest.mark.parametrize('name, flag', [
         (QUERY_FLAGS[0], QUERY_FLAGS[0]),  # regular query
@@ -655,6 +655,11 @@ class TestDataQualityFlag(object):
             query_dqsegdb(self.TEST_CLASS.query_dqsegdb,
                           'X1:GWPY-TEST:0', 0, 10)
         assert str(exc.value) == 'HTTP Error 404: Not found [X1:GWPY-TEST:0]'
+
+        with pytest.raises(TypeError):
+            self.TEST_CLASS.query(QUERY_FLAGS[0], 1, 2, 3)
+        with pytest.raises(TypeError):
+            self.TEST_CLASS.query(QUERY_FLAGS[0], (1, 2, 3))
 
     def test_query_dqsegdb_multi(self):
         segs = SegmentList([Segment(0, 2), Segment(8, 10)])

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -624,9 +624,9 @@ class TestDataQualityFlag(object):
         utils.assert_flag_equal(result, result2)
 
         with pytest.raises(TypeError):
-            self.TEST_CLASS.query(QUERY_FLAGS[0], 1, 2, 3)
+            self.TEST_CLASS.query_segdb(QUERY_FLAGS[0], 1, 2, 3)
         with pytest.raises(TypeError):
-            self.TEST_CLASS.query(QUERY_FLAGS[0], (1, 2, 3))
+            self.TEST_CLASS.query_segdb(QUERY_FLAGS[0], (1, 2, 3))
 
     @pytest.mark.parametrize('name, flag', [
         (QUERY_FLAGS[0], QUERY_FLAGS[0]),  # regular query
@@ -657,9 +657,9 @@ class TestDataQualityFlag(object):
         assert str(exc.value) == 'HTTP Error 404: Not found [X1:GWPY-TEST:0]'
 
         with pytest.raises(TypeError):
-            self.TEST_CLASS.query(QUERY_FLAGS[0], 1, 2, 3)
+            self.TEST_CLASS.query_dqsegdb(QUERY_FLAGS[0], 1, 2, 3)
         with pytest.raises(TypeError):
-            self.TEST_CLASS.query(QUERY_FLAGS[0], (1, 2, 3))
+            self.TEST_CLASS.query_dqsegdb(QUERY_FLAGS[0], (1, 2, 3))
 
     def test_query_dqsegdb_multi(self):
         segs = SegmentList([Segment(0, 2), Segment(8, 10)])


### PR DESCRIPTION
This PR modifies the configuration for CI builds using docker images, or macOS, to prevent implicit upgrades of system-installed dependencies and extras with `pip`. This should allow more robust testing of gwpy against system packages for debian/el/macos.