### PR TITLE
Bumped pycbc version in development requirements file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ pyRXP
 lscsoft-glue
 dqsegdb
 ligotimegps
-pycbc != 1.10.0 ; python_version == '2.7'
+pycbc >= 1.10.1 ; python_version == '2.7'
 git+https://github.com/duncanmmacleod/ligo.org.git
 sqlalchemy
 psycopg2


### PR DESCRIPTION
This PR bumps the pycbc version to >= [1.10.1](https://github.com/gwastro/pycbc/tree/v1.10.1), a non-broken version that accepts window as numpy array for `pycbc.psd.welch`.