### PR TITLE
Updated tests for O1_16KHZ dataset

### DIFF
--- a/gwpy/io/losc.py
+++ b/gwpy/io/losc.py
@@ -278,4 +278,4 @@ def find_datasets(start, end, detector=None, strict=False, host=LOSC_URL):
             epochs.append(Dataset(epoch, abs(epochseg), gap))
 
     # sort epochs by coverage
-    return list(zip(*sorted(epochs, key=attrgetter('gap', 'span'))))[0]
+    return list(zip(*sorted(epochs, key=attrgetter('gap', 'span', 'name'))))[0]

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -754,10 +754,14 @@ class TestIoLosc(object):
         assert str(exc.value).startswith('Failed to parse LOSC JSON')
 
     @pytest.mark.parametrize('segment, detector, strict, result', [
-        ((1126257414, 1126261510), 'H1', False, ('GW150914', 'O1_16KHZ', 'O1', 'tenyear')),
-        ((1126250000, 1126270000), 'H1', False, ('O1_16KHZ', 'O1', 'tenyear', 'GW150914')),
-        ((1126250000, 1126270000), 'H1', True, ('O1_16KHZ', 'O1', 'tenyear',)),
-        ((1126250000, 1126270000), 'V1', False, ('tenyear',)),
+        ((1126257414, 1126261510), 'H1', False,
+         ('GW150914', 'O1', 'O1_16KHZ', 'tenyear')),
+        ((1126250000, 1126270000), 'H1', False,
+         ('O1', 'O1_16KHZ', 'tenyear', 'GW150914')),
+        ((1126250000, 1126270000), 'H1', True,
+         ('O1', 'O1_16KHZ', 'tenyear',)),
+        ((1126250000, 1126270000), 'V1', False,
+         ('tenyear',)),
     ])
     def test_find_datasets(self, segment, detector, strict, result):
         try:

--- a/gwpy/tests/test_io.py
+++ b/gwpy/tests/test_io.py
@@ -754,9 +754,9 @@ class TestIoLosc(object):
         assert str(exc.value).startswith('Failed to parse LOSC JSON')
 
     @pytest.mark.parametrize('segment, detector, strict, result', [
-        ((1126257414, 1126261510), 'H1', False, ('GW150914', 'O1', 'tenyear')),
-        ((1126250000, 1126270000), 'H1', False, ('O1', 'tenyear', 'GW150914')),
-        ((1126250000, 1126270000), 'H1', True, ('O1', 'tenyear',)),
+        ((1126257414, 1126261510), 'H1', False, ('GW150914', 'O1_16KHZ', 'O1', 'tenyear')),
+        ((1126250000, 1126270000), 'H1', False, ('O1_16KHZ', 'O1', 'tenyear', 'GW150914')),
+        ((1126250000, 1126270000), 'H1', True, ('O1_16KHZ', 'O1', 'tenyear',)),
         ((1126250000, 1126270000), 'V1', False, ('tenyear',)),
     ])
     def test_find_datasets(self, segment, detector, strict, result):


### PR DESCRIPTION
This PR updates `test_io.py` to account for the new `O1_16KHZ` dataset published by losc.ligo.org.