### PR TITLE
Pin pandas version in requirements-dev.txt for python3.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,8 @@ pycbc ; python_version == '2.7'
 git+https://github.com/duncanmmacleod/ligo.org.git
 sqlalchemy
 psycopg2
-pandas
+pandas ; python_version != '3.4'
+pandas < 0.21 ; python_version == '3.4'
 
 # docs
 sphinx >= 1.6.1


### PR DESCRIPTION
This PR pins the `pandas` version to `< 0.21` for python3.4; pandas >= 0.21 is python==2.7,>3.4 only.