### PR TITLE
Deprecated custom Axes properties

### DIFF
--- a/gwpy/plotter/axes.py
+++ b/gwpy/plotter/axes.py
@@ -29,6 +29,7 @@ from matplotlib.projections import register_projection
 
 from .decorators import auto_refresh
 from . import html
+from ..utils.decorators import deprecated_property
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __all__ = ['Axes']
@@ -53,7 +54,7 @@ class Axes(_Axes):
     # -- text properties ------------------------
 
     # x-axis label
-    @property
+    @deprecated_property
     def xlabel(self):
         """Label for the x-axis
 
@@ -75,7 +76,7 @@ class Axes(_Axes):
         self.set_xlabel("")
 
     # y-axis label
-    @property
+    @deprecated_property
     def ylabel(self):
         """Label for the y-axis
 
@@ -98,7 +99,7 @@ class Axes(_Axes):
 
     # -- limit properties -----------------------
 
-    @property
+    @deprecated_property
     def xlim(self):
         """Limits for the x-axis
 
@@ -117,7 +118,7 @@ class Axes(_Axes):
         self.relim()
         self.autoscale_view(scalex=True, scaley=False)
 
-    @property
+    @deprecated_property
     def ylim(self):
         """Limits for the y-axis
 
@@ -137,7 +138,7 @@ class Axes(_Axes):
 
     # -- scale properties -----------------------
 
-    @property
+    @deprecated_property
     def logx(self):
         """Display the x-axis with a logarithmic scale
 
@@ -153,7 +154,7 @@ class Axes(_Axes):
         elif self.logx and not log:
             self.set_xscale('linear')
 
-    @property
+    @deprecated_property
     def logy(self):
         """Display the y-axis with a logarithmic scale
 

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -332,6 +332,7 @@ class TestPlot(PlottingTestBase):
 class TestAxes(PlottingTestBase):
 
     # -- test properties ------------------------
+    # all of these properties are DEPRECATED
 
     @pytest.mark.parametrize('axis', ('x', 'y'))
     def test_label(self, axis):
@@ -342,20 +343,24 @@ class TestAxes(PlottingTestBase):
         get_label = getattr(ax, 'get_%slabel' % axis)
 
         # assert ax.xlabel is ax.xaxis.label
-        assert getattr(ax, label) is axis_obj.label
+        with pytest.warns(DeprecationWarning):
+            assert getattr(ax, label) is axis_obj.label
 
         # ax.xlabel = 'Test label'
-        setattr(ax, label, 'Test label')
+        with pytest.warns(DeprecationWarning):
+            setattr(ax, label, 'Test label')
         # assert ax.get_xlabel() == 'Test label'
         assert get_label() == 'Test label'
 
         # check Text object gets preserved
         t = ax.text(0, 0, 'Test text')
-        setattr(ax, label, t)
+        with pytest.warns(DeprecationWarning):
+            setattr(ax, label, t)
         assert axis_obj.label is t
 
         # check deleter works
-        delattr(ax, label)
+        with pytest.warns(DeprecationWarning):
+            delattr(ax, label)
         assert get_label() == ''
 
     @pytest.mark.parametrize('axis', ('x', 'y'))
@@ -366,12 +371,15 @@ class TestAxes(PlottingTestBase):
         get_lim = getattr(ax, 'get_%slim' % axis)
 
         # check getter/setter
-        setattr(ax, lim, (24, 36))
+        with pytest.warns(DeprecationWarning):
+            setattr(ax, lim, (24, 36))
         assert get_lim() == (24, 36)
-        assert getattr(ax, lim) == get_lim()
+        with pytest.warns(DeprecationWarning):
+            assert getattr(ax, lim) == get_lim()
 
         # check deleter
-        delattr(ax, lim)
+        with pytest.warns(DeprecationWarning):
+            delattr(ax, lim)
 
     @pytest.mark.parametrize('axis', ('x', 'y'))
     def test_log(self, axis):
@@ -381,16 +389,21 @@ class TestAxes(PlottingTestBase):
         set_scale = getattr(ax, 'set_%sscale' % axis)
 
         # check default is not log
-        assert getattr(ax, log) is False
+        with pytest.warns(DeprecationWarning):
+            assert getattr(ax, log) is False
 
         # set log and assert that the scale gets set properly
-        setattr(ax, log, True)
-        assert getattr(ax, log) is True
+        with pytest.warns(DeprecationWarning):
+            setattr(ax, log, True)
+        with pytest.warns(DeprecationWarning):
+            assert getattr(ax, log) is True
         assert get_scale() == 'log'
 
         # set not log and check
-        setattr(ax, log, False)
-        assert getattr(ax, log) is False
+        with pytest.warns(DeprecationWarning):
+            setattr(ax, log, False)
+        with pytest.warns(DeprecationWarning):
+            assert getattr(ax, log) is False
         assert get_scale() == 'linear'
 
     # -- test methods ---------------------------

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Decorators for GWpy
+"""
+
+import warnings
+from functools import wraps
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+class deprecated_property(property):  # pylint: disable=invalid-name
+    """sub-class of `property` that invokes DeprecationWarning on every call
+    """
+    def __init__(self, fget=None, fset=None, fdel=None, doc=None):
+        # get name  of property
+        pname = fget.__name__
+
+        # build a wrapper that will spawn a DeprecationWarning for all calls
+        def _warn(func):
+            @wraps(func)
+            def _wrapped(self, *args, **kwargs):
+                parent = type(self).__name__  # parent class name
+                warnings.warn('the {0}.{1} property is deprecated, and will '
+                              'be removed in a future release, please stop '
+                              'using it.'.format(parent, pname),
+                              DeprecationWarning)
+                return func(self, *args, **kwargs)
+
+            return _wrapped
+
+        # wrap the property methods
+        if fdel:
+            fdel = _warn(fdel)
+        if fset:
+            fset = _warn(fset)
+        if not fset and not fdel:  # only wrap once
+            fget = _warn(fget)
+
+        super(deprecated_property, self).__init__(fget, fset, fdel, doc)


### PR DESCRIPTION
This PR deprecates the following custom `Axes` properties 

- `Axes.xlabel`
- `Axes.xlim`
- `Axes.logx`
- `Axes.ylabel`
- `Axes.ylim`
- `Axes.logy`

These don't really add functionality, have never been documented, and are a pain to maintain.
