### PR TITLE
Fixed ascii header bug on Windows

### DIFF
--- a/gwpy/table/io/cwb.py
+++ b/gwpy/table/io/cwb.py
@@ -65,9 +65,11 @@ class CwbHeader(core.BaseHeader):
         self.names = []
         include_cuts = False
         for line in lines:
-            if not line.startswith('# '):
-                break  # End of header lines
-            elif line.startswith('# -/+'):
+            if not line:  # ignore empty lines in header (windows)
+                continue
+            if not line.startswith('# '):  # end of header lines
+                break
+            if line.startswith('# -/+'):
                 include_cuts = True
             else:
                 match = re_name_def.search(line)

--- a/gwpy/table/io/omega.py
+++ b/gwpy/table/io/omega.py
@@ -41,12 +41,13 @@ class OmegaHeader(core.BaseHeader):
         re_name_def = re.compile(r'^\s*%\s+(?P<colname>\w+)')
         self.names = []
         for line in lines:
-            if not line.startswith('%'):
-                break  # End of header lines
-            else:
-                match = re_name_def.search(line)
-                if match:
-                    self.names.append(match.group('colname'))
+            if not line:  # ignore empty lines in header (windows)
+                continue
+            if not line.startswith('%'):  # end of header lines
+                break
+            match = re_name_def.search(line)
+            if match:
+                self.names.append(match.group('colname'))
 
         if not self.names:
             raise core.InconsistentTableError(


### PR DESCRIPTION
This PR fixes an issue reading ASCII tables on Windows, which seems to receive extra empty lines when reading ASCII tables relative to Unix.