### PR TITLE
Include lalsuite in requirements-dev.txt for testing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@
 pymysql
 pyRXP
 lscsoft-glue
+lalsuite
 dqsegdb
 ligotimegps
 pycbc >= 1.10.1 ; python_version == '2.7'


### PR DESCRIPTION
This PR adds `lalsuite` to the `requirements-dev.txt` file, meaning it will get installed during testing for the 'basic' python builds on travis-CI. This should mean some more robust tests.

We should think about having staged jobs on travis whereby a small set of initial tests gets run without any of the `requirements-dev` extras to make sure that the core requirements are enough to run the core tests.