### PR TITLE
Fixed autoscaling after segment plotting in SegmentAxes

### DIFF
--- a/gwpy/plot/segments.py
+++ b/gwpy/plot/segments.py
@@ -130,7 +130,7 @@ class SegmentAxes(Axes):
             args.pop(0)
         if args:
             out.extend(super(SegmentAxes, self).plot(*args, **kwargs))
-        self.autoscale(axis='y')
+        self.autoscale(enable=None, axis='both', tight=False)
         return out
 
     def plot_dict(self, flags, label='key', known='x', **kwargs):


### PR DESCRIPTION
This PR fixes `SegmentAxes.plot` to not overwrite user settings for autoscaling, which would ignore any set y-axis limits, for example.