### PR TITLE
Raise error on any floating point issues during whitening in q_transform

### DIFF
--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1682,8 +1682,9 @@ class TimeSeries(TimeSeriesBase):
                 elif overlap is None:
                     overlap = recommended_overlap(window) * fftlength
                 whiten = self.asd(fftlength, overlap, method=method, **asd_kw)
-            # apply whitening
-            wdata = self.whiten(fftlength, overlap, asd=whiten)
+            # apply whitening (with errors on dividing by zero)
+            with numpy.errstate(all='raise'):
+                wdata = self.whiten(fftlength, overlap, asd=whiten)
             fdata = wdata.fft().value
         else:
             fdata = self.fft().value


### PR DESCRIPTION
This PR closes #836 by modifying `TimeSeries.q_transform` to raise any and all exceptions related to floating point numbers when calling `TimeSeries.whiten`. This means that any zeros in the ASD will result in an exception being raised (`FloatingPointError`), rather than allowing the Q-transform to filter over `nan`s.

This may have impacts for GravitySpy and LDVW.

cc: @areeda, @scottcoughlin2014 