### PR TITLE
Fixed bug in Axes.scatter, need to cast to array before c_sorting

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -167,9 +167,9 @@ class Axes(_Axes):
             c_sort = kwargs.pop('c_sort', True)
             if c_sort:
                 sortidx = c_array.argsort()
-                x = x[sortidx]
-                y = y[sortidx]
-                c = c[sortidx]
+                x = numpy.asarray(x)[sortidx]
+                y = numpy.asarray(y)[sortidx]
+                c = numpy.asarray(c)[sortidx]
 
         return super(Axes, self).scatter(x, y, c=c, **kwargs)
 

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -64,6 +64,9 @@ class TestAxes(AxesTestBase):
         # check that c=None works
         ax.scatter(x, y, c=None)
 
+        # check that using non-array data works
+        ax.scatter([1], [1], c=[1])
+
     def test_imshow(self, ax):
         # overloaded imshow call (Array2D)
         array = Array2D(numpy.random.random((10, 10)), dx=.1, dy=.2)


### PR DESCRIPTION
This PR fixes a bug in `gwpy.plot.Axes.scatter`, which presumed the inputs were already `numpy.ndarray`s, which isn't required by matplotlib.