### PR TITLE
Fixed labelling bug in SeriesAxes.plot_mmm

### DIFF
--- a/gwpy/plotter/series.py
+++ b/gwpy/plotter/series.py
@@ -121,7 +121,7 @@ class SeriesAxes(Axes):
         return line
 
     @auto_refresh
-    def plot_mmm(self, mean_, min_=None, max_=None, **kwargs):
+    def plot_mmm(self, mean_, min_=None, max_=None, alpha=.1, **kwargs):
         """Plot a `Series` onto these axes, with shaded regions
 
         The ``mean_`` `Series` is plotted normally, while the ``min_``
@@ -139,9 +139,14 @@ class SeriesAxes(Axes):
         max_ : `~gwpy.types.Series`
             second data set to shade to ``mean_``
 
+        alpha : `float`, `None`, optional
+            value for alpha channel for min and max lines and shading,
+            default: ``0.1``
+
         **kwargs
             any other keyword arguments acceptable for
-            :meth:`~matplotlib.Axes.plot`
+            :meth:`~matplotlib.Axes.plot`, only used to draw the
+            lines
 
         Returns
         -------
@@ -163,7 +168,10 @@ class SeriesAxes(Axes):
         meanline = self.plot_series(mean_, **kwargs)[0]
 
         # modify keywords for shading
-        kwargs['label'] = None
+        kwargs.update({
+            'label': None,
+            'alpha': alpha,
+        })
         color = kwargs.pop('color', meanline.get_color())
         linewidth = kwargs.pop('linewidth', meanline.get_linewidth()) / 2
 
@@ -171,7 +179,7 @@ class SeriesAxes(Axes):
             line = self.plot(series, color=color, linewidth=linewidth,
                              **kwargs)
             coll = self.fill_between(series.xindex.value, series.value,
-                                     mean_.value, alpha=.1, color=color,
+                                     mean_.value, alpha=alpha, color=color,
                                      rasterized=kwargs.get('rasterized'))
             return line, coll
 

--- a/gwpy/plotter/series.py
+++ b/gwpy/plotter/series.py
@@ -163,7 +163,7 @@ class SeriesAxes(Axes):
         meanline = self.plot_series(mean_, **kwargs)[0]
 
         # modify keywords for shading
-        kwargs.pop('label', None)
+        kwargs['label'] = None
         color = kwargs.pop('color', meanline.get_color())
         linewidth = kwargs.pop('linewidth', meanline.get_linewidth()) / 2
 

--- a/gwpy/plotter/series.py
+++ b/gwpy/plotter/series.py
@@ -169,7 +169,7 @@ class SeriesAxes(Axes):
 
         # modify keywords for shading
         kwargs.update({
-            'label': None,
+            'label': '',
             'alpha': alpha,
         })
         color = kwargs.pop('color', meanline.get_color())

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -589,6 +589,22 @@ class TestTimeSeriesAxes(TimeSeriesMixin, TestAxes):
         assert len(ax.lines) == 3
         assert len(ax.collections) == 2
         self.save_and_close(fig)
+
+        # test with labels
+        fig, ax = self.new()
+        minname = self.mmm[1].name
+        maxname = self.mmm[2].name
+        self.mmm[1].name = 'min'
+        self.mmm[2].name = 'max'
+        try:
+            ax.plot_mmm(*self.mmm, label='test')
+            leg = ax.legend()
+            assert len(leg.get_lines()) == 1
+        finally:
+            self.mmm[1].name = minname
+            self.mmm[2].name = maxname
+        self.save_and_close(fig)
+
         # test min only
         fig, ax = self.new()
         artists = ax.plot_mmm(self.mmm[0], min_=self.mmm[1])
@@ -598,6 +614,7 @@ class TestTimeSeriesAxes(TimeSeriesMixin, TestAxes):
         assert len(ax.lines) == 2
         assert len(ax.collections) == 1
         self.save_and_close(fig)
+
         # test max only
         fig, ax = self.new()
         artists = ax.plot_mmm(self.mmm[0], max_=self.mmm[2])
@@ -679,6 +696,22 @@ class TestFrequencySeriesAxes(FrequencySeriesMixin, TestAxes):
         assert len(ax.lines) == 3
         assert len(ax.collections) == 2
         self.save_and_close(fig)
+
+        # test with labels
+        fig, ax = self.new()
+        minname = self.mmm[1].name
+        maxname = self.mmm[2].name
+        self.mmm[1].name = 'min'
+        self.mmm[2].name = 'max'
+        try:
+            ax.plot_mmm(*self.mmm, label='test')
+            leg = ax.legend()
+            assert len(leg.get_lines()) == 1
+        finally:
+            self.mmm[1].name = minname
+            self.mmm[2].name = maxname
+        self.save_and_close(fig)
+
         # test min only
         fig, ax = self.new()
         artists = ax.plot_mmm(self.mmm[0], min_=self.mmm[1])
@@ -688,6 +721,7 @@ class TestFrequencySeriesAxes(FrequencySeriesMixin, TestAxes):
         assert len(ax.lines) == 2
         assert len(ax.collections) == 1
         self.save_and_close(fig)
+
         # test max only
         fig, ax = self.new()
         artists = ax.plot_mmm(self.mmm[0], max_=self.mmm[2])

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -581,17 +581,17 @@ class TestTimeSeriesAxes(TimeSeriesMixin, TestAxes):
         assert ax.get_xlim() == tuple(self.ts.span)
         self.save_and_close(fig)
 
-    def test_plot_timeseries_mmm(self):
+    def test_plot_mmm(self):
         fig, ax = self.new()
         # test default
-        artists = ax.plot_timeseries_mmm(*self.mmm)
+        artists = ax.plot_mmm(*self.mmm)
         assert len(artists) == 5
         assert len(ax.lines) == 3
         assert len(ax.collections) == 2
         self.save_and_close(fig)
         # test min only
         fig, ax = self.new()
-        artists = ax.plot_timeseries_mmm(self.mmm[0], min_=self.mmm[1])
+        artists = ax.plot_mmm(self.mmm[0], min_=self.mmm[1])
         assert len(artists) == 5
         assert artists[3] is None
         assert artists[4] is None
@@ -600,12 +600,18 @@ class TestTimeSeriesAxes(TimeSeriesMixin, TestAxes):
         self.save_and_close(fig)
         # test max only
         fig, ax = self.new()
-        artists = ax.plot_timeseries_mmm(self.mmm[0], max_=self.mmm[2])
+        artists = ax.plot_mmm(self.mmm[0], max_=self.mmm[2])
         assert len(artists) == 5
         assert artists[1] is None
         assert artists[2] is None
         assert len(ax.lines) == 2
         assert len(ax.collections) == 1
+
+    def test_plot_timeseries_mmm(self):
+        fig, ax = self.new()
+        with pytest.warns(DeprecationWarning):
+            ax.plot_timeseries_mmm(*self.mmm)
+        self.save_and_close(fig)
 
     def test_plot_spectrogram(self):
         fig, ax = self.new()
@@ -665,17 +671,17 @@ class TestFrequencySeriesAxes(FrequencySeriesMixin, TestAxes):
         nptest.assert_array_equal(line.get_ydata(), self.asd.value)
         self.save_and_close(fig)
 
-    def test_plot_frequencyseries_mmm(self):
+    def test_plot_mmm(self):
         fig, ax = self.new()
         # test defaults
-        artists = ax.plot_frequencyseries_mmm(*self.mmm)
+        artists = ax.plot_mmm(*self.mmm)
         assert len(artists) == 5
         assert len(ax.lines) == 3
         assert len(ax.collections) == 2
         self.save_and_close(fig)
         # test min only
         fig, ax = self.new()
-        artists = ax.plot_frequencyseries_mmm(self.mmm[0], min_=self.mmm[1])
+        artists = ax.plot_mmm(self.mmm[0], min_=self.mmm[1])
         assert len(artists) == 5
         assert artists[3] is None
         assert artists[4] is None
@@ -684,12 +690,18 @@ class TestFrequencySeriesAxes(FrequencySeriesMixin, TestAxes):
         self.save_and_close(fig)
         # test max only
         fig, ax = self.new()
-        artists = ax.plot_frequencyseries_mmm(self.mmm[0], max_=self.mmm[2])
+        artists = ax.plot_mmm(self.mmm[0], max_=self.mmm[2])
         assert len(artists) == 5
         assert artists[1] is None
         assert artists[2] is None
         assert len(ax.lines) == 2
         assert len(ax.collections) == 1
+
+    def test_plot_frequencyseries_mmm(self):
+        fig, ax = self.new()
+        with pytest.warns(DeprecationWarning):
+            ax.plot_frequencyseries_mmm(*self.mmm)
+        self.save_and_close(fig)
 
 
 # -- Table plotters -----------------------------------------------------------


### PR DESCRIPTION
This PR fixes a bug in the labelling for `SeriesAxes.plot_mmm`, whereby the min and max lines were also labelled, if those `Series` had names.