### PR TITLE
Catch `IndexError` from pickle.loads

### DIFF
--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -662,9 +662,14 @@ class TestTimeSeries(TestTimeSeriesBase):
 
     @utils.skip_missing_dependency('h5py')
     @pytest.mark.parametrize('ext', ('hdf5', 'h5'))
-    def test_read_write_hdf5(self, ext):
+    @pytest.mark.parametrize('channel', [
+        None,
+        'test',
+        'X1:TEST-CHANNEL',
+    ])
+    def test_read_write_hdf5(self, ext, channel):
         array = self.create()
-        array.channel = 'X1:TEST-CHANNEL'
+        array.channel = channel
 
         with tempfile.NamedTemporaryFile(suffix='.%s' % ext) as f:
             # check array with no name fails

--- a/gwpy/types/io/hdf5.py
+++ b/gwpy/types/io/hdf5.py
@@ -77,7 +77,8 @@ def _unpickle_channel(raw):
     """
     try:
         return pickle.loads(raw)
-    except (ValueError, pickle.UnpicklingError, EOFError, TypeError) as exc:
+    except (ValueError, pickle.UnpicklingError, EOFError, TypeError,
+            IndexError) as exc:
         # maybe not pickled
         if isinstance(raw, bytes):
             raw = raw.decode('utf-8')


### PR DESCRIPTION
This PR improves the error handling inside `gwpy.types.io.hdf5.read_hdf5_array` to handle an `IndexError` raised by `pickle.loads`, which will happen whenever a channel name is stored in HDF5 as text without any delimiters:

```python
>>> from gwpy.timeseries import TimeSeries
>>> a = TimeSeries([1, 2, 3], channel='test')
>>> a.write('test.h5', path='/test', overwrite=True)
>>> TimeSeries.read('test.h5')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
...
  File "/Users/duncan/Library/Python/2.7/lib/python/site-packages/gwpy/timeseries/io/hdf5.py", line 42, in read_hdf5_timeseries
    series = read_hdf5_array(h5f, path=path, **kwargs)
  File "/Users/duncan/Library/Python/2.7/lib/python/site-packages/gwpy/io/hdf5.py", line 59, in decorated_func
    return func(h5f, *args, **kwargs)
  File "/Users/duncan/Library/Python/2.7/lib/python/site-packages/gwpy/types/io/hdf5.py", line 65, in read_hdf5_array
    attrs['channel'] = _unpickle_channel(attrs['channel'])
  File "/Users/duncan/Library/Python/2.7/lib/python/site-packages/gwpy/types/io/hdf5.py", line 79, in _unpickle_channel
    return pickle.loads(raw)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 1388, in loads
    return Unpickler(file).load()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 864, in load
    dispatch[key](self)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 1000, in load_tuple
    k = self.marker()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 880, in marker
    while stack[k] is not mark: k = k-1
IndexError: list index out of range
```