### PR TITLE
Present better error for empty data given to Axes.hist if logbins=True, range=None

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -235,7 +235,14 @@ class Axes(_Axes):
             # get range
             hrange = kwargs.pop('range', None)
             if hrange is None:
-                hrange = numpy.min(x), numpy.max(x)
+                try:
+                    hrange = numpy.min(x), numpy.max(x)
+                except ValueError as exc:
+                    if str(exc).startswith('zero-size array'):  # no data
+                        exc.args = ('cannot generate log-spaced histogram '
+                                    'bins for zero-size array, '
+                                    'please pass `bins` or `range` manually',)
+                    raise
             # log-scale the axis and extract the base
             if kwargs.get('orientation') == 'horizontal':
                 self.set_yscale('log', nonposy='clip')

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -223,6 +223,8 @@ class Axes(_Axes):
         return self.pcolormesh(xcoord, ycoord, array.value.T, **kwargs)
 
     def hist(self, x, *args, **kwargs):
+        x = numpy.asarray(x)
+
         # re-format weights as array if given as float
         weights = kwargs.get('weights', None)
         if isinstance(weights, Number):

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -112,7 +112,8 @@ class TestAxes(AxesTestBase):
         assert str(exc.value).startswith('cannot generate log-spaced '
                                          'histogram bins')
         # assert it works if we give the range manually
-        ax.hist([], logbins=True, range=(1, 100))
+        if mpl_version >= '1.5.0':
+            ax.hist([], logbins=True, range=(1, 100))
 
     @pytest.mark.xfail(mpl_version < '1.4.0',
                        reason='bugs in matplotlib-1.4.0')

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -104,6 +104,16 @@ class TestAxes(AxesTestBase):
                                  11, endpoint=True),
         )
 
+    def test_hist_error(self, ax):
+        """Test that `ax.hist` presents the right error message for empty data
+        """
+        with pytest.raises(ValueError) as exc:
+            ax.hist([], logbins=True)
+        assert str(exc.value).startswith('cannot generate log-spaced '
+                                         'histogram bins')
+        # assert it works if we give the range manually
+        ax.hist([], logbins=True, range=(1, 100))
+
     @pytest.mark.xfail(mpl_version < '1.4.0',
                        reason='bugs in matplotlib-1.4.0')
     def test_tile(self, ax):


### PR DESCRIPTION
This PR improves the error message for `ax.hist([], logbins=True, range=None)` to explain exactly what the problem is.