### PR TITLE
Modified gwpy.plot to just plot arrays, not quantities

### DIFF
--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -116,8 +116,8 @@ class TestFrequencySeries(_TestSeries):
         with rc_context(rc={'text.usetex': False}):
             plot = array.plot()
             line = plot.gca().lines[0]
-            utils.assert_array_equal(line.get_xdata(), array.xindex)
-            utils.assert_array_equal(line.get_ydata(), array)
+            utils.assert_array_equal(line.get_xdata(), array.xindex.value)
+            utils.assert_array_equal(line.get_ydata(), array.value)
             with tempfile.NamedTemporaryFile(suffix='.png') as f:
                 plot.save(f.name)
 

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -313,13 +313,13 @@ class Axes(_Axes):
         })
 
         # plot lower and upper Series
-        fill = [data.xindex, data, data]
+        fill = [data.xindex.value, data.value, data.value]
         if lower is not None:
             out.extend(self.plot(lower, **kwargs))
-            fill[1] = lower
+            fill[1] = lower.value
         if upper is not None:
             out.extend(self.plot(upper, **kwargs))
-            fill[2] = upper
+            fill[2] = upper.value
 
         # fill between
         out.append(self.fill_between(
@@ -502,7 +502,7 @@ class PlotArgsProcessor(_process_plot_var_args):
         newargs = type(args)()
         for arg in args:
             if isinstance(arg, Series) and arg.ndim == 1:
-                newargs += (arg.xindex, arg)
+                newargs += (arg.xindex.value, arg.value)
             else:
                 newargs += (arg,)
         return super(PlotArgsProcessor, self)._grab_next_args(

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -314,12 +314,10 @@ class Axes(_Axes):
 
         # plot lower and upper Series
         fill = [data.xindex.value, data.value, data.value]
-        if lower is not None:
-            out.extend(self.plot(lower, **kwargs))
-            fill[1] = lower.value
-        if upper is not None:
-            out.extend(self.plot(upper, **kwargs))
-            fill[2] = upper.value
+        for i, bound in enumerate((lower, upper)):
+            if bound is not None:
+                out.extend(self.plot(bound, **kwargs))
+                fill[i+1] = bound.value
 
         # fill between
         out.append(self.fill_between(

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -65,8 +65,8 @@ class TestPlot(FigureTestBase):
         assert len(ax.lines) == 1
 
         line = ax.lines[0]
-        utils.assert_quantity_equal(line.get_xdata(), a.xindex)
-        utils.assert_quantity_equal(line.get_ydata(), a)
+        utils.assert_array_equal(line.get_xdata(), a.xindex.value)
+        utils.assert_array_equal(line.get_ydata(), a.value)
 
         plot.close()
 

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -145,8 +145,8 @@ class TestTimeSeriesBase(_TestSeries):
         with rc_context(rc={'text.usetex': False}):
             plot = array.plot()
             line = plot.gca().lines[0]
-            utils.assert_array_equal(line.get_xdata(), array.xindex)
-            utils.assert_quantity_sub_equal(line.get_ydata(), array)
+            utils.assert_array_equal(line.get_xdata(), array.xindex.value)
+            utils.assert_array_equal(line.get_ydata(), array.value)
             with tempfile.NamedTemporaryFile(suffix='.png') as f:
                 plot.save(f.name)
             return plot  # allow subclasses to extend tests
@@ -346,9 +346,9 @@ class TestTimeSeriesBaseDict(object):
             plot = instance.plot()
             for line, key in zip(plot.gca().lines, instance):
                 utils.assert_array_equal(line.get_xdata(),
-                                         instance[key].xindex)
-                utils.assert_quantity_sub_equal(line.get_ydata(),
-                                                instance[key])
+                                         instance[key].xindex.value)
+                utils.assert_array_equal(line.get_ydata(),
+                                         instance[key].value)
             with tempfile.NamedTemporaryFile(suffix='.png') as f:
                 plot.save(f.name)
             return plot  # allow subclasses to extend tests

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -255,8 +255,8 @@ class TestStateVector(_TestTimeSeriesBase):
             # test timeseries plotting as normal
             plot = array.plot(format='timeseries')
             line = plot.gca().lines[0]
-            utils.assert_array_equal(line.get_xdata(), array.xindex)
-            utils.assert_quantity_sub_equal(line.get_ydata(), array)
+            utils.assert_array_equal(line.get_xdata(), array.xindex.value)
+            utils.assert_array_equal(line.get_ydata(), array.value)
             plot.close()
 
     def test_resample(self, array):


### PR DESCRIPTION
This PR removes the last vestiges of passing `Quantity` arrays to matplotlib, since a number of the internals to matplotlib fall over when given those objects as opposed to scalars or arrays, especially when the units don't match across axes.