### PR TITLE
Use TemporaryFilename contextmanager for tests

### DIFF
--- a/gwpy/cli/tests/base.py
+++ b/gwpy/cli/tests/base.py
@@ -20,7 +20,6 @@
 """
 
 import os
-import tempfile
 import warnings
 from argparse import ArgumentParser
 
@@ -38,8 +37,6 @@ from ...tests import (utils, mocks)
 from ...tests.mocks import mock
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-
-_, TEMP_PLOT_FILE = tempfile.mkstemp(prefix='GWPY-UNITTEST_', suffix='.png')
 
 
 # -- utilities ----------------------------------------------------------------
@@ -249,11 +246,11 @@ class _TestCliProduct(object):
     def test_run(self, prod):
         conn, _ = mock_nds2_connection()
         with mock.patch('nds2.connection') as mocker, \
-                tempfile.NamedTemporaryFile(suffix='.png') as f:
+                utils.TemporaryFilename(suffix='.png') as tmp:
             mocker.return_value = conn
-            prod.args.out = f.name
+            prod.args.out = tmp
             prod.run()
-            assert os.path.isfile(f.name)
+            assert os.path.isfile(tmp)
             assert prod.plot_num == 1
             assert not prod.has_more_plots()
 

--- a/gwpy/detector/tests/test_channel.py
+++ b/gwpy/detector/tests/test_channel.py
@@ -21,7 +21,6 @@
 
 import json
 import os.path
-from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -462,11 +461,10 @@ class TestChannelList(object):
 
     def test_read_write_omega_config(self):
         # write OMEGA_CONFIG to file and read it back
-        try:
-            with NamedTemporaryFile(suffix='.txt', mode='w',
-                                    delete=False) as f:
+        with utils.TemporaryFilename(suffix='.txt') as tmp:
+            with open(tmp, 'w') as f:
                 f.write(OMEGA_CONFIG)
-            cl = self.TEST_CLASS.read(f.name, format='omega-scan')
+            cl = self.TEST_CLASS.read(tmp, format='omega-scan')
             assert len(cl) == 2
             assert cl[0].name == 'L1:GDS-CALIB_STRAIN'
             assert cl[0].sample_rate == 4096 * units.Hertz
@@ -488,29 +486,20 @@ class TestChannelList(object):
             }
             assert cl[1].name == 'L1:PEM-CS_SEIS_LVEA_VERTEX_Z_DQ'
             assert cl[1].frametype == 'L1_R'
-        finally:
-            if os.path.isfile(f.name):
-                os.remove(f.name)
 
-        # write omega config again using ChannelList.write and read it back
-        # and check that the two lists match
-        try:
-            with NamedTemporaryFile(suffix='.txt', delete=False,
-                                    mode='w') as f2:
-                cl.write(f2, format='omega-scan')
-            cl2 = type(cl).read(f2.name, format='omega-scan')
+            # write omega config again using ChannelList.write and read it back
+            # and check that the two lists match
+            with open(tmp, 'w') as f:
+                cl.write(f, format='omega-scan')
+            cl2 = type(cl).read(tmp, format='omega-scan')
             assert cl == cl2
-        finally:
-            if os.path.isfile(f2.name):
-                os.remove(f2.name)
 
     def test_read_write_clf(self):
         # write clf to file and read it back
-        try:
-            with NamedTemporaryFile(suffix='.ini', delete=False,
-                                    mode='w') as f:
+        with utils.TemporaryFilename(suffix='.ini') as tmp:
+            with open(tmp, 'w') as f:
                 f.write(CLF)
-            cl = ChannelList.read(f.name)
+            cl = ChannelList.read(tmp)
             assert len(cl) == 4
             a = cl[0]
             assert a.name == 'H1:GDS-CALIB_STRAIN'
@@ -533,18 +522,10 @@ class TestChannelList(object):
             assert d.name == 'H1:ISI-GND_STS_HAM2_Z_DQ'
             assert d.safe is True
             assert d.params['fidelity'] == 'glitchy'
-        finally:
-            if os.path.isfile(f.name):
-                os.remove(f.name)
-        # write omega config again using ChannelList.write and read it back
-        # and check that the two lists match
-        try:
-            with NamedTemporaryFile(suffix='.ini', delete=False,
-                                    mode='w') as f2:
 
-                cl.write(f2)
-            cl2 = type(cl).read(f2.name)
+            # write omega config again using ChannelList.write and read it back
+            # and check that the two lists match
+            with open(tmp, 'w') as f:
+                cl.write(f)
+            cl2 = type(cl).read(tmp)
             assert cl == cl2
-        finally:
-            if os.path.isfile(f2.name):
-                os.remove(f2.name)

--- a/gwpy/io/tests/test_cache.py
+++ b/gwpy/io/tests/test_cache.py
@@ -29,7 +29,7 @@ import numpy
 import pytest
 
 from ...segments import (Segment, SegmentList)
-from ...tests.utils import skip_missing_dependency
+from ...tests.utils import (skip_missing_dependency, TemporaryFilename)
 from .. import cache as io_cache
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -65,25 +65,26 @@ def segments():
 
 @pytest.fixture
 def tmpfile():
-    with tempfile.NamedTemporaryFile() as f:
-        yield f
+    with TemporaryFilename() as tmp:
+        yield tmp
 
 
 # -- tests --------------------------------------------------------------------
 
 def test_read_write_cache(cache, tmpfile):
-    io_cache.write_cache(cache, tmpfile)
-    tmpfile.seek(0)
+    with open(tmpfile, 'w') as f:
+        io_cache.write_cache(cache, f)
 
     # read from fileobj
-    c2 = io_cache.read_cache(tmpfile)
+    with open(tmpfile) as f:
+        c2 = io_cache.read_cache(tmpfile)
     assert cache == c2
 
     # write with file name
-    io_cache.write_cache(cache, tmpfile.name)
+    io_cache.write_cache(cache, tmpfile)
 
     # read from file name
-    c3 = io_cache.read_cache(tmpfile.name)
+    c3 = io_cache.read_cache(tmpfile)
     assert cache == c3
 
 

--- a/gwpy/io/tests/test_kerberos.py
+++ b/gwpy/io/tests/test_kerberos.py
@@ -21,11 +21,11 @@
 
 import os
 import sys
-import tempfile
 
 import pytest
 
 from ...tests.mocks import mock
+from ...tests.utils import TemporaryFilename
 from .. import kerberos as io_kerberos
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -104,10 +104,10 @@ def test_kinit(raw_input_, getpass, mocked_popen, which, capsys):
         ['/bin/kinit', 'rainer.weiss@LIGO.ORG'], **popen_kwargs)
 
     # test keytab from enviroment found
-    with tempfile.NamedTemporaryFile(suffix='.keytab') as f:
-        io_kerberos.kinit(keytab=f.name)
+    with TemporaryFilename(suffix='.keytab') as tmp:
+        io_kerberos.kinit(keytab=tmp)
         mocked_popen.assert_called_with(
-            ['/bin/kinit', '-k', '-t', f.name, 'albert.einstein@LIGO.ORG'],
+            ['/bin/kinit', '-k', '-t', tmp, 'albert.einstein@LIGO.ORG'],
             **popen_kwargs)
 
     os.environ.pop('KRB5_KTNAME', None)

--- a/gwpy/io/tests/test_utils.py
+++ b/gwpy/io/tests/test_utils.py
@@ -25,6 +25,7 @@ import tempfile
 
 from six import PY2
 
+from ...tests.utils import TemporaryFilename
 from .. import utils as io_utils
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -32,28 +33,21 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 def test_gopen():
     # test simple use
-    try:
-        with tempfile.NamedTemporaryFile(delete=False, mode='w') as f:
+    with TemporaryFilename() as tmp:
+        with open(tmp, 'w') as f:
             f.write('blah blah blah')
         f2 = io_utils.gopen(f.name)
         assert f2.read() == 'blah blah blah'
-    finally:
-        if os.path.isfile(f.name):
-            os.remove(f.name)
 
     # test gzip file (with and without extension)
     for suffix in ('.txt.gz', ''):
-        try:
-            fn = tempfile.mktemp(suffix=suffix)
-            text = 'blah blah blah' if PY2 else b'blah blah blah'
-            with gzip.open(fn, 'wb') as f:
-                f.write(text)
-            f2 = io_utils.gopen(fn, mode='rb')
-            assert isinstance(f2, gzip.GzipFile)
-            assert f2.read() == text
-        finally:
-            if os.path.isfile(fn):
-                os.remove(f.name)
+        with TemporaryFilename(suffix=suffix) as tmp:
+            text = b'blah blah blah'
+            with gzip.open(tmp, 'wb') as fobj:
+                fobj.write(text)
+            fobj2 = io_utils.gopen(tmp, mode='rb')
+            assert isinstance(fobj2, gzip.GzipFile)
+            assert fobj2.read() == text
 
 
 def test_identify_factory():

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -20,7 +20,6 @@
 """
 
 import os.path
-import tempfile
 
 from six.moves import StringIO
 
@@ -100,9 +99,9 @@ class TestPlot(FigureTestBase):
         plot.close()
 
     def test_save(self, fig):
-        with tempfile.NamedTemporaryFile(suffix='.png') as f:
-            fig.save(f.name)
-            assert os.path.isfile(f.name)
+        with utils.TemporaryFilename(suffix='.png') as tmp:
+            fig.save(tmp)
+            assert os.path.isfile(tmp)
 
     def test_get_axes(self, fig):
         fig.add_subplot(2, 1, 1, projection='rectilinear')

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -122,20 +122,20 @@ class TestTable(object):
         table = self.create(
             100, ['peak_time', 'peak_time_ns', 'snr', 'central_freq'],
             ['i4', 'i4', 'f4', 'f4'])
-        with tempfile.NamedTemporaryFile(suffix='.{}'.format(ext),
-                                         delete=False) as f:
+        with utils.TemporaryFilename(suffix='.{}'.format(ext)) as tmp:
             def _read(*args, **kwargs):
                 kwargs.setdefault('format', 'ligolw')
                 kwargs.setdefault('tablename', 'sngl_burst')
-                return self.TABLE.read(f, *args, **kwargs)
+                return self.TABLE.read(tmp, *args, **kwargs)
 
             def _write(*args, **kwargs):
                 kwargs.setdefault('format', 'ligolw')
                 kwargs.setdefault('tablename', 'sngl_burst')
-                return table.write(f.name, *args, **kwargs)
+                return table.write(tmp, *args, **kwargs)
 
             # check simple write (using open file descriptor, not file path)
-            table.write(f, format='ligolw', tablename='sngl_burst')
+            with open(tmp, 'w+b') as f:
+                table.write(f, format='ligolw', tablename='sngl_burst')
 
             # check simple read
             t2 = _read()
@@ -153,7 +153,7 @@ class TestTable(object):
 
             # check reading multiple tables works
             try:
-                t3 = self.TABLE.read([f.name, f.name], format='ligolw',
+                t3 = self.TABLE.read([tmp, tmp], format='ligolw',
                                      tablename='sngl_burst')
             except NameError as e:
                 if not PY2:  # ligolw not patched for python3 just yet
@@ -164,7 +164,7 @@ class TestTable(object):
             # check writing to existing file raises IOError
             with pytest.raises(IOError) as exc:
                 _write()
-            assert str(exc.value) == 'File exists: %s' % f.name
+            assert str(exc.value) == 'File exists: %s' % tmp
 
             # check overwrite=True, append=False rewrites table
             try:
@@ -190,14 +190,14 @@ class TestTable(object):
 
             # write another table and check we can still get back the first
             insp = self.create(10, ['end_time', 'snr', 'chisq_dof'])
-            insp.write(f.name, format='ligolw', tablename='sngl_inspiral',
+            insp.write(tmp, format='ligolw', tablename='sngl_inspiral',
                        append=True)
             t3 = _read()
             utils.assert_table_equal(t2, t3)
 
             # write another table with append=False and check the first table
             # is gone
-            insp.write(f.name, format='ligolw', tablename='sngl_inspiral',
+            insp.write(tmp, format='ligolw', tablename='sngl_inspiral',
                        append=False, overwrite=True)
             with pytest.raises(ValueError) as exc:
                 _read()
@@ -226,10 +226,7 @@ class TestTable(object):
 
     @utils.skip_missing_dependency('root_numpy')
     def test_read_write_root(self, table):
-        tempdir = tempfile.mkdtemp()
-        try:
-            fp = tempfile.mktemp(suffix='.root', dir=tempdir)
-
+        with utils.TemporaryFilename(suffix='.root') as fp:
             # check write
             table.write(fp)
 
@@ -258,19 +255,15 @@ class TestTable(object):
                                  ('time', filters.in_segmentlist, segs)),
             )
 
-        finally:
-            if os.path.isdir(tempdir):
-                shutil.rmtree(tempdir)
-
     def test_read_write_gwf(self):
         table = self.create(100, ['time', 'blah', 'frequency'])
         columns = table.dtype.names
-        tempdir = tempfile.mkdtemp()
-        try:
-            fp = tempfile.mktemp(suffix='.gwf', dir=tempdir)
-
+        with utils.TemporaryFilename(suffix='.gwf') as fp:
             # check write
-            table.write(fp, 'test_read_write_gwf')
+            try:
+                table.write(fp, 'test_read_write_gwf')
+            except ImportError as e:
+                pytest.skip(str(e))
 
             # check read gives back same table
             t2 = self.TABLE.read(fp, 'test_read_write_gwf', columns=columns)
@@ -281,12 +274,6 @@ class TestTable(object):
                                  columns=columns, selection='frequency>500')
             utils.assert_table_equal(
                 filter_table(t2, 'frequency>500'), t3)
-
-        except ImportError as e:
-            pytest.skip(str(e))
-        finally:
-            if os.path.isdir(tempdir):
-                shutil.rmtree(tempdir)
 
 
 class TestEventTable(TestTable):
@@ -439,7 +426,6 @@ class TestEventTable(TestTable):
     def test_read_write_ascii(self, table, fmtname):
         fmt = 'ascii.%s' % fmtname.lower()
         with tempfile.NamedTemporaryFile(suffix='.txt', mode='w') as f:
-            print(f.name)
             # check write/read returns the same table
             table.write(f, format=fmt)
             f.seek(0)

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -226,19 +226,19 @@ class TestTable(object):
 
     @utils.skip_missing_dependency('root_numpy')
     def test_read_write_root(self, table):
-        with utils.TemporaryFilename(suffix='.root') as fp:
+        with utils.TemporaryFilename(suffix='.root') as tmp:
             # check write
-            table.write(fp)
+            table.write(tmp)
 
             def _read(*args, **kwargs):
-                return type(table).read(fp, *args, **kwargs)
+                return type(table).read(tmp, *args, **kwargs)
 
             # check read gives back same table
             utils.assert_table_equal(table, _read())
 
             # check that reading table from file with multiple trees without
             # specifying fails
-            table.write(fp, treename='test')
+            table.write(tmp, treename='test')
             with pytest.raises(ValueError) as exc:
                 _read()
             assert str(exc.value).startswith('Multiple trees found')
@@ -258,19 +258,19 @@ class TestTable(object):
     def test_read_write_gwf(self):
         table = self.create(100, ['time', 'blah', 'frequency'])
         columns = table.dtype.names
-        with utils.TemporaryFilename(suffix='.gwf') as fp:
+        with utils.TemporaryFilename(suffix='.gwf') as tmp:
             # check write
             try:
-                table.write(fp, 'test_read_write_gwf')
+                table.write(tmp, 'test_read_write_gwf')
             except ImportError as e:
                 pytest.skip(str(e))
 
             # check read gives back same table
-            t2 = self.TABLE.read(fp, 'test_read_write_gwf', columns=columns)
+            t2 = self.TABLE.read(tmp, 'test_read_write_gwf', columns=columns)
             utils.assert_table_equal(table, t2, meta=False, almost_equal=True)
 
             # check selections works
-            t3 = self.TABLE.read(fp, 'test_read_write_gwf',
+            t3 = self.TABLE.read(tmp, 'test_read_write_gwf',
                                  columns=columns, selection='frequency>500')
             utils.assert_table_equal(
                 filter_table(t2, 'frequency>500'), t3)

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -432,10 +432,12 @@ class TestEventTable(TestTable):
             utils.assert_table_equal(table, self.TABLE.read(tmp, format=fmt),
                                      almost_equal=True)
 
-        with tempfile.NamedTemporaryFile(suffix='.txt') as f:
+        with utils.TemporaryFilename(suffix='.txt') as tmp:
+            with open(tmp, 'w') as f:
+                pass  # write empty file
             # assert reading blank file doesn't work with column name error
             with pytest.raises(InconsistentTableError) as exc:
-                self.TABLE.read(f, format=fmt)
+                self.TABLE.read(tmp, format=fmt)
             assert str(exc.value) == ('No column names found in %s header'
                                       % fmtname)
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -425,11 +425,11 @@ class TestEventTable(TestTable):
     @pytest.mark.parametrize('fmtname', ('Omega', 'cWB'))
     def test_read_write_ascii(self, table, fmtname):
         fmt = 'ascii.%s' % fmtname.lower()
-        with tempfile.NamedTemporaryFile(suffix='.txt', mode='w') as f:
+        with utils.TemporaryFilename(suffix='.txt') as tmp:
             # check write/read returns the same table
-            table.write(f, format=fmt)
-            f.seek(0)
-            utils.assert_table_equal(table, self.TABLE.read(f, format=fmt),
+            with open(tmp, 'w') as fobj:
+                table.write(fobj, format=fmt)
+            utils.assert_table_equal(table, self.TABLE.read(tmp, format=fmt),
                                      almost_equal=True)
 
         with tempfile.NamedTemporaryFile(suffix='.txt') as f:

--- a/gwpy/tests/utils.py
+++ b/gwpy/tests/utils.py
@@ -21,6 +21,7 @@
 
 import os.path
 import tempfile
+from contextlib import contextmanager
 from importlib import import_module
 
 from six import PY2
@@ -219,6 +220,29 @@ def assert_zpk_equal(a, b, almost_equal=False):
 
 # -- I/O helpers --------------------------------------------------------------
 
+@contextmanager
+def TemporaryFilename(*args, **kwargs):  # pylint: disable=invalid-name
+    """Create and return a temporary filename
+
+    Calls `tempfile.mktemp` to create a temporary filename, and deletes
+    the named file (if it exists) when the context ends.
+
+    This method **does not create the named file**.
+
+    Examples
+    --------
+    >>> with TemporaryFilename(suffix='.txt') as tmp:
+    ...     print(tmp)
+    '/var/folders/xh/jdrqg2bx3s5f4lkq0rf2903c0000gq/T/tmpnNxivL.txt'
+    """
+    name = tempfile.mktemp(*args, **kwargs)
+    try:
+        yield name
+    finally:
+        if os.path.isfile(name):
+            os.remove(name)
+
+
 def test_read_write(data, format,
                     extension=None, autoidentify=True,
                     read_args=[], read_kw={},
@@ -267,10 +291,7 @@ def test_read_write(data, format,
 
     DataClass = type(data)
 
-    try:
-        # write data to a file
-        fp = tempfile.mktemp(suffix=extension)
-
+    with TemporaryFilename(suffix=extension) as fp:
         try:
             data.write(fp, *write_args, format=format, **write_kw)
         except TypeError as e:
@@ -292,8 +313,3 @@ def test_read_write(data, format,
         if autoidentify:
             new = DataClass.read(fp, *read_args, **read_kw)
             assert_equal(new, data, **assert_kw)
-
-    finally:
-        # make sure and clean up after ourselves
-        if os.path.exists(fp):
-            os.remove(fp)


### PR DESCRIPTION
This PR introduces a new `TemporaryFilename` context manager for the test suite, which resolves an error testing under Windows where open files cannot be written to via their file name. The new context manager just creates a new file path as a `str` and returns that, cleaning up that file path upon exit, if the file was written.

This isn't threadsafe, but is good enough for testing purposes.