### PR TITLE
Added gwpy.time.gps_types tuple

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,7 +171,7 @@ script:  # run tests
 after_success:
   # fix paths in coverage file for docker-based runs
   - |
-    if [ -z ${DOCKER_IMAGE+x} ]; then
+    if [ ! -z ${DOCKER_IMAGE+x} ]; then
         sed -i 's|"'${GWPY_PATH}'|"'`pwd`'|g' .coverage;
     fi
   # install coveralls

--- a/gwpy/tests/test_time.py
+++ b/gwpy/tests/test_time.py
@@ -21,6 +21,7 @@
 
 from datetime import datetime
 from decimal import Decimal
+from operator import attrgetter
 
 import pytest
 
@@ -131,3 +132,13 @@ def test_tconvert(in_, out):
     """Test :func:`gwpy.time.tconvert`
     """
     _test_with_errors(time.tconvert, in_, out)
+
+
+@pytest.mark.parametrize('gpstype', time.gps_types,
+                         ids=attrgetter('__module__'))
+def test_gps_types(gpstype):
+    assert gpstype.__name__ == 'LIGOTimeGPS'
+    gps = gpstype(123, 456000000)
+    assert gps.gpsSeconds == 123
+    assert gps.gpsNanoSeconds == 456000000
+    assert gps == 123.456

--- a/gwpy/time/__init__.py
+++ b/gwpy/time/__init__.py
@@ -26,6 +26,8 @@ All other time conversions can be easily completed using the `Time`
 object.
 """
 
+from importlib import import_module
+
 from astropy.time import Time
 
 # try and import LIGOTimeGPS from LAL, otherwise use the pure-python backup
@@ -38,3 +40,15 @@ except ImportError:
 from ._tconvert import (tconvert, to_gps, from_gps)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+# build list of compatible gps types
+gps_types = tuple()
+for _modname in ('lal', 'ligotimegps', 'glue.lal',):
+    try:
+        _mod = import_module(_modname)
+    except ImportError:
+        continue
+    _gps = getattr(_mod, 'LIGOTimeGPS')
+    gps_types = gps_types + (_gps,)
+
+del import_module

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -54,7 +54,7 @@ from astropy.io import registry as io_registry
 from ..types import (Array2D, Series)
 from ..detector import (Channel, ChannelList)
 from ..io import datafind
-from ..time import (Time, LIGOTimeGPS, to_gps)
+from ..time import (Time, LIGOTimeGPS, gps_types, to_gps)
 from ..utils import gprint
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -73,7 +73,7 @@ _UFUNC_STRING = {
 
 
 def _format_time(gps):
-    if isinstance(gps, LIGOTimeGPS):
+    if isinstance(gps, gps_types):
         return float(gps)
     if isinstance(gps, Time):
         return gps.gps

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pymysql
 lscsoft-glue
 dqsegdb
 https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
+ligotimegps
 pycbc != 1.10.0 ; python_version == '2.7'
 git+https://github.com/duncanmmacleod/ligo.org.git
 sqlalchemy


### PR DESCRIPTION
This PR adds the `gwpy.time.gps_types` tuple, similar to `six.string_types`, which contains all available, known implementations of `LIGOTimeGPS`, e.g.:

```python
>>> from gwpy.time import gps_types
>>> print(gps_types)
(<type 'lal.LIGOTimeGPS'>, <class 'ligotimegps.LIGOTimeGPS'>, <class 'glue.lal.LIGOTimeGPS'>)
```

This is mainly useful for `isinstance` checks.

This includes a unit test that the included gps types are all API compliant.