### PR TITLE
Fixed bugs in default labels for Plots and EventTable plotting

### DIFF
--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -145,8 +145,8 @@ class Plot(figure.Figure):
         axarr = numpy.empty((nrows, ncols), dtype=object)
 
         # set default labels
-        defxlabel = 'xlabel' not in kwargs
-        defylabel = 'ylabel' not in kwargs
+        defxlabel = 'xlabel' not in axes_kw
+        defylabel = 'ylabel' not in axes_kw
         flatdata = [s for group in axes_groups for s in group]
         for axis in ('x', 'y'):
             unit = _common_axis_unit(flatdata, axis=axis)

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -552,11 +552,10 @@ class EventTable(Table):
         try:
             tcol = self._get_time_column()
         except ValueError:
-            pass
-        else:
-            if args[0].name == tcol:  # map X column to GPS axis
-                kwargs.setdefault('figsize', (12, 6))
-                kwargs.setdefault('xscale', 'auto-gps')
+            tcol = None
+        if args[0].name == tcol:  # map X column to GPS axis
+            kwargs.setdefault('figsize', (12, 6))
+            kwargs.setdefault('xscale', 'auto-gps')
 
         kwargs['method'] = method
         plot = Plot(*args, **kwargs)

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -21,6 +21,7 @@
 
 import warnings
 from functools import wraps
+from operator import attrgetter
 from math import ceil
 
 from six import string_types
@@ -562,13 +563,15 @@ class EventTable(Table):
 
         # set default labels
         ax = plot.gca()
-        for axis, col in zip((ax.xaxis, ax.yaxis), args[:2]):
-            if axis.isDefault_label:
-                name = r'\texttt{{{0}}}'.format(label_to_latex(col.name))
-                if isinstance(col, Quantity):
-                    name += ' [{0}]'.format(col.unit.to_string('latex_inline'))
-                axis.set_label_text(name)
-                axis.isDefault_label = True
+        for axis, col in zip(
+                filter(attrgetter('isDefault_label'), (ax.xaxis, ax.yaxis)),
+                args[:2],
+        ):
+            name = r'\texttt{{{0}}}'.format(label_to_latex(col.name))
+            if isinstance(col, Quantity):
+                name += ' [{0}]'.format(col.unit.to_string('latex_inline'))
+            axis.set_label_text(name)
+            axis.isDefault_label = True
 
         return plot
 

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -562,12 +562,13 @@ class EventTable(Table):
 
         # set default labels
         ax = plot.gca()
-        for axis, column in zip((ax.xaxis, ax.yaxis), args[:2]):
-            name = r'\texttt{{{0}}}'.format(label_to_latex(column.name))
-            if isinstance(column, Quantity):
-                name += ' [{0}]'.format(column.unit.to_string('latex_inline'))
-            axis.set_label_text(name)
-            axis.isDefault_label = True
+        for axis, col in zip((ax.xaxis, ax.yaxis), args[:2]):
+            if axis.isDefault_label:
+                name = r'\texttt{{{0}}}'.format(label_to_latex(col.name))
+                if isinstance(col, Quantity):
+                    name += ' [{0}]'.format(col.unit.to_string('latex_inline'))
+                axis.set_label_text(name)
+                axis.isDefault_label = True
 
         return plot
 


### PR DESCRIPTION
This PR fixes two bugs related to default labels:

- [6a9a69d] preserve user-given labels during `Plot` creation
- [965ae61] preserve user-given labels during `EventTable.scatter` and `EventTable.tile`