### PR TITLE
Fixed bug in parsing git --version on macos

### DIFF
--- a/setup_utils.py
+++ b/setup_utils.py
@@ -104,7 +104,7 @@ def get_gitpython_version():
     else:
         if isinstance(gitv, bytes):
             gitv = gitv.decode('utf-8')
-        git_version = gitv.rstrip().split()[-1]
+        git_version = gitv.strip().split()[2]
 
     # if git>=2.15, we need GitPython>=2.1.8
     if LooseVersion(git_version) >= '2.15':


### PR DESCRIPTION
This PR fixes a naivety in `setup_utils.py` when parsing the output of `git --version`. On macOS:

```
$ /usr/bin/git --version
git version 2.14.3 (Apple Git-98)
```

so we need to strip the 2th (3rd) word of the output, and not the last.

cc: @scottcoughlin2014