### PR TITLE
Added config declaring travis-pro for coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-pro

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,10 +177,10 @@ after_success:
   # install coveralls
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-        sudo -H /opt/local/bin/python${PYTHON_VERSION} -m pip install --quiet coveralls
+        sudo -H /opt/local/bin/python${PYTHON_VERSION} -m pip install --quiet coveralls PyYAML
         COVERALLS=$(/opt/local/bin/python${PYTHON_VERSION} -c "import sys; print(sys.prefix)")/bin/coveralls
     else
-        python${PYTHON_VERSION} -m pip install --quiet coveralls
+        python${PYTHON_VERSION} -m pip install --quiet coveralls PyYAML
         COVERALLS=coveralls
     fi
   # submit coverage results


### PR DESCRIPTION
This PR adds `.coveralls.yml` declaring that `service_name: travis-pro` which might fix the broken link between travis and coveralls since the migration to travis-ci.com.