### PR TITLE
Enabled setting extra attributes for DataQualityFlag when writing to LIGO_LW

### DIFF
--- a/docs/segments/io.rst
+++ b/docs/segments/io.rst
@@ -78,6 +78,10 @@ To replace the segment tables in an existing file, while preserving other tables
 
     >>> f.write('new-table.xml', append=True, overwrite=True)
 
+Extra attributes can be written to the tables via the ``attrs={}`` keyword, all attributes are set for all three of the segment-related tables::
+
+    >>> f.write('new-table.xml', append=True, overwrite=True, attrs={'process_id': 0})
+
 `DataQualityDict`
 -----------------
 

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -472,6 +472,52 @@ def list_tables(source):
     return tables
 
 
+def to_table_type(val, cls, colname):
+    """Cast a value to the correct type for inclusion in a LIGO_LW table
+
+    This method returns the input unmodified if a type mapping for ``colname``
+    isn't found.
+
+    Parameters
+    ----------
+    val : `object`
+        The input object to convert, of any type
+
+    cls : `type`
+        The sub-class of :class:`~glue.ligolw.table.Table` to map against
+
+    colname : `str`
+        The name of the mapping column
+
+    Returns
+    -------
+    obj : `object`
+        The input ``val`` cast to the correct type
+
+    Examples
+    --------
+    >>> from gwpy.io.ligolw import to_table_type as to_ligolw_type
+    >>> from glue.ligolw.lsctables import SnglBurstTable
+    >>> print(to_ligolw_type(1.0, SnglBurstTable, 'central_freq')))
+    1.0
+    >>> print(to_ligolw_type(1, SnglBurstTable, 'process_id')))
+    sngl_burst:process_id:1
+    """
+    from glue.ligolw.ilwd import get_ilwdchar_class
+    from glue.ligolw.types import ToNumPyType as numpytypes
+
+    if val is None:
+        return None
+    try:
+        llwtype = cls.validcolumns[colname]
+    except KeyError:
+        return val
+    else:
+        if llwtype == 'ilwd:char':
+            return get_ilwdchar_class(cls.tableName, colname)(val)
+        return numpy.typeDict[numpytypes[llwtype]](val)
+
+
 # -- identify -----------------------------------------------------------------
 
 def is_ligolw(origin, filepath, fileobj, *args, **kwargs):

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -516,22 +516,20 @@ def to_table_type(val, cls, colname):
     from glue.ligolw.types import (ToNumPyType as numpytypes,
                                    ToPyType as pytypes)
 
-    if val is None:
+    # if nothing to do...
+    if val is None or colname not in cls.validcolumns:
         return val
 
+    llwtype = cls.validcolumns[colname]
+
+    # don't mess with formatted IlwdChar
+    if llwtype == 'ilwd:char':
+        return _to_ilwd(val, cls.tableName, colname)
+    # otherwise map to numpy or python types
     try:
-        llwtype = cls.validcolumns[colname]
+        return numpy.typeDict[numpytypes[llwtype]](val)
     except KeyError:
-        return val
-    else:
-        # don't mess with formatted IlwdChar
-        if llwtype == 'ilwd:char':
-            return _to_ilwd(val, cls.tableName, colname)
-        # otherwise map to numpy or python types
-        try:
-            return numpy.typeDict[numpytypes[llwtype]](val)
-        except KeyError:
-            return pytypes[llwtype](val)
+        return pytypes[llwtype](val)
 
 
 def _to_ilwd(value, tablename, colname):
@@ -540,7 +538,7 @@ def _to_ilwd(value, tablename, colname):
 
     if isinstance(value, IlwdChar) and value.column_name != colname:
         raise ValueError("ilwdchar '{0!s}' doesn't match column "
-                                 "{1!r}".format(value, colname))
+                         "{1!r}".format(value, colname))
     if isinstance(value, IlwdChar):
         return value
     if isinstance(value, int):

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -110,7 +110,7 @@ def read_ligolw_flag(source, flag=None, **kwargs):
 
 # -- write --------------------------------------------------------------------
 
-def write_ligolw(flags, target, **kwargs):
+def write_ligolw(flags, target, attrs=None, **kwargs):
     """Write this `DataQualityFlag` to the given LIGO_LW Document
 
     Parameters
@@ -120,6 +120,9 @@ def write_ligolw(flags, target, **kwargs):
 
     target : `str`, `file`, :class:`~glue.ligolw.ligolw.Document`
         the file or document to write into
+
+    attrs : `dict`, optional
+        extra attributes to write into segment tables
 
     **kwargs
         keyword arguments to use when writing
@@ -131,8 +134,7 @@ def write_ligolw(flags, target, **kwargs):
     """
     if isinstance(flags, DataQualityFlag):
         flags = DataQualityDict({flags.name: flags})
-
-    return write_tables(target, flags.to_ligolw_tables(), **kwargs)
+    return write_tables(target, flags.to_ligolw_tables(**attrs or dict()), **kwargs)
 
 
 # -- register -----------------------------------------------------------------

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -134,7 +134,8 @@ def write_ligolw(flags, target, attrs=None, **kwargs):
     """
     if isinstance(flags, DataQualityFlag):
         flags = DataQualityDict({flags.name: flags})
-    return write_tables(target, flags.to_ligolw_tables(**attrs or dict()), **kwargs)
+    return write_tables(target, flags.to_ligolw_tables(**attrs or dict()),
+                        **kwargs)
 
 
 # -- register -----------------------------------------------------------------

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -32,7 +32,8 @@ except ImportError:
 from ...io import registry
 from ...io.ligolw import (is_ligolw, read_table as read_ligolw_table,
                           write_tables as write_ligolw_tables,
-                          patch_ligotimegps)
+                          patch_ligotimegps,
+                          to_table_type as to_ligolw_table_type)
 from .. import (Table, EventTable)
 from .utils import read_with_selection
 
@@ -269,7 +270,6 @@ def table_to_ligolw(table, tablename):
     """Convert a `astropy.table.Table` to a :class:`glue.ligolw.table.Table`
     """
     from glue.ligolw import (lsctables, types)
-    from glue.ligolw.ilwd import get_ilwdchar_class
 
     # create new LIGO_LW table
     columns = table.columns.keys()
@@ -286,14 +286,8 @@ def table_to_ligolw(table, tablename):
     for row in table:
         llwrow = llwtable.RowType()
         for name in columns:
-            llwtype = llwtable.validcolumns[name]
-            if row[name] is None:
-                val = None
-            elif llwtype == 'ilwd:char':
-                val = get_ilwdchar_class(tablename, name)(row[name])
-            else:
-                val = types.ToPyType[llwtype](row[name])
-            setattr(llwrow, name, val)
+            setattr(llwrow, name,
+                    to_ligolw_table_type(row[name], llwtable, name))
         llwtable.append(llwrow)
 
     return llwtable

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -273,7 +273,14 @@ def table_to_ligolw(table, tablename):
 
     # create new LIGO_LW table
     columns = table.columns.keys()
-    llwtable = lsctables.New(lsctables.TableByName[tablename], columns=columns)
+    cls = lsctables.TableByName[tablename]
+    llwcolumns = list(columns)
+    for col, llwcols in _get_property_columns(cls, columns).items():
+        idx = llwcolumns.index(col)
+        llwcolumns.pop(idx)
+        for name in llwcols[::-1]:
+            llwcolumns.insert(idx, name)
+    llwtable = lsctables.New(cls, columns=llwcolumns)
 
     # map rows across
     for row in table:

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -494,6 +494,7 @@ class TestIoLigolw(object):
         (1.0, 'peak_time', numpy.int32(1)),
         (1, 'process_id', 'sngl_burst:process_id:1'),
         (1.0, 'invalidname', 1.0),
+        ('process:process_id:100', 'process_id', 'process:process_id:100'),
     ])
     def test_to_table_type(self, value, name, result):
         from glue.ligolw.lsctables import SnglBurstTable
@@ -504,6 +505,16 @@ class TestIoLigolw(object):
             result = ilwdchar(result)
         assert isinstance(out, type(result))
         assert out == result
+
+    @utils.skip_missing_dependency('glue.ligolw.lsctables')  # check for LAL
+    def test_to_table_type_ilwd(self):
+        from glue.ligolw.ilwd import ilwdchar
+        from glue.ligolw.lsctables import SnglBurstTable
+        ilwd = ilwdchar('process:process_id:0')
+        with pytest.raises(ValueError) as exc:
+            io_ligolw.to_table_type(ilwd, SnglBurstTable, 'event_id')
+        assert str(exc.value) == ('ilwdchar \'process:process_id:0\' doesn\'t '
+                                  'match column \'event_id\'')
 
 
 # -- gwpy.io.datafind ---------------------------------------------------------

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -488,6 +488,23 @@ class TestIoLigolw(object):
             f.seek(0)
             assert io_ligolw.list_tables(f) == names
 
+    @utils.skip_missing_dependency('glue.ligolw.lsctables')  # check for LAL
+    @pytest.mark.parametrize('value, name, result', [
+        (None, 'peak_time', None),
+        (1.0, 'peak_time', numpy.int32(1)),
+        (1, 'process_id', 'sngl_burst:process_id:1'),
+        (1.0, 'invalidname', 1.0),
+    ])
+    def test_to_table_type(self, value, name, result):
+        from glue.ligolw.lsctables import SnglBurstTable
+        from glue.ligolw.ilwd import ilwdchar
+        from glue.ligolw._ilwd import ilwdchar as IlwdChar
+        out = io_ligolw.to_table_type(value, SnglBurstTable, name)
+        if isinstance(out, IlwdChar):
+            result = ilwdchar(result)
+        assert isinstance(out, type(result))
+        assert out == result
+
 
 # -- gwpy.io.datafind ---------------------------------------------------------
 

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -589,10 +589,11 @@ class TestDataQualityFlag(object):
     def test_write_ligolw_attrs(self, flag):
         from gwpy.io.ligolw import read_table
         with tempfile.NamedTemporaryFile(suffix='.xml') as f:
-            flag.write(f, format='ligolw', attrs={'process_id': 100})
+            flag.write(f, format='ligolw',
+                       attrs={'process_id': 'process:process_id:100'})
             segdeftab = read_table(f, 'segment_definer')
             assert str(segdeftab[0].process_id) == (
-                'segment_definer:process_id:100')
+                'process:process_id:100')
 
     # -- test queries ---------------------------
 

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -585,6 +585,15 @@ class TestDataQualityFlag(object):
                 _read_write(autoidentify=True)
             _read_write(autoidentify=True, write_kw={'overwrite': True})
 
+    @utils.skip_missing_dependency('glue.ligolw.lsctables')
+    def test_write_ligolw_attrs(self, flag):
+        from gwpy.io.ligolw import read_table
+        with tempfile.NamedTemporaryFile(suffix='.xml') as f:
+            flag.write(f, format='ligolw', attrs={'process_id': 100})
+            segdeftab = read_table(f, 'segment_definer')
+            assert str(segdeftab[0].process_id) == (
+                'segment_definer:process_id:100')
+
     # -- test queries ---------------------------
 
     @pytest.mark.parametrize('api', ('dqsegdb', 'segdb'))

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -243,7 +243,8 @@ class TestTable(object):
                 utils.assert_array_equal(llw.get_peak(), table['peak'])
 
             # read table and assert gpsproperty was repacked properly
-            t2 = self.TABLE.read(f, columns=table.colnames, use_numpy_dtypes=True)
+            t2 = self.TABLE.read(f, columns=table.colnames,
+                                 use_numpy_dtypes=True)
             utils.assert_table_equal(t2, table, almost_equal=True)
 
     @utils.skip_missing_dependency('root_numpy')

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -42,10 +42,12 @@ from astropy.io.ascii import InconsistentTableError
 from astropy.table import vstack
 
 from gwpy.frequencyseries import FrequencySeries
+from gwpy.io import ligolw as io_ligolw
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.table import (Table, EventTable, filters, GravitySpyTable)
 from gwpy.table.filter import filter_table
 from gwpy.table.io.hacr import (HACR_COLUMNS, get_hacr_triggers)
+from gwpy.time import LIGOTimeGPS
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 from gwpy.plotter import (EventTablePlot, EventTableAxes, TimeSeriesPlot,
                           HistogramPlot)
@@ -144,12 +146,6 @@ class TestTable(object):
             utils.assert_table_equal(table, t2, almost_equal=True)
             assert t2.meta.get('tablename', None) == 'sngl_burst'
 
-            # check accessing get_xxx columns works (and pulls in gpscols)
-            t3 = _read(columns=['peak'])
-            assert 'peak' in t3.columns
-            utils.assert_array_equal(
-                t3['peak'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
-
             # check auto-discovery of 'time' columns works
             from glue.ligolw.lsctables import LIGOTimeGPS
             with pytest.warns(DeprecationWarning):
@@ -230,6 +226,25 @@ class TestTable(object):
                 _read(get_as_columns=True)
             with pytest.warns(DeprecationWarning):
                 _read(on_attributeerror='anything')
+
+    @utils.skip_missing_dependency('glue.ligolw.lsctables')
+    def test_read_write_ligolw_property_columns(self):
+        table = self.create(100, ['peak', 'snr', 'central_freq'],
+                            ['f8', 'f4', 'f4'])
+        with tempfile.NamedTemporaryFile(suffix='.xml') as f:
+            # write table
+            table.write(f, format='ligolw', tablename='sngl_burst')
+
+            # read raw ligolw and check gpsproperty was unpacked properly
+            llw = io_ligolw.read_table(f, tablename='sngl_burst')
+            for col in ('peak_time', 'peak_time_ns'):
+                assert col in llw.columnnames
+            with io_ligolw.patch_ligotimegps():
+                utils.assert_array_equal(llw.get_peak(), table['peak'])
+
+            # read table and assert gpsproperty was repacked properly
+            t2 = self.TABLE.read(f, columns=table.colnames, use_numpy_dtypes=True)
+            utils.assert_table_equal(t2, table, almost_equal=True)
 
     @utils.skip_missing_dependency('root_numpy')
     def test_read_write_root(self, table):


### PR DESCRIPTION
This PR improves the `LIGO_LW` XML interface, mainly to support writing `'process_id'`-like columns to LIGO_LW-format XML files for `DataQualityFlag`.