### PR TITLE
Added contract keyword to DataQualityFlag.round

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -829,11 +829,15 @@ class DataQualityFlag(object):
             padded out to integer boundaries.
         """
         def _round(seg):
-            if contract and abs(seg) < 1:
+            if contract:  # round inwards
+                a = ceil(seg[0])
+                b = floor(seg[1])
+            else:  # round outwards
+                a = floor(seg[0])
+                b = ceil(seg[1])
+            if a >= b:  # if segment is too short, return 'null' segment
                 return type(seg)(0, 0)  # will get coalesced away
-            if contract:
-                return type(seg)(ceil(seg[0]), floor(seg[1]))
-            return type(seg)(floor(seg[0]), ceil(seg[1]))
+            return type(seg)(a, b)
 
         new = self.copy()
         new.active = type(new.active)(map(_round, new.active))

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -477,9 +477,13 @@ class TestDataQualityFlag(object):
         utils.assert_segmentlist_equal(flag.known, KNOWN)
         utils.assert_segmentlist_equal(flag.active, ACTIVE)
 
-    def test_round(self):
-        flag = self.create(active=ACTIVE_CONTRACTED)
-        r = flag.round()
+    @pytest.mark.parametrize('contract, active', [
+        (False, ACTIVE_CONTRACTED),
+        (True, ACTIVE_PROTRACTED),
+    ])
+    def test_round(self, contract, active):
+        flag = self.create(active=active)
+        r = flag.round(contract=contract)
         utils.assert_segmentlist_equal(r.known, KNOWN)
         utils.assert_segmentlist_equal(r.active, KNOWNACTIVE)
 


### PR DESCRIPTION
This PR adds a `contract=False` keyword to `DataQualityFlag.round()` to reverse the logic to round start time up and end time down, and return the set of integer segments wholly contained within the active segments.