### PR TITLE
Improvements to EventTable._get_time_column and dependents

### DIFF
--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -54,7 +54,7 @@ def _rates_preprocess(func):
             try:
                 kwargs['timecolumn'] = self._get_time_column()
             except ValueError as exc:
-                exc.args = ('{0}, , please give `timecolumn` '
+                exc.args = ('{0}, please give `timecolumn` '
                             'keyword'.format(exc.args[0]),)
                 raise
         # otherwise use anything (it doesn't matter)

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -119,14 +119,26 @@ class EventTable(Table):
     # -- utilities ------------------------------
 
     def _get_time_column(self):
-        if 'time' in self.columns or not self:
+        """Return the name of the 'time' column in this table.
+
+        This method tries the following:
+
+        - look for a column named 'time'
+        - look for a single column with a GPS type (e.g. `LIGOTimeGPS`)
+
+        So, its not foolproof.
+        """
+        if 'time' in self.columns:
             return 'time'
         try:
             time, = [name for name in self.columns if
                      isinstance(self[name][0], gps_types)]
-        except ValueError as exc:
-            exc.args = ('cannot identify timecolumn for event_rate(), '
-                        'please specify',)
+        except (ValueError, IndexError) as exc:
+            msg = ('cannot identify time column for table, no column '
+                   'named \'time\' and none with GPS dtypes')
+            if isinstance(exc, IndexError):
+                raise ValueError(msg)
+            exc.args = (msg,)
             raise
         return time
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -107,7 +107,7 @@ class TestTable(object):
                 dtp = None
             # use map() to support non-primitive types
             if dtype(dtp).name == 'object':
-                data.append(map(dtp, random.rand(n) * 1000))
+                data.append(list(map(dtp, random.rand(n) * 1000)))
             else:
                 data.append((random.rand(n) * 1000).astype(dtp))
         return cls.TABLE(data, names=names)

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -306,9 +306,15 @@ class TestEventTable(TestTable):
         # check that single GPS column can be identified
         t = self.create(10, ('blah', 'blah2'), dtypes=(float, LIGOTimeGPS))
         assert t._get_time_column() == 'blah2'
-        t.add_column(t['blah2'], name='blah3')
-        with pytest.raises(ValueError):
-            t._get_time_column()
+
+        # check that two GPS columns causes issues
+        try:
+            t.add_column(t['blah2'], name='blah3')
+        except TypeError:  # astropy < 2.0 (or something like that)
+            pass
+        else:
+            with pytest.raises(ValueError):
+                t._get_time_column()
 
     def test_filter(self, table):
         # check simple filter

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -376,8 +376,9 @@ class TestEventTable(TestTable):
         # (and no data) if and only if start/end are both given
         t2 = self.create(10, names=['a', 'b'])
         print(t2)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as exc:
             t2.event_rate(1)
+        assert 'please give `timecolumn` keyword' in str(exc.value)
         with pytest.raises(ValueError):
             t2.event_rate(1, start=0)
         with pytest.raises(ValueError):
@@ -399,8 +400,9 @@ class TestEventTable(TestTable):
         # check that method can function without explicit time column
         # (and no data) if and only if start/end are both given
         t2 = self.create(0, names=['a', 'b'])
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as exc:
             t2.binned_event_rates(1, 'a', (10, 100))
+        assert 'please give `timecolumn` keyword' in str(exc.value)
         with pytest.raises(ValueError):
             t2.binned_event_rates(1, 'a', (10, 100), start=0)
         with pytest.raises(ValueError):


### PR DESCRIPTION
This PR improves the new private `EventTable._get_time_column` method, which attempts to guess the 'time' column for a table (which is tricksy if there isn't a column named `'time'`), and its usage in `EventTable.{binned_}event_rate{s}`.