### PR TITLE
Use BytesIO to test plot savefig() without touching the disk

### DIFF
--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -20,6 +20,7 @@
 """
 
 import tempfile
+from io import BytesIO
 
 import pytest
 
@@ -117,8 +118,7 @@ class TestFrequencySeries(_TestSeries):
             line = plot.gca().lines[0]
             utils.assert_array_equal(line.get_xdata(), array.xindex.value)
             utils.assert_array_equal(line.get_ydata(), array.value)
-            with tempfile.NamedTemporaryFile(suffix='.png') as f:
-                plot.save(f.name)
+            plot.save(BytesIO(), format='png')
             plot.close()
 
     def test_ifft(self):

--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -19,7 +19,7 @@
 """Unit test for frequencyseries module
 """
 
-import tempfile
+from io import BytesIO
 
 import pytest
 
@@ -108,8 +108,7 @@ class TestSpectralVariance(_TestArray2D):
         with rc_context(rc={'text.usetex': False}):
             plot = array.plot(yscale='linear')
             assert len(plot.gca().collections) == 1
-            with tempfile.NamedTemporaryFile(suffix='.png') as f:
-                plot.save(f.name)
+            plot.save(BytesIO(), format='png')
             plot.close()
 
     def test_value_at(self, array):

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -21,6 +21,7 @@
 
 import os.path
 import tempfile
+from io import BytesIO
 from ssl import SSLError
 
 from six.moves.urllib.error import (URLError, HTTPError)
@@ -300,8 +301,7 @@ class TestDataQualityFlag(object):
             assert len(plot.gca().collections[0].get_paths()) == len(ACTIVE)
             assert plot.gca().collections[0].get_label() == flag.label
 
-            with tempfile.NamedTemporaryFile(suffix='.png') as f:
-                plot.save(f.name)
+            plot.save(BytesIO(), format='png')
             plot.close()
 
         flag.label = None
@@ -675,8 +675,7 @@ class TestDataQualityDict(object):
         with rc_context(rc={'text.usetex': False}):
             plot = instance.plot(figsize=(6.4, 3.8))
             assert isinstance(plot.gca(), SegmentAxes)
-            with tempfile.NamedTemporaryFile(suffix='.png') as f:
-                plot.save(f.name)
+            plot.save(BytesIO(), format='png')
             plot.close()
 
     # -- test I/O -------------------------------

--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -19,7 +19,7 @@
 """Unit tests for :mod:`gwpy.spectrogram.spectrogram`
 """
 
-import tempfile
+from io import BytesIO
 
 import pytest
 
@@ -153,8 +153,7 @@ class TestSpectrogram(_TestArray2D):
             assert ax.get_epoch() == array.x0.value
             assert ax.get_xlim() == array.xspan
             assert ax.get_ylim() == array.yspan
-            with tempfile.NamedTemporaryFile(suffix='.png') as f:
-                plot.save(f.name)
+            plot.save(BytesIO(), format='png')
             plot.close()
 
     def test_zpk(self, array):

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -22,6 +22,7 @@
 import os.path
 import shutil
 import tempfile
+from io import BytesIO
 
 from six import PY2
 
@@ -419,15 +420,13 @@ class TestEventTable(TestTable):
 
     def test_scatter(self, table):
         plot = table.scatter('time', 'frequency', color='snr')
-        with tempfile.NamedTemporaryFile(suffix='.png') as f:
-            plot.save(f.name)
+        plot.save(BytesIO(), format='png')
         plot.close()
 
     def test_hist(self, table):
         plot = table.hist('snr')
         assert len(plot.gca().patches) == 10
-        with tempfile.NamedTemporaryFile(suffix='.png') as f:
-            plot.save(f.name)
+        plot.save(BytesIO(), format='png')
         plot.close()
 
     def test_get_column(self, table):

--- a/gwpy/tests/test_plotter.py
+++ b/gwpy/tests/test_plotter.py
@@ -19,8 +19,8 @@
 """Unit tests for plotter module
 """
 
-import tempfile
 import warnings
+from io import BytesIO
 
 import pytest
 
@@ -121,8 +121,7 @@ class PlottingTestBase(object):
         return rcParams['text.usetex']
 
     def save(self, fig, suffix='.png'):
-        with tempfile.NamedTemporaryFile(suffix=suffix) as f:
-            fig.save(f.name)
+        fig.save(BytesIO(), format=suffix.lstrip('.'))
         return fig
 
     def save_and_close(self, fig, suffix='.png'):

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -20,7 +20,7 @@
 """
 
 import os
-import tempfile
+from io import BytesIO
 
 import pytest
 
@@ -147,8 +147,7 @@ class TestTimeSeriesBase(_TestSeries):
             line = plot.gca().lines[0]
             utils.assert_array_equal(line.get_xdata(), array.xindex.value)
             utils.assert_array_equal(line.get_ydata(), array.value)
-            with tempfile.NamedTemporaryFile(suffix='.png') as f:
-                plot.save(f.name)
+            plot.save(BytesIO(), format='png')
             plot.close()
 
     @utils.skip_missing_dependency('nds2')
@@ -349,8 +348,7 @@ class TestTimeSeriesBaseDict(object):
                                          instance[key].xindex.value)
                 utils.assert_array_equal(line.get_ydata(),
                                          instance[key].value)
-            with tempfile.NamedTemporaryFile(suffix='.png') as f:
-                plot.save(f.name)
+            plot.save(BytesIO(), format='png')
             plot.close()
 
 

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -19,7 +19,7 @@
 """Unit test for timeseries module
 """
 
-import tempfile
+from io import BytesIO
 
 import pytest
 
@@ -248,8 +248,7 @@ class TestStateVector(_TestTimeSeriesBase):
             assert plot.gca().lines == []
             # assert one collection for each of known and active segmentlists
             assert len(plot.gca().collections) == len(array.bits) * 2
-            with tempfile.NamedTemporaryFile(suffix='.png') as f:
-                plot.save(f.name)
+            plot.save(BytesIO(), format='png')
             plot.close()
 
             # test timeseries plotting as normal


### PR DESCRIPTION
This PR modifies all tests to use `BytesIO()` when testing saving images, so that we never actually write anything to the filesystem.