### PR TITLE
Added error check to guard against no data from nds2 iterate()

### DIFF
--- a/gwpy/tests/mocks.py
+++ b/gwpy/tests/mocks.py
@@ -163,7 +163,8 @@ def nds2_connection(host='nds.test.gwpy', port=31200, buffers=[]):
     NdsConnection.get_port.return_value = int(port)
 
     def iterate(start, end, names):
-        print(start, end, names)
+        if not buffers:
+            return []
         return [[b for b in buffers if
                  '%s,%s' % (b.channel.name,
                             b.channel.channel_type_to_string(b.channel_type))

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -158,5 +158,9 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
                     out.append({chan: series}, pad=pad, gap=gap)
                 count += buffer_.length / buffer_.channel.sample_rate
                 bar.update(count)
+            # sometimes NDS2 returns no data at all
+            if not count and gap != 'pad':
+                raise RuntimeError("no data received from {0} for {1}".format(
+                    connection.get_host(), seg))
 
     return out


### PR DESCRIPTION
This PR adds a check against an empty return from `nds2.connection.iterate()`, which previously would result in an empty `TimeSeriesDict` being returned from `TimeSeriesDict.fetch`.