### PR TITLE
Fixed bug slicing Series with null boolean array

### DIFF
--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -77,9 +77,13 @@ def slice_axis_attributes(old, oldaxis, new, newaxis, slice_):
         setattr(new, index(newaxis), getattr(old, index(oldaxis))[slice_])
 
     # otherwise if using a slice, use origin and delta properties
-    elif isinstance(slice_, slice):
-        offset = slice_.start or 0
-        step = slice_.step or 1
+    elif isinstance(slice_, slice) or not slice_.sum():
+        if isinstance(slice_, slice):
+            offset = slice_.start or 0
+            step = slice_.step or 1
+        else:  # empty ndarray slice (so just set attributes)
+            offset = 0
+            step = 1
 
         dx = getattr(old, delta(oldaxis))
         x0 = getattr(old, origin(oldaxis))

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -155,6 +155,22 @@ class TestSeries(_TestArray):
             name=array.name, epoch=array.epoch, unit=array.unit),
         )
 
+    def test_empty_slice(self, array):
+        """Check that we can slice a `Series` into nothing
+
+        This tests against a bug in sliceutils.py.
+        """
+        a2 = array[:0]
+        assert a2.x0 == array.x0
+        assert a2.dx == array.dx
+
+        idx = numpy.array([False]*array.size)  # False slice array
+        a3 = array[idx]
+        utils.assert_quantity_sub_equal(a2, a3)
+
+        a4 = array[idx[:0]]  # empty slice array
+        utils.assert_quantity_sub_equal(a2, a4)
+
     def test_zip(self, array):
         z = array.zip()
         utils.assert_array_equal(

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -164,7 +164,7 @@ class TestSeries(_TestArray):
         assert a2.x0 == array.x0
         assert a2.dx == array.dx
 
-        idx = numpy.array([False]*array.size)  # False slice array
+        idx = numpy.array([False]*array.shape[0])  # False slice array
         a3 = array[idx]
         utils.assert_quantity_sub_equal(a2, a3)
 


### PR DESCRIPTION
This PR fixes a bug in `gwpy.types.seriesutils` that caused a slice of a `Series` using a null boolean array (either no elements, or all `False`) to crash, and adds a regression test.