### PR TITLE
Explicitly cast padding to float

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -345,9 +345,9 @@ class DataQualityFlag(object):
     @padding.setter
     def padding(self, pad):
         if pad is None:
-            self._padding = (float(0), float(0))
+            self._padding = (0., 0.)
         else:
-            self._padding = (float(pad[0]), float(pad[1]))
+            self._padding = tuple([0. if p == None else float(p) for p in pad])
 
     @padding.deleter
     def padding(self):

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -351,7 +351,7 @@ class DataQualityFlag(object):
 
     @padding.deleter
     def padding(self):
-        self._padding = (float(0), float(0))
+        self._padding = (0., 0.)
 
     # -- read-only properties -------------------
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -345,13 +345,13 @@ class DataQualityFlag(object):
     @padding.setter
     def padding(self, pad):
         if pad is None:
-            self._padding = (0, 0)
+            self._padding = (float(0), float(0))
         else:
-            self._padding = (pad[0], pad[1])
+            self._padding = (float(pad[0]), float(pad[1]))
 
     @padding.deleter
     def padding(self):
-        self._padding = (0, 0)
+        self._padding = (float(0), float(0))
 
     # -- read-only properties -------------------
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -345,9 +345,8 @@ class DataQualityFlag(object):
     @padding.setter
     def padding(self, pad):
         if pad is None:
-            self._padding = (0., 0.)
-        else:
-            self._padding = tuple([0. if p is None else float(p) for p in pad])
+            pad = (None, None)
+        self._padding = tuple(float(p or 0.) for p in pad)
 
     @padding.deleter
     def padding(self):

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -347,7 +347,7 @@ class DataQualityFlag(object):
         if pad is None:
             self._padding = (0., 0.)
         else:
-            self._padding = tuple([0. if p == None else float(p) for p in pad])
+            self._padding = tuple([0. if p is None else float(p) for p in pad])
 
     @padding.deleter
     def padding(self):


### PR DESCRIPTION
Both `lal.LIGOTimeGPS.__add__()` and `glue.lal.LIGOTimeGPS.__add__()` are incompatible with `numpy.int32` datatypes, so padding values had to be cast to float when initializing a `DataQualityFlag`. This recovers the intended functionality of `DataQualityFlag.pad()` with `self.padding` as the intended padding window. It also fixes the bug with `DataQualityFlag.populate()` and `DataQualityDict.populate()` using padding windows from veto definers.

Fixes #750 