### PR TITLE
Added support for the GWPY_CACHE environment variable to automatically set cache=True

### DIFF
--- a/docs/timeseries/remote-access.rst
+++ b/docs/timeseries/remote-access.rst
@@ -53,6 +53,14 @@ You can then trivially plot these data:
 
 For more details on plotting a `TimeSeries`, see :ref:`gwpy-timeseries-plot`.
 
+.. note::
+
+   :meth:`TimeSeries.fetch_open_data` accepts the keyword `cache`, which,
+   wnen set to `True` will store the downloaded data so that repeated requests
+   for a given URL result in only one download.
+   The ``GWPY_CACHE`` environment variable can be set (``GWPY_CACHE=1``)
+   to automatically set `cache=True` for all open data downloads.
+
 .. _gwpy-timeseries-remote-nds2:
 
 =============================

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -367,7 +367,7 @@ class TimeSeriesBase(Series):
     def fetch_open_data(cls, ifo, start, end, sample_rate=4096,
                         tag=None, version=None,
                         format=None, host='https://losc.ligo.org',
-                        verbose=False, cache=False, **kwargs):
+                        verbose=False, cache=None, **kwargs):
         """Fetch open-access data from the LIGO Open Science Center
 
         Parameters
@@ -414,7 +414,8 @@ class TimeSeriesBase(Series):
 
         cache : `bool`, optional
             save/read a local copy of the remote URL, default: `False`;
-            useful if the same remote data are to be accessed multiple times
+            useful if the same remote data are to be accessed multiple times.
+            Set `GWPY_CACHE=1` in the environment to auto-cache.
 
         **kwargs
             any other keyword arguments are passed to the `TimeSeries.read`

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -92,6 +92,14 @@ def _parse_formats(formats, cls=TimeSeries):
     return [formats]
 
 
+def _download_file(url, cache=None, verbose=False):
+    if cache is None:
+        cache = os.getenv('GWPY_CACHE', 'no').lower() in (
+            '1', 'true', 'yes', 'y',
+        )
+    return get_readable_fileobj(url, cache=cache, show_progress=verbose)
+
+
 # -- JSON handling ------------------------------------------------------------
 
 def _match_urls(urls, start, end, tag=None, version=None):
@@ -246,7 +254,7 @@ def _fetch_losc_data_file(url, *args, **kwargs):
     """Internal function for fetching a single LOSC file and returning a Series
     """
     cls = kwargs.pop('cls', TimeSeries)
-    cache = kwargs.pop('cache', False)
+    cache = kwargs.pop('cache', None)
     verbose = kwargs.pop('verbose', False)
 
     # match file format
@@ -261,7 +269,7 @@ def _fetch_losc_data_file(url, *args, **kwargs):
     elif ext == '.gwf':
         kwargs.setdefault('format', 'gwf')
 
-    with get_readable_fileobj(url, cache=cache, show_progress=verbose) as rem:
+    with _download_file(url, cache, verbose=verbose) as rem:
         if verbose:
             print('Reading data...', end=' ')
         try:


### PR DESCRIPTION
This PR adds support for a new `GWPY_CACHE` environment variable, which allows automatic setting of `cache=True` for `TimeSeries.fetch_open_data` and similar methods. This can be very useful for repeated documentation/examples builds where the same data are downloaded many times (without hard-coding `cache=True` into the example code).