### PR TITLE
Patch to work around segmentation fault when iterating in frameCPP

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -183,7 +183,11 @@ def read_gwf(framefile, channels, start=None, end=None, ctype=None,
                     pass
                 elif start and dataend < start:  # don't need this frame
                     continue
-            for vect in data.data:  # loop hopefully over single vector
+            for j in range(data.data.size()):
+                # we use range(data.data.size()) to avoid segfault
+                # related to iterating directly over data.data
+                vect = data.data[j]
+
                 # only read FrVect with matching name (or no name set)
                 #    frame spec allows for arbitrary other FrVects
                 #    to hold other information


### PR DESCRIPTION
This PR patches `gwpy.timeseries.io.gwf.framecpp` to work around a segmentation default from `LDAStools.frameCPP` when iterating directly over `FrAdcData.data`. The trick is to extract the size first and enumerate that (credit to @emaros for working that out).