### PR TITLE
Fixed creation of empty Plot with geometry

### DIFF
--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -23,6 +23,8 @@ import itertools
 import warnings
 from collections import (KeysView, ValuesView)
 
+from six.moves import zip_longest
+
 import numpy
 
 from matplotlib import (backends, figure, get_backend, _pylab_helpers)
@@ -148,7 +150,7 @@ class Plot(figure.Figure):
                                    unit.to_string('latex_inline_dimensional'))
 
         # create axes for each group and draw each data object
-        for group, (row, col) in itertools.zip_longest(
+        for group, (row, col) in zip_longest(
                 axes_groups, itertools.product(range(nrows), range(ncols)),
                 fillvalue=[]):
             # create Axes

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -148,7 +148,7 @@ class Plot(figure.Figure):
                                    unit.to_string('latex_inline_dimensional'))
 
         # create axes for each group and draw each data object
-        for group, (row, col) in itertools.izip_longest(
+        for group, (row, col) in itertools.zip_longest(
                 axes_groups, itertools.product(range(nrows), range(ncols)),
                 fillvalue=[]):
             # create Axes

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -51,6 +51,11 @@ class TestPlot(FigureTestBase):
         assert tuple(plot.get_size_inches()) == (4., 3.)
         assert plot.colorbars == []
 
+    def test_init_empty(self):
+        plot = self.FIGURE_CLASS(geometry=(2, 2))
+        assert len(plot.axes) == 4
+        assert plot.axes[-1].get_geometry() == (2, 2, 4)
+
     def test_init_with_data(self):
         a = Series(range(10), dx=.1)
         plot = self.FIGURE_CLASS(a)


### PR DESCRIPTION
This PR fixes up the `Plot` constructor to enable creating empty plots with multiple axes.