### PR TITLE
Fixed sorting of tags in changelogs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ matrix:
 
     # macOS
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.2
       env: PYTHON_VERSION='2.7'
       language: minimal
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ matrix:
 
     # macOS
     - os: osx
+      osx_image: xcode9.3
       env: PYTHON_VERSION='2.7'
       language: minimal
       sudo: required


### PR DESCRIPTION
This PR patches `setup_utils.py` so that tags are sorted properly (by semantic version), so that 0.10.0 is sorted **after** 0.9.0.

This also bumps the xcode version to 9.2 in an attempt to fix [this build error](https://travis-ci.org/gwpy/gwpy/jobs/368544942).