### PR TITLE
Build universal wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,16 +181,6 @@ deploy:
       tags: true
       python: '2.7'
       repo: gwpy/gwpy
-  - provider: pypi
-    user: duncanmmacleod
-    password: ${PYPI_PASSWD}
-    distributions: bdist_wheel
-    on:
-      condition: -z "${DOCKER_IMAGE}"
-      branch: master
-      tags: true
-      python: '3.6'
-      repo: gwpy/gwpy
 
 notifications:
   slack:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,6 @@ omit =
 
 [changelog]
 start_tag = v0.5.2
+
+[metadata]
+license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [aliases]
 test = pytest
 
+[bdist_wheel]
+universal = 1
+
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
This PR modifies `setup.cfg` to build universal wheels, since this package is python2 and python3 compatible. This also simplifies the travis-ci configuration, since we now only need to deploy from a single version of python.