### PR TITLE
Don't install pycbc-1.10.0, its broken

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ pymysql
 lscsoft-glue
 dqsegdb
 https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
-pycbc ; python_version == '2.7'
+pycbc != 1.10.0 ; python_version == '2.7'
 git+https://github.com/duncanmmacleod/ligo.org.git
 sqlalchemy
 psycopg2


### PR DESCRIPTION
This PR modifies the dependency spec in `requirements-dev.txt` to force not installing pycbc-1.10.0 (the current release), which is broken.