### PR TITLE
Added support for parsing histogram plot params in plot constructors

### DIFF
--- a/gwpy/plotter/histogram.py
+++ b/gwpy/plotter/histogram.py
@@ -186,23 +186,20 @@ class HistogramPlot(Plot):
     def __init__(self, *data, **kwargs):
         """Generate a new `HistogramPlot` from some ``data``.
         """
-        # extract histogram arguments
-        histargs = dict()
-        for key in ['bins', 'range', 'normed', 'weights', 'cumulative',
-                    'bottom', 'histtype', 'align', 'orientation', 'rwidth',
-                    'log', 'color', 'label', 'stacked', 'logbins']:
-            try:
-                histargs[key] = kwargs.pop(key)
-            except KeyError:
-                pass
+        # separate keyword arguments
+        axargs, histargs = self._parse_kwargs(kwargs)
+
         # generate Figure
         super(HistogramPlot, self).__init__(**kwargs)
-        # plot data
+
+        # create axes
         if data:
-            ax = self.gca()
+            ax = self.gca(**axargs)
             data = list(data)
         else:
             ax = None
+
+        # plot data
         while data:
             dataset = data.pop(0)
             if isinstance(dataset, Series):
@@ -212,6 +209,7 @@ class HistogramPlot(Plot):
                 ax.hist_table(dataset, column, **histargs)
             else:
                 ax.hist(dataset, **histargs)
+
         if ax and histargs.get('logbins', False):
             if histargs.get('orientation', 'vertical') == 'vertical':
                 ax.set_xscale('log')

--- a/gwpy/plotter/utils.py
+++ b/gwpy/plotter/utils.py
@@ -46,10 +46,20 @@ IMAGE_PARAMS = [
     'imshow', 'cmap', 'vmin', 'vmax', 'norm', 'rasterized', 'extent',
     'origin', 'interpolation', 'aspect',
 ]
-ARTIST_PARAMS = set(LINE_PARAMS + COLLECTION_PARAMS + IMAGE_PARAMS)
+HIST_PARAMS = [
+    'bins', 'range', 'normed', 'weights', 'cumulative', 'bottom',
+    'histtype', 'align', 'orientation', 'rwidth', 'log', 'color',
+    'label', 'stacked', 'logbins',
+]
 LEGEND_PARAMS = [
     'loc', 'borderaxespad', 'ncol',
 ]
+ARTIST_PARAMS = set(itertools.chain.from_iterable([
+    LINE_PARAMS,
+    COLLECTION_PARAMS,
+    IMAGE_PARAMS,
+    HIST_PARAMS,
+]))
 
 
 def color_cycle(colors=None):

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -895,7 +895,16 @@ class HistogramMixin(object):
 
 
 class TestHistogramPlot(HistogramMixin, TestPlot):
-    pass
+    def test_init(self):
+        super(TestHistogramPlot, self).test_init()
+
+        # test with data
+        bins = [1, 2, 5]
+        plot = self.FIGURE_CLASS([1, 2, 3, 4, 5], bins=bins)
+        assert len(plot.axes) == 1
+        ax = plot.gca()
+        assert len(ax.containers) == 1
+        assert len(ax.containers[0].patches) == len(bins) - 1
 
 
 class TestHistogramAxes(HistogramMixin, TestAxes):


### PR DESCRIPTION
This PR adds support for parsing `ax.hist` keywords directly in `Plot` constructors as part of `Plot._parse_kwargs`. This allowed a simplification of the `HistogramPlot` constructor which, until now, contained its own list of `ax.hist` keywords.