### PR TITLE
Use tqdm for progress bars

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -23,7 +23,7 @@
 # enable lscsoft jessie-proposed (first required for python-tqdm gwpy/gwpy#735)
 if [[ `cat /etc/debian_version` == "8."* ]]; then
     cat << EOF > /etc/apt/sources.list.d/lscsoft-proposed.list
-echo "deb http://software.ligo.org/lscsoft/debian jessie-proposed contrib"
+deb http://software.ligo.org/lscsoft/debian jessie-proposed contrib
 EOF
     cat << EOF > /etc/apt/preferences.d/lscsoft-proposed.pref
 Package: *

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -30,6 +30,7 @@ Package: *
 Pin: release n=jessie-proposed
 Pin-Priority: 100
 EOF
+    apt-get update -yqq
 fi
 
 # install pip for system python

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -84,6 +84,7 @@ for PREF in ${PREFICES}; do
     echo "-------------------------------------------------------"
     dpkg --install ${GWPY_DEB} || { \
         apt-get -y -f install;  # install dependencies and package
+        apt-get -yq install ${PREF}-tqdm;  # install tqdm from backports
         dpkg --install ${GWPY_DEB};  # shouldn't fail
     }
 done

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -20,6 +20,18 @@
 # Build Debian package
 #
 
+# enable lscsoft jessie-proposed (first required for python-tqdm gwpy/gwpy#735)
+if [[ `cat /etc/debian_version` == "8."* ]]; then
+    cat << EOF > /etc/apt/source.list.d/lscsoft-proposed.list
+echo "deb http://software.ligo.org/lscsoft/debian jessie-proposed contrib"
+EOF
+    cat << EOF > /etc/apt/preferences.d/lscsoft-proposed.pref
+Package: *
+Pin: release n=jessie-proposed
+Pin-Priority: 100
+EOF
+fi
+
 # install pip for system python
 apt-get -yq install python-pip
 

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -22,7 +22,7 @@
 
 # enable lscsoft jessie-proposed (first required for python-tqdm gwpy/gwpy#735)
 if [[ `cat /etc/debian_version` == "8."* ]]; then
-    cat << EOF > /etc/apt/source.list.d/lscsoft-proposed.list
+    cat << EOF > /etc/apt/sources.list.d/lscsoft-proposed.list
 echo "deb http://software.ligo.org/lscsoft/debian jessie-proposed contrib"
 EOF
     cat << EOF > /etc/apt/preferences.d/lscsoft-proposed.pref

--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Depends: ${misc:Depends},
          python-astropy (>= 1.1.1),
          python-matplotlib (>= 1.2.0),
          lal-python (>= 6.14.0),
-         python-glue (>= 1.55.2)
+         python-glue (>= 1.55.2),
          python-tqdm (>= 4.10.0)
 Recommends: python-h5py (>= 1.3)
 Suggests: python-pymysql,
@@ -56,7 +56,7 @@ Depends: ${misc:Depends},
          python3-astropy (>= 1.1.1),
          python3-matplotlib (>= 1.2.0),
          lal-python3 (>= 6.14.0),
-         python3-glue (>= 1.55.2)
+         python3-glue (>= 1.55.2),
          python3-tqdm (>= 4.10.0)
 Recommends: python3-h5py (>= 1.3)
 Suggests: python3-pymysql,

--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Depends: ${misc:Depends},
          python-matplotlib (>= 1.2.0),
          lal-python (>= 6.14.0),
          python-glue (>= 1.55.2)
+         python-tqdm (>= 4.10.0)
 Recommends: python-h5py (>= 1.3)
 Suggests: python-pymysql,
           python-dqsegdb,
@@ -56,6 +57,7 @@ Depends: ${misc:Depends},
          python3-matplotlib (>= 1.2.0),
          lal-python3 (>= 6.14.0),
          python3-glue (>= 1.55.2)
+         python3-tqdm (>= 4.10.0)
 Recommends: python3-h5py (>= 1.3)
 Suggests: python3-pymysql,
           python3-dqsegdb,

--- a/etc/Portfile.template
+++ b/etc/Portfile.template
@@ -41,7 +41,9 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-matplotlib \
                         port:py${python.version}-astropy \
                         port:py${python.version}-lal \
-                        port:glue
+                        port:glue \
+                        port:py${python.version}-tqdm
+
     if {${python.version} < 34} {
         depends_lib-append port:py${python.version}-enum34
     }

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -35,6 +35,7 @@ Requires:       python-matplotlib
 Requires:       python-astropy
 Requires:       lal-python >= 6.14.0
 Requires:       glue
+Requires:       python2-tqdm
 
 %{?python_provide:%python_provide python2-%{srcname}}
 
@@ -54,6 +55,7 @@ Requires:       python%{python3_pkgversion}-matplotlib
 Requires:       python%{python3_pkgversion}-astropy
 Requires:       lal-python%{python3_pkgversion} >= 6.14.0
 Requires:       python%{python3_pkgversion}-glue
+Requires:       python%{python3_pkgversion}-tqdm
 
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
 

--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -90,12 +90,11 @@ def read_multi(flatten, cls, source, *args, **kwargs):
 
     # format verbosity
     if verbose is True:
-        verbose = 'Reading ({}):'.format(kwargs['format'])
+        verbose = 'Reading ({})'.format(kwargs['format'])
 
     # read files
     output = mp_utils.multiprocess_with_queues(
-        nproc, _read_single_file, files, raise_exceptions=False,
-        verbose=verbose)
+        nproc, _read_single_file, files, verbose=verbose, unit='files')
 
     # raise exceptions (from multiprocessing, single process raises inline)
     for fobj, exc in output:

--- a/gwpy/table/gravityspy.py
+++ b/gwpy/table/gravityspy.py
@@ -182,7 +182,7 @@ class GravitySpyTable(EventTable):
 
         # read files
         output = mp_utils.multiprocess_with_queues(
-            nproc, _download_single_image, images, raise_exceptions=False)
+            nproc, _download_single_image, images)
 
         # raise exceptions (from multiprocessing, single process raises inline)
         for f, x in output:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1229,7 +1229,7 @@ class TimeSeriesBaseDict(OrderedDict):
         out = cls()
         for frametype, clist in frametypes.items():
             if verbose:
-                verbose = "Reading {} frames:".format(frametype)
+                verbose = "Reading {} frames".format(frametype)
             # parse as a ChannelList
             channellist = ChannelList.from_names(*clist)
             # strip trend tags from channel names

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -20,17 +20,14 @@
 """
 
 import operator
-import sys
 import warnings
-from math import ceil
 
-from six.moves import (reduce, StringIO)
-
-from astropy.utils.console import ProgressBarOrSpinner
+from six.moves import reduce
 
 from ...io import nds2 as io_nds2
 from ...segments import (Segment, SegmentList)
 from ...utils import gprint
+from ...utils.progress import progress_bar
 from .. import (TimeSeries)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -147,19 +144,19 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
     out = series_class.DictClass()
     for seg in qsegs:
         duration = seg[1] - seg[0]
-        msg = 'Downloading data ({}-{} | {}s):'.format(
-            seg[1], seg[0], duration)
-        stream = sys.stdout if verbose else StringIO()
-        count = 0
-        with ProgressBarOrSpinner(duration, msg, file=stream) as bar:
+        msg = 'Downloading data'
+        total = 0.
+        with progress_bar(total=duration, desc=msg, unit='s',
+                          disable=not bool(verbose)) as bar:
             for buffers in connection.iterate(int(seg[0]), int(seg[1]), names):
                 for buffer_, chan in zip(buffers, channels):
                     series = series_class.from_nds2_buffer(buffer_)
                     out.append({chan: series}, pad=pad, gap=gap)
-                count += buffer_.length / buffer_.channel.sample_rate
-                bar.update(count)
+                new = buffer_.length / buffer_.channel.sample_rate
+                total += new
+                bar.update(new)
             # sometimes NDS2 returns no data at all
-            if not count and gap != 'pad':
+            if not total and gap != 'pad':
                 raise RuntimeError("no data received from {0} for {1}".format(
                     connection.get_host(), seg))
 

--- a/gwpy/utils/progress.py
+++ b/gwpy/utils/progress.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilities for multi-processing
+"""
+
+import sys
+
+from tqdm import tqdm
+
+TQDM_BAR_FORMAT = ("{desc}: |{bar}| "
+                   "{n_fmt}/{total_fmt} ({percentage:3.0f}%) "
+                   "ETA {remaining:6s}")
+
+
+def progress_bar(**kwargs):
+    """Create a `tqdm.tqdm` progress bar
+
+    This is just a thin wrapper around `tqdm.tqdm` to set some updated defaults
+    """
+    tqdm_kw = {
+        'desc': 'Processing',
+        'file': sys.stdout,
+        'bar_format': TQDM_BAR_FORMAT,
+    }
+    tqdm_kw.update(kwargs)
+    pbar = tqdm(**tqdm_kw)
+    if not pbar.disable:
+        pbar.desc = pbar.desc.rstrip(': ')
+        pbar.refresh()
+    return pbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ astropy >= 1.1.1, < 3.0.0 ; python_version < '3'
 astropy >= 1.1.1 ; python_version >= '3'
 matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
 lscsoft-glue >= 1.55.2
+tqdm >= 4.10.0

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ dependencies = {
     'matplotlib': '>= 1.2.0',
     'astropy': '>= 1.1.1',
     'lscsoft-glue': '>= 1.55.2',
+    'tqdm': '>= 4.10.0',
 }
 
 # include fancy dependencies


### PR DESCRIPTION
This PR updates `gwpy.utils.mp` and adds a new module `gwpy.utils.progress` that uses [`tqdm`](https://pypi.org/project/tqdm/) for verbose progress bars.

This adds `tqdm` as a hard dependency for gwpy, which might be an issue for debian jessie.

UPDATE: this PR probably needs to sit here until `python-tqdm` is moved into production as part of the `lscsoft` `jessie` distributions. You can follow along [here](https://bugs.ligo.org/redmine/issues/6135) (required LIGO.ORG auth).