### PR TITLE
Removed lscsoft-glue from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ dependencies = {
     'matplotlib': '>= 1.2.0',
     'astropy': '>= 1.1.1',
     'h5py': '>= 1.3',
-    'lscsoft-glue': '>= 1.55.2',
     'ligo-segments': '>= 1.0.0',
     'tqdm': '>= 4.10.0',
 }


### PR DESCRIPTION
This PR removes `lscsoft-glue` from `setup.py`; this should have been removed as part of #768.