### PR TITLE
Make FrequencySeries.ifft() consistent with TimeSeries.fft()

### DIFF
--- a/gwpy/frequencyseries/core.py
+++ b/gwpy/frequencyseries/core.py
@@ -230,8 +230,7 @@ class FrequencySeries(Series):
         # Undo normalization from TimeSeries.fft
         # The DC component does not have the factor of two applied
         # so we account for it here
-        dift = npfft.irfft(self.value * nout)
-        dift /= 2
+        dift = npfft.irfft(self.value * nout) / 2
         new = TimeSeries(dift, epoch=self.epoch, channel=self.channel,
                          unit=self.unit, dx=1/self.dx/nout)
         return new

--- a/gwpy/frequencyseries/core.py
+++ b/gwpy/frequencyseries/core.py
@@ -231,9 +231,9 @@ class FrequencySeries(Series):
         # The DC component does not have the factor of two applied
         # so we account for it here
         dift = npfft.irfft(self.value * nout)
-        dift[1:] /= 2
+        dift /= 2
         new = TimeSeries(dift, epoch=self.epoch, channel=self.channel,
-                         unit=self.unit * units.Hertz, dx=1/self.dx/nout)
+                         unit=self.unit, dx=1/self.dx/nout)
         return new
 
     def zpk(self, zeros, poles, gain, analog=True):

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -37,6 +37,7 @@ use('agg')  # nopep8
 
 from astropy import units
 
+from gwpy.timeseries import TimeSeries
 from gwpy.frequencyseries import (FrequencySeries, SpectralVariance)
 from gwpy.plotter import (FrequencySeriesPlot, FrequencySeriesAxes)
 from gwpy.segments import Segment
@@ -137,9 +138,9 @@ class TestFrequencySeries(TestSeries):
     def test_ifft(self):
         # construct a TimeSeries, then check that it is unchanged by
         # the operation TimeSeries.fft().ifft()
-        from gwpy.timeseries import TimeSeries
-        timeseries = TimeSeries([1.0, 0.0, -1.0, 0.0], sample_rate=1.0)
-        assert timeseries.fft().ifft() == timeseries
+        ts = TimeSeries([1.0, 0.0, -1.0, 0.0], sample_rate=1.0)
+        assert ts.fft().ifft() == ts
+        utils.assert_allclose(ts.fft().ifft().value, ts.value)
 
     def test_filter(self, array):
         a2 = array.filter([100], [1], 1e-2)

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -134,6 +134,13 @@ class TestFrequencySeries(TestSeries):
             with tempfile.NamedTemporaryFile(suffix='.png') as f:
                 plot.save(f.name)
 
+    def test_ifft(self):
+        # construct a TimeSeries, then check that it is unchanged by
+        # the operation TimeSeries.fft().ifft()
+        from gwpy.timeseries import TimeSeries
+        timeseries = TimeSeries([1.0, 0.0, -1.0, 0.0], sample_rate=1.0)
+        assert timeseries.fft().ifft() == timeseries
+
     def test_filter(self, array):
         a2 = array.filter([100], [1], 1e-2)
         assert isinstance(a2, type(array))


### PR DESCRIPTION
I've taken a stab at altering the units and normalization of `FrequencySeries.ifft()` so that it reproduces the original timeseries after `TimeSeries.fft().ifft()`. I've also added a unit test to make sure this is the case.

This fixes https://github.com/gwpy/gwpy/issues/729.