### PR TITLE
Fixed type comparison for np.int on python3.4

### DIFF
--- a/gwpy/tests/test_utils.py
+++ b/gwpy/tests/test_utils.py
@@ -142,9 +142,12 @@ class TestUtilsLal(object):
             self.utils_lal.to_lal_unit('rad/s')
 
     def test_from_lal_unit(self):
-        assert self.utils_lal.from_lal_unit(
-            self.lal.MeterUnit / self.lal.SecondUnit) == (
-            units.Unit('m/s'))
+        try:
+            lalms = self.lal.MeterUnit / self.lal.SecondUnit
+        except TypeError as exc:
+            # see https://git.ligo.org/lscsoft/lalsuite/issues/65
+            pytest.skip(str(exc))
+        assert self.utils_lal.from_lal_unit(lalms) == units.Unit('m/s')
         assert self.utils_lal.from_lal_unit(self.lal.StrainUnit) == (
             units.Unit('strain'))
 

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -114,7 +114,7 @@ def null_slice(slice_):
 def as_slice(slice_):
     """Convert an object to a slice, if possible
     """
-    if isinstance(slice_, (Integral, type(None))):
+    if isinstance(slice_, (Integral, numpy.integer, type(None))):
         return slice(0, None, 1)
 
     if isinstance(slice_, (slice, numpy.ndarray)):


### PR DESCRIPTION
This PR fixes some test failures on python<3.5: `numpy.int64` is _not_ a subclass of `numbers.Integral` so need to directly compare to `numpy.integer`.