### PR TITLE
Added init file for gwpy.tests sub-package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ pip-delete-this-directory.txt
 
 # py.test cache dir
 /.cache
+/.pytest_cache/
 
 # dqsegdb files
 __dqsegdb*.json

--- a/gwpy/tests/__init__.py
+++ b/gwpy/tests/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2018)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for GWpy
+"""

--- a/gwpy/tests/test_array.py
+++ b/gwpy/tests/test_array.py
@@ -36,7 +36,7 @@ from gwpy.detector import Channel
 from gwpy.segments import Segment
 from gwpy.time import LIGOTimeGPS
 
-import utils
+from . import utils
 
 warnings.filterwarnings('always', category=units.UnitsWarning)
 warnings.filterwarnings('always', category=UserWarning)

--- a/gwpy/tests/test_astro.py
+++ b/gwpy/tests/test_astro.py
@@ -31,7 +31,7 @@ from gwpy import astro
 from gwpy.timeseries import TimeSeries
 from gwpy.frequencyseries import FrequencySeries
 
-import utils
+from . import utils
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/tests/test_cli.py
+++ b/gwpy/tests/test_cli.py
@@ -35,9 +35,8 @@ use('agg')  # nopep8
 from gwpy.timeseries import TimeSeries
 
 # local imports
-import mocks
-from mocks import mock
-import utils
+from . import (utils, mocks)
+from .mocks import mock
 
 warnings.filterwarnings(
     'ignore', category=UserWarning, message=".*non-GUI backend.*")

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -33,9 +33,8 @@ from gwpy.detector import (Channel, ChannelList)
 from gwpy.detector.units import parse_unit
 from gwpy.segments import SegmentListDict
 
-import utils
-import mocks
-from mocks import mock
+from . import (utils, mocks)
+from .mocks import mock
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/tests/test_frequencyseries.py
+++ b/gwpy/tests/test_frequencyseries.py
@@ -42,8 +42,8 @@ from gwpy.frequencyseries import (FrequencySeries, SpectralVariance)
 from gwpy.plotter import (FrequencySeriesPlot, FrequencySeriesAxes)
 from gwpy.segments import Segment
 
-import utils
-from test_array import (TestSeries, TestArray2D)
+from . import utils
+from .test_array import (TestSeries, TestArray2D)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -45,9 +45,8 @@ from gwpy.io import (cache as io_cache,
                      utils as io_utils)
 from gwpy.segments import (Segment, SegmentList)
 
-import utils
-import mocks
-from mocks import mock
+from . import (utils, mocks)
+from .mocks import mock
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -61,7 +61,7 @@ from gwpy.plotter.tex import (float_to_latex, label_to_latex,
                               unit_to_latex, HAS_TEX)
 from gwpy.plotter.table import get_column_string
 
-import utils
+from . import utils
 
 # ignore matplotlib complaining about GUIs
 warnings.filterwarnings(

--- a/gwpy/tests/test_segments.py
+++ b/gwpy/tests/test_segments.py
@@ -38,9 +38,8 @@ from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 from gwpy.time import LIGOTimeGPS
 
-import utils
-import mocks
-from mocks import mock
+from . import (utils, mocks)
+from .mocks import mock
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/tests/test_signal.py
+++ b/gwpy/tests/test_signal.py
@@ -44,7 +44,7 @@ from gwpy.signal.fft import (get_default_fft_api,
                              registry as fft_registry, ui as fft_ui)
 from gwpy.timeseries import TimeSeries
 
-import utils
+from . import utils
 
 ONE_HZ = units.Quantity(1, 'Hz')
 

--- a/gwpy/tests/test_spectrogram.py
+++ b/gwpy/tests/test_spectrogram.py
@@ -35,8 +35,8 @@ from astropy import units
 from gwpy.spectrogram import Spectrogram
 from gwpy.plotter import (TimeSeriesPlot, TimeSeriesAxes)
 
-import utils
-from test_array import TestArray2D
+from . import utils
+from .test_array import TestArray2D
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/tests/test_table.py
+++ b/gwpy/tests/test_table.py
@@ -54,8 +54,8 @@ from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 from gwpy.plotter import (EventTablePlot, EventTableAxes, TimeSeriesPlot,
                           HistogramPlot)
 
-import utils
-from mocks import mock
+from . import utils
+from .mocks import mock
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/tests/test_timeseries.py
+++ b/gwpy/tests/test_timeseries.py
@@ -62,10 +62,9 @@ from gwpy.plotter import (TimeSeriesPlot, SegmentPlot)
 from gwpy.utils.misc import null_context
 from gwpy.signal import filter_design
 
-import mocks
-import utils
-from mocks import mock
-from test_array import TestSeries
+from . import (mocks, utils)
+from .mocks import mock
+from .test_array import TestSeries
 
 SEED = 1
 numpy.random.seed(SEED)

--- a/gwpy/tests/test_utils.py
+++ b/gwpy/tests/test_utils.py
@@ -34,7 +34,7 @@ from astropy import units
 from gwpy.utils import (shell, mp as utils_mp)
 from gwpy.utils import deps  # deprecated
 
-import utils
+from . import utils
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
     packages=find_packages(),
     scripts=get_scripts(),
     include_package_data=True,
+    test_suite='gwpy.tests',
 
     # dependencies
     cmdclass=CMDCLASS,


### PR DESCRIPTION
This PR adds `/gwpy/tests/__init__.py`, elevating `gwpy.tests` to a proper sub-package, enabling running the tests as:

```
py.test --pyargs gwpy
```