### PR TITLE
Fixed creating Plot from a list of numbers

### DIFF
--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -516,8 +516,11 @@ def _group_axes_data(inputs, separate=None, flat=False):
         #     the iterable is presumed to be a list of independent data
         #     structures, unless its a list of scalars in which case we
         #     should plot them all as one
-        if isinstance(x, iterable_types) and (
-                not len(x) or not numpy.isscalar(x[0])):
+        if (
+                isinstance(x, (KeysView, ValuesView)) or (
+                isinstance(x, (list, tuple)) and (
+                    not x or not numpy.isscalar(x[0])))
+        ):
             out.append(x)
 
         # dataset starts a new group

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -512,11 +512,12 @@ def _group_axes_data(inputs, separate=None, flat=False):
         if isinstance(x, dict):  # unwrap dict
             x = list(x.values())
 
-        # new group from iterable
-        # notes: numpy.ndim will return 0 for iterators, so this call just
-        #        checks whether we are passing a list/tuple of numbers,
-        #        which we presume should be plotted as a single thing
-        if isinstance(x, iterable_types) and numpy.ndim(x) != 1:
+        # new group from iterable, notes:
+        #     the iterable is presumed to be a list of independent data
+        #     structures, unless its a list of scalars in which case we
+        #     should plot them all as one
+        if isinstance(x, iterable_types) and not (
+                len(x) and numpy.isscalar(x[0])):
             out.append(x)
 
         # dataset starts a new group

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -516,8 +516,8 @@ def _group_axes_data(inputs, separate=None, flat=False):
         #     the iterable is presumed to be a list of independent data
         #     structures, unless its a list of scalars in which case we
         #     should plot them all as one
-        if isinstance(x, iterable_types) and not (
-                len(x) and numpy.isscalar(x[0])):
+        if isinstance(x, iterable_types) and (
+                not len(x) or not numpy.isscalar(x[0])):
             out.append(x)
 
         # dataset starts a new group

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -517,9 +517,9 @@ def _group_axes_data(inputs, separate=None, flat=False):
         #     structures, unless its a list of scalars in which case we
         #     should plot them all as one
         if (
-                isinstance(x, (KeysView, ValuesView)) or (
+                isinstance(x, (KeysView, ValuesView)) or
                 isinstance(x, (list, tuple)) and (
-                    not x or not numpy.isscalar(x[0])))
+                    not x or not numpy.isscalar(x[0]))
         ):
             out.append(x)
 

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -513,7 +513,10 @@ def _group_axes_data(inputs, separate=None, flat=False):
             x = list(x.values())
 
         # new group from iterable
-        if isinstance(x, iterable_types):
+        # notes: numpy.ndim will return 0 for iterators, so this call just
+        #        checks whether we are passing a list/tuple of numbers,
+        #        which we presume should be plotted as a single thing
+        if isinstance(x, iterable_types) and numpy.ndim(x) != 1:
             out.append(x)
 
         # dataset starts a new group

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -57,28 +57,32 @@ class TestPlot(FigureTestBase):
         assert plot.axes[-1].get_geometry() == (2, 2, 4)
 
     def test_init_with_data(self):
-        a = Series(range(10), dx=.1)
-        plot = self.FIGURE_CLASS(a)
+        # list
+        plot = self.FIGURE_CLASS([1, 2, 3, 4])
         assert len(plot.axes) == 1
-
-        ax = plot.gca()
-        assert len(ax.lines) == 1
-
-        line = ax.lines[0]
-        utils.assert_array_equal(line.get_xdata(), a.xindex.value)
-        utils.assert_array_equal(line.get_ydata(), a.value)
-
+        utils.assert_array_equal(plot.gca().lines[-1].get_ydata(),
+                                 numpy.array([1, 2, 3, 4]))
         plot.close()
 
-        # ----
+        # series
+        a = Series(range(10), dx=.1)
+        plot = self.FIGURE_CLASS(a)
+        ax = plot.gca()
+        line = ax.lines[0]
+        assert len(plot.axes) == 1
+        assert len(ax.lines) == 1
+        utils.assert_array_equal(line.get_xdata(), a.xindex.value)
+        utils.assert_array_equal(line.get_ydata(), a.value)
+        plot.close()
 
+        # two series
         b = Series(range(10), dx=.1)
-
         plot = self.FIGURE_CLASS(a, b)
         assert len(plot.axes) == 1
         assert len(plot.axes[0].lines) == 2
         plot.close()
 
+        # two series on separate axes
         plot = self.FIGURE_CLASS(a, b, separate=True, sharex=True, sharey=True)
         assert len(plot.axes) == 2
         for i, ax in enumerate(plot.axes):
@@ -87,6 +91,7 @@ class TestPlot(FigureTestBase):
         assert plot.axes[1]._sharex is plot.axes[0]
         plot.close()
 
+        # Array2D with imshow
         array = Array2D(numpy.random.random((10, 10)), dx=.1, dy=.2)
         plot = self.FIGURE_CLASS(array, method='imshow')
         assert len(plot.axes[0].images) == 1


### PR DESCRIPTION
This PR fixes `Plot([1, 2, 3, 4])`, which used to plot each integer separately, I think.