### PR TITLE
Fixed bugs with specifying frequencies in BodePlot

### DIFF
--- a/gwpy/plotter/filter.py
+++ b/gwpy/plotter/filter.py
@@ -151,7 +151,7 @@ class BodePlot(Plot):
         if (frequencies is None and len(filters) == 1 and
                 isinstance(filters[0], FrequencySeries)):
             frequencies = filters[0].frequencies.value
-        if frequencies is not None:
+        if not isinstance(frequencies, (type(None), int)):
             frequencies = frequencies[frequencies > 0]
             self.maxes.set_xlim(frequencies.min(), frequencies.max())
 
@@ -203,8 +203,8 @@ class BodePlot(Plot):
                                  "digital (analog=False) filter")
             sample_rate = Quantity(sample_rate, 'Hz').value
             dt = 2 * pi / sample_rate
-            if frequencies is not None:
-                frequencies = atleast_1d(frequencies)
+            if not isinstance(frequencies, (type(None), int)):
+                frequencies = numpy.atleast_1d(frequencies).copy()
                 frequencies *= dt
 
         # parse filter (without digital conversions)


### PR DESCRIPTION
This PR fixes a bug (or two) in handling `frequencies` in `BodePlot`.