### PR TITLE
Fixed to_gps('0')

### DIFF
--- a/gwpy/tests/test_time.py
+++ b/gwpy/tests/test_time.py
@@ -69,6 +69,7 @@ def _test_with_errors(func, in_, out):
 @pytest.mark.parametrize('in_, out', [
     (1126259462, int(GW150914)),
     (LIGOTimeGPS(1126259462, 391000000), GW150914),
+    ('0', 0),
     ('Jan 1 2017', 1167264018),
     ('Sep 14 2015 09:50:45.391', GW150914),
     ((2017, 1, 1), 1167264018),

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -25,6 +25,8 @@ Peter Shawhan.
 import datetime
 from decimal import Decimal
 
+from six import string_types
+
 from dateutil import parser as dateparser
 
 from astropy.units import Quantity
@@ -131,9 +133,16 @@ def to_gps(t, *args, **kwargs):
     >>> to_gps(Time(57754, format='mjd'))
     LIGOTimeGPS(1167264018, 0)
     """
+    # if input is a string of a float, get back to float quickly
+    if isinstance(t, string_types):
+        try:
+            t = float(t)
+        except (TypeError, ValueError):
+            pass
+
     # -- convert input to Time, or something we can pass to LIGOTimeGPS
 
-    if isinstance(t, str):  # str -> datetime.datetime
+    if isinstance(t, string_types):  # str -> datetime.datetime
         t = _str_to_datetime(t)
 
     if isinstance(t, (tuple, list)):  # tuple -> datetime.datetime


### PR DESCRIPTION
This PR fixes a bug in `gwpy.time.to_gps` whereby it couldn't handle `str` representations of `float`.