### PR TITLE
Fixed inclusion of segments in docs

### DIFF
--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -15,6 +15,8 @@ GWpy examples
 
    spectrogram/index
 
+   segments/index
+
    table/index
 
    miscellaneous/index

--- a/examples/segments/open-data.py
+++ b/examples/segments/open-data.py
@@ -38,9 +38,9 @@ h1month1 = DataQualityFlag.fetch_open_data('H1_DATA', 'Sep 12 2015',
 l1month1 = DataQualityFlag.fetch_open_data('L1_DATA', 'Sep 12 2015',
                                            'Oct 12 2015')
 bothon = h1month1 & l1month1
-plot = h1month1.plot(color='gwpy:ligo-hanford')
+plot = h1month1.plot()
 ax = plot.gca()
-ax.plot(l1month1, color='gwpy:ligo-livingston')
-ax.plot(bothon, color='C1', label='Both')
+ax.plot(l1month1)
+ax.plot(bothon, label='Both')
 
 plot.show()


### PR DESCRIPTION
This PR fixes a bug in the docs that mean that the examples under `/examples/segments/` were not being rendered.