### PR TITLE
Install latex under docker for CI tests

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -101,6 +101,7 @@ apt-get -yqq install \
     git \
     ${PY_PREFIX}-pip \
     libkrb5-dev krb5-user \
+    dvipng texlive-latex-base \
     ${PY_PREFIX}-glue \
     ${PY_PREFIX}-sqlalchemy \
     ${PY_PREFIX}-psycopg2 \

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -101,7 +101,7 @@ apt-get -yqq install \
     git \
     ${PY_PREFIX}-pip \
     libkrb5-dev krb5-user \
-    dvipng texlive-latex-base \
+    dvipng texlive-latex-base texlive-latex-extra \
     ${PY_PREFIX}-glue \
     ${PY_PREFIX}-sqlalchemy \
     ${PY_PREFIX}-psycopg2 \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -81,7 +81,8 @@ yum -y -q install \
     ldas-tools-framecpp-python \
     lalframe-python \
     lalsimulation-python \
-    texlive-dvipng-bin texlive-latex-bin-bin texlive-type1cm
+    texlive-dvipng-bin texlive-latex-bin-bin \
+    texlive-type1cm texlive-collection-fontsrecommended
 
 # HACK: fix missing file from ldas-tools-framecpp
 if [ -d /usr/lib64/$PYTHON/site-packages/LDAStools -a \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -80,7 +80,8 @@ yum -y -q install \
     nds2-client-python \
     ldas-tools-framecpp-python \
     lalframe-python \
-    lalsimulation-python
+    lalsimulation-python \
+    texlive-dvipng-bin texlive-latex-bin-bin
 
 # HACK: fix missing file from ldas-tools-framecpp
 if [ -d /usr/lib64/$PYTHON/site-packages/LDAStools -a \

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -81,7 +81,7 @@ yum -y -q install \
     ldas-tools-framecpp-python \
     lalframe-python \
     lalsimulation-python \
-    texlive-dvipng-bin texlive-latex-bin-bin
+    texlive-dvipng-bin texlive-latex-bin-bin texlive-type1cm
 
 # HACK: fix missing file from ldas-tools-framecpp
 if [ -d /usr/lib64/$PYTHON/site-packages/LDAStools -a \


### PR DESCRIPTION
This PR adds the necessary latex binary installs for EL and Debian Linux-based CI jobs. This should allow slightly more complete tests.