### PR TITLE
Deprecated the @axes_methods decorator

### DIFF
--- a/examples/signal/gw150914.py
+++ b/examples/signal/gw150914.py
@@ -92,9 +92,10 @@ plot.show()
 
 plot = b.crop(1126259462, 1126259462.6).plot(
     figsize=[12, 4], color='gwpy:ligo-hanford')
-plot.set_title('LIGO-Hanford strain data around GW150914')
-plot.set_ylabel('Amplitude [strain]')
-plot.set_epoch(1126259462.427)
+ax = plot.gca()
+ax.set_title('LIGO-Hanford strain data around GW150914')
+ax.set_ylabel('Amplitude [strain]')
+ax.set_epoch(1126259462.427)
 plot.show()
 
 # Congratulations, you have succesfully filtered LIGO data to uncover the

--- a/examples/table/rate.py
+++ b/examples/table/rate.py
@@ -51,7 +51,8 @@ rate = events.event_rate(1, start=968654552, end=968654562)
 # `~gwpy.timeseries.TimeSeries`, so we can display this using the
 # :meth:`~gwpy.timeseries.TimeSeries.plot` method of that object:
 plot = rate.plot()
-plot.set_xlim(968654552, 968654562)
-plot.set_ylabel('Event rate [Hz]')
-plot.set_title('LIGO Hanford Observatory event rate for HW100916')
+ax = plot.gca()
+ax.set_xlim(968654552, 968654562)
+ax.set_ylabel('Event rate [Hz]')
+ax.set_title('LIGO Hanford Observatory event rate for HW100916')
 plot.show()

--- a/examples/table/rate_binned.py
+++ b/examples/table/rate_binned.py
@@ -54,8 +54,9 @@ rates = events.binned_event_rates(1, 'snr', [2, 3, 5, 8], operator='>=',
 
 # Finally, we can make a plot:
 plot = rates.plot(label='name')
-plot.set_xlim(968654552, 968654562)
-plot.set_ylabel('Event rate [Hz]')
-plot.set_title('LIGO Hanford Observatory event rate for HW100916')
-plot.add_legend()
+ax = plot.gca()
+ax.set_xlim(968654552, 968654562)
+ax.set_ylabel('Event rate [Hz]')
+ax.set_title('LIGO Hanford Observatory event rate for HW100916')
+ax.legend()
 plot.show()

--- a/examples/timeseries/public.py
+++ b/examples/timeseries/public.py
@@ -39,7 +39,8 @@ from gwpy.timeseries import TimeSeries
 data = TimeSeries.fetch_open_data('L1', 968654552, 968654562)
 
 # and then we can make a plot:
-plot = data.plot()
-plot.set_title('LIGO Livingston Observatory data for HW100916')
-plot.set_ylabel('Gravitational-wave strain amplitude')
+plot = data.plot(
+    title='LIGO Livingston Observatory data for HW100916',
+    ylabel='Gravitational-wave strain amplitude',
+)
 plot.show()

--- a/examples/timeseries/statevector.py
+++ b/examples/timeseries/statevector.py
@@ -53,6 +53,6 @@ data = data.resample(16)
 # Finally, we make a :meth:`~StateVector.plot`, passing `insetlabels=True` to
 # display the bit names inside the axes:
 plot = data.plot(insetlabels=True)
-plot.set_title('LLO ETMX internal seismic isolation state')
+plot.gca().set_title('LLO ETMX internal seismic isolation state')
 plot.add_bitmask('0b11101110')
 plot.show()

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -550,10 +550,10 @@ class CliProduct(object):
     # -- plotting -------------------------------
 
     def show_plot_info(self):
-        self.log(3, ('X-scale: %s, Y-scale: %s' % (self.plot.get_xscale(),
-                                                   self.plot.get_yscale())))
-        self.log(3, ('X-limits %s, Y-limits %s' % (self.plot.xlim,
-                                                   self.plot.ylim)))
+        self.log(3, ('X-scale: %s, Y-scale: %s' % (self.ax.get_xscale(),
+                                                   self.ax.get_yscale())))
+        self.log(3, ('X-limits %s, Y-limits %s' % (self.ax.get_xlim(),
+                                                   self.ax.get_ylim())))
 
     def config_plot(self, arg_list):
         """Configure global plot parameters
@@ -791,7 +791,7 @@ class CliProduct(object):
             title += spec
 
         title = label_to_latex(title)
-        self.plot.set_title(title, fontsize=12)
+        self.ax.set_title(title, fontsize=12)
         self.log(3, ('Title is: %s' % title))
 
         if args.xlabel:
@@ -799,7 +799,7 @@ class CliProduct(object):
         else:
             xlabel = self.get_xlabel()
         if xlabel:
-            self.plot.set_xlabel(xlabel)
+            self.ax.set_xlabel(xlabel)
             self.log(3, ('X-axis label is: %s' % xlabel))
 
         all_units = set()
@@ -820,7 +820,7 @@ class CliProduct(object):
             ylabel = self.get_ylabel(args)
 
         if ylabel:
-            self.plot.set_ylabel(ylabel)
+            self.ax.set_ylabel(ylabel)
             self.log(3, ('Y-axis label is: %s' % ylabel))
 
         if not args.nogrid:
@@ -846,7 +846,7 @@ class CliProduct(object):
             unit = xscale.get_unit_name()
             utc = re.sub(r'\.0+', '',
                          Time(epoch, format='gps', scale='utc').iso)
-            self.plot.set_xlabel('Time (%s) from %s (%s)' % (unit, utc, epoch))
+            self.ax.set_xlabel('Time (%s) from %s (%s)' % (unit, utc, epoch))
             self.ax.set_xscale(unit, epoch=epoch)
 
         # if they specified an output file write it

--- a/gwpy/plotter/decorators.py
+++ b/gwpy/plotter/decorators.py
@@ -19,6 +19,7 @@
 """Decorator for GWpy plotting
 """
 
+import warnings
 from functools import wraps
 
 from matplotlib.figure import Figure
@@ -68,6 +69,10 @@ def axes_method(func):
     def wrapper(figure, *args, **kwargs):
         """Find the relevant `Axes` and call the method
         """
+        warnings.warn('Plot.{0}() is been deprecated, and will be removed in '
+                      'an upcoming release; please update your code to call '
+                      'Axes.{0}() directly'.format(func.__name__),
+                      DeprecationWarning)
         axes = [ax for ax in figure.axes if ax not in figure._coloraxes]
         if not axes:
             raise RuntimeError("No axes found for which '%s' is applicable"

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -198,31 +198,41 @@ class TestPlot(PlottingTestBase):
         fig_set = getattr(fig, 'set_%s' % name)
         ax_get = getattr(ax, 'get_%s' % name)
 
-        assert fig_get() == ax_get()
-        fig_set(args)
-        assert fig_get() == args
-        assert fig_get() == ax_get()
+        # note: @axes_methods is deprecated
+        with pytest.warns(DeprecationWarning):
+            assert fig_get() == ax_get()
+        with pytest.warns(DeprecationWarning):
+            fig_set(args)
+        with pytest.warns(DeprecationWarning):
+            assert fig_get() == args
+        with pytest.warns(DeprecationWarning):
+            assert fig_get() == ax_get()
 
     @pytest.mark.parametrize('axis', ('x', 'y'))
     def test_log(self, axis):
         fig, ax = self.new()
 
         # fig.set_xlim(0.1, 10)
-        getattr(fig, 'set_%slim' % axis)(0.1, 10)
+        with pytest.warns(DeprecationWarning):
+            getattr(fig, 'set_%slim' % axis)(0.1, 10)
 
         # fig.logx = True
-        setattr(fig, 'log%s' % axis, True)
+        with pytest.warns(DeprecationWarning):
+            setattr(fig, 'log%s' % axis, True)
 
         # assert ax.get_xscale() == 'log'
         assert getattr(ax, 'get_%sscale' % axis)() == 'log'
 
         # assert fig.logx is True
-        assert getattr(fig, 'log%s' % axis) is True
+        with pytest.warns(DeprecationWarning):
+            assert getattr(fig, 'log%s' % axis) is True
 
         # fig.logx = False
-        setattr(fig, 'log%s' % axis, False)
+        with pytest.warns(DeprecationWarning):
+            setattr(fig, 'log%s' % axis, False)
         assert getattr(ax, 'get_%sscale' % axis)() == 'linear'
-        assert getattr(fig, 'log%s' % axis) is False
+        with pytest.warns(DeprecationWarning):
+            assert getattr(fig, 'log%s' % axis) is False
 
         self.save_and_close(fig)
 
@@ -469,14 +479,16 @@ class TestTimeSeriesPlot(TimeSeriesMixin, TestPlot):
         # test empty
         fig, ax = self.new()
         assert isinstance(ax, self.AXES_CLASS)
+
         # test passing arguments
         fig = self.FIGURE_CLASS(figsize=[9, 6])
         assert fig.get_figwidth() == 9
         fig = self.FIGURE_CLASS(self.ts)
         ax = fig.gca()
         assert len(ax.lines) == 1
-        assert fig.get_epoch() == self.ts.x0.value
-        assert fig.get_xlim() == self.ts.span
+        assert ax.get_epoch() == self.ts.x0.value
+        assert ax.get_xlim() == self.ts.span
+
         # test passing multiple timeseries
         fig = self.FIGURE_CLASS(self.ts, self.ts)
         assert len(fig.gca().lines) == 2
@@ -485,6 +497,7 @@ class TestTimeSeriesPlot(TimeSeriesMixin, TestPlot):
         for ax in fig.axes:
             assert len(ax.lines) == 1
         assert fig.axes[1]._sharex is fig.axes[0]
+
         # test kwarg parsing
         fig = self.FIGURE_CLASS(self.ts, figsize=[12, 6], rasterized=True)
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1525,8 +1525,9 @@ class TimeSeries(TimeSeriesBase):
 
         >>> q = data.q_transform()
         >>> plot = q.plot()
-        >>> plot.set_xlim(-.2, .2)
-        >>> plot.set_epoch(0)
+        >>> ax = plot.gca()
+        >>> ax.set_xlim(-.2, .2)
+        >>> ax.set_epoch(0)
         >>> plot.show()
         """  # nopep8
         from scipy.interpolate import (interp2d, InterpolatedUnivariateSpline)


### PR DESCRIPTION
This PR deprecates the `@axes_methods` decorator used in `gwpy.plotter.Plot` and subclasses to project methods of `Axes` onto `Plot` with a single `Axes`.

This magic was never documented properly, and is potentially confusing to use - it presents a non-standard usage for `Plot`s with multiple `Axes` - and potentially annoying to maintain.

@areeda, this includes a small change to `gwpy.cli` to remove usage of the decorator, so please take a look.