### PR TITLE
Set matplotlib backend for docs in rcParams

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,9 @@ autosummary_generate = True
 # -- plot_directive -----------------------------
 
 plot_rcparams = GWPY_PLOT_PARAMS
+plot_rcparams.update({
+    'backend': 'agg',
+})
 plot_apply_rcparams = True
 plot_formats = ['png']
 plot_include_source = True


### PR DESCRIPTION
This PR modifies `/docs/conf.py` to set the matplotlib backend via `rcParams`, so that the `.. plot` directive can't override it.