### PR TITLE
Added more variants on degrees_C in detector.units

### DIFF
--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -153,12 +153,13 @@ units.add_enabled_units(units.imperial)
 
 # 1) alternative names
 registry = units.get_current_unit_registry().registry
-for alias, unit in [
-        ('Degrees_C', units.Unit('Celsius')),
-        ('Degrees_F', units.Unit('Fahrenheit')),
+for unit, aliases in [
+        (units.Unit('Celsius'), ('Degrees_C', 'DegC')),
+        (units.Unit('Fahrenheit'), ('Degrees_F', 'DegF')),
 ]:
-    unit.names.append(alias)
-    registry[alias] = unit
+    unit.names.extend(aliases)
+    for alias in aliases:
+        registry[alias] = unit
 
 # 2) new units
 _ns = {}

--- a/gwpy/tests/test_detector.py
+++ b/gwpy/tests/test_detector.py
@@ -113,6 +113,7 @@ channels =
     ('Amp', units.ampere),
     ('MPC', units.megaparsec),
     ('degrees_C', units.Unit('Celsius')),
+    ('DegC', units.Unit('Celsius')),
     ('degrees_F', units.Unit('Fahrenheit')),
 ])
 def test_parse_unit(arg, unit):


### PR DESCRIPTION
This PR adds another variant of the `'degrees_C'` unit to `gwpy.detector.units`; its easier on LIGO to just patch the weird units here, rather than letting individuals handle it on their own