### PR TITLE
Added CI job for python3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,17 @@ jobs:
     environment:
       PYTHON_VERSION: "3.6"
 
+  python:3.7:
+    <<: *python-build
+    docker:
+      - image: python:3.7
+    environment:
+      PYTHON_VERSION: "3.7"
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - python:2.7
       - python:3.6
+      - python:3.7

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -39,6 +39,11 @@ from .units import parse_unit
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+try:  # python >= 3.7
+    Pattern = re.Pattern
+except AttributeError:  # python < 3.7
+    Pattern = re._pattern_type
+
 QUOTE_REGEX = re.compile(r'^[\s\"\']+|[\s\"\']+$')
 
 
@@ -740,7 +745,7 @@ class ChannelList(list):
             a new `ChannelList` containing the matching channels
         """
         # format name regex
-        if isinstance(name, re._pattern_type):
+        if isinstance(name, Pattern):
             flags = name.flags
             name = name.pattern
         else:

--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Intended Audience :: Science/Research',
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This PR is a first attempt to 'officially' support python3.7, by adding a CircleCI job on that version, and the relevant classifier in `setup.py`.