### PR TITLE
Added more packages for python3 on debian

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -100,6 +100,8 @@ done
 apt-get -yqq install \
     git \
     ${PY_PREFIX}-pip \
+    krb5-user \
+    ${PY_PREFIX}-kerberos \
     ${PY_PREFIX}-glue \
     ${PY_PREFIX}-sqlalchemy \
     ${PY_PREFIX}-psycopg2 \

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -100,8 +100,7 @@ done
 apt-get -yqq install \
     git \
     ${PY_PREFIX}-pip \
-    krb5-user \
-    ${PY_PREFIX}-kerberos \
+    libkrb5-dev krb5-user \
     ${PY_PREFIX}-glue \
     ${PY_PREFIX}-sqlalchemy \
     ${PY_PREFIX}-psycopg2 \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,6 @@
 
 # extras
 pymysql
-pykerberos
 pyRXP
 lscsoft-glue
 dqsegdb


### PR DESCRIPTION
This PR attempts to fix (for example) [this build failure](https://travis-ci.com/gwpy/gwpy/jobs/136282460) when testing python3 on debian stretch by installing more packages with `apt`, so that `pip` has less to do.