### PR TITLE
Demodulation method for TimeSeries objects

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1168,16 +1168,16 @@ class TestTimeSeries(TestTimeSeriesBase):
         demod = data.demodulate(f, stride=stride, exp=True)
         assert demod.unit == data.unit
         assert len(demod) == duration // stride
-        assert_allclose(numpy.abs(demod.value), amp, rtol=1e-5)
-        assert_allclose(numpy.angle(demod.value), phase, rtol=1e-5)
+        utils.assert_allclose(numpy.abs(demod.value), amp, rtol=1e-5)
+        utils.assert_allclose(numpy.angle(demod.value), phase, rtol=1e-5)
 
         # test with exp=False
         mag, ph = data.demodulate(f, stride=stride)
         assert mag.unit == data.unit
         assert len(mag) == len(ph)
         assert ph.unit == 'deg'
-        assert_allclose(mag.value, amp, rtol=1e-5)
-        assert_allclose(ph.value, numpy.rad2deg(phase), rtol=1e-5)
+        utils.assert_allclose(mag.value, amp, rtol=1e-5)
+        utils.assert_allclose(ph.value, numpy.rad2deg(phase), rtol=1e-5)
 
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1158,14 +1158,16 @@ class TestTimeSeries(TestTimeSeriesBase):
         # create a timeseries that is simply one loud sinusoidal oscillation
         # at a particular frequency, then demodulate at that frequency and
         # recover the amplitude and phase
-        amp, phase, f = 1., 0., 30
-        t = numpy.linspace(0, 10, 10*16384)
-        data = amp * numpy.cos(2*numpy.pi*f*t + phase)
-        data = TimeSeries(data, unit='strain', times=t)
-        assert data.demodulate(f).unit == data.unit
-        assert len(data.demodulate(f)) == 10
-        assert all(x <= 1e-4 for x in numpy.abs(data.demodulate(f).value - amp))
-        assert all(x <= 1e-4 for x in (numpy.angle(data.demodulate(f)) - phase))
+        amp, phase, f = 1., numpy.pi/4, 30
+        duration, sample_rate, stride = 600, 4096, 60
+        t = numpy.linspace(0, duration, duration*sample_rate)
+        data = TimeSeries(amp * numpy.cos(2*numpy.pi*f*t - phase),
+                                   unit='', times=t)
+        demod = data.demodulate(f, stride=stride)
+        assert demod.unit == data.unit
+        assert len(demod) == duration // stride
+        assert_allclose(numpy.abs(demod.value), amp, rtol=1e-5)
+        assert_allclose(numpy.angle(demod.value), phase, rtol=1e-5)
 
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1163,11 +1163,21 @@ class TestTimeSeries(TestTimeSeriesBase):
         t = numpy.linspace(0, duration, duration*sample_rate)
         data = TimeSeries(amp * numpy.cos(2*numpy.pi*f*t - phase),
                                    unit='', times=t)
-        demod = data.demodulate(f, stride=stride)
+
+        # test with exp=True
+        demod = data.demodulate(f, stride=stride, exp=True)
         assert demod.unit == data.unit
         assert len(demod) == duration // stride
         assert_allclose(numpy.abs(demod.value), amp, rtol=1e-5)
         assert_allclose(numpy.angle(demod.value), phase, rtol=1e-5)
+
+        # test with exp=False
+        mag, ph = data.demodulate(f, stride=stride)
+        assert mag.unit == data.unit
+        assert len(mag) == len(ph)
+        assert ph.unit == 'deg'
+        assert_allclose(mag.value, amp, rtol=1e-5)
+        assert_allclose(ph.value, numpy.rad2deg(phase), rtol=1e-5)
 
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1163,8 +1163,8 @@ class TestTimeSeries(TestTimeSeriesBase):
         data = TimeSeries(data, unit='strain', times=t)
         assert data.demod(f).unit == data.unit
         assert len(data.demod(f)) == 10
-        assert all( x <= 1e-4 for x in numpy.abs(data.demod(f).value - amp) )
-        assert all( x <= 1e-4 for x in (numpy.angle(data.demod(f)) - phase) )
+        assert all(x <= 1e-4 for x in numpy.abs(data.demod(f).value - amp))
+        assert all(x <= 1e-4 for x in (numpy.angle(data.demod(f)) - phase))
 
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1162,7 +1162,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         duration, sample_rate, stride = 600, 4096, 60
         t = numpy.linspace(0, duration, duration*sample_rate)
         data = TimeSeries(amp * numpy.cos(2*numpy.pi*f*t - phase),
-                                   unit='', times=t)
+            unit='', times=t)
 
         # test with exp=True
         demod = data.demodulate(f, stride=stride, exp=True)

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1154,6 +1154,18 @@ class TestTimeSeries(TestTimeSeriesBase):
         rms = losc.rms(1.)
         assert rms.sample_rate == 1 * units.Hz
 
+    def test_demod(self):
+        # create a timeseries with two loud lines with different phases
+        # at different frequencies
+        amp, phase, f = 1., 0., 30
+        t = numpy.linspace(0, 10, 10*16384)
+        data = amp * numpy.cos(2*numpy.pi*f*t + phase)
+        data = TimeSeries(data, unit='strain', times=t)
+        assert data.demod(f).unit == data.unit
+        assert len(data.demod(f)) == 10
+        assert all( x <= 1e-4 for x in numpy.abs(data.demod(f).value - amp) )
+        assert all( x <= 1e-4 for x in (numpy.angle(data.demod(f)) - phase) )
+
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz
         noise = self.TEST_CLASS(

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1154,17 +1154,18 @@ class TestTimeSeries(TestTimeSeriesBase):
         rms = losc.rms(1.)
         assert rms.sample_rate == 1 * units.Hz
 
-    def test_demod(self):
-        # create a timeseries with two loud lines with different phases
-        # at different frequencies
+    def test_demodulate(self):
+        # create a timeseries that is simply one loud sinusoidal oscillation
+        # at a particular frequency, then demodulate at that frequency and
+        # recover the amplitude and phase
         amp, phase, f = 1., 0., 30
         t = numpy.linspace(0, 10, 10*16384)
         data = amp * numpy.cos(2*numpy.pi*f*t + phase)
         data = TimeSeries(data, unit='strain', times=t)
-        assert data.demod(f).unit == data.unit
-        assert len(data.demod(f)) == 10
-        assert all(x <= 1e-4 for x in numpy.abs(data.demod(f).value - amp))
-        assert all(x <= 1e-4 for x in (numpy.angle(data.demod(f)) - phase))
+        assert data.demodulate(f).unit == data.unit
+        assert len(data.demodulate(f)) == 10
+        assert all(x <= 1e-4 for x in numpy.abs(data.demodulate(f).value - amp))
+        assert all(x <= 1e-4 for x in (numpy.angle(data.demodulate(f)) - phase))
 
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1171,13 +1171,18 @@ class TestTimeSeries(TestTimeSeriesBase):
         utils.assert_allclose(numpy.abs(demod.value), amp, rtol=1e-5)
         utils.assert_allclose(numpy.angle(demod.value), phase, rtol=1e-5)
 
-        # test with exp=False
+        # test with exp=False, deg=True
         mag, ph = data.demodulate(f, stride=stride)
         assert mag.unit == data.unit
         assert len(mag) == len(ph)
         assert ph.unit == 'deg'
         utils.assert_allclose(mag.value, amp, rtol=1e-5)
         utils.assert_allclose(ph.value, numpy.rad2deg(phase), rtol=1e-5)
+
+        # test with exp=False, deg=False
+        mag, ph = data.demodulate(f, stride=stride, deg=False)
+        assert ph.unit == 'rad'
+        utils.assert_allclose(ph.value, phase, rtol=1e-5)
 
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1161,8 +1161,8 @@ class TestTimeSeries(TestTimeSeriesBase):
         amp, phase, f = 1., numpy.pi/4, 30
         duration, sample_rate, stride = 600, 4096, 60
         t = numpy.linspace(0, duration, duration*sample_rate)
-        data = TimeSeries(amp * numpy.cos(2*numpy.pi*f*t - phase),
-            unit='', times=t)
+        data = TimeSeries(amp * numpy.cos(2*numpy.pi*f*t + phase),
+                          unit='', times=t)
 
         # test with exp=True
         demod = data.demodulate(f, stride=stride, exp=True)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1323,19 +1323,19 @@ class TimeSeries(TimeSeriesBase):
         --------
         Demodulation is useful when trying to examine steady sinusoidal
         signals we know to be contained within data. For instance,
-        we can download some data from LOSC to look for fluctuations
-        in the 60 Hz power line harmonic:
+        we can download some data from LOSC to look at trends of the
+        amplitude and phase of Livingston's calibration line at 331.3 Hz:
 
         >>> from gwpy.timeseries import TimeSeries
         >>> data = TimeSeries.fetch_open_data('L1', 1131350417, 1131357617)
 
-        We can demodulate the `TimeSeries` at 60 Hz with a stride of once
+        We can demodulate the `TimeSeries` at 331.3 Hz with a stride of once
         per minute:
 
-        >>> amp, phase = data.demodulate(60, stride=60)
+        >>> amp, phase = data.demodulate(331.3, stride=60)
 
         We can then plot these trends to visualize changes in the amplitude
-        and phase of the 60 Hz line:
+        and phase of the calibration line:
 
         >>> from gwpy.plotter import TimeSeriesPlot
         >>> plot = TimeSeriesPlot(amp, phase, sep=True)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1313,7 +1313,7 @@ class TimeSeries(TimeSeriesBase):
         # mix with a complex oscillator and stride through the TimeSeries,
         # taking the average over each stride
         data = numpy.zeros(nsteps, dtype=complex)
-        mixed = 2 * numpy.exp( 2*numpy.pi*1j*f*self.times.value ) * self.value
+        mixed = 2 * numpy.exp(2*numpy.pi*1j*f*self.times.value) * self.value
         for step in range(nsteps):
             # find step TimeSeries
             idx = int(stridesamp * step)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1328,8 +1328,8 @@ class TimeSeries(TimeSeriesBase):
         out.sample_rate = 1/float(stride)
         out._unit = self.unit
         mixed = 2 * numpy.exp(-2*numpy.pi*1j*f*self.times.value) * self.value
+        # stride through the TimeSeries
         for step in range(nsteps):
-            # find step TimeSeries
             idx = int(stridesamp * step)
             idx_end = idx + stridesamp
             stepseries = mixed[idx:idx_end]
@@ -1337,15 +1337,11 @@ class TimeSeries(TimeSeriesBase):
             out.value[step] = demod_
         if exp:
             return out
-        else:
-            mag = numpy.abs(out)
-            phase = numpy.angle(out, deg=deg).view(type(self))
-            phase.__metadata_finalize__(out)
-            if deg:
-                phase._unit = 'deg'
-            else:
-                phase._unit = 'rad'
-            return mag, phase
+        mag = numpy.abs(out)
+        phase = numpy.angle(out, deg=deg).view(type(self))
+        phase.__metadata_finalize__(out)
+        phase.override_unit('deg' if deg else 'rad')
+        return mag, phase
 
     def whiten(self, fftlength, overlap=0, method='scipy-welch',
                window='hanning', detrend='constant', asd=None, **kwargs):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1290,7 +1290,7 @@ class TimeSeries(TimeSeriesBase):
         return self.__class__(data, channel=self.channel, t0=self.t0,
                               name=name, sample_rate=(1/float(stride)))
 
-    def demod(self, f, stride=1):
+    def demodulate(self, f, stride=1):
         """Compute the average magnitude and phase of this `TimeSeries`
            once per stride at a given frequency.
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1318,6 +1318,28 @@ class TimeSeries(TimeSeriesBase):
         out : `TimeSeries`
             if `exp=True`, returns a single `TimeSeries` with magnitude and
             phase trends represented as `mag * exp(1j*phase)` with `dt=stride`
+
+        Examples
+        --------
+        Demodulation is useful when trying to examine steady sinusoidal
+        fluctuations we know are contained within some data. For instance,
+        we can download some data from LOSC to look for fluctuations
+        in the 60 Hz power line harmonic:
+
+        >>> from gwpy.timeseries import TimeSeries
+        >>> data = TimeSeries.fetch_open_data('L1', 1131350417, 1131357617)
+        
+        To look at fluctuations we can demodulate the `TimeSeries` at 60 Hz
+        with a stride of once per minute:
+
+        >>> amp, phase = data.demodulate(60, stride=60)
+        
+        We can then plot these trends to visualize changes in the amplitude
+        and phase of the 60 Hz line:
+
+        >>> from gwpy.plotter import TimeSeriesPlot
+        >>> plot = TimeSeriesPlot(amp, phase, sep=True)
+        >>> plot.show()
         """
         stridesamp = int(stride * self.sample_rate.value)
         nsteps = int(self.size // stridesamp)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1341,8 +1341,10 @@ class TimeSeries(TimeSeriesBase):
             mag = numpy.abs(out)
             phase = numpy.angle(out, deg=deg).view(type(self))
             phase.__metadata_finalize__(out)
-            if deg: phase._unit = 'deg'
-            else: phase._unit = 'rad'
+            if deg:
+                phase._unit = 'deg'
+            else:
+                phase._unit = 'rad'
             return mag, phase
 
     def whiten(self, fftlength, overlap=0, method='scipy-welch',

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1322,18 +1322,18 @@ class TimeSeries(TimeSeriesBase):
         Examples
         --------
         Demodulation is useful when trying to examine steady sinusoidal
-        fluctuations we know are contained within some data. For instance,
+        signals we know to be contained within data. For instance,
         we can download some data from LOSC to look for fluctuations
         in the 60 Hz power line harmonic:
 
         >>> from gwpy.timeseries import TimeSeries
         >>> data = TimeSeries.fetch_open_data('L1', 1131350417, 1131357617)
-        
-        To look at fluctuations we can demodulate the `TimeSeries` at 60 Hz
-        with a stride of once per minute:
+
+        We can demodulate the `TimeSeries` at 60 Hz with a stride of once
+        per minute:
 
         >>> amp, phase = data.demodulate(60, stride=60)
-        
+
         We can then plot these trends to visualize changes in the amplitude
         and phase of the 60 Hz line:
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1327,7 +1327,7 @@ class TimeSeries(TimeSeriesBase):
         out.__metadata_finalize__(self)
         out.sample_rate = 1/float(stride)
         out._unit = self.unit
-        mixed = 2 * numpy.exp(2*numpy.pi*1j*f*self.times.value) * self.value
+        mixed = 2 * numpy.exp(-2*numpy.pi*1j*f*self.times.value) * self.value
         for step in range(nsteps):
             # find step TimeSeries
             idx = int(stridesamp * step)


### PR DESCRIPTION
This is my first pass at implementing a demodulation method for `TimeSeries` objects. The proposed method takes in a frequency and stride, and returns a new `TimeSeries` object with `dt=stride` which represents the original signal's average magnitude and phase at the given frequency as a complex number.

Also included in this pull request is a unit test which creates a pure sinusoid and then checks that `demod` correctly measures the amplitude and phase within acceptable precision. (Note, the error in this calculation decreases for arbitrary amplitude and phase as the stride increases.)