### PR TITLE
Set x-axis limit for each Q plot in gwpy.cli

### DIFF
--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -175,6 +175,10 @@ class Qtransform(Spectrogram):
 
         return qtrans
 
+    def scale_axes_from_data(self):
+        self.args.xmin, self.args.xmax = self.result.xspan
+        return super(Qtransform, self).scale_axes_from_data()
+
     def has_more_plots(self):
         """any ranges left to plot?
         """


### PR DESCRIPTION
This PR fixes a bug in `gwpy.cli.Qtransform` where all generated figures would have the X-axis limits from the first generated figure. The fix is just to manually overwrite the `xmin` and `xmax` according to `outseg` for each figure.

cc: @areeda