### PR TITLE
Agg problem Issue #818

### DIFF
--- a/bin/gwpy-plot
+++ b/bin/gwpy-plot
@@ -24,10 +24,16 @@ import time
 
 import os
 import sys
-from importlib import import_module
-from argparse import (ArgumentParser, ArgumentDefaultsHelpFormatter)
 
 from matplotlib import use
+# if launched from a terminal with no display use the right backend
+# this must be done before anyone imports  pylab, matplotlib.pyplot,
+# or matplotlib.backends 
+if len(os.getenv('DISPLAY', '')) == 0:
+    use('Agg')
+
+from importlib import import_module
+from argparse import (ArgumentParser, ArgumentDefaultsHelpFormatter)
 
 from gwpy import __version__
 from gwpy.cli import PRODUCTS
@@ -87,9 +93,6 @@ for product in PRODUCTS:
 
 # -- run ----------------------------------------------------------------------
 
-# if launched from a terminal with no display
-if len(os.getenv('DISPLAY', '')) == 0:
-    use('Agg')
 
 # parse the command line and create a product object
 args = parser.parse_args()

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -50,7 +50,7 @@ from ..plot.tex import label_to_latex
 
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 
-BAD_UNITS = {'*', }
+BAD_UNITS = {'*', 'Counts.', }
 
 
 # -- utilities ----------------------------------------------------------------

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -176,7 +176,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
         imin = args.imin if args.imin is not None else imin
         imax = args.imax if args.imax is not None else imax
         self.log(3,('Colorbar limits set to %f - %f' % (imin, imax)))
-        
+
         try:
             image = self.ax.images[0]
         except IndexError:

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -175,7 +175,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
             imax = percentile(specgram, 100.)
         imin = args.imin if args.imin is not None else imin
         imax = args.imax if args.imax is not None else imax
-        self.log(3,('Colorbar limits set to %f - %f' % (imin, imax)))
+        self.log(3, ('Colorbar limits set to %f - %f' % (imin, imax)))
 
         try:
             image = self.ax.images[0]

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -175,6 +175,8 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
             imax = percentile(specgram, 100.)
         imin = args.imin if args.imin is not None else imin
         imax = args.imax if args.imax is not None else imax
+        self.log(3,('Colorbar limits set to %f - %f' % (imin, imax)))
+        
         try:
             image = self.ax.images[0]
         except IndexError:


### PR DESCRIPTION
It looks like there was a recent update to `gwpy.__version__` that imports at least 1 of `matplotlib.pyplot`, or `matplotlib.backends` which prevents us from setting the backend to something that works in a headless environment.

This PR moves our matplotlib.use() to as early as possible in gwpy-plot