### PR TITLE
Added overloaded array methods for flatten and transpose

### DIFF
--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -144,6 +144,11 @@ class SpectralVariance(Array2D):
                            fdel=Array2D.xindex.__delete__,
                            doc="""Array of frequencies for each sample""")
 
+    @property
+    def T(self):
+        raise NotImplementedError(
+            "transposing a {0} is not supported".format(type(self).__name__))
+
     # -- i/O ------------------------------------
 
     @classmethod

--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -76,6 +76,9 @@ class TestSpectralVariance(_TestArray2D):
     def test_yindex(self, array):
         utils.assert_array_equal(array.yindex, array.bins[:-1])
 
+    def test_transpose(self, array):
+        return NotImplemented
+
     # -- test utilities -------------------------
 
     def test_getitem(self, array):

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -232,6 +232,11 @@ class StateTimeSeries(TimeSeriesBase):
         else:
             return super(StateTimeSeries, self).__getitem__(item)
 
+    def tolist(self):
+        return self.value.tolist()
+
+    tolist.__doc__ = numpy.ndarray.tolist.__doc__
+
 
 # -- Bits ---------------------------------------------------------------------
 

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -434,3 +434,38 @@ class Array(Quantity):
             if a `str` cannot be parsed as a valid unit
         """
         self._unit = parse_unit(unit, parse_strict=parse_strict)
+
+    def flatten(self, order='C'):
+        """Return a copy of the array collapsed into one dimension.
+
+        Any index information is removed as part of the flattening,
+        and the result is returned as a `~astropy.units.Quantity` array.
+
+        Parameters
+        ----------
+        order : {'C', 'F', 'A', 'K'}, optional
+            'C' means to flatten in row-major (C-style) order.
+            'F' means to flatten in column-major (Fortran-
+            style) order. 'A' means to flatten in column-major
+            order if `a` is Fortran *contiguous* in memory,
+            row-major order otherwise. 'K' means to flatten
+            `a` in the order the elements occur in memory.
+            The default is 'C'.
+
+        Returns
+        -------
+        y : `~astropy.units.Quantity`
+            A copy of the input array, flattened to one dimension.
+
+        See Also
+        --------
+        ravel : Return a flattened array.
+        flat : A 1-D flat iterator over the array.
+
+        Examples
+        --------
+        >>> a = Array([[1,2], [3,4]], unit='m', name='Test')
+        >>> a.flatten()
+        <Quantity [1., 2., 3., 4.] m>
+        """
+        return super(Array, self).flatten(order=order).view(Quantity)

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -348,6 +348,22 @@ class Array2D(Series):
             y0 = self.y0.to(self.yunit).value
             return Segment(y0, y0+self.shape[1]*dy)
 
+    @property
+    def T(self):
+        trans = self.value.T.view(type(self))
+        trans.__array_finalize__(self)
+        if hasattr(self, '_xindex'):
+            trans.yindex = self.xindex.view()
+        else:
+            trans.y0 = self.x0
+            trans.dy = self.dx
+        if hasattr(self, '_yindex'):
+            trans.xindex = self.yindex.view()
+        else:
+            trans.x0 = self.y0
+            trans.dx = self.dy
+        return trans
+
     # -- Array2D methods ------------------------
 
     def is_compatible(self, other):

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -116,7 +116,7 @@ class Array2D(Series):
 
         # create new object
         new = super(Array2D, cls).__new__(cls, data, unit=unit, xindex=xindex,
-                                          x0=x0, dx=dx, **kwargs)
+                                          xunit=xunit, x0=x0, dx=dx, **kwargs)
 
         # set y-axis metadata from yindex
         if yindex is not None:

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -536,7 +536,7 @@ class Series(Array):
         new = super(Series, self).__getitem__(item)
 
         # slice axis 0 metadata
-        slice_ = sliceutils.format_nd_slice(item, self.ndim)[0]
+        slice_, = sliceutils.format_nd_slice(item, 1)
         if not sliceutils.null_slice(slice_):
             sliceutils.slice_axis_attributes(self, 'x', new, 'x', slice_)
 

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -33,9 +33,7 @@ def format_nd_slice(item, ndim):
     """
     if not isinstance(item, tuple):
         item = (item,)
-    if len(item) == ndim:
-        return item
-    return item + (None,) * (ndim - len(item))
+    return item[:ndim] + (None,) * (ndim - len(item))
 
 
 def slice_axis_attributes(old, oldaxis, new, newaxis, slice_):
@@ -109,6 +107,8 @@ def null_slice(slice_):
     except TypeError:
         return False
 
+    if isinstance(slice_, numpy.ndarray) and numpy.all(slice_):
+        return True
     if isinstance(slice_, slice) and slice_ in (
             slice(None, None, None), slice(0, None, 1)
     ):

--- a/gwpy/types/tests/test_array.py
+++ b/gwpy/types/tests/test_array.py
@@ -259,3 +259,10 @@ class TestArray(object):
         array.override_unit('blah', parse_strict='silent')
         assert isinstance(array.unit, units.IrreducibleUnit)
         assert str(array.unit) == 'blah'
+
+    def test_flatten(self, array):
+        flat = array.flatten()
+        assert flat.ndim == 1
+        assert type(flat) is units.Quantity  # pylint: disable=C0123
+        assert flat.shape[0] == numpy.prod(array.shape)
+        utils.assert_quantity_equal(array.flatten('C'), array.T.flatten('F'))

--- a/gwpy/types/tests/test_array.py
+++ b/gwpy/types/tests/test_array.py
@@ -265,4 +265,10 @@ class TestArray(object):
         assert flat.ndim == 1
         assert type(flat) is units.Quantity  # pylint: disable=C0123
         assert flat.shape[0] == numpy.prod(array.shape)
-        utils.assert_quantity_equal(array.flatten('C'), array.T.flatten('F'))
+        try:
+            utils.assert_quantity_equal(
+                array.flatten('C'),
+                array.T.flatten('F'),
+            )
+        except NotImplementedError:
+            pass

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -136,6 +136,13 @@ class TestArray2D(_TestSeries):
         series = self.create(yindex=y)
         assert series.yspan == (y[0], y[-1] + y[-1] - y[-2])
 
+    def test_transpose(self, array):
+        trans = array.T
+        utils.assert_array_equal(trans.value, array.value.T)
+        assert trans.unit is array.unit
+        utils.assert_array_equal(trans.xindex, array.yindex)
+        utils.assert_array_equal(trans.yindex, array.xindex)
+
     # -- test methods ---------------------------
 
     @pytest.mark.parametrize('create_kwargs', [


### PR DESCRIPTION
This PR adds two new overloaded methods:

- `gwpy.types.Array.flatten` - returns a basic `Quantity` array, rather than the input subclass
- `gwpy.types.Array2D.T` (transpose property) - properly formats index arrays and units