### PR TITLE
Removed python3 CI builds for el7 and debian8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,20 +82,10 @@ matrix:
       sudo: required
       services:
         - docker
-    - env: DOCKER_IMAGE="ligo/base:el7"
-      python: '3.4'
-      sudo: required
-      services:
-        - docker
 
     # debian 8
     - env: DOCKER_IMAGE="ligo/base:jessie"
       python: '2.7'
-      sudo: required
-      services:
-        - docker
-    - env: DOCKER_IMAGE="ligo/base:jessie"
-      python: '3.4'
       sudo: required
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,22 +159,8 @@ script:  # run tests
   - ci_run ". ${GWPY_PATH}/ci/test.sh"
 
 after_success:
-  # fix paths in coverage file for docker-based runs
-  - |
-    if [ ! -z ${DOCKER_IMAGE+x} ]; then
-        sed -i 's|"'${GWPY_PATH}'|"'`pwd`'|g' .coverage;
-    fi
-  # install coveralls
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-        sudo -H /opt/local/bin/python${PYTHON_VERSION} -m pip install --quiet coveralls
-        COVERALLS=$(/opt/local/bin/python${PYTHON_VERSION} -c "import sys; print(sys.prefix)")/bin/coveralls
-    else
-        python${PYTHON_VERSION} -m pip install --quiet coveralls
-        COVERALLS=coveralls
-    fi
   # submit coverage results
-  - $COVERALLS
+  - . ./ci/coveralls.sh
 
   # build and deploy package files
   - . ./ci/deploy.sh

--- a/ci/coveralls.sh
+++ b/ci/coveralls.sh
@@ -24,7 +24,7 @@
 
 # fix paths in coverage file for docker-based runs
 if [ ! -z ${DOCKER_IMAGE+x} ]; then
-    sed -i 's|"'${GWPY_PATH}'|"'`pwd`'|g' .coverage;
+    sed -i 's|"'${GWPY_PATH}'|"'$(pwd)'|g' .coverage;
 fi
 
 # install coveralls

--- a/ci/coveralls.sh
+++ b/ci/coveralls.sh
@@ -21,6 +21,7 @@
 #
 
 . ci/lib.sh
+get_environment
 
 # fix paths in coverage file for docker-based runs
 if [ ! -z ${DOCKER_IMAGE+x} ]; then

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -100,7 +100,6 @@ done
 apt-get -yqq install \
     git \
     ${PY_PREFIX}-pip \
-    ${PY_PREFIX}-pymysql \
     ${PY_PREFIX}-glue \
     ${PY_PREFIX}-sqlalchemy \
     ${PY_PREFIX}-psycopg2 \
@@ -123,8 +122,10 @@ if [ "${PY_MAJOR_VERSION}" -eq 2 ]; then
         libroot-graf2d-postscript-dev
 fi
 
-# install LIGO-specific extras that may or may not exist
+# install other packages that may or may not exist for this
+# debian version, or this python version
 for pckg in \
+    ${PY_PREFIX}-pymysql \
     ${PY_PREFIX}-nds2-client \
     ${PY_PREFIX}-dqsegdb ${PY_PREFIX}-m2crypto \
     ldas-tools-framecpp-${PY_PREFIX} \

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -90,19 +90,38 @@ for PREF in ${PREFICES}; do
     }
 done
 
-# install system-level extras for the correct python version
+# install extras
+apt-get -yqq install \
+    git \
+    ${PY_PREFIX}-pip \
+    ${PY_PREFIX}-pymysql \
+    ${PY_PREFIX}-glue \
+    ${PY_PREFIX}-sqlalchemy \
+    ${PY_PREFIX}-psycopg2 \
+    ${PY_PREFIX}-pandas \
+    ${PY_PREFIX}-pytest \
+    ${PY_PREFIX}-coverage \
+    ${PY_PREFIX}-freezegun \
+    ${PY_PREFIX}-sqlparse \
+    ${PY_PREFIX}-bs4 \
+    lalframe-${PY_PREFIX} \
+    lalsimulation-${PY_PREFIX}
+
+# install extras for python2 only
+if [ "${PY_MAJOR_VERSION}" -eq 2 ]; then
+    apt-get -yqq install \
+        ${PY_PREFIX}-mock \
+        libroot-bindings-python5.34 \
+        libroot-tree-treeplayer-dev \
+        libroot-math-physics-dev \
+        libroot-graf2d-postscript-dev
+fi
+
+# install LIGO-specific extras that may or may not exist
 for pckg in \
-    libroot-bindings-python5.34 libroot-tree-treeplayer-dev \
-    libroot-math-physics-dev libroot-graf2d-postscript-dev \
     ${PY_PREFIX}-nds2-client \
     ${PY_PREFIX}-dqsegdb ${PY_PREFIX}-m2crypto \
-    ${PY_PREFIX}-sqlalchemy \
-    ${PY_PREFIX}-pandas \
-    ${PY_PREFIX}-psycopg2 \
-    ${PY_PREFIX}-pymysql \
     ldas-tools-framecpp-${PY_PREFIX} \
-    lalframe-${PY_PREFIX} \
-    lalsimulation-${PY_PREFIX} \
 ; do
     apt-get -yqq install $pckg || true
 done

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -20,6 +20,8 @@
 # Build Debian package
 #
 
+# -- prep ---------------------------------------------------------------------
+
 # enable lscsoft jessie-proposed (first required for python-tqdm gwpy/gwpy#735)
 if [ "${OS_VERSION}" -eq 8 ]; then
     cat << EOF > /etc/apt/sources.list.d/lscsoft-proposed.list
@@ -64,6 +66,8 @@ pip install --quiet "GitPython>=2.1.8"
 # prepare the tarball (sdist generates debian/changelog)
 python setup.py --quiet sdist
 
+# -- build and install --------------------------------------------------------
+
 # make the debian package
 mkdir -p dist/debian
 pushd dist/debian
@@ -89,6 +93,8 @@ for PREF in ${PREFICES}; do
         dpkg --install ${GWPY_DEB};  # shouldn't fail
     }
 done
+
+# -- third-party packages -----------------------------------------------------
 
 # install extras
 apt-get -yqq install \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -71,7 +71,7 @@ yum -y -q install \
     python-beautifulsoup4 \
     python-sqlalchemy \
     python2-PyMySQL \
-    python-m2crypto \
+    m2crypto \
     glue \
     dqsegdb \
     python-psycopg2 \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -70,6 +70,7 @@ yum -y -q install \
     python-sqlparse \
     python-beautifulsoup4 \
     python-sqlalchemy \
+    python-m2crypto \
     glue \
     dqsegdb \
     python-psycopg2 \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -20,17 +20,15 @@
 # Build RedHat (Enterprise Linux) packages
 #
 
-# get python3 version
+# -- prep ---------------------------------------------------------------------
+
 . ci/lib.sh
-PYTHON3_VERSION=$(get_python3_version)
-PY3XY=${PYTHON3_VERSION/./}
 
 # update system
 yum -y -q update
 
 # install sdist dependencies
 yum -y -q install \
-    rpm-build \
     git \
     python2-pip \
     python-jinja2 \
@@ -38,11 +36,10 @@ yum -y -q install \
 
 # install build dependencies
 yum -y -q install \
+    rpm-build \
     python-rpm-macros \
-    epel-rpm-macros \
-    python3-rpm-macros \
-    python2-setuptools \
-    python${PY3XY}-setuptools
+    python2-rpm-macros \
+    python2-setuptools
 
 GWPY_VERSION=$(python setup.py --version)
 
@@ -51,35 +48,33 @@ if [[ "${GWPY_VERSION}" == *"+"* ]]; then
     pip install "setuptools>=25"
 fi
 
+# -- build --------------------------------------------------------------------
+
 # build the RPM using tarball
 python setup.py --quiet sdist
 rpmbuild --define "_rpmdir $(pwd)/dist" -tb dist/gwpy-*.tar.gz
 
 # install the rpm
-if [ ${PY_XY} -lt 30 ]; then
-    GWPY_RPM="dist/noarch/python2-gwpy-*.noarch.rpm"  # install python2 only
-else
-    GWPY_RPM="dist/noarch/python*-gwpy-*.noarch.rpm"  # install both 2 and 3
-fi
+GWPY_RPM="dist/noarch/python2-gwpy-*.noarch.rpm"
 yum -y -q --nogpgcheck localinstall ${GWPY_RPM}
 
-# install system-level extras
+# -- install ------------------------------------------------------------------
+
+# install system-level extras that use standard prefix
 yum -y -q install \
-    nds2-client-${PY_PREFIX} \
-    ldas-tools-framecpp-${PY_PREFIX} \
-    lalframe-${PY_PREFIX} \
-    lalsimulation-${PY_PREFIX} \
-|| true
+    python2-pip \
+    python2-freezegun \
+    python2-root
+
+# install LIGO axtras
+yum -y -q install \
+    nds2-client-python \
+    ldas-tools-framecpp-python \
+    lalframe-python \
+    lalsimulation-python
 
 # HACK: fix missing file from ldas-tools-framecpp
 if [ -d /usr/lib64/$PYTHON/site-packages/LDAStools -a \
      ! -f /usr/lib64/$PYTHON/site-packages/LDAStools/__init__.py ]; then
     touch /usr/lib64/$PYTHON/site-packages/LDAStools/__init__.py
-fi
-
-# install system-level extras that might use python2- prefix
-if [ ${PY_XY} -lt 30 ]; then
-    yum -y -q install python2-root
-else
-    yum -y -q install ${PY_PREFIX}-root
 fi

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -70,6 +70,7 @@ yum -y -q install \
     python-sqlparse \
     python-beautifulsoup4 \
     python-sqlalchemy \
+    python2-PyMySQL \
     python-m2crypto \
     glue \
     dqsegdb \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -48,7 +48,7 @@ if [[ "${GWPY_VERSION}" == *"+"* ]]; then
     pip install "setuptools>=25"
 fi
 
-# -- build --------------------------------------------------------------------
+# -- build and install --------------------------------------------------------
 
 # build the RPM using tarball
 python setup.py --quiet sdist
@@ -58,16 +58,23 @@ rpmbuild --define "_rpmdir $(pwd)/dist" -tb dist/gwpy-*.tar.gz
 GWPY_RPM="dist/noarch/python2-gwpy-*.noarch.rpm"
 yum -y -q --nogpgcheck localinstall ${GWPY_RPM}
 
-# -- install ------------------------------------------------------------------
+# -- third-party packages -----------------------------------------------------
 
-# install system-level extras that use standard prefix
+# install system-level extras
 yum -y -q install \
     python2-pip \
+    python2-pytest \
+    python-coverage \
+    python2-mock \
     python2-freezegun \
-    python2-root
-
-# install LIGO axtras
-yum -y -q install \
+    python-sqlparse \
+    python-beautifulsoup4 \
+    python-sqlalchemy \
+    glue \
+    dqsegdb \
+    python-psycopg2 \
+    python-pandas \
+    python2-root \
     nds2-client-python \
     ldas-tools-framecpp-python \
     lalframe-python \

--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -76,9 +76,9 @@ sudo port -q install ${PY_PREFIX}-gwpy +nds2 +segments
 # install extras (see requirements-dev.txt)
 sudo port -q install \
     kerberos5 \
-    ${PY_PREFIX}-matplotlib \
     ${PY_PREFIX}-lalsimulation \
     ${PY_PREFIX}-pymysql \
+    ${PY_PREFIX}-lscsoft-glue \
     ${PY_PREFIX}-sqlalchemy \
     ${PY_PREFIX}-psycopg2 \
     ${PY_PREFIX}-pandas \

--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -78,7 +78,6 @@ sudo port -q install \
     kerberos5 \
     ${PY_PREFIX}-lalsimulation \
     ${PY_PREFIX}-pymysql \
-    ${PY_PREFIX}-lscsoft-glue \
     ${PY_PREFIX}-sqlalchemy \
     ${PY_PREFIX}-psycopg2 \
     ${PY_PREFIX}-pandas \
@@ -87,6 +86,11 @@ sudo port -q install \
     ${PY_PREFIX}-freezegun \
     ${PY_PREFIX}-sqlparse \
     ${PY_PREFIX}-beautifulsoup4
+
+# install python2-only extras
+if [ "${PY_MAJOR_VERSION}" -eq 2 ]; then
+    sudo port -q install glue
+fi
 
 # install m2cyrpto if needed
 if [ "$(port info --version dqsegdb)" == "version: 1.4.0" ]; then

--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -98,11 +98,3 @@ if [ "$(port info --version dqsegdb)" == "version: 1.4.0" ]; then
 fi
 
 kill -9 $wvbpid &> /dev/null
-
-# hacky fix for installing NOT mpl 2.1.x
-#     this can be removed as soon as mpl 2.1.2 is released
-MPL_VERSION=$(port -q installed ${PY_PREFIX}-matplotlib | grep active | \
-              awk -F '[\@\_]' '{print $2}')
-if [[ "${MPL_VERSION}" =~ 2.1.[01] ]]; then
-    ${PIP} install "matplotlib >= 1.2.0, != 2.1.0, != 2.1.1"
-fi

--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -40,7 +40,6 @@ sudo port -q install \
     ${PY_PREFIX}-gitpython
 
 # make Portfile
-cd ${GWPY_PATH}
 GWPY_VERSION=$(python setup.py --version)
 $PYTHON setup.py --quiet sdist
 $PYTHON setup.py port --tarball dist/gwpy-${GWPY_VERSION}.tar.gz
@@ -56,9 +55,9 @@ gsed -i 's|pypi:g/gwpy|file://'$(pwd)'/dist/ \\\n                    pypi:g/gwpy
 
 # add local port repo to sources
 sudo gsed -i 's|rsync://rsync.macports|file://'${PORT_REPO}'\nrsync://rsync.macports|' /opt/local/etc/macports/sources.conf
-cd ${PORT_REPO}
+pushd ${PORT_REPO}
 portindex
-cd ${GWPY_PATH}
+popd
 
 # set up utility to ping STDOUT every 10 seconds, prevents timeout
 # https://github.com/travis-ci/travis-ci/issues/6591#issuecomment-275804717

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -172,16 +172,11 @@ get_environment() {
             ;;
         centos2|rhel2|fedora2)
             PY_DIST="python"
-            PY_PREFIX="python"
+            PY_PREFIX="python2"
             ;;
         centos3|rhel3|fedora2)
-            if [ "${PYTHON_VERSION}" == "${PYTHON3_VERSION}" ]; then # IUS
-                PY_DIST="python${PY_XY}u"
-                PY_PREFIX="python${PY_XY}u"
-            else  # base repo
-                PY_DIST="python${PY_XY}"
-                PY_PREFIX="python${PY_XY}"
-            fi
+            PY_DIST="python${PY_XY}"
+            PY_PREFIX="python${PY_XY}"
             ;;
     esac
     export PY_DIST PY_PREFIX PIP

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -37,7 +37,11 @@ get_python_version  # sets PYTHON_VERSION
 set -ex && trap 'set +xe' RETURN
 
 # install test dependencies
-${PIP} install ${PIP_FLAGS} coverage "setuptools>=17.1" "pytest>=3.1"
+${PIP} install ${PIP_FLAGS} \
+    "setuptools>=17.1" \
+    "pytest>=3.1" \
+    "coverage" \
+    "freezegun>=0.2.3"
 
 # run tests
 ${PYTHON} -m coverage run ./setup.py --quiet test

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -39,12 +39,5 @@ set -ex && trap 'set +xe' RETURN
 # install test dependencies
 ${PIP} install ${PIP_FLAGS} coverage "setuptools>=17.1" "pytest>=3.1"
 
-# fix broken glue dependency
-#     this is required because the LIGO glue package isn't
-#     distributed as lscsoft-glue in system packages,
-#     only in pypi, so once it is, this line should have
-#     no effect
-${PIP} install ${PIP_FLAGS} lscsoft-glue
-
 # run tests
 ${PYTHON} -m coverage run ./setup.py --quiet test

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -38,7 +38,6 @@ set -ex && trap 'set +xe' RETURN
 
 # install test dependencies
 ${PIP} install ${PIP_FLAGS} coverage "setuptools>=17.1" "pytest>=3.1"
-COVERAGE=coverage-${PYTHON_VERSION}
 
 # fix broken glue dependency
 #     this is required because the LIGO glue package isn't
@@ -48,4 +47,4 @@ COVERAGE=coverage-${PYTHON_VERSION}
 ${PIP} install ${PIP_FLAGS} lscsoft-glue
 
 # run tests
-${COVERAGE} run ./setup.py --quiet test
+${PYTHON} -m coverage run ./setup.py --quiet test

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -44,7 +44,7 @@ ${PIP} install ${PIP_FLAGS} \
     "freezegun>=0.2.3"
 
 # run tests
-${PYTHON} -m coverage --source=gwpy run ./setup.py --quiet test
+${PYTHON} -m coverage run ./setup.py --quiet test
 
 # print coverage
 ${PYTHON} -m coverage report

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -40,7 +40,7 @@ set -ex && trap 'set +xe' RETURN
 ${PIP} install ${PIP_FLAGS} \
     "setuptools>=17.1" \
     "pytest>=3.1" \
-    "coverage" \
+    "coverage>=4.0.0" \
     "freezegun>=0.2.3"
 
 # run tests

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -37,11 +37,7 @@ get_python_version  # sets PYTHON_VERSION
 set -ex && trap 'set +xe' RETURN
 
 # install test dependencies
-${PIP} install ${PIP_FLAGS} \
-    "setuptools>=17.1" \
-    "pytest>=3.1" \
-    "coverage>=4.0.0" \
-    "freezegun>=0.2.3"
+${PIP} install ${PIP_FLAGS} -r requirements-test.txt
 
 # run tests
 ${PYTHON} -m coverage run ./setup.py --quiet test

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -16,10 +16,8 @@ Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{sr
 BuildArch:      noarch
 BuildRequires:  rpm-build
 BuildRequires:  python-rpm-macros
-BuildRequires:  python3-rpm-macros
+BuildRequires:  python2-rpm-macros
 BuildRequires:  python2-setuptools
-BuildRequires:  python%{python3_pkgversion}-setuptools
-BuildRequires:  python3-rpm-macros
 
 %description
 {{ long_description }}
@@ -46,40 +44,15 @@ Requires:       python2-tqdm
 %description -n python2-%{srcname}
 {{ long_description }}
 
-
-# -- python3x-gwpy ------------------------------------------------------------
-
-%package -n python%{python3_pkgversion}-%{srcname}
-Summary:        %{summary}
-Requires:       python%{python3_pkgversion}-six
-Requires:       python%{python3_pkgversion}-dateutil
-Requires:       python%{python3_pkgversion}-numpy
-Requires:       python%{python3_pkgversion}-scipy
-Requires:       python%{python3_pkgversion}-matplotlib
-Requires:       python%{python3_pkgversion}-astropy
-Requires:       python%{python3_pkgversion}-h5py
-Requires:       lal-python%{python3_pkgversion} >= 6.14.0
-Requires:       python%{python3_pkgversion}-ligo-segments
-Requires:       python%{python3_pkgversion}-tqdm
-
-%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
-
-%description -n python%{python3_pkgversion}-%{srcname}
-{{ long_description }}
-
 # -- build stages -------------------------------------------------------------
 
 %prep
 %autosetup -n %{srcname}-%{version}
 
 %build
-# build python3 first
-%py3_build
-# so that the scripts come from python2
 %py2_build
 
 %install
-%py3_install
 %py2_install
 
 # -- files --------------------------------------------------------------------
@@ -89,11 +62,6 @@ Requires:       python%{python3_pkgversion}-tqdm
 %doc README.md
 %{python2_sitelib}/*
 %{_bindir}/gwpy-plot
-
-%files -n python%{python3_pkgversion}-%{srcname}
-%license LICENSE
-%doc README.md
-%{python3_sitelib}/*
 
 # -- changelog ----------------------------------------------------------------
 

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -681,7 +681,7 @@ class TestDataQualityDict(object):
 
     # -- test I/O -------------------------------
 
-    @utils.skip_missing_dependency('lal')
+    @utils.skip_missing_dependency('glue.ligolw.lsctables')
     def test_from_veto_definer_file(self, veto_definer):
         # read veto definer
         vdf = self.TEST_CLASS.from_veto_definer_file(veto_definer)

--- a/gwpy/segments/tests/test_segments.py
+++ b/gwpy/segments/tests/test_segments.py
@@ -77,7 +77,7 @@ class TestSegmentList(object):
 
     # -- test I/O -------------------------------
 
-    @skip_missing_dependency('lal')
+    @skip_missing_dependency('glue.segmentsUtils')
     def test_read_write_segwizard(self, segmentlist):
         with tempfile.NamedTemporaryFile(suffix='.txt', mode='w') as f:
             # check write/read returns the same list

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -240,7 +240,7 @@ class TestStateVector(_TestTimeSeriesBase):
             array.get_bit_series(['blah'])
         assert str(exc.value) == "Bit 'blah' not found in StateVector"
 
-    @utils.skip_missing_dependency('lal')
+    @utils.skip_missing_dependency('glue.segmentsUtils')
     def test_plot(self, array):
         with rc_context(rc={'text.usetex': False}):
             plot = array.plot()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,6 +30,6 @@ requests
 pytest >= 3.1
 coveralls
 mock ; python_version < '3'
-freezegun
-sqlparse
-bs4
+freezegun >= 0.2.3
+sqlparse >= 0.2.0
+beautifulsoup4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,18 @@
-# include core requirements
+# core
 -r requirements.txt
 
-# dependencies for glue
-pykerberos
-pyRXP
+# tests
+-r requirements-test.txt
+
+# docs
+-r requirements-doc.txt
 
 # extras
 pymysql
+pykerberos
+pyRXP
 lscsoft-glue
 dqsegdb
-https://github.com/ligovirgo/trigfind/archive/v0.4.tar.gz
 ligotimegps
 pycbc != 1.10.0 ; python_version == '2.7'
 git+https://github.com/duncanmmacleod/ligo.org.git
@@ -17,19 +20,3 @@ sqlalchemy
 psycopg2
 pandas ; python_version != '3.4'
 pandas < 0.21 ; python_version == '3.4'
-
-# docs
-sphinx >= 1.6.1
-numpydoc
-sphinx-bootstrap-theme >= 0.6
-sphinxcontrib-programoutput
-sphinx-automodapi
-requests
-
-# tests
-pytest >= 3.1
-coveralls
-mock ; python_version < '3'
-freezegun >= 0.2.3
-sqlparse >= 0.2.0
-beautifulsoup4

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,0 +1,7 @@
+# requirements for GWpy docs
+sphinx >= 1.6.1
+numpydoc
+sphinx-bootstrap-theme >= 0.6
+sphinxcontrib-programoutput
+sphinx-automodapi
+requests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,6 @@
 # requirements for GWpy tests
 pytest >= 3.1
 coverage >= 4.0.0
-coveralls
 mock ; python_version < '3'
 freezegun >= 0.2.3
 sqlparse >= 0.2.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,8 @@
+# requirements for GWpy tests
+pytest >= 3.1
+coverage >= 4.0.0
+coveralls
+mock ; python_version < '3'
+freezegun >= 0.2.3
+sqlparse >= 0.2.0
+beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ tests_require = [
     'pytest>=3.1',
     'freezegun',
     'sqlparse',
-    'bs4',
+    'beautifulsoup4',
 ]
 if sys.version < '3':
     tests_require.append('mock')

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ extras_require['all'] = set(p for extra in extras_require.values()
 tests_require = [
     'pytest>=3.1',
     'freezegun>=0.2.3',
-    'sqlparse',
+    'sqlparse>=0.2.0',
     'beautifulsoup4',
 ]
 if sys.version < '3':

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ extras_require['all'] = set(p for extra in extras_require.values()
 # test dependencies
 tests_require = [
     'pytest>=3.1',
-    'freezegun',
+    'freezegun>=0.2.3',
     'sqlparse',
     'beautifulsoup4',
 ]


### PR DESCRIPTION
This PR removes the python3 builds for RHEL7 (el7) and Debian Jessie (debian8), because they don't work, and those systems are too old to give useful python3 package support.