### PR TITLE
New _get_time_column method for EventTable

### DIFF
--- a/examples/table/histogram.py
+++ b/examples/table/histogram.py
@@ -37,7 +37,7 @@ __currentmodule__ = 'gwpy.table'
 from gwpy.table import EventTable
 events = EventTable.read(
     'H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst',
-    columns=['time', 'snr'])
+    columns=['peak', 'snr'])
 
 # .. note::
 #

--- a/examples/table/rate.py
+++ b/examples/table/rate.py
@@ -36,7 +36,7 @@ __currentmodule__ = 'gwpy.table'
 # :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz',
-                         tablename='sngl_burst', columns=['time', 'snr'])
+                         tablename='sngl_burst', columns=['peak', 'snr'])
 
 # .. note::
 #

--- a/examples/table/rate_binned.py
+++ b/examples/table/rate_binned.py
@@ -36,7 +36,7 @@ __currentmodule__ = 'gwpy.table'
 # :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz',
-                         tablename='sngl_burst', columns=['time', 'snr'])
+                         tablename='sngl_burst', columns=['peak', 'snr'])
 
 # .. note::
 #

--- a/examples/table/scatter.py
+++ b/examples/table/scatter.py
@@ -36,7 +36,7 @@ __currentmodule__ = 'gwpy.table'
 from gwpy.table import EventTable
 events = EventTable.read(
     'H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst',
-    columns=['time', 'central_freq', 'snr'])
+    columns=['peak', 'central_freq', 'snr'])
 
 # .. note::
 #
@@ -45,7 +45,7 @@ events = EventTable.read(
 
 # We can now make a scatter plot by specifying the x- and y-axis columns,
 # and (optionally) the colour:
-plot = events.plot('time', 'central_freq', color='snr')
+plot = events.plot('peak', 'central_freq', color='snr')
 ax = plot.gca()
 ax.set_yscale('log')
 ax.set_ylabel('Frequency [Hz]')

--- a/examples/table/tiles.py
+++ b/examples/table/tiles.py
@@ -36,7 +36,7 @@ __currentmodule__ = 'gwpy.table'
 from gwpy.table import EventTable
 events = EventTable.read(
     'H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst',
-    columns=['time', 'central_freq', 'bandwidth', 'duration', 'snr'])
+    columns=['peak', 'central_freq', 'bandwidth', 'duration', 'snr'])
 
 # .. note::
 #
@@ -45,7 +45,7 @@ events = EventTable.read(
 
 # We can make a plot of these events as 2-dimensional tiles by specifying
 # the x- and y-axis columns, and the widths in those directions:
-plot = events.plot('time', 'central_freq', 'duration', 'bandwidth',
+plot = events.plot('peak', 'central_freq', 'duration', 'bandwidth',
                    color='snr')
 ax = plot.gca()
 ax.set_yscale('log')

--- a/gwpy/plotter/table.py
+++ b/gwpy/plotter/table.py
@@ -34,7 +34,7 @@ import numpy
 from matplotlib import (collections, pyplot)
 from matplotlib.projections import register_projection
 
-from ..table import Table
+from ..table import (Table, EventTable)
 from .core import Plot
 from .timeseries import (TimeSeriesAxes, TimeSeriesPlot)
 from .frequencyseries import FrequencySeriesPlot
@@ -369,8 +369,13 @@ class _EventTableMetaPlot(type):
             plotclass = kwargs.pop('base')
         elif a2:
             xcol = a2[0]
+            if isinstance(args[0], EventTable):  # get 'time' column for table
+                try:
+                    tcol = args[0]._get_time_column()
+                except ValueError:
+                    tcol = None
             # initialise figure as a TimeSeriesPlot
-            if re.search(r'time\Z', xcol, re.I):
+            if re.search(r'time\Z', xcol, re.I) or xcol == tcol:
                 plotclass = TimeSeriesPlot
             # or as a FrequencySeriesPlot
             elif re.search(r'(freq\Z|frequency\Z)', xcol, re.I):


### PR DESCRIPTION
This PR introduces a new internal method `EventTable._get_time_column` to try and work out which column (if any) represents 'time' in the current table. This is useful for methods like `event_rate()` which require a time column to operate.

I also fixed the examples for `table` which were all still referring to the old magic 'time' column from the `sngl_burst` table.