### PR TITLE
Simplified gwpy.utils.shell

### DIFF
--- a/gwpy/utils/shell.py
+++ b/gwpy/utils/shell.py
@@ -19,8 +19,8 @@
 """Utilities for calling out to the shell
 """
 
-import os
 import warnings
+from distutils.spawn import find_executable
 from subprocess import (Popen, PIPE, CalledProcessError)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -44,20 +44,10 @@ def which(program):
     ValueError
         if not executable program is found
     """
-    def is_exe(fpath):
-        """Return `True` if the given file path is executable
-        """
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    absolute = os.path.dirname(program)
-    if absolute and is_exe(program):  # absolute path given, and executable
-        return program
-    elif not absolute:  # relative path given, walk PATH
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-    raise ValueError("No executable '%s' found in PATH" % program)
+    exe = find_executable(program)
+    if exe is None:
+        raise ValueError("No executable '%s' found in PATH" % program)
+    return exe
 
 
 def call(cmd, stdout=PIPE, stderr=PIPE, on_error='raise', **kwargs):

--- a/gwpy/utils/tests/test_shell.py
+++ b/gwpy/utils/tests/test_shell.py
@@ -20,6 +20,7 @@
 """
 
 import subprocess
+from distutils.spawn import find_executable
 
 import pytest
 
@@ -33,9 +34,7 @@ def test_shell_call():
     assert out == 'This works\n'
     assert err == ''
 
-    out2, err2 = shell.call("echo 'This works'")
-    assert out == out2
-    assert err == err2
+    shell.call("echo 'This works'")
 
     with pytest.raises(OSError):
         shell.call(['this-command-doesnt-exist'])
@@ -48,10 +47,6 @@ def test_shell_call():
 
 
 def test_which():
-    try:
-        result, _ = shell.call('which true')
-    except Exception as e:
-        pytest.skip(str(e))
-    else:
-        result = result.rstrip('\n')
-    assert shell.which('true') == result
+    assert shell.which('python') == find_executable('python')
+    with pytest.raises(ValueError):
+        shell.which('gwpy-no-executable')


### PR DESCRIPTION
This PR simplifies `gwpy.utils.shell` as follows:

- use `distutils.spawn.find_executable` for `which`
- simplified tests to run under Windows