### PR TITLE
Partial reversion of 724 to not set alpha for mmm lines

### DIFF
--- a/gwpy/plotter/series.py
+++ b/gwpy/plotter/series.py
@@ -140,8 +140,7 @@ class SeriesAxes(Axes):
             second data set to shade to ``mean_``
 
         alpha : `float`, `None`, optional
-            value for alpha channel for min and max lines and shading,
-            default: ``0.1``
+            value for alpha channel for shading, default: ``0.1``
 
         **kwargs
             any other keyword arguments acceptable for
@@ -170,7 +169,6 @@ class SeriesAxes(Axes):
         # modify keywords for shading
         kwargs.update({
             'label': '',
-            'alpha': alpha,
         })
         color = kwargs.pop('color', meanline.get_color())
         linewidth = kwargs.pop('linewidth', meanline.get_linewidth()) / 2

--- a/gwpy/plotter/series.py
+++ b/gwpy/plotter/series.py
@@ -174,8 +174,8 @@ class SeriesAxes(Axes):
         linewidth = kwargs.pop('linewidth', meanline.get_linewidth()) / 2
 
         def _plot_shade(series):
-            line = self.plot(series, color=color, linewidth=linewidth,
-                             **kwargs)
+            line, = self.plot(series, color=color, linewidth=linewidth,
+                              **kwargs)
             coll = self.fill_between(series.xindex.value, series.value,
                                      mean_.value, alpha=alpha, color=color,
                                      rasterized=kwargs.get('rasterized'))

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -33,6 +33,7 @@ from matplotlib import (use, rc_context, __version__ as mpl_version)
 use('agg')  # nopep8
 from matplotlib import (pyplot, rcParams)
 from matplotlib.legend import Legend
+from matplotlib.lines import Line2D
 from matplotlib.colors import (LogNorm, ColorConverter)
 from matplotlib.collections import (PathCollection, PatchCollection,
                                     PolyCollection)
@@ -584,8 +585,11 @@ class TestTimeSeriesAxes(TimeSeriesMixin, TestAxes):
     def test_plot_mmm(self):
         fig, ax = self.new()
         # test default
-        artists = ax.plot_mmm(*self.mmm)
-        assert len(artists) == 5
+        a, b, c, d, e = ax.plot_mmm(*self.mmm)
+        for line in (a, b, d):
+            assert isinstance(line, Line2D)
+        for coll in (c, e):
+            assert isinstance(coll, PolyCollection)
         assert len(ax.lines) == 3
         assert len(ax.collections) == 2
         self.save_and_close(fig)
@@ -607,20 +611,18 @@ class TestTimeSeriesAxes(TimeSeriesMixin, TestAxes):
 
         # test min only
         fig, ax = self.new()
-        artists = ax.plot_mmm(self.mmm[0], min_=self.mmm[1])
-        assert len(artists) == 5
-        assert artists[3] is None
-        assert artists[4] is None
+        a, b, c, d, e = ax.plot_mmm(self.mmm[0], min_=self.mmm[1])
+        assert d is None
+        assert e is None
         assert len(ax.lines) == 2
         assert len(ax.collections) == 1
         self.save_and_close(fig)
 
         # test max only
         fig, ax = self.new()
-        artists = ax.plot_mmm(self.mmm[0], max_=self.mmm[2])
-        assert len(artists) == 5
-        assert artists[1] is None
-        assert artists[2] is None
+        a, b, c, d, e = ax.plot_mmm(self.mmm[0], max_=self.mmm[2])
+        assert b is None
+        assert c is None
         assert len(ax.lines) == 2
         assert len(ax.collections) == 1
 
@@ -691,8 +693,11 @@ class TestFrequencySeriesAxes(FrequencySeriesMixin, TestAxes):
     def test_plot_mmm(self):
         fig, ax = self.new()
         # test defaults
-        artists = ax.plot_mmm(*self.mmm)
-        assert len(artists) == 5
+        a, b, c, d, e = ax.plot_mmm(*self.mmm)
+        for line in (a, b, d):
+            assert isinstance(line, Line2D)
+        for coll in (c, e):
+            assert isinstance(coll, PolyCollection)
         assert len(ax.lines) == 3
         assert len(ax.collections) == 2
         self.save_and_close(fig)
@@ -714,22 +719,21 @@ class TestFrequencySeriesAxes(FrequencySeriesMixin, TestAxes):
 
         # test min only
         fig, ax = self.new()
-        artists = ax.plot_mmm(self.mmm[0], min_=self.mmm[1])
-        assert len(artists) == 5
-        assert artists[3] is None
-        assert artists[4] is None
+        a, b, c, d, e = ax.plot_mmm(self.mmm[0], min_=self.mmm[1])
+        assert d is None
+        assert e is None
         assert len(ax.lines) == 2
         assert len(ax.collections) == 1
         self.save_and_close(fig)
 
         # test max only
         fig, ax = self.new()
-        artists = ax.plot_mmm(self.mmm[0], max_=self.mmm[2])
-        assert len(artists) == 5
-        assert artists[1] is None
-        assert artists[2] is None
+        a, b, c, d, e = ax.plot_mmm(self.mmm[0], max_=self.mmm[2])
+        assert b is None
+        assert c is None
         assert len(ax.lines) == 2
         assert len(ax.collections) == 1
+        self.save_and_close(fig)
 
     def test_plot_frequencyseries_mmm(self):
         fig, ax = self.new()


### PR DESCRIPTION
This PR partially undoes some of the changes from #724 to not set `alpha` for the min and max lines, only the `fill_between` collections.

This PR also fixes a bug in the return from `SeriesAxes.plot_mmm`