### PR TITLE
Use ligo/base docker images during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ sudo: false
 
 env:
   global:
-    secure: KXq3Kn+i5pDl7ApqYkMKAZlxC7OOLDmiBn46t/JYKyRAchacp1PR84vrwTNj7OfhZek0tlTkKwQtwpFaw6llhYSpB9xl9SsPNmoYsBtZb9zC8z/oRXlXgYudesPSt7cltlt0K21pV9gRflOezRjlJRDoccbw3pe90vYpMdvr7+0=
+    - PIP_FLAGS="--quiet"
+    - secure: KXq3Kn+i5pDl7ApqYkMKAZlxC7OOLDmiBn46t/JYKyRAchacp1PR84vrwTNj7OfhZek0tlTkKwQtwpFaw6llhYSpB9xl9SsPNmoYsBtZb9zC8z/oRXlXgYudesPSt7cltlt0K21pV9gRflOezRjlJRDoccbw3pe90vYpMdvr7+0=
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,7 @@ script:  # run tests
 
 after_success:
   # submit coverage results
-  - pip install coveralls
+  - pip install --quiet coveralls
   - sed -i 's|"'${GWPY_PATH}'|"'`pwd`'|g' .coverage
   - coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,36 +76,36 @@ matrix:
     # -- reference OS builds --------------------
 
     # EL7
-    - env: DOCKER_IMAGE="ligo/software:el7"
+    - env: DOCKER_IMAGE="ligo/base:el7"
       python: '2.7'
       sudo: required
       services:
         - docker
-    - env: DOCKER_IMAGE="ligo/software:el7"
+    - env: DOCKER_IMAGE="ligo/base:el7"
       python: '3.4'
       sudo: required
       services:
         - docker
 
     # debian 8
-    - env: DOCKER_IMAGE="ligo/software:jessie"
+    - env: DOCKER_IMAGE="ligo/base:jessie"
       python: '2.7'
       sudo: required
       services:
         - docker
-    - env: DOCKER_IMAGE="ligo/software:jessie"
+    - env: DOCKER_IMAGE="ligo/base:jessie"
       python: '3.4'
       sudo: required
       services:
         - docker
 
     # debian 9
-    - env: DOCKER_IMAGE="ligo/software:stretch"
+    - env: DOCKER_IMAGE="ligo/base:stretch"
       python: '2.7'
       sudo: required
       services:
         - docker
-    - env: DOCKER_IMAGE="ligo/software:stretch"
+    - env: DOCKER_IMAGE="ligo/base:stretch"
       python: '3.5'
       sudo: required
       services:
@@ -120,12 +120,12 @@ matrix:
 
     # -- full build -----------------------------
 
-    - env: DOCKER_IMAGE="ligo/software:stretch" EXTRAS=true
+    - env: DOCKER_IMAGE="ligo/base:stretch" EXTRAS=true
       python: '2.7'
       sudo: required
       services:
         - docker
-    - env: DOCKER_IMAGE="ligo/software:stretch" EXTRAS=true
+    - env: DOCKER_IMAGE="ligo/base:stretch" EXTRAS=true
       python: '3.5'
       sudo: required
       services:
@@ -133,11 +133,11 @@ matrix:
 
   allow_failures:
     - env: PIP_FLAGS="--upgrade --pre --quiet"
-    - env: DOCKER_IMAGE="ligo/software:el7"
+    - env: DOCKER_IMAGE="ligo/base:el7"
       python: '3.4'
-    - env: DOCKER_IMAGE="ligo/software:jessie"
+    - env: DOCKER_IMAGE="ligo/base:jessie"
       python: '3.4'
-    - env: DOCKER_IMAGE="ligo/software:stretch" EXTRAS=true
+    - env: DOCKER_IMAGE="ligo/base:stretch" EXTRAS=true
       python: '3.5'
 
   fast_finish: true

--- a/ci/docker-install.sh
+++ b/ci/docker-install.sh
@@ -45,7 +45,7 @@ sudo docker run \
     --env PYTHON_VERSION="${TRAVIS_PYTHON_VERSION}" \
     --env GWPY_PATH="${GWPY_PATH}" \
     --env EXTRAS="${EXTRAS}" \
-    --volume `pwd`:${GWPY_PATH}:rw \
+    --volume $(pwd):${GWPY_PATH}:rw \
     ${DOCKER_IMAGE}
 
 sleep 5

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -107,3 +107,8 @@ for pckg in \
 ; do
     apt-get -yqq install $pckg || true
 done
+
+# HACK: fix missing file from ldas-tools-framecpp
+if [ ! -f /usr/lib/$PYTHON/dist-packages/LDAStools/__init__.py ]; then
+    touch /usr/lib/$PYTHON/dist-packages/LDAStools/__init__.py
+fi

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -109,6 +109,7 @@ for pckg in \
 done
 
 # HACK: fix missing file from ldas-tools-framecpp
-if [ ! -f /usr/lib/$PYTHON/dist-packages/LDAStools/__init__.py ]; then
+if [ -d /usr/lib/$PYTHON/dist-packages/LDAStools/ -a \
+     ! -f /usr/lib/$PYTHON/dist-packages/LDAStools/__init__.py ]; then
     touch /usr/lib/$PYTHON/dist-packages/LDAStools/__init__.py
 fi

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -48,7 +48,7 @@ apt-get -yq install \
     python-jinja2 \
 
 # get versions
-GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
+GWPY_VERSION=$(python setup.py --version)
 GWPY_RELEASE=${GWPY_VERSION%%+*}
 
 # upgrade setuptools for development builds only to prevent version munging

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -21,7 +21,7 @@
 #
 
 # enable lscsoft jessie-proposed (first required for python-tqdm gwpy/gwpy#735)
-if [[ `cat /etc/debian_version` == "8."* ]]; then
+if [ "${OS_VERSION}" -eq 8 ]; then
     cat << EOF > /etc/apt/sources.list.d/lscsoft-proposed.list
 deb http://software.ligo.org/lscsoft/debian jessie-proposed contrib
 EOF

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -72,6 +72,11 @@ yum -yq install \
     h5py \
 || true
 
+# HACK: fix missing file from ldas-tools-framecpp
+if [ ! -f /usr/lib64/$PYTHON/site-packages/LDAStools/__init__.py ]; then
+    touch /usr/lib64/$PYTHON/site-packages/LDAStools/__init__.py
+fi
+
 # install system-level extras that might use python2- prefix
 if [ ${PY_XY} -lt 30 ]; then
     yum -yq install python2-root

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -61,10 +61,10 @@ if [ ${PY_XY} -lt 30 ]; then
 else
     GWPY_RPM="dist/noarch/python*-gwpy-*.noarch.rpm"  # install both 2 and 3
 fi
-yum -y --nogpgcheck localinstall ${GWPY_RPM}
+yum -yq --nogpgcheck localinstall ${GWPY_RPM}
 
 # install system-level extras
-yum -y install \
+yum -yq install \
     nds2-client-${PY_PREFIX} \
     ldas-tools-framecpp-${PY_PREFIX} \
     lalframe-${PY_PREFIX} \
@@ -74,7 +74,7 @@ yum -y install \
 
 # install system-level extras that might use python2- prefix
 if [ ${PY_XY} -lt 30 ]; then
-    yum -y install python2-root
+    yum -yq install python2-root
 else
-    yum -y install ${PY_PREFIX}-root
+    yum -yq install ${PY_PREFIX}-root
 fi

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -24,7 +24,7 @@
 yum -yq update
 yum -yq install rpm-build git2u python-jinja2 ${PY_PREFIX}-jinja2
 
-GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
+GWPY_VERSION=$(python setup.py --version)
 
 # upgrade setuptools for development builds only to prevent version munging
 if [[ "${GWPY_VERSION}" == *"+"* ]]; then

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -73,7 +73,8 @@ yum -yq install \
 || true
 
 # HACK: fix missing file from ldas-tools-framecpp
-if [ ! -f /usr/lib64/$PYTHON/site-packages/LDAStools/__init__.py ]; then
+if [ -d /usr/lib64/$PYTHON/site-packages/LDAStools -a \
+     ! -f /usr/lib64/$PYTHON/site-packages/LDAStools/__init__.py ]; then
     touch /usr/lib64/$PYTHON/site-packages/LDAStools/__init__.py
 fi
 

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -21,10 +21,8 @@
 #
 
 # update system
-yum clean all
-yum makecache
-yum -y update
-yum -y install rpm-build git2u python-jinja2 ${PY_PREFIX}-jinja2
+yum -yq update
+yum -yq install rpm-build git2u python-jinja2 ${PY_PREFIX}-jinja2
 
 GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
 
@@ -36,14 +34,15 @@ fi
 # upgrade GitPython (required for git>=2.15.0)
 pip install "GitPython>=2.1.8"
 
-# build the RPM
-python setup.py bdist_rpm
+# build the RPM using tarball
+python setup.py sdist
+rpmbuild --define "_rpmdir $(pwd)/dist" -tb dist/gwpy-*.tar.gz
 
 # install the rpm
 if [ ${PY_XY} -lt 30 ]; then
-    GWPY_RPM="dist/python2-gwpy-*.noarch.rpm"  # install python2 only
+    GWPY_RPM="dist/noarch/python2-gwpy-*.noarch.rpm"  # install python2 only
 else
-    GWPY_RPM="dist/python*-gwpy-*.noarch.rpm"  # install both 2 and 3
+    GWPY_RPM="dist/noarch/python*-gwpy-*.noarch.rpm"  # install both 2 and 3
 fi
 yum -y --nogpgcheck localinstall ${GWPY_RPM}
 

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -20,9 +20,28 @@
 # Build RedHat (Enterprise Linux) packages
 #
 
+# get python3 version
+. ci/lib.sh
+PYTHON3_VERSION=$(get_python3_version)
+PY3XY=${PYTHON3_VERSION/./}
+
 # update system
 yum -yq update
-yum -yq install rpm-build git2u python-jinja2 ${PY_PREFIX}-jinja2
+
+# install sdist dependencies
+yum -yq install \
+    rpm-build \
+    git \
+    python2-pip \
+    python-jinja2 \
+    GitPython
+
+# install build dependencies
+yum -yq install \
+    python-rpm-macros \
+    python3-rpm-macros \
+    python2-setuptools \
+    python${PY3XY}-setuptools
 
 GWPY_VERSION=$(python setup.py --version)
 
@@ -30,9 +49,6 @@ GWPY_VERSION=$(python setup.py --version)
 if [[ "${GWPY_VERSION}" == *"+"* ]]; then
     pip install "setuptools>=25"
 fi
-
-# upgrade GitPython (required for git>=2.15.0)
-pip install "GitPython>=2.1.8"
 
 # build the RPM using tarball
 python setup.py sdist

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -39,6 +39,7 @@ yum -yq install \
 # install build dependencies
 yum -yq install \
     python-rpm-macros \
+    epel-rpm-macros \
     python3-rpm-macros \
     python2-setuptools \
     python${PY3XY}-setuptools

--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -46,13 +46,13 @@ $PYTHON setup.py sdist
 $PYTHON setup.py port --tarball dist/gwpy-${GWPY_VERSION}.tar.gz
 
 # create mock portfile repo and install
-PORT_REPO=`pwd`/ports
+PORT_REPO=$(pwd)/ports
 GWPY_PORT_PATH=${PORT_REPO}/python/py-gwpy
 mkdir -p ${GWPY_PORT_PATH}
 cp Portfile ${GWPY_PORT_PATH}/
 
 # munge Portfile for local install
-gsed -i 's|pypi:g/gwpy|file://'`pwd`'/dist/ \\\n                    pypi:g/gwpy|' ${GWPY_PORT_PATH}/Portfile
+gsed -i 's|pypi:g/gwpy|file://'$(pwd)'/dist/ \\\n                    pypi:g/gwpy|' ${GWPY_PORT_PATH}/Portfile
 
 # add local port repo to sources
 sudo gsed -i 's|rsync://rsync.macports|file://'${PORT_REPO}'\nrsync://rsync.macports|' /opt/local/etc/macports/sources.conf
@@ -90,7 +90,7 @@ sudo port -N install \
     ${PY_PREFIX}-beautifulsoup4
 
 # install m2cyrpto if needed
-if [ "`port info --version dqsegdb`" == "version: 1.4.0" ]; then
+if [ "$(port info --version dqsegdb)" == "version: 1.4.0" ]; then
     sudo port -N install ${PY_PREFIX}-m2crypto
 fi
 

--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -41,7 +41,7 @@ sudo port -N install \
 
 # make Portfile
 cd ${GWPY_PATH}
-GWPY_VERSION=`python setup.py version | grep Version | cut -d\  -f2`
+GWPY_VERSION=$(python setup.py --version)
 $PYTHON setup.py sdist
 $PYTHON setup.py port --tarball dist/gwpy-${GWPY_VERSION}.tar.gz
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -24,7 +24,6 @@ cd ${GWPY_PATH}
 
 . ci/lib.sh
 
-get_python_version 1> /dev/null
 get_environment
 
 set -x

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -49,7 +49,7 @@ if [ ${EXTRAS} ]; then
     ${PIP} install -r requirements-dev.txt --quiet ${PIP_FLAGS}
 
     # install root_numpy if pyroot is installed for this python version
-    _rootpyv=`root-config --python-version 2> /dev/null || true`
+    _rootpyv=$(root-config --python-version 2> /dev/null || true)
     if [[ "${_rootpyv}" == "${PYTHON_VERSION}" ]]; then
         NO_ROOT_NUMPY_TMVA=1 ${PIP} install root_numpy --quiet ${PIP_FLAGS}
     fi
@@ -58,7 +58,7 @@ fi
 set +x
 
 cd /tmp
-_gwpyloc=`${PYTHON} -c 'import gwpy; print(gwpy.__file__)'`
+_gwpyloc=$(${PYTHON} -c 'import gwpy; print(gwpy.__file__)')
 echo "------------------------------------------------------------------------"
 echo
 echo "GWpy installed to $_gwpyloc"

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -109,7 +109,7 @@ install_package() {
 
 get_python_version() {
     if [ -z "${PYTHON_VERSION}" ]; then
-        PYTHON_VERSION=$(python -c 'import sys; print(sys.version[:3])))')
+        PYTHON_VERSION=$(python -c 'import sys; print(sys.version[:3])')
     fi
     export PYTHON_VERSION
     echo ${PYTHON_VERSION}

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -156,31 +156,31 @@ get_environment() {
 
     export PIP="${PYTHON} -m pip"
 
-    case "$pkger" in
-        "port")
+    case "${OS_NAME}${PY_MAJOR_VERSION}" in
+        macos*)  # macports
             PY_DIST="python${PY_XY}"
             PY_PREFIX="py${PY_XY}"
             PIP="sudo ${PIP}"
             ;;
-        "apt-get")
-            if [ ${PY_MAJOR_VERSION} == 2 ]; then
-                PY_DIST="python"
-                PY_PREFIX="python"
-            else
-                PY_DIST="python${PY_MAJOR_VERSION}"
-                PY_PREFIX="python${PY_MAJOR_VERSION}"
-            fi
+        debian2)
+            PY_DIST="python"
+            PY_PREFIX="python"
             ;;
-        "yum")
-            if [ ${PY_MAJOR_VERSION} == 2 ]; then
-                PY_DIST="python"
-                PY_PREFIX="python"
-            elif [ ${PY_XY} -eq 34 ]; then
-                PY_DIST="python${PY_XY}"
-                PY_PREFIX="python${PY_XY}"
-            else
+        debian3)
+            PY_DIST="python${PY_MAJOR_VERSION}"
+            PY_PREFIX="python${PY_MAJOR_VERSION}"
+            ;;
+        centos2|rhel2|fedora2)
+            PY_DIST="python"
+            PY_PREFIX="python"
+            ;;
+        centos3|rhel3|fedora2)
+            if [ "${PYTHON_VERSION}" == "${PYTHON3_VERSION}" ]; then # IUS
                 PY_DIST="python${PY_XY}u"
                 PY_PREFIX="python${PY_XY}u"
+            else  # base repo
+                PY_DIST="python${PY_XY}"
+                PY_PREFIX="python${PY_XY}"
             fi
             ;;
     esac

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -51,24 +51,33 @@ get_os_type() {
     fi
 }
 
-get_debian_version() {
-    cat /etc/debian_version | cut -d\. -f1
+get_os_version() {
+    case "$(uname -s)" in
+        Darwin)
+            sw_vers -productVersion
+            ;;
+        *)
+            source /etc/os-release
+            echo ${VERSION_ID}
+    esac
 }
 
 get_package_manager() {
-    local ostype=`get_os_type`
-    if [ $ostype == macos ]; then
-        echo port
-    elif [[ $ostype =~ ^(centos|rhel|fedora)$ ]]; then
-        echo yum
-    else
-        echo apt-get
-    fi
+    case "$(get_os_type)" in
+        macos)
+            echo port
+            ;;
+        centos|rhel|fedora)
+            echo yum
+            ;;
+        *)
+            echo apt-get
+    esac
 }
 
 update_package_manager() {
     local pkger=`get_package_manager`
-    case "$pkger" in
+    case "$(get_package_manager)" in
         "port")
             port selfupdate
             ;;
@@ -100,48 +109,82 @@ install_package() {
 
 get_python_version() {
     if [ -z "${PYTHON_VERSION}" ]; then
-        PYTHON_VERSION=`python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))'`
+        PYTHON_VERSION=$(python -c 'import sys; print(sys.version[:3])))')
     fi
     export PYTHON_VERSION
     echo ${PYTHON_VERSION}
 }
 
+get_python2_version() {
+    echo '2.7'
+}
+
+get_python3_version() {
+    case "$(get_os_type)$(get_os_version)" in
+        centos7|debian8)
+           echo '3.4'
+           ;;
+        debian9)
+           echo '3.5'
+           ;;
+        debian10|macos*)
+           echo '3.6'
+           ;;
+        macos*)
+           echo '3.6'
+           ;;
+    esac
+}
+
 get_environment() {
-    local pkger=`get_package_manager`
-    local pyversion=`get_python_version`
-    IFS='.' read PY_MAJOR_VERSION PY_MINOR_VERSION <<< "$pyversion"
-    PY_XY="${PY_MAJOR_VERSION}${PY_MINOR_VERSION}"
-    PYTHON=python$pyversion
-    PIP="${PYTHON} -m pip"
+    local pkger=$(get_package_manager)
+
+    # OS variables
+    export OS_NAME=$(get_os_type)
+    export OS_VERSION=$(get_os_version)
+
+    # PYTHON VARIABLES
+    export PYTHON_VERSION=$(get_python_version)
+    export PYTHON="python${PYTHON_VERSION}"
+    export PYTHON2_VERSION=$(get_python2_version)
+    export PYTHON2="python${PYTHON2_VERSION}"
+    export PYTHON3_VERSION=$(get_python3_version)
+    export PYTHON3="python${PYTHON3_VERSION}"
+
+    IFS='.' read PY_MAJOR_VERSION PY_MINOR_VERSION <<< "${PYTHON_VERSION}"
+    export PY_XY="${PY_MAJOR_VERSION}${PY_MINOR_VERSION}"
+
+    export PIP="${PYTHON} -m pip"
+
     case "$pkger" in
         "port")
-            PY_DIST=python${PY_XY}
-            PY_PREFIX=py${PY_XY}
+            PY_DIST="python${PY_XY}"
+            PY_PREFIX="py${PY_XY}"
             PIP="sudo ${PIP}"
             ;;
         "apt-get")
             if [ ${PY_MAJOR_VERSION} == 2 ]; then
-                PY_DIST=python
-                PY_PREFIX=python
+                PY_DIST="python"
+                PY_PREFIX="python"
             else
-                PY_DIST=python${PY_MAJOR_VERSION}
-                PY_PREFIX=python${PY_MAJOR_VERSION}
+                PY_DIST="python${PY_MAJOR_VERSION}"
+                PY_PREFIX="python${PY_MAJOR_VERSION}"
             fi
             ;;
         "yum")
             if [ ${PY_MAJOR_VERSION} == 2 ]; then
-                PY_DIST=python
-                PY_PREFIX=python
+                PY_DIST="python"
+                PY_PREFIX="python"
             elif [ ${PY_XY} -eq 34 ]; then
-                PY_DIST=python${PY_XY}
-                PY_PREFIX=python${PY_XY}
+                PY_DIST="python${PY_XY}"
+                PY_PREFIX="python${PY_XY}"
             else
-                PY_DIST=python${PY_XY}u
-                PY_PREFIX=python${PY_XY}u
+                PY_DIST="python${PY_XY}u"
+                PY_PREFIX="python${PY_XY}u"
             fi
             ;;
     esac
-    export PYTHON PY_MAJOR_VERSION PY_MINOR_VERSION PY_XY PY_DIST PY_PREFIX PIP
+    export PY_DIST PY_PREFIX PIP
 }
 
 install_python() {

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -23,7 +23,7 @@
 
 # set path to build directory
 if [ -z "${DOCKER_IMAGE}" ]; then
-    GWPY_PATH=`pwd`
+    GWPY_PATH=$(pwd)
 else
     GWPY_PATH="/gwpy"
 fi
@@ -46,7 +46,7 @@ get_os_type() {
     if [ -f /etc/os-release ]; then
         . /etc/os-release
         echo $ID
-    elif [[ ${TRAVIS_OS_NAME} == "osx" ]] || [[ "`uname`" == "Darwin" ]]; then
+    elif [[ ${TRAVIS_OS_NAME} == "osx" ]] || [[ "$(uname)" == "Darwin" ]]; then
         echo macos
     fi
 }
@@ -76,7 +76,7 @@ get_package_manager() {
 }
 
 update_package_manager() {
-    local pkger=`get_package_manager`
+    local pkger=$(get_package_manager)
     case "$(get_package_manager)" in
         "port")
             port selfupdate
@@ -93,7 +93,7 @@ update_package_manager() {
 }
 
 install_package() {
-    local pkger=`get_package_manager`
+    local pkger=$(get_package_manager)
     case "$pkger" in
         "port")
             port -N install $@

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -36,7 +36,7 @@ get_environment  # sets PIP variables etc
 get_python_version  # sets PYTHON_VERSION
 
 # install test dependencies
-${PIP} install coverage "setuptools>=17.1" "pytest>=3.1"
+${PIP} install ${PIP_FLAGS} coverage "setuptools>=17.1" "pytest>=3.1"
 COVERAGE=coverage-${PYTHON_VERSION}
 
 # fix broken glue dependency
@@ -44,7 +44,7 @@ COVERAGE=coverage-${PYTHON_VERSION}
 #     distributed as lscsoft-glue in system packages,
 #     only in pypi, so once it is, this line should have
 #     no effect
-${PIP} install lscsoft-glue
+${PIP} install ${PIP_FLAGS} lscsoft-glue
 
 # run tests
 ${COVERAGE} run ./setup.py test --addopts gwpy/tests/

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -27,7 +27,7 @@ cd ${GWPY_PATH}
 set -ex && trap 'set +xe' RETURN
 
 # macports PATH doesn't persist from install stage, which is annoying
-if [ `get_package_manager` == port ]; then
+if [ $(get_package_manager) == port ]; then
     . terryfy/travis_tools.sh
     export PATH=$MACPORTS_PREFIX/bin:$PATH
 fi

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -14,6 +14,9 @@ URL:            {{ url }}
 Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
 
 BuildArch:      noarch
+BuildRequires:  rpm-build
+BuildRequires:  python-rpm-macros
+BuildRequires:  python3-rpm-macros
 BuildRequires:  python2-setuptools
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python3-rpm-macros

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,8 @@ tag_prefix = v
 parentdir_prefix = gwpy-
 
 [tool:pytest]
-; print name of each test, print skip reasons, use gwpy/tests/ modules
-addopts = --verbose -r s
+; print skip reasons
+addopts = -r s
 
 [coverage:run]
 source = gwpy


### PR DESCRIPTION
This PR modifies the travis configuration to use the `ligo/base` images instead of `ligo/software` - I am informed that they are much smaller, and so should provide a faster build.