### PR TITLE
Support for injections in GWpy TimeSeries objects

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1199,6 +1199,22 @@ class TestTimeSeries(TestTimeSeriesBase):
         assert ph.unit == 'rad'
         utils.assert_allclose(ph.value, phase, rtol=1e-5)
 
+    def test_add(self):
+        # create a timeseries out of an array of zeros
+        duration, sample_rate = 1, 4096
+        data = TimeSeries(numpy.zeros(duration*sample_rate), t0=0,
+                          sample_rate=sample_rate, unit='')
+
+        # create a second timeseries to add to the first
+        waveform = numpy.cos(2*numpy.pi*30*data.times.value)
+        waveform = TimeSeries(waveform, times=data.times.value)
+
+        # test that we recover this waveform when we add it to data
+        new_data = data.add(waveform)
+        assert new_data.unit == data.unit
+        assert len(new_data) == len(data)
+        utils.assert_allclose(new_data.value, waveform.value)
+
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz
         noise = self.TEST_CLASS(

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1382,6 +1382,32 @@ class TimeSeries(TimeSeriesBase):
 
         Examples
         --------
+        It can often be useful to add a simulated signal to some data
+        stream. For example, we like to quantify our sensitivity to
+        gravitational wave signals by injecting simulated ones into otherwise
+        quiet stretches of data. To see this, we can download some data
+        from LOSC:
+
+        >>> from gwpy.timeseries import TimeSeries
+        >>> strain = TimeSeries.fetch_open_data('H1', 1131350417, 1131350467)
+
+        These data are reasonably quiet, but we can also grab a simulation
+        of what we expect a binary black hole waveform to look like and add
+        it to our strain data:
+
+        >>> import numpy, urllib2
+        >>> source = 'https://losc.ligo.org/s/events/GW150914/P150914/'
+        >>> filename = 'fig2-unfiltered-waveform-H.txt'
+        >>> download = urllib2.urlopen('%s/%s' % (source, filename))
+        >>> t, h = numpy.recfromtxt(download, skip_header=1, unpack=True)
+        >>> h *= 1e-21
+
+        We will need to store this as a `TimeSeries` and downsample to 4096 Hz:
+        >>> waveform = TimeSeries(h, t0=1131350417, sample_rate=16384)
+        >>> waveform = waveform.resample(strain.sample_rate.value)
+
+        Finally, we can add this simulation to our strain data:
+        >>> injected = strain.add(waveform)
 
         Notes
         -----


### PR DESCRIPTION
This is a first pass at a method that allows for injections with GWpy.

The pull request includes a new method, called `add()`, which takes in a `TimeSeries` object and sums it to `self` along their overlapping time samples.

If `self` and the new `TimeSeries` have inconsistent sample rates, the method will raise a `ValueError`. If the timeseries have non-overlapping time stamps, the method will raise a warning and return the original (unaltered) `TimeSeries`.

This pull request also includes a unit test which injects a pure sinusoid into silence and then checks that the units, length, and values are all as expected.

Lastly, the method's doctstring includes an example which downloads strain data and a simulated waveform (corresponding to GW150914) from LOSC, then adds them together. I think it would be nice to add a Q-scan to this example showing that the injection was successful, but I'll want to hear your thoughts first. (I know those Q transform plots can be slow, so I don't know how you feel about adding them to the documentation.)

This addresses issue 477 (https://github.com/gwpy/gwpy/issues/477) by @ecm0.