### PR TITLE
Added keyword to handle missing flags when reading DataQualityDict

### DIFF
--- a/gwpy/segments/io/hdf5.py
+++ b/gwpy/segments/io/hdf5.py
@@ -121,7 +121,7 @@ def read_hdf5_segmentlist(h5f, path=None, gpstype=LIGOTimeGPS, **kwargs):
 
 
 @io_hdf5.with_read_hdf5
-def read_hdf5_dict(h5f, names=None, path=None, **kwargs):
+def read_hdf5_dict(h5f, names=None, path=None, on_missing='error', **kwargs):
     """Read a `DataQualityDict` from an HDF5 file
     """
     if path:
@@ -145,7 +145,16 @@ def read_hdf5_dict(h5f, names=None, path=None, **kwargs):
     # read data
     out = DataQualityDict()
     for name in names:
-        out[name] = read_hdf5_flag(h5f, name, **kwargs)
+        try:
+            out[name] = read_hdf5_flag(h5f, name, **kwargs)
+        except KeyError as exc:
+            if on_missing == 'ignore':
+                pass
+            elif on_missing == 'warn':
+                warnings.warn(str(exc))
+            else:
+                raise ValueError('no H5Group found for flag '
+                                 '{0!r}'.format(name))
 
     return out
 

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -51,7 +51,7 @@ def segment_content_handler():
 
 # -- read ---------------------------------------------------------------------
 
-def read_ligolw_dict(source, flags=None, gpstype=LIGOTimeGPS, coalesce=False):
+def read_ligolw_dict(source, names=None, coalesce=False, **kwargs):
     """Read segments for the given flag from the LIGO_LW XML file.
 
     Parameters
@@ -59,8 +59,8 @@ def read_ligolw_dict(source, flags=None, gpstype=LIGOTimeGPS, coalesce=False):
     source : `file`, `str`, :class:`~glue.ligolw.ligolw.Document`, `list`
         one (or more) open files or file paths, or LIGO_LW `Document` objects
 
-    flags : `list`, `None`, optional
-        list of flags to read or `None` to read all into a single
+    names : `list`, `None`, optional
+        list of names to read or `None` to read all into a single
         `DataQualityFlag`.
 
     gpstype : `type`, `callable`, optional
@@ -91,8 +91,8 @@ def read_ligolw_dict(source, flags=None, gpstype=LIGOTimeGPS, coalesce=False):
 
     # parse tables
     with patch_ligotimegps():
-        out = DataQualityDict.from_ligolw_tables(*tables, names=flags,
-                                                 gpstype=gpstype)
+        out = DataQualityDict.from_ligolw_tables(*tables, names=names,
+                                                 **kwargs)
 
     # coalesce
     if coalesce:
@@ -102,10 +102,11 @@ def read_ligolw_dict(source, flags=None, gpstype=LIGOTimeGPS, coalesce=False):
     return out
 
 
-def read_ligolw_flag(source, flag=None, **kwargs):
+def read_ligolw_flag(source, name=None, **kwargs):
     """Read a single `DataQualityFlag` from a LIGO_LW XML file
     """
-    return list(read_ligolw_dict(source, flags=flag, **kwargs).values())[0]
+    name = [name] if name is not None else None
+    return list(read_ligolw_dict(source, names=name, **kwargs).values())[0]
 
 
 # -- write --------------------------------------------------------------------


### PR DESCRIPTION
This PR does two things:

- added `on_missing='error'` keyword for `DataQualityDict.read`, to handle user-supplied names that are not found,
- renamed `flag->name` and `flags->names` keywords for `DataQualityFlag.read` and `DataQualityDict.read` respectively (with deprecationwarnings)

This patch is mainly to fix the issue of reading a list of flag names from multiple files when not all flags exist in every file, but are split across the list.

cc: @lauranuttall