### PR TITLE
Fixed import of scipy windows module for 1.1.0rc1

### DIFF
--- a/gwpy/signal/window.py
+++ b/gwpy/signal/window.py
@@ -23,7 +23,10 @@ import numpy
 
 from math import ceil
 
-from scipy.signal import windows as scipy_windows
+try:  # scipy 1.1.0rc1
+    from scipy.signal.windows import windows as scipy_windows
+except ImportError:  # scipy <= 1.0.x
+    from scipy.signal import windows as scipy_windows
 
 from scipy.special import expit
 


### PR DESCRIPTION
This PR updates the import of the underlying `windows.py` module in scipy to `scipy.signal.windows.windows` for 1.1.0rc1. This is required to resolve the `_win_equiv` mapping used in the `canonical_name` method.