### PR TITLE
Simplified EventTableAxes.add_loudest method to not use LaTeX

### DIFF
--- a/gwpy/plotter/table.py
+++ b/gwpy/plotter/table.py
@@ -32,11 +32,9 @@ from matplotlib import (collections, pyplot)
 from matplotlib.projections import register_projection
 
 from ..table import Table
-from ..time import LIGOTimeGPS
 from .core import Plot
 from .timeseries import (TimeSeriesAxes, TimeSeriesPlot)
 from .frequencyseries import FrequencySeriesPlot
-from .tex import float_to_latex
 
 __all__ = ['EventTableAxes', 'EventTablePlot']
 
@@ -291,40 +289,41 @@ class EventTableAxes(TimeSeriesAxes):
         text : `~matplotlib.text.Text`
             the text added to these `Axes` with loudest event parameters
         """
-        ylim = self.get_ylim()
+        # get loudest row
         idx = table[rank].argmax()
         row = table[idx]
-        disp = "Loudest event:"
-        columns = [x, y, rank] + list(columns)
-        scat = []
-        for i, column in enumerate(columns):
-            if not column or column in columns[:i]:
-                continue
-            if i:
-                disp += ','
-            val = row[column]
-            if i < 2:
-                scat.append([float(val)])
-            column = get_column_string(column)
-            if pyplot.rcParams['text.usetex'] and column.endswith('Time'):
-                disp += (r" %s$= %s$" % (column, LIGOTimeGPS(float(val))))
-            elif pyplot.rcParams['text.usetex']:
-                disp += (r" %s$=$ %s" % (column, float_to_latex(val, '%.3g')))
-            else:
-                disp += " %s = %.2g" % (column, val)
-        disp = disp.rstrip(',')
-        pos = kwargs.pop('position', [0.5, 1.00])
-        kwargs.setdefault('transform', self.axes.transAxes)
-        kwargs.setdefault('verticalalignment', 'bottom')
-        kwargs.setdefault('horizontalalignment', 'center')
-        args = pos + [disp]
-        coll = self.scatter(*scat, marker='*', zorder=1000, facecolor='gold',
+
+        # mark loudest row with star
+        coll = self.scatter([float(row[x])], [float(row[y])],
+                            marker='*', zorder=1000, facecolor='gold',
                             edgecolor='black', s=200)
-        text = self.text(*args, **kwargs)
-        if self.get_title():
-            pos = self.title.get_position()
-            self.title.set_position((pos[0], pos[1] + 0.05))
-        self.set_ylim(*ylim)
+
+        # get text
+        columns = [x, y, rank] + list(columns)
+        loudtext = _loudest_text(row, columns)
+
+        # get position for new text
+        try:
+            pos = kwargs.pop('position')
+        except KeyError:  # user didn't specify, set default and shunt title
+            pos = [0.5, 1.00]
+            tpos = self.title.get_position()
+            self.title.set_position((tpos[0], tpos[1] + 0.05))
+
+        # parse text kwargs
+        text_kw = {  # defaults
+            'transform': self.axes.transAxes,
+            'verticalalignment': 'bottom',
+            'horizontalalignment': 'center',
+        }
+        text_kw.update(kwargs)
+        if 'ha' in text_kw:  # handle short versions or alignment params
+            text_kw['horizontalalignment'] = text_kw.pop('ha')
+        if 'va' in text_kw:
+            text_kw['verticalalignment'] = text_kw.pop('va')
+
+        # add text
+        text = self.text(pos[0], pos[1], loudtext, **text_kw)
 
         return coll, text
 
@@ -667,3 +666,26 @@ def get_column_string(column):
             # escape underscore
             words[i] = re.sub(r'(?<!\\)_', r'\_', words[i])
     return ' '.join(words)
+
+
+def _loudest_text(row, columns):
+    """Format the text for `EventTableAxes.add_loudest`
+    """
+    coltxt = []
+    for i, col in enumerate(columns):
+        # ignore null and duplicates
+        if not col or col in columns[:i]:
+            continue
+
+        # format column name
+        colstr = get_column_string(col)
+
+        # format row value
+        try:
+            valstr = '{0:.2f}'.format(row[col]).rstrip('.0')
+        except ValueError:  # not float()able
+            valstr = str(row[col])
+
+        coltxt.append('{col} = {val}'.format(col=colstr, val=valstr))
+
+    return 'Loudest event: {0}'.format(', '.join(coltxt))

--- a/gwpy/plotter/table.py
+++ b/gwpy/plotter/table.py
@@ -279,17 +279,17 @@ class EventTableAxes(TimeSeriesAxes):
         y : `str`
             name of column to display on the Y-axis
 
-        color : `str`, optional
-            name of column by which to colour the data
-
         **kwargs
             any other arguments applicable to
             :meth:`~matplotlib.axes.Axes.text`
 
         Returns
         -------
-        out : `tuple`
-            (`collection`, `text`) tuple of items added to the `Axes`
+        collection : `~matplotlib.collections.PolyCollection`
+            the collection returned by :meth:`~matplotlib.axes.Axesscatter`
+            when marking the loudest event
+        text : `~matplotlib.text.Text`
+            the text added to these `Axes` with loudest event parameters
         """
         ylim = self.get_ylim()
         idx = table[rank].argmax()
@@ -318,13 +318,15 @@ class EventTableAxes(TimeSeriesAxes):
         kwargs.setdefault('verticalalignment', 'bottom')
         kwargs.setdefault('horizontalalignment', 'center')
         args = pos + [disp]
-        self.scatter(*scat, marker='*', zorder=1000, facecolor='gold',
-                     edgecolor='black', s=200)
-        self.text(*args, **kwargs)
+        coll = self.scatter(*scat, marker='*', zorder=1000, facecolor='gold',
+                            edgecolor='black', s=200)
+        text = self.text(*args, **kwargs)
         if self.get_title():
             pos = self.title.get_position()
             self.title.set_position((pos[0], pos[1] + 0.05))
         self.set_ylim(*ylim)
+
+        return coll, text
 
 
 register_projection(EventTableAxes)

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -86,6 +86,20 @@ else:
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+@pytest.fixture(scope='function', params=[False, True])
+def usetex(request):
+    """Fixture to test plotting function with and without `usetex`
+
+    Returns
+    -------
+    usetex : `bool`
+        the value of the `text.usetex` rcParams settings
+    """
+    use_ = request.param
+    with rc_context(rc={'text.usetex': use_}):
+        yield use_
+
+
 class PlottingTestBase(object):
     FIGURE_CLASS = Plot
     AXES_CLASS = Axes
@@ -796,9 +810,6 @@ class TestEventTableAxes(EventTableMixin, TestAxes):
         c = ax.plot_table(table, 'time', 'frequency', 'snr',
                           size_by='snr')
         nptest.assert_array_equal(c.get_array(), snrs)
-        # test add_loudest
-        ax.set_title('title')
-        ax.add_loudest(table, 'snr', 'time', 'frequency')
 
     def test_plot_tiles(self, table):
         fig, ax = self.new()
@@ -827,6 +838,48 @@ class TestEventTableAxes(EventTableMixin, TestAxes):
             assert get_column_string('reduced_chisq') == r'Reduced $\chi^2$'
             assert get_column_string('flow') == r'f$_{\mbox{\small low}}$'
             assert get_column_string('end_time_ns') == r'End Time $(ns)$'
+
+    def test_add_loudest(self, usetex, table):
+        table.add_column(table.Column(data=['test'] * len(table), name='test'))
+        loudest = table[table['snr'].argmax()]
+        t, f, s = loudest['time'], loudest['frequency'], loudest['snr']
+
+        # make plot
+        fig, ax = self.new()
+        ax.scatter(table['time'], table['frequency'])
+        tpos = ax.title.get_position()
+
+        # call function
+        coll, text = ax.add_loudest(table, 'snr', 'time', 'frequency', 'test')
+
+        # check marker was placed at the right point
+        utils.assert_array_equal(coll.get_offsets(), [(t, f)])
+
+        # check text
+        result = ('Loudest event: Time = {0}, Frequency = {1}, SNR = {2}, '
+                  'Test = test'.format(
+                      *('{0:.2f}'.format(x) for x in (t, f, s))))
+
+        assert text.get_text() == result
+        assert text.get_position() == (.5, 1.)
+
+        # assert title got moved
+        assert ax.title.get_position() == (tpos[0], tpos[1] + .05)
+
+        # -- with more kwargs
+
+        _, t = ax.add_loudest(table, 'snr', 'time', 'frequency',
+                              position=(0., 0.), ha='left', va='top')
+        assert t.get_position() == (0., 0.)
+
+        # assert title doesn't get moved again if we specify position
+        assert ax.title.get_position() == (tpos[0], tpos[1] + .05)
+
+        # assert kw handling
+        assert t.get_horizontalalignment() == 'left'
+        assert t.get_verticalalignment() == 'top'
+
+        self.save_and_close(fig)
 
 
 # -- Segment plotter ----------------------------------------------------------


### PR DESCRIPTION
This PR simplifies the `EventTableAxes.add_loudest` method to not do anything with LaTeX, but just represent the parameters of the loudest row with `'%.2f'` or `str`.

This PR also adds a comprehensive unit test of the method.