### PR TITLE
New whitening scheme based on inverse spectrum truncation

### DIFF
--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -50,8 +50,8 @@ class TestCliQtransform(_TestCliSpectrogram):
         assert prod.qxfrm_args['qrange'] == (100., 110.)
 
     def test_get_title(self, dataprod):
-        t = ('Q=45.25, whitened, calc f-range=[36.01, 161.51], '
-             'calc e-range=[-0.09, 15.00]')
+        t = ('Q=22.63, whitened, calc f-range=[45.02, 161.52], '
+             'calc e-range=[-0.09, 14.38]')
         assert dataprod.get_title() == t
 
     def test_get_suptitle(self, prod):

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -74,6 +74,22 @@ BANDPASS_FIR_100HZ_200HZ = signal.firwin(
 )
 
 
+def test_truncate():
+    series = numpy.ones(64)
+
+    # test truncate_transfer
+    trunc1 = filter_design.truncate_transfer(series)
+    assert trunc1[0] == 0
+    assert trunc1[-1] == 0
+    utils.assert_allclose(trunc1[5:59], trunc1[5:59])
+
+    # test truncate_impulse
+    trunc2 = filter_design.truncate_impulse(series, ntaps=10)
+    assert trunc2[0] != 0
+    assert trunc2[-1] != 0
+    utils.assert_allclose(trunc2[5:59], numpy.zeros(54))
+
+
 def test_notch_design():
     # test simple notch
     zpk = filter_design.notch(60, 16384)

--- a/gwpy/signal/tests/test_window.py
+++ b/gwpy/signal/tests/test_window.py
@@ -19,8 +19,10 @@
 """Unit tests for :mod:`gwpy.signal.window`
 """
 
+import numpy
 import pytest
 
+from ...tests import utils
 from .. import window
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -42,3 +44,11 @@ def test_recommended_overlap():
         window.recommended_overlap('kaiser')
     assert str(exc.value) == ('no recommended overlap for \'kaiser\' '
                               'window')
+
+
+def test_planck():
+    series = numpy.ones(64)
+    wseries = series * window.planck(64, nleft=5, nright=5)
+    assert wseries[0] == 0
+    assert wseries[-1] == 0
+    utils.assert_allclose(wseries[5:59], series[5:59])

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -823,7 +823,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
         whitened = data.whiten(2, 1)
 
-        assert noise.size == whitened.size
+        assert whitened.size == noise.size - 2*noise.sample_rate.value
         nptest.assert_almost_equal(whitened.mean().value, 0.0, decimal=4)
 
         tmax = whitened.times[whitened.argmax()]
@@ -866,9 +866,9 @@ class TestTimeSeries(_TestTimeSeriesBase):
         # test simple q-transform
         qspecgram = losc.q_transform(method='scipy-welch', fftlength=2)
         assert isinstance(qspecgram, Spectrogram)
-        assert qspecgram.shape == (4000, 2403)
+        assert qspecgram.shape == (2000, 2222)
         assert qspecgram.q == 5.65685424949238
-        nptest.assert_almost_equal(qspecgram.value.max(), 146.61970478954652)
+        nptest.assert_almost_equal(qspecgram.value.max(), 60.77958301153789)
 
         # test whitening args
         asd = losc.asd(2, 1, method='scipy-welch')
@@ -885,7 +885,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         with pytest.warns(UserWarning):
             qspecgram = losc.q_transform(method='scipy-welch',
                                          frange=(0, 10000))
-            nptest.assert_almost_equal(qspecgram.yspan[1], 1291.5316316157107)
+            nptest.assert_almost_equal(qspecgram.yspan[1], 1291.0632632314212)
 
         # test other normalisations work (or don't)
         q2 = losc.q_transform(method='scipy-welch', norm='median')


### PR DESCRIPTION
This pull request addresses a common issue with filter transients in the current whitening method by replacing it with an alternative scheme which designs and applies an FIR (finite impulse response) filter using inverse spectrum truncation.

Other new features added include:
* A method `FrequencySeries.interpolate()` and functions `timeseries._fft_length_default`, `signal.filter_design.truncate_transfer`, and `signal.filter_design.truncate_impulse`, all used to design the FIR filter
* New keyword arguments for filter duration (in the time domain) and highpass corner frequency
* In `TimeSeries.whiten()`, a default value of `fftlength`which  causes it to be set to `max(2, int(2048 // self.sample_rate.decompose().value))`
* Automatic cropping of the beginning and end of the whitened timeseries by a segment of length `filter_duration`
* Updates to the documentation for `TimeSeries.whiten()` addressing these changes
* Updates to `q_transform()` that address these recent changes, including a new default `fftlength` that mirrors the one for `TimeSeries.whiten`
* Unit tests for new functionality, a unit test for `signal.window.planck()`, and a bug fix in the unit test for `FrequencySeries.inject()`

Note, these changes make it so that a simple call to `TimeSeries.whiten()` with no other arguments returns something sensible in most cases. It is also backwards compatible.

This fixes #867. It is also related to #358 and #451.