### PR TITLE
Remove dependency on glue.lal.Cache object

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,7 +1,9 @@
+scanner:
+  diff_only: True
+
 pycodestyle:
   exclude:
     - docs/conf.py
-    - ez_setup.py
     - versioneer.py
     - gwpy/_version.py
     - gwpy/utils/sphinx/epydoc.py

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -60,3 +60,6 @@
 
 .. |sphinx-automodapi| replace:: `sphinx-automodapi`
 .. _sphinx-automodapi: http://sphinx-automodapi.readthedocs.io/
+
+.. |LIGO-T050017| replace:: LIGO-T050017
+.. _LIGO-T050017: https://dcc.ligo.org/LIGO-T050017/public

--- a/gwpy/frequencyseries/core.py
+++ b/gwpy/frequencyseries/core.py
@@ -140,17 +140,24 @@ class FrequencySeries(Series):
 
         Parameters
         ----------
-        source : `str`, :class:`~glue.lal.Cache`
-            source of data, any of the following:
+        source : `str`, `list`
+            Source of data, any of the following:
 
-            - `str` path of single data file
-            - `str` path of LAL-format cache file
-            - :class:`~glue.lal.Cache` describing one or more data files,
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
+
+        *args
+            Other arguments are (in general) specific to the given
+            ``format``.
 
         format : `str`, optional
-            source format identifier. If not given, the format will be
+            Source format identifier. If not given, the format will be
             detected if possible. See below for list of acceptable
-            formats
+            formats.
+
+        **kwargs
+            Other keywords are (in general) specific to the given ``format``.
 
         Notes
         -----"""

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -155,17 +155,24 @@ class SpectralVariance(Array2D):
 
         Parameters
         ----------
-        source : `str`, :class:`~glue.lal.Cache`
-            source of data, any of the following:
+        source : `str`, `list`
+            Source of data, any of the following:
 
-            - `str` path of single data file
-            - `str` path of LAL-format cache file
-            - :class:`~glue.lal.Cache` describing one or more data files,
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
+
+        *args
+            Other arguments are (in general) specific to the given
+            ``format``.
 
         format : `str`, optional
-            source format identifier. If not given, the format will be
+            Source format identifier. If not given, the format will be
             detected if possible. See below for list of acceptable
-            formats
+            formats.
+
+        **kwargs
+            Other keywords are (in general) specific to the given ``format``.
 
         Notes
         -----"""

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -121,7 +121,7 @@ def write_cache(cache, fobj):
     # open file
     if isinstance(fobj, string_types):
         with open(fobj, 'w') as fobj2:
-            write_cache(cache, fobj2)
+            return write_cache(cache, fobj2)
 
     # write file
     for entry in cache:

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -52,13 +52,13 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 try:  # python2.x
     FILE_LIKE = (
         file, GzipFile,
-        tempfile._TemporaryFileWrapper, # pylint: disable=protected-access
+        tempfile._TemporaryFileWrapper,  # pylint: disable=protected-access
     )
 except NameError:  # python3.x
     from io import IOBase
     FILE_LIKE = (
         IOBase, GzipFile,
-        tempfile._TemporaryFileWrapper, # pylint: disable=protected-access
+        tempfile._TemporaryFileWrapper,  # pylint: disable=protected-access
     )
 
 

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -329,4 +329,4 @@ def sieve(cache, segment=None):
     segment : `~gwpy.segments.Segment`
         The ``[start, stop)`` interval to match against.
     """
-    return [e for e in cache if segment.intersects(file_segment(e))]
+    return type(cache)(e for e in cache if segment.intersects(file_segment(e)))

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -19,7 +19,7 @@
 """Input/Output utilities for LAL Cache files.
 """
 
-from __future__ import (division, print_function)
+from __future__ import division
 
 import os.path
 import tempfile
@@ -118,11 +118,12 @@ def write_cache(cache, fobj):
             return write_cache(cache, fobj2)
 
     # write file
-    for line in map(str, cache):
+    for entry in cache:
+        line = '{0}\n'.format(entry)
         try:
-            print(line, file=fobj)
-        except TypeError:  # python3 'wb' mode
-            print(line.encode('utf-8'), file=fobj)
+            fobj.write(line)
+        except TypeError as exc:  # python3 'wb' mode
+            fobj.write(line.encode('utf-8'))
 
 
 def is_cache(cache):

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -142,14 +142,10 @@ def is_cache(cache):
     """
     if isinstance(cache, string_types + FILE_LIKE):
         try:
-            c = read_cache(cache)
+            return bool(len(read_cache(cache)))
         except (TypeError, ValueError, UnicodeDecodeError, ImportError):
             # failed to parse cache
             return False
-        else:
-            if not c:  # return empty file as False
-                return False
-            return True
     if HAS_CACHE and isinstance(cache, Cache):
         return True
     if (isinstance(cache, (list, tuple)) and cache and
@@ -164,7 +160,7 @@ def is_cache_entry(path):
         return True
     try:
         file_segment(path)
-    except (ValueError, AttributeError):
+    except (ValueError, TypeError, AttributeError):
         return False
     return True
 

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -167,6 +167,7 @@ def is_cache_entry(path):
         return False
     return True
 
+
 # -- cache manipulation -------------------------------------------------------
 
 def file_list(flist):

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -224,15 +224,14 @@ def read_table(source, tablename=None, columns=None, contenthandler=None,
 
     Parameters
     ----------
-    source : `Document`, `file`, `str`, `CacheEntry`, `list`, `Cache`
+    source : `Document`, `file`, `str`, `CacheEntry`, `list`
         object representing one or more files. One of
 
         - a LIGO_LW :class:`~glue.ligolw.ligolw.Document`
         - an open `file`
         - a `str` pointing to a file path on disk
-        - a formatted `~lal.utils.CacheEntry` representing one file
-        - a `list` of `str` file paths
-        - a formatted :class:`~glue.lal.Cache` representing many files
+        - a formatted :class:`~lal.utils.CacheEntry` representing one file
+        - a `list` of `str` file paths or :class:`~lal.utils.CacheEntry`
 
     tablename : `str`
         name of the table to read.

--- a/gwpy/spectrogram/core.py
+++ b/gwpy/spectrogram/core.py
@@ -236,17 +236,24 @@ class Spectrogram(Array2D):
 
         Parameters
         ----------
-        source : `str`, :class:`~glue.lal.Cache`
-            source of data, any of the following:
+        source : `str`, `list`
+            Source of data, any of the following:
 
-            - `str` path of single data file
-            - `str` path of LAL-format cache file
-            - :class:`~glue.lal.Cache` describing one or more data files,
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
+
+        *args
+            Other arguments are (in general) specific to the given
+            ``format``.
 
         format : `str`, optional
-            source format identifier. If not given, the format will be
+            Source format identifier. If not given, the format will be
             detected if possible. See below for list of acceptable
-            formats
+            formats.
+
+        **kwargs
+            Other keywords are (in general) specific to the given ``format``.
 
         Returns
         -------

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -186,8 +186,8 @@ def filter_empty_files(files, ifo=None):
 
     Parameters
     ----------
-    files : `list` of `str`, :class:`~glue.lal.Cache`
-        a list of file paths to test
+    files : `list`
+        A list of file paths to test.
 
     ifo : `str`, optional
         prefix for the interferometer of interest (e.g. ``'L1'``),

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -84,8 +84,12 @@ class EventTable(Table):
 
         Parameters
         ----------
-        source : `str`, `list`, :class:`~glue.lal.Cache`
-            file or list of files from which to read events
+        source : `str`, `list`
+            Source of data, any of the following:
+
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
 
         *args
             other positional arguments will be passed directly to the

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -35,8 +35,6 @@ import numpy
 
 import pytest
 
-from glue.lal import Cache
-
 from gwpy.io import (cache as io_cache,
                      datafind as io_datafind,
                      gwf as io_gwf,
@@ -207,21 +205,13 @@ class TestIoCache(object):
             pytest.skip(str(e))
 
         segs = SegmentList()
-        cache = Cache()
+        cache = []
         for seg in [(0, 1), (1, 2), (4, 5)]:
             d = seg[1] - seg[0]
             f = 'A-B-%d-%d.tmp' % (seg[0], d)
             cache.append(CacheEntry.from_T050017(f, coltype=int))
             segs.append(Segment(*seg))
         return cache, segs
-
-    @staticmethod
-    def write_cache(cache, f):
-        for entry in cache:
-            try:
-                print(str(entry), file=f)
-            except TypeError:
-                f.write(('%s\n' % str(entry)).encode('utf-8'))
 
     def test_read_write_cache(self):
         cache = self.make_cache()[0]
@@ -240,27 +230,23 @@ class TestIoCache(object):
             c3 = io_cache.read_cache(f.name)
             assert cache == c3
 
+    @pytest.mark.parametrize('input_, result', [
+        (None, False),
+        ([], False),
+        (['A-B-12345-6.txt'], True),
+    ])
+    def test_is_cache(self, input_, result):
+        assert io_cache.is_cache(input_) is result
+
     @utils.skip_missing_dependency('lal.utils')
-    def test_is_cache(self):
-        # sanity check
-        assert io_cache.is_cache(None) is False
+    def test_is_cache_lal(self):
+        cache = [io_cache.CacheEntry.from_T050017('/tmp/A-B-12345-6.txt')]
+        assert io_cache.is_cache(cache)
+        assert not io_cache.is_cache(cache + [None])
 
-        # make sure Cache is returned as True
-        cache = io_cache.Cache()
-        assert io_cache.is_cache(cache) is True
-
-        # check file(path) is return as True if parsed as Cache
-        cache.append(io_cache.CacheEntry.from_T050017('/tmp/A-B-12345-6.txt'))
-        with tempfile.NamedTemporaryFile() as f:
-            # empty file should return False
-            assert io_cache.is_cache(f) is False
-            assert io_cache.is_cache(f.name) is False
-
-            # cache file should return True
-            io_cache.write_cache(cache, f)
-            f.seek(0)
-            assert io_cache.is_cache(f) is True
-            assert io_cache.is_cache(f.name) is True
+    @utils.skip_missing_dependency('glue.lal')
+    def test_is_cache_glue(self):
+        assert io_cache.is_cache(io_cache.Cache())
 
         # check ASCII file gets returned as False
         a = numpy.array([[1, 2], [3, 4]])
@@ -269,19 +255,30 @@ class TestIoCache(object):
             f.seek(0)
             assert io_cache.is_cache(f) is False
 
-        # check HDF5 file gets returned as False
+    @utils.skip_missing_dependency('lal.utils')
+    def test_is_cache_file(self):
+        # check file(path) is return as True if parsed as Cache
+        e = io_cache.CacheEntry.from_T050017('/tmp/A-B-12345-6.txt')
+        with tempfile.NamedTemporaryFile() as f:
+            # empty file should return False
+            assert io_cache.is_cache(f) is False
+            assert io_cache.is_cache(f.name) is False
+
+            # cache file should return True
+            io_cache.write_cache([e], f)
+            f.seek(0)
+            assert io_cache.is_cache(f) is True
+            assert io_cache.is_cache(f.name) is True
+
+    def test_is_cache_entry(self):
+        assert io_cache.is_cache_entry('/tmp/A-B-12345-6.txt')
+        assert not io_cache.is_cache_entry('random-file-name.blah')
         try:
-            import h5py
-        except ImportError:
+            e = io_cache.CacheEntry.from_T050017('/tmp/A-B-12345-6.txt')
+        except AttributeError:
             pass
         else:
-            fp = tempfile.mktemp()
-            try:
-                h5py.File(fp, 'w').close()
-                assert io_cache.is_cache(fp) is False
-            finally:
-                if os.path.isfile(fp):
-                    os.remove(fp)
+            assert io_cache.is_cache_entry(e)
 
     def test_file_list(self):
         cache = self.make_cache()[0]
@@ -297,13 +294,13 @@ class TestIoCache(object):
         with tempfile.NamedTemporaryFile(suffix='.lcf', mode='w') as f:
             io_cache.write_cache(cache, f)
             f.seek(0)
-            assert io_cache.file_list(f.name) == cache.pfnlist()
+            assert io_cache.file_list(f.name) == [e.path for e in cache]
 
         # test comma-separated list -> list
         assert io_cache.file_list('A,B,C,D') == ['A', 'B', 'C', 'D']
 
         # test cache object -> pfnlist
-        assert io_cache.file_list(cache) == cache.pfnlist()
+        assert io_cache.file_list(cache) == [e.path for e in cache]
 
         # test list -> list
         assert io_cache.file_list(['A', 'B', 'C', 'D']) == ['A', 'B', 'C', 'D']
@@ -384,7 +381,9 @@ class TestIoCache(object):
         a, segs = self.make_cache()
         segs.coalesce()
         for i, cache in enumerate(io_cache.find_contiguous(a)):
-            assert cache.to_segmentlistdict()['A'].extent() == segs[i]
+            io_cache.cache_segments(cache).extent() == segs[i]
+
+        assert not list(io_cache.find_contiguous())
 
 
 # -- gwpy.io.gwf --------------------------------------------------------------

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -385,6 +385,15 @@ class TestIoCache(object):
 
         assert not list(io_cache.find_contiguous())
 
+    def test_sieve(self):
+        cache, segs = self.make_cache()
+        sieved = io_cache.sieve(cache, segs[0])
+        assert type(sieved) is type(cache)
+        assert sieved == cache[:1]
+
+        segs.coalesce()
+        assert io_cache.sieve(cache, segs[0]) == cache[:2]
+
 
 # -- gwpy.io.gwf --------------------------------------------------------------
 

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -46,8 +46,6 @@ use('agg')  # nopep8
 from astropy import units
 from astropy.io.registry import (get_reader, register_reader)
 
-from glue.lal import Cache
-
 from gwpy.detector import Channel
 from gwpy.time import (Time, LIGOTimeGPS)
 from gwpy.timeseries import (TimeSeriesBase, TimeSeriesBaseDict,
@@ -648,13 +646,13 @@ class TestTimeSeries(TestTimeSeriesBase):
                 with pytest.warns(DeprecationWarning):
                     type(array).read(f, array.name, format=api)
 
-            # check reading from cache
+            # check reading from multiple files
             a2 = self.create(name='TEST', t0=array.span[1], dt=array.dx)
             suffix = '-%d-%d.gwf' % (a2.t0.value, a2.duration.value)
             with tempfile.NamedTemporaryFile(prefix='GWpy-',
                                              suffix=suffix) as f2:
                 a2.write(f2.name)
-                cache = Cache.from_urls([f.name, f2.name], coltype=int)
+                cache = [f.name, f2.name]
                 comb = type(array).read(cache, 'TEST', format=fmt, nproc=2)
                 utils.assert_quantity_sub_equal(
                     comb, array.append(a2, inplace=False),

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -24,6 +24,7 @@ import os
 import pytest
 import tempfile
 from itertools import (chain, product)
+from ssl import SSLError
 
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import URLError
@@ -36,7 +37,6 @@ try:
     from numpy import shares_memory
 except ImportError:  # old numpy
     from numpy import may_share_memory as shares_memory
-
 
 from scipy import signal
 
@@ -109,6 +109,8 @@ LOSC_GW150914_DQ_BITS = {
         'BURST_CAT3',
     ],
 }
+
+LOSC_FETCH_ERROR = (URLError, SSLError)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -542,7 +544,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         try:
             return self.TEST_CLASS.fetch_open_data(
                 LOSC_IFO, *LOSC_GW150914_SEGMENT)
-        except URLError as e:
+        except LOSC_FETCH_ERROR as e:
             pytest.skip(str(e))
 
     @pytest.fixture(scope='class')
@@ -550,7 +552,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         try:
             return self.TEST_CLASS.fetch_open_data(
                 LOSC_IFO, *LOSC_GW150914_SEGMENT, sample_rate=16384)
-        except URLError as e:
+        except LOSC_FETCH_ERROR as e:
             pytest.skip(str(e))
 
     # -- test class functionality ---------------
@@ -709,7 +711,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         try:
             ts = self.TEST_CLASS.fetch_open_data(
                 LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, verbose=True)
-        except URLError as e:
+        except LOSC_FETCH_ERROR as e:
             pytest.skip(str(e))
         utils.assert_quantity_sub_equal(ts, losc, exclude=['name', 'unit'])
 
@@ -732,7 +734,7 @@ class TestTimeSeries(TestTimeSeriesBase):
             assert str(exc.value).lower().startswith('multiple losc url tags')
             self.TEST_CLASS.fetch_open_data(LOSC_IFO, 1187008880, 1187008884,
                                             tag='CLN')
-        except URLError:
+        except LOSC_FETCH_ERROR:
             pass
 
     @utils.skip_missing_dependency('nds2')
@@ -1350,7 +1352,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         try:
             tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
             tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-        except URLError as exc:
+        except LOSC_FETCH_ERROR as exc:
             pytest.skip(str(exc))
         coh = tsh.coherence(tsl, fftlength=1.0)
         assert coh.df == 1 * units.Hz
@@ -1360,7 +1362,7 @@ class TestTimeSeries(TestTimeSeriesBase):
         try:
             tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
             tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-        except URLError as exc:
+        except LOSC_FETCH_ERROR as exc:
             pytest.skip(str(exc))
         cohsg = tsh.coherence_spectrogram(tsl, 4, fftlength=1.0)
         assert cohsg.t0 == tsh.t0
@@ -1633,7 +1635,7 @@ class TestStateVector(TestTimeSeriesBase):
         try:
             sv = self.TEST_CLASS.fetch_open_data(
                 LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, version=1)
-        except URLError as e:
+        except LOSC_FETCH_ERROR as e:
             pytest.skip(str(e))
         utils.assert_quantity_sub_equal(
             sv,

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -235,12 +235,12 @@ class TimeSeriesBase(Series):
 
         Parameters
         ----------
-        source : `str`, :class:`~glue.lal.Cache`
-            source of data, any of the following:
+        source : `str`, `list`
+            Source of data, any of the following:
 
-            - `str` path of single data file
-            - `str` path of LAL-format cache file
-            - :class:`~glue.lal.Cache` describing one or more data files,
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
 
         name : `str`, `~gwpy.detector.Channel`
             the name of the channel to read, or a `Channel` object.
@@ -261,12 +261,6 @@ class TimeSeriesBase(Series):
         nproc : `int`, optional
             number of parallel processes to use, serial process by
             default.
-
-            .. note::
-
-               Parallel frame reading, via the ``nproc`` keyword argument,
-               is only available when giving a :class:`~glue.lal.Cache` of
-               frames, or using the ``format='cache'`` keyword argument.
 
         gap : `str`, optional
             how to handle gaps in the cache, one of
@@ -844,9 +838,12 @@ class TimeSeriesBaseDict(OrderedDict):
 
         Parameters
         ----------
-        source : `str`, :class:`~glue.lal.Cache`
-            a single file path `str`, or a :class:`~glue.lal.Cache` containing
-            a contiguous list of files.
+        source : `str`, `list`
+            Source of data, any of the following:
+
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
 
         channels : `~gwpy.detector.channel.ChannelList`, `list`
             a list of channels to read from the source.
@@ -867,12 +864,6 @@ class TimeSeriesBaseDict(OrderedDict):
         nproc : `int`, optional
             number of parallel processes to use, serial process by
             default.
-
-            .. note::
-
-               Parallel frame reading, via the ``nproc`` keyword argument,
-               is only available when giving a :class:`~glue.lal.Cache` of
-               frames, or using the ``format='cache'`` keyword argument.
 
         gap : `str`, optional
             how to handle gaps in the cache, one of

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""I/O utilities for reading `TimeSeries` from a :class:`~glue.lal.Cache`
+"""I/O utilities for reading `TimeSeries` from a `list` of file paths.
 """
 
 from six import string_types
@@ -28,29 +28,28 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 
 def preformat_cache(cache, start=None, end=None):
-    """Preprocess a :class:`~glue.lal.Cache` for reading
+    """Preprocess a `list` of file paths for reading.
 
     - read the cache from the file (if necessary)
     - sieve the cache to only include data we need
 
     Parameters
     ----------
-    cache : :class:`glue.lal.Cache`, `str`
-        cache of GWF frame files, or path to a LAL-format cache file
-        on disk
+    cache : `list`, `str`
+        List of file paths, or path to a LAL-format cache file on disk.
 
     start : `~gwpy.time.LIGOTimeGPS`, `float`, `str`, optional
         GPS start time of required data, defaults to start of data found;
-        any input parseable by `~gwpy.time.to_gps` is fine
+        any input parseable by `~gwpy.time.to_gps` is fine.
 
     end : `~gwpy.time.LIGOTimeGPS`, `float`, `str`, optional
         GPS end time of required data, defaults to end of data found;
-        any input parseable by `~gwpy.time.to_gps` is fine
+        any input parseable by `~gwpy.time.to_gps` is fine.
 
     Returns
     -------
-    modcache : :class:`~glue.lal.Cache`
-        a parsed, sieved cache based on the input arguments
+    modcache : `list`
+        A parsed, sieved list of paths based on the input arguments.
     """
     # format cache file
     if isinstance(cache, FILE_LIKE + string_types):  # open cache file

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -21,7 +21,7 @@
 
 from six import string_types
 
-from ...io.cache import (read_cache, FILE_LIKE)
+from ...io.cache import (FILE_LIKE, read_cache, sieve)
 from ...segments import Segment
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -64,4 +64,4 @@ def preformat_cache(cache, start=None, end=None):
     if end is None:  # end time of latest file
         end = cache[-1].segment[-1]
 
-    return cache.sieve(segment=Segment(start, end))  # sieve
+    return sieve(cache, segment=Segment(start, end))  # sieve

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -59,8 +59,8 @@ def preformat_cache(cache, start=None, end=None):
 
     # get timing
     if start is None:  # start time of earliest file
-        start = cache[0].segment[0]
+        start = file_segment(cache[0])[0]
     if end is None:  # end time of latest file
-        end = cache[-1].segment[-1]
+        end = file_segment(cache[-1])[-1]
 
     return sieve(cache, segment=Segment(start, end))  # sieve

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -21,7 +21,7 @@
 
 from six import string_types
 
-from ...io.cache import (FILE_LIKE, read_cache, sieve)
+from ...io.cache import (FILE_LIKE, read_cache, file_segment, sieve)
 from ...segments import Segment
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -55,7 +55,7 @@ def preformat_cache(cache, start=None, end=None):
     if isinstance(cache, FILE_LIKE + string_types):  # open cache file
         cache = read_cache(cache)
     cache = type(cache)(cache)  # copy cache
-    cache.sort(key=lambda e: e.segment)  # sort
+    cache.sort(key=file_segment)  # sort
 
     # get timing
     if start is None:  # start time of earliest file

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -38,15 +38,12 @@ from six import string_types
 
 import numpy
 
-from astropy.io.registry import (get_formats, get_reader, get_writer)
-
-from glue.lal import Cache
+from astropy.io.registry import (get_reader, get_writer)
 
 from ....segments import Segment
 from ....time import to_gps
 from ....io.gwf import identify_gwf
-from ....io.cache import (FILE_LIKE, read_cache as read_cache_file,
-                          find_contiguous)
+from ....io import cache as io_cache
 from ....io.registry import (register_reader,
                              register_writer,
                              register_identifier)
@@ -143,7 +140,7 @@ def get_default_gwf_api():
     for lib in APIS:
         try:
             import_gwf_library(lib)
-        except ImportError as e:
+        except ImportError:
             continue
         else:
             return lib
@@ -188,11 +185,12 @@ def register_gwf_api(library):
 
         Parameters
         ----------
-        source : `str`, :class:`glue.lal.Cache`, `list`
-            data source object, one of:
+        source : `str`, `list`
+            Source of data, any of the following:
 
-            - `str` : frame file path
-            - :class:`glue.lal.Cache`, `list` : contiguous list of frame paths
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
 
         channels : `list`
             list of channel names (or `Channel` objects) to read from frame.
@@ -246,15 +244,15 @@ def register_gwf_api(library):
 
         # read cache file up-front
         if (isinstance(source, string_types) and
-                source.endswith(('.lcf', '.cache'))) or (
-                    isinstance(source, FILE_LIKE) and
-                    source.name.endswith(('.lcf', '.cache'))):
-            source = read_cache_file(source)
+                    source.endswith(('.lcf', '.cache'))) or (
+                isinstance(source, io_cache.FILE_LIKE) and
+                source.name.endswith(('.lcf', '.cache'))):
+            source = io_cache.read_cache(source)
         # separate cache into contiguous segments
-        if isinstance(source, Cache):
+        if io_cache.is_cache(source):
             if start is not None and end is not None:
-                source = source.sieve(segment=Segment(start, end))
-            source = list(find_contiguous(source))
+                source = io_cache.sieve(source, segment=Segment(start, end))
+            source = list(io_cache.find_contiguous(source))
         # convert everything else into a list if needed
         if not isinstance(source, (list, tuple)):
             source = [source]

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -244,9 +244,9 @@ def register_gwf_api(library):
 
         # read cache file up-front
         if (isinstance(source, string_types) and
-                    source.endswith(('.lcf', '.cache'))) or (
-                isinstance(source, io_cache.FILE_LIKE) and
-                source.name.endswith(('.lcf', '.cache'))):
+                source.endswith(('.lcf', '.cache'))) or (
+                    isinstance(source, io_cache.FILE_LIKE) and
+                    source.name.endswith(('.lcf', '.cache'))):
             source = io_cache.read_cache(source)
         # separate cache into contiguous segments
         if io_cache.is_cache(source):

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -527,12 +527,12 @@ class StateVector(TimeSeriesBase):
 
         Parameters
         ----------
-        source : `str`, :class:`~glue.lal.Cache`
-            source of data, any of the following:
+        source : `str`, `list`
+            Source of data, any of the following:
 
-            - `str` path of single data file
-            - `str` path of LAL-format cache file
-            - :class:`~glue.lal.Cache` describing one or more data files,
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
 
         channel : `str`, `~gwpy.detector.Channel`
             the name of the channel to read, or a `Channel` object.
@@ -557,12 +557,6 @@ class StateVector(TimeSeriesBase):
         nproc : `int`, optional, default: `1`
             number of parallel processes to use, serial process by
             default.
-
-            .. note::
-
-               Parallel frame reading, via the ``nproc`` keyword argument,
-               is only available when giving a :class:`~glue.lal.Cache` of
-               frames, or using the ``format='cache'`` keyword argument.
 
         gap : `str`, optional
             how to handle gaps in the cache, one of
@@ -883,9 +877,12 @@ class StateVectorDict(TimeSeriesBaseDict):
 
         Parameters
         ----------
-        source : `str`, :class:`~glue.lal.Cache`
-            a single file path `str`, or a :class:`~glue.lal.Cache` containing
-            a contiguous list of files.
+        source : `str`, `list`
+            Source of data, any of the following:
+
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
 
         channels : `~gwpy.detector.channel.ChannelList`, `list`
             a list of channels to read from the source.
@@ -910,12 +907,6 @@ class StateVectorDict(TimeSeriesBaseDict):
         nproc : `int`, optional, default: ``1``
             number of parallel processes to use, serial process by
             default.
-
-            .. note::
-
-               Parallel frame reading, via the ``nproc`` keyword argument,
-               is only available when giving a :class:`~glue.lal.Cache` of
-               frames, or using the ``format='cache'`` keyword argument.
 
         gap : `str`, optional
             how to handle gaps in the cache, one of

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -344,17 +344,24 @@ class Series(Array):
 
         Parameters
         ----------
-        source : `str`, :class:`~glue.lal.Cache`
-            source of data, any of the following:
+        source : `str`, `list`
+            Source of data, any of the following:
 
-            - `str` path of single data file
-            - `str` path of LAL-format cache file
-            - :class:`~glue.lal.Cache` describing one or more data files,
+            - `str` path of single data file,
+            - `str` path of LAL-format cache file,
+            - `list` of paths.
+
+        *args
+            Other arguments are (in general) specific to the given
+            ``format``.
 
         format : `str`, optional
-            source format identifier. If not given, the format will be
+            Source format identifier. If not given, the format will be
             detected if possible. See below for list of acceptable
-            formats
+            formats.
+
+        **kwargs
+            Other keywords are (in general) specific to the given ``format``.
 
         Returns
         -------


### PR DESCRIPTION
This PR removes any direct dependency on the `glue.lal.Cache` object, which has a complicated set up now that the `CacheEntry` is part of `lal.utils`.

This reduces our overall dependency on `glue` itself, meaning when we can move to using `ligo.segments`, we might be able to not rely on that package at all.