### PR TITLE
Fixed colorbar in open-data-spectrogram.py

### DIFF
--- a/examples/miscellaneous/open-data-spectrogram.py
+++ b/examples/miscellaneous/open-data-spectrogram.py
@@ -75,6 +75,6 @@ ax.set_yscale('log')
 ax.set_ylabel('Frequency [Hz]')
 ax.set_title('LIGO-Hanford strain data')
 ax.colorbar(cmap='viridis', norm='log', clim=(1e-23, 1e-19),
-            use_axesgrid=False, label=r'Strain noise [1/\rtHz]')
+            label=r'Strain noise [1/\rtHz]')
 plot.add_segments_bar(h1segs)
 plot.show()


### PR DESCRIPTION
This PR fixes the colorbar in the `open-data-spectrogram.py` example script, which was left including a debugging statement, presumably from testing of #790.