### PR TITLE
Removed unused code from test suite

### DIFF
--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -64,7 +64,6 @@ class TestSpectrogram(_TestArray2D):
 
     def test_value_at(self, array):
         super(TestSpectrogram, self).test_value_at(array)
-        print(array)
         v = array.value_at(5000 * units.millisecond,
                            2000 * units.milliHertz)
         assert v == self.data[5][2] * array.unit

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -339,7 +339,6 @@ class TestEventTable(TestTable):
         table.filter(u'snr > 100')
 
     def test_filter_in_segmentlist(self, table):
-        print(table)
         # check filtering on segments works
         segs = SegmentList([Segment(100, 200), Segment(400, 500)])
         inseg = table.filter(('time', filters.in_segmentlist, segs))
@@ -378,7 +377,6 @@ class TestEventTable(TestTable):
         # check that method can function without explicit time column
         # (and no data) if and only if start/end are both given
         t2 = self.create(10, names=['a', 'b'])
-        print(t2)
         with pytest.raises(ValueError) as exc:
             t2.event_rate(1)
         assert 'please give `timecolumn` keyword' in str(exc.value)

--- a/gwpy/types/tests/test_array.py
+++ b/gwpy/types/tests/test_array.py
@@ -20,7 +20,6 @@
 """
 
 import os
-import tempfile
 import pickle
 import warnings
 
@@ -260,28 +259,3 @@ class TestArray(object):
         array.override_unit('blah', parse_strict='silent')
         assert isinstance(array.unit, units.IrreducibleUnit)
         assert str(array.unit) == 'blah'
-
-    # -- test I/O -------------------------------
-
-    def _test_read_write(self, format, extension=None, auto=True, exclude=[],
-                         readkwargs={}, writekwargs={}):
-        """Helper method for testing unified I/O for `Array` instances
-        """
-        if extension is None:
-            extension = format
-        extension = '.%s' % extension.lstrip('.')
-        try:
-            fp = tempfile.mktemp(suffix=extension)
-            self.TEST_ARRAY.write(fp, format=format, **writekwargs)
-            if auto:
-                self.TEST_ARRAY.write(fp, **writekwargs)
-            b = self.TEST_ARRAY.read(fp, self.TEST_ARRAY.name,
-                                     format=format, **readkwargs)
-            if auto:
-                self.TEST_ARRAY.read(fp, self.TEST_ARRAY.name,
-                                     **readkwargs)
-            utils.assert_array_equal(self.TEST_ARRAY, b, exclude=exclude)
-            return b
-        finally:
-            if os.path.exists(fp):
-                os.remove(fp)

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -20,7 +20,6 @@
 """
 
 import os
-import tempfile
 import warnings
 
 import numpy
@@ -350,19 +349,3 @@ class TestSeries(_TestArray):
         elif ts1.xunit == units.Hz:
             assert ts1.value_at(1500 * units.milliHertz) == (
                 self.data[3] * ts1.unit)
-
-    # -- test I/O -------------------------------
-
-    def _test_read_write_ascii(self, format='txt'):
-        extension = '.%s' % format.lstrip('.')
-        try:
-            with tempfile.NamedTemporaryFile(suffix=extension, mode='w',
-                                             delete=False) as f:
-                self.TEST_ARRAY.write(f.name, format=format)
-                self.TEST_ARRAY.write(f.name)
-                b = self.TEST_ARRAY.read(f.name, format=format)
-                self.TEST_ARRAY.read(f.name)
-                utils.assert_array_equal(self.TEST_ARRAY.value, b.value)
-        finally:
-            if os.path.exists(f.name):
-                os.remove(f.name)


### PR DESCRIPTION
This PR removes some unused methods, and unnecessary `print()` calls from the test modules.