### PR TITLE
Fixed critical bug in TimeSeries.coherence_spectrogram, and added tests for coherence methods

### DIFF
--- a/gwpy/spectrogram/coherence.py
+++ b/gwpy/spectrogram/coherence.py
@@ -58,10 +58,10 @@ def _from_timeseries(ts1, ts2, stride, fftlength=None, overlap=None,
     if overlap is None:
         overlap = 0
 
-    stride = int(stride * sampling)
+    nstride = int(stride * sampling)
 
     # get size of spectrogram
-    nsteps = int(ts1.size // stride)
+    nsteps = int(ts1.size // nstride)
     nfreqs = int(fftlength * sampling // 2 + 1)
 
     # generate output spectrogram
@@ -74,8 +74,8 @@ def _from_timeseries(ts1, ts2, stride, fftlength=None, overlap=None,
     # stride through TimeSeries, recording PSDs as columns of spectrogram
     for step in range(nsteps):
         # find step TimeSeries
-        idx = stride * step
-        idx_end = idx + stride
+        idx = nstride * step
+        idx_end = idx + nstride
         stepseries1 = ts1[idx:idx_end]
         stepseries2 = ts2[idx:idx_end]
         stepcoh = stepseries1.coherence(stepseries2, fftlength=fftlength,

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -1328,6 +1328,29 @@ class TestTimeSeries(TestTimeSeriesBase):
         assert comp.name == '%s >= 2.0' % (array.name)
         assert (array == array).name == '{0} == {0}'.format(array.name)
 
+    def test_coherence(self):
+        try:
+            tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
+            tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
+        except URLError as exc:
+            pytest.skip(str(exc))
+        coh = tsh.coherence(tsl, fftlength=1.0)
+        assert coh.df == 1 * units.Hz
+        assert coh.frequencies[coh.argmax()] == 60 * units.Hz
+
+    def test_coherence_spectrogram(self):
+        try:
+            tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
+            tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
+        except URLError as exc:
+            pytest.skip(str(exc))
+        cohsg = tsh.coherence_spectrogram(tsl, 4, fftlength=1.0)
+        assert cohsg.t0 == tsh.t0
+        assert cohsg.dt == 4 * units.second
+        assert cohsg.df == 1 * units.Hz
+        tmax, fmax = numpy.unravel_index(cohsg.argmax(), cohsg.shape)
+        assert cohsg.frequencies[fmax] == 60 * units.Hz
+
 
 # -- TimeSeriesDict -----------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes a ridiculous bug in `TimeSeries.coherence_spectrogram` where the `dt` was set wildly incorrectly. This PR also adds unit tests for this and `TimeSeries.coherence`.