### PR TITLE
Reworked internals of gwpy.time to reduce complexity

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -84,21 +84,25 @@ def _parse_query_segments(args, func):
 
     Returns a SegmentList in all cases
     """
+    # user passed SegmentList
     if len(args) == 1 and isinstance(args[0], SegmentList):
         return args[0]
-    if len(args) == 1 and len(args[0]) == 2:
-        return SegmentList([Segment(to_gps(args[0][0]),
-                                    to_gps(args[0][1]))])
+
+    # otherwise unpack two arguments as a segment
+    if len(args) == 1:
+        args = args[0]
+
+    # if not two arguments, panic
     try:
-        return SegmentList([Segment(*map(to_gps, args))])
-    except (TypeError, RuntimeError) as exc:
-        msg = ('{0}() takes 2 arguments for start and end GPS times, '
-               'or 1 argument containing a Segment or '
-               'SegmentList'.format(func.__name__))
-        if isinstance(exc, TypeError):
-            exc.args = (msg,)
-            raise
-        raise TypeError(msg)
+        start, end = args
+    except ValueError as exc:
+        exc.args = ('{0}() takes 2 arguments for start and end GPS time, '
+                    'or 1 argument containing a Segment or SegmentList'.format(
+                        func.__name__),)
+        raise
+
+    # return list with one Segment
+    return SegmentList([Segment(to_gps(start), to_gps(end))])
 
 
 # -- DataQualityFlag ----------------------------------------------------------

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -633,9 +633,9 @@ class TestDataQualityFlag(object):
                               QUERY_FLAGS[0], SegmentList([(0, 10)]))
         utils.assert_flag_equal(result, result2)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             self.TEST_CLASS.query_segdb(QUERY_FLAGS[0], 1, 2, 3)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             self.TEST_CLASS.query_segdb(QUERY_FLAGS[0], (1, 2, 3))
 
     @pytest.mark.parametrize('name, flag', [
@@ -666,9 +666,9 @@ class TestDataQualityFlag(object):
                           'X1:GWPY-TEST:0', 0, 10)
         assert str(exc.value) == 'HTTP Error 404: Not found [X1:GWPY-TEST:0]'
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             self.TEST_CLASS.query_dqsegdb(QUERY_FLAGS[0], 1, 2, 3)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             self.TEST_CLASS.query_dqsegdb(QUERY_FLAGS[0], (1, 2, 3))
 
     def test_query_dqsegdb_multi(self):

--- a/gwpy/tests/test_time.py
+++ b/gwpy/tests/test_time.py
@@ -20,8 +20,11 @@
 """
 
 from datetime import datetime
+from decimal import Decimal
 
 import pytest
+
+import numpy
 
 from freezegun import freeze_time
 
@@ -31,91 +34,83 @@ from astropy.units import (UnitConversionError, Quantity)
 from glue.lal import LIGOTimeGPS as GlueGPS
 
 from gwpy import time
+from gwpy.time import LIGOTimeGPS
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+GW150914 = LIGOTimeGPS(1126259462, 391000000)
+GW150914_DT = datetime(2015, 9, 14, 9, 50, 45, 391000)
+FREEZE = '2015-09-14 09:50:45.391'
+NOW = 1126259462
+TODAY = 1126224017
+TOMORROW = 1126310417
+YESTERDAY = 1126137617
 
-def test_to_gps():
+
+def _test_with_errors(func, in_, out):
+    # assert error
+    if isinstance(out, type) and issubclass(out, Exception):
+        with pytest.raises(out):
+            func(in_)
+    # assert not error
+    else:
+        with freeze_time(FREEZE):
+            assert func(in_) == out
+
+
+# -- test functions -----------------------------------------------------------
+
+@pytest.mark.parametrize('in_, out', [
+    (1126259462, int(GW150914)),
+    (LIGOTimeGPS(1126259462, 391000000), GW150914),
+    ('Jan 1 2017', 1167264018),
+    ('Sep 14 2015 09:50:45.391', GW150914),
+    ((2017, 1, 1), 1167264018),
+    (datetime(2017, 1, 1), 1167264018),
+    (Time(57754, format='mjd'), 1167264018),
+    (Time(57754.0001, format='mjd'), LIGOTimeGPS(1167264026, 640000000)),
+    (Quantity(1167264018, 's'), 1167264018),
+    (Decimal('1126259462.391000000'), GW150914),
+    (GlueGPS(GW150914.gpsSeconds, GW150914.gpsNanoSeconds), GW150914),
+    (numpy.int32(NOW), NOW),  # fails with lal-6.18.0
+    ('now', NOW),
+    ('today', TODAY),
+    ('tomorrow', TOMORROW),
+    ('yesterday', YESTERDAY),
+    (Quantity(1, 'm'), UnitConversionError),
+    ('random string', ValueError),
+])
+def test_to_gps(in_, out):
     """Test :func:`gwpy.time.to_gps`
     """
-    # str conversion
-    t = time.to_gps('Jan 1 2017')
-    assert isinstance(t, time.LIGOTimeGPS)
-    assert t == 1167264018
-    assert time.to_gps('Sep 14 2015 09:50:45.391') == (
-        time.LIGOTimeGPS(1126259462, 391000000))
-    # datetime conversion
-    assert time.to_gps(datetime(2017, 1, 1)) == 1167264018
-
-    # astropy.time.Time conversion
-    assert time.to_gps(Time(57754, format='mjd')) == 1167264018
-
-    # tuple
-    assert time.to_gps((2017, 1, 1)) == 1167264018
-
-    # Quantity
-    assert time.to_gps(Quantity(1167264018, 's')) == 1167264018
-
-    # keywords
-    with freeze_time('2015-09-14 09:50:45.391'):
-        assert time.to_gps('now') == 1126259462
-        assert time.to_gps('today') == 1126224017
-        assert time.to_gps('tomorrow') == 1126310417
-        assert time.to_gps('yesterday') == 1126137617
-
-    # errors
-    with pytest.raises(UnitConversionError):
-        time.to_gps(Quantity(1, 'm'))
-    with pytest.raises((ValueError, TypeError)) as exc:
-        time.to_gps('random string')
-    assert 'Cannot parse date string \'random string\': ' in str(exc.value)
+    _test_with_errors(time.to_gps, in_, out)
 
 
-def test_from_gps():
+@pytest.mark.parametrize('in_, out', [
+    (1167264018, datetime(2017, 1, 1)),
+    ('1167264018', datetime(2017, 1, 1)),
+    (1126259462.391, datetime(2015, 9, 14, 9, 50, 45, 391000)),
+    ('1.13e9', datetime(2015, 10, 27, 16, 53, 3)),
+    (GlueGPS(GW150914.gpsSeconds, GW150914.gpsNanoSeconds), GW150914_DT),
+    ('test', ValueError),
+])
+def test_from_gps(in_, out):
     """Test :func:`gwpy.time.from_gps`
-   """
-    # basic
-    d = time.from_gps(1167264018)
-    assert isinstance(d, datetime)
-    assert d == datetime(2017, 1, 1)
-
-    # str
-    assert time.from_gps('1167264018') == datetime(2017, 1, 1)
-
-    # float
-    assert time.from_gps(1126259462.391) == (
-        datetime(2015, 9, 14, 9, 50, 45, 391000))
-    assert time.from_gps('1.13e9') == datetime(2015, 10, 27, 16, 53, 3)
-
-    # errors
-    with pytest.raises((RuntimeError, ValueError)):
-        time.from_gps('test')
+    """
+    _test_with_errors(time.from_gps, in_, out)
 
 
-def test_tconvert():
+@pytest.mark.parametrize('in_, out', [
+    (float(GW150914), GW150914_DT),
+    (GW150914, GW150914_DT),
+    (GW150914_DT, GW150914),
+    (GlueGPS(float(GW150914)), GW150914_DT),
+    ('now', NOW),
+    ('today', TODAY),
+    ('tomorrow', TOMORROW),
+    ('yesterday', YESTERDAY),
+])
+def test_tconvert(in_, out):
     """Test :func:`gwpy.time.tconvert`
     """
-    # from GPS
-    assert time.tconvert(1126259462.391) == (
-        datetime(2015, 9, 14, 9, 50, 45, 391000))
-
-    # from GPS using LAL LIGOTimeGPS
-    assert time.tconvert(time.LIGOTimeGPS(1126259462.391)) == (
-        datetime(2015, 9, 14, 9, 50, 45, 391000))
-    assert time.tconvert(GlueGPS(1126259462.391)) == (
-        datetime(2015, 9, 14, 9, 50, 45, 391000))
-
-    # to GPS
-    assert time.tconvert(datetime(2015, 9, 14, 9, 50, 45, 391000)) == (
-        time.LIGOTimeGPS(1126259462, 391000000))
-
-    # special cases
-    now = time.tconvert()
-    now2 = time.tconvert('now')
-    assert now == now2
-    today = float(time.tconvert('today'))
-    yesterday = float(time.tconvert('yesterday'))
-    assert today - yesterday == pytest.approx(86400)
-    assert now >= today
-    tomorrow = float(time.tconvert('tomorrow'))
-    assert tomorrow - today == pytest.approx(86400)
+    _test_with_errors(time.tconvert, in_, out)

--- a/gwpy/tests/test_time.py
+++ b/gwpy/tests/test_time.py
@@ -47,9 +47,15 @@ TOMORROW = 1126310417
 YESTERDAY = 1126137617
 
 
+def _is_error_type(obj):
+    if isinstance(obj, (list, tuple)):
+        return all(map(_is_error_type, obj))
+    return isinstance(obj, type) and issubclass(obj, Exception)
+
+
 def _test_with_errors(func, in_, out):
     # assert error
-    if isinstance(out, type) and issubclass(out, Exception):
+    if _is_error_type(out):
         with pytest.raises(out):
             func(in_)
     # assert not error
@@ -78,7 +84,7 @@ def _test_with_errors(func, in_, out):
     ('tomorrow', TOMORROW),
     ('yesterday', YESTERDAY),
     (Quantity(1, 'm'), UnitConversionError),
-    ('random string', ValueError),
+    ('random string', (ValueError, TypeError)),
 ])
 def test_to_gps(in_, out):
     """Test :func:`gwpy.time.to_gps`

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -197,6 +197,7 @@ def _now():
 def _today():
     return datetime.date.today()
 
+
 def _today_delta(**delta):
     return _today() + datetime.timedelta(**delta)
 

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -256,6 +256,6 @@ def _time_to_gps(time):
         Nano-second precision `LIGOTimeGPS` time
     """
     time = time.utc
-    dt = time.datetime
-    micro = dt.microsecond if isinstance(dt, datetime.datetime) else 0
+    date = time.datetime
+    micro = date.microsecond if isinstance(date, datetime.datetime) else 0
     return LIGOTimeGPS(int(time.gps), int(micro*1e3))

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -188,34 +188,47 @@ def from_gps(gps):
 
 
 # -- utilities ----------------------------------------------------------------
+# special case strings
+
+def _now():
+    return datetime.datetime.utcnow().replace(microsecond=0)
+
+
+def _today():
+    return datetime.date.today()
+
+def _today_delta(**delta):
+    return _today() + datetime.timedelta(**delta)
+
+
+def _tomorrow():
+    return _today_delta(days=1)
+
+
+def _yesterday():
+    return _today_delta(days=-1)
+
+
+DATE_STRINGS = {
+    'now': _now,
+    'today': _today,
+    'tomorrow': _tomorrow,
+    'yesterday': _yesterday,
+}
+
 
 def _str_to_datetime(datestr):
     """Convert `str` to `datetime.datetime`.
     """
-    datestrl = str(datestr).lower()
-
-    # handle special cases
-    if datestrl == 'now':
-        return datetime.datetime.utcnow().replace(microsecond=0)
-
-    if datestrl == 'today':
-        return datetime.date.today()
-
-    if datestrl == 'tomorrow':
-        today = datetime.date.today()
-        return today + datetime.timedelta(days=1)
-
-    if datestrl == 'yesterday':
-        today = datetime.date.today()
-        return today - datetime.timedelta(days=1)
-
-    # any other string
-    try:
-        return dateparser.parse(datestr)
-    except (ValueError, TypeError) as exc:
-        exc.args = ("Cannot parse date string {0!r}: {1}".format(
-            datestr, exc.args[0]),)
-        raise
+    try:  # try known string
+        return DATE_STRINGS[str(datestr).lower()]()
+    except KeyError:  # any other string
+        try:
+            return dateparser.parse(datestr)
+        except (ValueError, TypeError) as exc:
+            exc.args = ("Cannot parse date string {0!r}: {1}".format(
+                datestr, exc.args[0]),)
+            raise
 
 
 def _datetime_to_time(dtm):

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -239,12 +239,15 @@ def _datetime_to_time(dtm):
     return Time(dtm, scale='utc')
 
 
-def _time_to_gps(t):
+def _time_to_gps(time):
     """Convert a `Time` into `LIGOTimeGPS`.
+
+    This method uses `datetime.datetime` underneath, which restricts
+    to microsecond precision by design. This should probably be fixed...
 
     Parameters
     ----------
-    t : `~astropy.time.Time`
+    time : `~astropy.time.Time`
         formatted `Time` object to convert
 
     Returns
@@ -252,7 +255,7 @@ def _time_to_gps(t):
     gps : `LIGOTimeGPS`
         Nano-second precision `LIGOTimeGPS` time
     """
-    t = t.utc
-    dt = t.datetime
+    time = time.utc
+    dt = time.datetime
     micro = dt.microsecond if isinstance(dt, datetime.datetime) else 0
-    return LIGOTimeGPS(int(t.gps), int(micro*1e3))
+    return LIGOTimeGPS(int(time.gps), int(micro*1e3))


### PR DESCRIPTION
This PR simplifies `gwpy.time._tconvert` to reduce the complexity of the module, which has the nice consequence of removing any (optional) dependency on LAL.

This also rewrites the tests for this module to use `parametrize()` to simplify the actual test functions.