### PR TITLE
Fixed typo in deprecation warning

### DIFF
--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -231,7 +231,7 @@ def register_gwf_api(library):
                           DeprecationWarning)
         if not isinstance(resample, dict):
             resample = dict((c, resample) for c in channels)
-        if resample is not None:
+        if dtype is not None:
             warnings.warn('the dtype keyword for is deprecated, instead '
                           'you should manually call astype() after reading',
                           DeprecationWarning)


### PR DESCRIPTION
This PR fixes a typo in deprecating the `dtype` keyword to `gwpy.timeseries.io.gwf.read`, introduced by #739.