### PR TITLE
Updated behaviour of known segments for DataQualityFlag logic operations

### DIFF
--- a/docs/segments/index.rst
+++ b/docs/segments/index.rst
@@ -45,6 +45,110 @@ Each `DataQualityFlag` has some key attributes:
 
 By convention, the :attr:`~DataQualityFlag.name` is typically constructed of three colon-separated components: the :attr:`~DataQualityFlag.ifo`, :attr:`~DataQualityFlag.tag`, and :attr:`~DataQualityFlag.version`, e.g. ``L1:DMT-ANALYSIS_READY:1``.
 
+=============================
+Combining `DataQualityFlag`\s
+=============================
+
+`DataQualityFlag`\s can be combined in a number of ways, using the standard python operators, e.g. `&` and `|`.
+
+.. _gwpy-segments-intersection
+
+--------------------
+Intersection (``&``)
+--------------------
+::
+
+   >>> a & b
+
+returns the intersection of both the `~DataQualityFlag.known` and
+`~DataQualityFlag.active` segment lists, e.g::
+
+   >>> a = DataQualityFlag(known=[(0, 5), (10, 15)], active=[(1, 5), (10, 12)])
+   >>> b = DataQualityFlag(known=[(0, 12)], active=[(3, 7), (10, 12)])
+   >>> print(a & b)
+   <DataQualityFlag(No name,
+                    known=[[0 ... 5)
+                           [10 ... 12)],
+                    active=[[3 ... 5)
+                            [10 ... 12)],
+                    description=None)>
+
+This new flag represents times when both ``a`` and ``b`` were known and
+when both were active.
+
+.. _gwpy-segments-union
+
+-------------
+Union (``|``)
+-------------
+::
+
+   >>> a | b
+
+returns the intersection of both the `~DataQualityFlag.known` and
+`~DataQualityFlag.active` segment lists, e.g::
+
+   >>> print(a | b)
+   <DataQualityFlag(No name,
+                 known=[[0 ... 15)],
+                 active=[[1 ... 7)
+                         [10 ... 12)],
+                 description=None)>
+
+This new flag represents times when either ``a`` or ``b`` were known and when
+either was active.
+
+.. _gwpy-segments-sub
+
+-------------------
+Subtraction (``-``)
+-------------------
+::
+
+   >>> a - b
+
+returns the union of the `~DataQualityFlag.known` segments, and the difference
+of the `~DataQualityFlag.active` segment lists, e.g.::
+
+   >>> print(a - b)
+   <DataQualityFlag(No name,
+                    known=[[0 ... 5)
+                           [10 ... 12)],
+                    active=[[1 ... 3)],
+                    description=None)>
+
+The new flag represents times when both ``a`` and ``b`` were *known*, but only ``a`` was active.
+
+.. _gwpy-segments-add
+
+----------------
+Addition (``+``)
+----------------
+::
+
+   >>> a + b
+
+This operation is the same as :ref:`gwpy-segments-union`.
+
+-----------------
+Inversion (``~``)
+-----------------
+::
+
+   >>> ~a
+
+returns the same `~DataQualityFlag.known` segments, and the inverse `~DataQualityFlag.active` segment lists, e.g::
+
+   >>> print(~a)
+   <DataQualityFlag(No name,
+                    known=[[0 ... 5)
+                           [10 ... 15)],
+                    active=[[0 ... 1)
+                            [12 ... 15)],
+                    description=None)>
+
+The new flag represents times when the state of ``a`` was known, but it was not active.
+
 =====================
 The `DataQualityDict`
 =====================

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -976,7 +976,9 @@ class DataQualityFlag(object):
     def __isub__(self, other):
         """Subtract the ``other`` `DataQualityFlag` from this one in-place.
         """
+        self.known &= other.known
         self.active -= other.active
+        self.active &= self.known
         return self
 
     def __or__(self, other):
@@ -996,8 +998,8 @@ class DataQualityFlag(object):
 
     def __invert__(self):
         new = self.copy()
-        new.known = ~self.known
         new.active = ~self.active
+        new.active &= new.known
         return new
 
 

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -440,23 +440,23 @@ class TestDataQualityFlag(object):
 
         # and
         x = a & b
-        utils.assert_segmentlist_equal(x.active, [])
-        utils.assert_segmentlist_equal(x.known, KNOWN)
+        utils.assert_segmentlist_equal(x.active, a.active & b.active)
+        utils.assert_segmentlist_equal(x.known, a.known & b.known)
 
         # sub
         x = a - b
-        utils.assert_segmentlist_equal(x.active, a.active)  # no overlap
-        utils.assert_segmentlist_equal(x.known, a.known)
+        utils.assert_segmentlist_equal(x.active, a.active - b.active)
+        utils.assert_segmentlist_equal(x.known, a.known & b.known)
 
         # or
         x = a | b
-        utils.assert_segmentlist_equal(x.active, ACTIVE)
-        utils.assert_segmentlist_equal(x.known, KNOWN)
+        utils.assert_segmentlist_equal(x.active, a.active | b.active)
+        utils.assert_segmentlist_equal(x.known, a.known | b.known)
 
         # invert
         x = ~a
-        utils.assert_segmentlist_equal(x.active, ~a.active)
-        utils.assert_segmentlist_equal(x.known, ~a.known)
+        utils.assert_segmentlist_equal(x.active, a.known & ~a.active)
+        utils.assert_segmentlist_equal(x.known, a.known)
 
     def test_coalesce(self):
         flag = self.create()


### PR DESCRIPTION
This PR modifies the behavour of the `known` segmentlist during `DataQualityFlag` logic operations. The thinking is that the result of a logic operation should only be 'known' when both of the flags (on either side of the operator) were known, with the exception of 'or' (`|`, union), where either flag can be known.

One example of where this is important is when subtracting hardware injection segments from observing segments. If there is a gap in the knowledge of the injection flag then the result of `observing - injection` should only be known (or active) when both the observing and injection flags were known, just in case an injection was present during the gap in the knowledge of the flag, or similar.