### PR TITLE
Improved dependency specifications in setup files

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -50,7 +50,7 @@ apt-get -yqq install \
     python-jinja2 \
 
 # get versions
-GWPY_VERSION=$(python setup.py --version)
+GWPY_VERSION=$(python -c "import versioneer; print(versioneer.get_version())")
 GWPY_RELEASE=${GWPY_VERSION%%+*}
 
 # upgrade setuptools for development builds only to prevent version munging

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -41,7 +41,7 @@ yum -y -q install \
     python2-rpm-macros \
     python2-setuptools
 
-GWPY_VERSION=$(python setup.py --version)
+GWPY_VERSION=$(python -c "import versioneer; print(versioneer.get_version())")
 
 # upgrade setuptools for development builds only to prevent version munging
 if [[ "${GWPY_VERSION}" == *"+"* ]]; then

--- a/ci/install-macos.sh
+++ b/ci/install-macos.sh
@@ -40,7 +40,7 @@ sudo port -q install \
     ${PY_PREFIX}-gitpython
 
 # make Portfile
-GWPY_VERSION=$(python setup.py --version)
+GWPY_VERSION=$($PYTHON setup.py --version)
 $PYTHON setup.py --quiet sdist
 $PYTHON setup.py port --tarball dist/gwpy-${GWPY_VERSION}.tar.gz
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends: debhelper (>= 9),
                python-all,
                python3-all,
                python-setuptools,
-               python3-setuptools,
+               python3-setuptools
 
 # -- python-gwpy --------------------------------------------------------------
 
@@ -24,11 +24,11 @@ Depends: ${misc:Depends},
          python-dateutil,
          python-enum34,
          python-numpy (>= 1.7.1),
-         python-scipy (>= 0.12.0),
+         python-scipy (>= 0.12.1),
          python-astropy (>= 1.1.1),
          python-h5py (>= 1.3),
          python-matplotlib (>= 1.2.0),
-         python-ligo-segments,
+         python-ligo-segments (>= 1.0.0),
          lal-python (>= 6.14.0),
          python-tqdm (>= 4.10.0)
 Suggests: python-pymysql,
@@ -37,11 +37,8 @@ Suggests: python-pymysql,
           python-psycopg2,
           python-pandas
 Description: A python package for gravitational-wave astrophysics
- .
-           GWpy is a collaboration-driven `Python <http://www.python.org>`_
-           package providing tools for studying data from ground-based
-           gravitational-wave detectors.
- .
+ GWpy is a collaboration-driven Python package providing tools
+ for studying data from ground-based gravitational-wave detectors.
 
 # -- python3-gwpy -------------------------------------------------------------
 
@@ -65,8 +62,5 @@ Suggests: python3-pymysql,
           python3-psycopg2,
           python3-pandas
 Description: A python package for gravitational-wave astrophysics
- .
-           GWpy is a collaboration-driven `python <http://www.python.org>`_
-           package providing tools for studying data from ground-based
-           gravitational-wave detectors.
- .
+ GWpy is a collaboration-driven Python package providing tools
+ for studying data from ground-based gravitational-wave detectors.

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -27,17 +27,17 @@ BuildRequires:  python2-setuptools
 
 %package -n python2-%{srcname}
 Summary:        %{summary}
-Requires:       python-six
+Requires:       python-six >= 1.5
 Requires:       python-dateutil
 Requires:       python-enum34
-Requires:       numpy
-Requires:       scipy
-Requires:       python-matplotlib
-Requires:       python-astropy
-Requires:       h5py
+Requires:       numpy >= 1.7.1
+Requires:       scipy >= 0.12.1
+Requires:       python-matplotlib >= 1.2.0
+Requires:       python-astropy >= 1.1.1
+Requires:       h5py >= 1.3
 Requires:       lal-python >= 6.14.0
-Requires:       python2-ligo-segments
-Requires:       python2-tqdm
+Requires:       python2-ligo-segments >= 1.0.0
+Requires:       python2-tqdm >= 4.10.0
 
 %{?python_provide:%python_provide python2-%{srcname}}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,6 @@ pyRXP
 lscsoft-glue
 lalsuite
 dqsegdb
-ligotimegps
 pycbc >= 1.10.1 ; python_version == '2.7'
 git+https://github.com/duncanmmacleod/ligo.org.git
 sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,11 @@ six >= 1.5
 python-dateutil
 enum34 ; python_version < '3'
 numpy >= 1.7.1
-scipy >= 0.12.0
+scipy >= 0.12.1
 astropy >= 1.1.1, < 3.0.0 ; python_version < '3'
 astropy >= 1.1.1 ; python_version >= '3'
 h5py >= 1.3
 matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
 ligo-segments >= 1.0.0
 tqdm >= 4.10.0
+ligotimegps >= 1.2.1

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@
 
 from __future__ import print_function
 
+import os
 import sys
 from distutils.version import LooseVersion
 
@@ -36,7 +37,7 @@ from setup_utils import (CMDCLASS, get_setup_requires, get_scripts)
 
 __version__ = versioneer.get_version()
 
-PEP_508 = LooseVersion(setuptools_version) >= '36.2'
+PEP_508 = LooseVersion(setuptools_version) >= '20.2.2'
 
 # read description
 with open('README.md', 'rb') as f:
@@ -48,59 +49,27 @@ with open('README.md', 'rb') as f:
 setup_requires = get_setup_requires()
 
 # runtime dependencies
-dependencies = {
-    'six': '>= 1.5',
-    'python-dateutil': None,
-    'numpy': '>= 1.7.1',
-    'scipy': '>= 0.12.1',
-    'matplotlib': '>= 1.2.0',
-    'astropy': '>= 1.1.1',
-    'h5py': '>= 1.3',
-    'ligo-segments': '>= 1.0.0',
-    'tqdm': '>= 4.10.0',
-}
+install_requires = [
+    'six >= 1.5',
+    'python-dateutil',
+    'enum34 ; python_version < \'3\'',
+    'numpy >= 1.7.1',
+    'scipy >= 0.12.1',
+    'matplotlib >= 1.2.0, != 2.1.0, != 2.1.1',
+    'astropy >= 1.1.1, < 3.0.0 ; python_version < \'3\'',
+    'astropy >= 1.1.1 ; python_version >= \'3\'',
+    'h5py >= 1.3',
+    'ligo-segments >= 1.0.0',
+    'tqdm >= 4.10.0',
+    'ligotimegps >= 1.2.1',
+]
 
-# include fancy dependencies
-if PEP_508:
-    # exclude astropy >= 3.0 on python2.7
-    adep = dependencies['astropy']
-    dependencies['astropy'] = (
-        '{0}, < 3.0.0 ; python_version < \'3\''.format(adep))
-    dependencies['astropy '] = (
-        '{0} ; python_version >= \'3\''.format(adep))
-
-    # exclude matplotlib 2.1.[01] (see matplotlib/matplotlib#10003)
-    dependencies['matplotlib'] += ', !=2.1.0, !=2.1.1'
-
-# unwrap dependencies into simple list
-install_requires = ['{0} {1}'.format(pkg.strip(), ver or '') for
-                    pkg, ver in dependencies.items()]
-
-# test for LAL
-try:
-    import lal  # pylint: disable=unused-import
-except ImportError as e:
-    install_requires.append('ligotimegps >= 1.2.1')
-
-# enum34 required for python < 3.4
-try:
-    import enum  # pylint: disable=unused-import
-except ImportError:
-    install_requires.append('enum34')
-
-# define extras
-extras_require = {
-    'root': ['root_numpy'],
-    'segments': ['dqsegdb'],
-    'hacr': ['pymysql'],
-    'docs': ['sphinx>=1.6.1', 'numpydoc', 'sphinx-bootstrap-theme>=0.6',
-             'sphinxcontrib-programoutput', 'sphinx-automodapi',
-             'requests'],
-}
-
-# define 'all' as the intersection of all extras
-extras_require['all'] = set(p for extra in extras_require.values()
-                            for p in extra)
+# if setuptools is too old and we are building an EL7
+# distribution, empty the install_requires,
+# the spec file will handle dependencies anyway
+# NOTE: this probably isn't very robust
+if not PEP_508 and os.getenv('RPM_BUILD_ROOT'):
+    install_requires = []
 
 # test dependencies
 tests_require = [
@@ -138,7 +107,6 @@ setup(
     setup_requires=setup_requires,
     install_requires=install_requires,
     tests_require=tests_require,
-    extras_require=extras_require,
 
     # classifiers
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -64,11 +64,12 @@ install_requires = [
     'ligotimegps >= 1.2.1',
 ]
 
-# if setuptools is too old and we are building an EL7
-# distribution, empty the install_requires,
-# the spec file will handle dependencies anyway
+# if setuptools is too old and we are building an EL7 or Debian 8
+# distribution, empty the install_requires, the distribution files
+# will handle dependencies anyway
 # NOTE: this probably isn't very robust
-if not PEP_508 and os.getenv('RPM_BUILD_ROOT'):
+if not PEP_508 and (
+        os.getenv('RPM_BUILD_ROOT') or os.getenv('PYBUILD_NAME')):
     install_requires = []
 
 # test dependencies


### PR DESCRIPTION
This PR improves the dependency spec in a number of ways, mainly so that dependencies are properly specified for all builds _except_ EL7, since `setuptools` is too old.