### PR TITLE
Added from_nds2_buffers method for TimeSeriesBaseDict

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1316,6 +1316,32 @@ class TimeSeriesBaseDict(OrderedDict):
                                            verbose=verbose, **kwargs))
                     for c in channels)
 
+    @classmethod
+    def from_nds2_buffers(cls, buffers, **metadata):
+        """Construct a new dict from a list of `nds2.buffer` objects
+
+        **Requires:** |nds2|_
+
+        Parameters
+        ----------
+        buffers : `list` of `nds2.buffer`
+            the input NDS2-client buffers to read
+
+        **metadata
+            any other metadata keyword arguments to pass to the `TimeSeries`
+            constructor
+
+        Returns
+        -------
+        dict : `TimeSeriesDict`
+            a new `TimeSeriesDict` containing the data from the given buffers
+        """
+        tsd = cls()
+        for buf in buffers:
+            tsd[buf.channel.name] = tsd.EntryClass.from_nds2_buffer(
+                buf, **metadata)
+        return tsd
+
     def plot(self, label='key', method='plot', figsize=(12, 4),
              xscale='auto-gps', **kwargs):
         """Plot the data for this `TimeSeriesBaseDict`.

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -622,6 +622,8 @@ class TimeSeriesBase(Series):
     def from_nds2_buffer(cls, buffer_, **metadata):
         """Construct a new `TimeSeries` from an `nds2.buffer` object
 
+        **Requires:** |nds2|_
+
         Parameters
         ----------
         buffer_ : `nds2.buffer`
@@ -635,10 +637,6 @@ class TimeSeriesBase(Series):
         timeseries : `TimeSeries`
             a new `TimeSeries` containing the data from the `nds2.buffer`,
             and the appropriate metadata
-
-        Notes
-        -----
-        This classmethod requires the nds2-client package
         """
         # cast as TimeSeries and return
         channel = Channel.from_nds2(buffer_.channel)

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -620,7 +620,7 @@ class TimeSeriesBase(Series):
 
     @classmethod
     def from_nds2_buffer(cls, buffer_, **metadata):
-        """Construct a new `TimeSeries` from an `nds2.buffer` object
+        """Construct a new series from an `nds2.buffer` object
 
         **Requires:** |nds2|_
 

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -104,7 +104,7 @@ class StateTimeSeries(TimeSeriesBase):
                 channel=None, name=None, **kwargs):
         """Generate a new StateTimeSeries
         """
-        if 'unit' in kwargs:
+        if kwargs.pop('unit', None) is not None:
             raise TypeError("%s does not accept keyword argument 'unit'"
                             % cls.__name__)
         if isinstance(data, (list, tuple)):
@@ -225,6 +225,12 @@ class StateTimeSeries(TimeSeriesBase):
                                   "TimeSeries, cannot be used with the "
                                   "StateTimeSeries because LAL has no "
                                   "BooleanTimeSeries structure")
+
+    @classmethod
+    @wraps(TimeSeriesBase.from_nds2_buffer)
+    def from_nds2_buffer(cls, buffer, **metadata):
+        metadata.setdefault('unit', None)
+        return super(StateTimeSeries, cls).from_nds2_buffer(buffer, **metadata)
 
     def __getitem__(self, item):
         if isinstance(item, (float, int)):

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -157,7 +157,8 @@ class TestTimeSeriesBase(_TestSeries):
         a = self.TEST_CLASS.from_nds2_buffer(nds_buffer)
         assert isinstance(a, self.TEST_CLASS)
         utils.assert_array_equal(a.value, self.data)
-        assert a.unit == units.m
+        if not type(a).__name__.startswith('State'):  # states don't have units
+            assert a.unit == units.m
         assert a.t0 == 1000000000 * units.s
         assert a.dt == units.s / self.data.shape[0]
         assert a.name == 'X1:TEST'

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -340,6 +340,23 @@ class TestTimeSeriesBaseDict(object):
     def test_get(self):
         return NotImplemented
 
+    @utils.skip_missing_dependency('nds2')
+    def test_from_nds2_buffers(self):
+        buffers = [
+            mocks.nds2_buffer('X1:TEST', numpy.arange(100), 1000000000,
+                              1, 'm'),
+            mocks.nds2_buffer('X1:TEST2', numpy.arange(100, 200), 1000000100,
+                              1, 'm'),
+        ]
+        a = self.TEST_CLASS.from_nds2_buffers(buffers)
+        assert isinstance(a, self.TEST_CLASS)
+        assert a['X1:TEST'].x0.value == 1000000000
+        assert a['X1:TEST2'].dx.value == 1
+        assert a['X1:TEST2'].x0.value == 1000000100
+
+        a = self.TEST_CLASS.from_nds2_buffers(buffers, sample_rate=.01)
+        assert a['X1:TEST'].dx.value == 100
+
     def test_plot(self, instance):
         with rc_context(rc={'text.usetex': False}):
             plot = instance.plot()

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -117,9 +117,6 @@ class TestStateTimeSeries(_TestTimeSeriesBase):
     def test_to_from_lal(self):
         return NotImplemented
 
-    def test_from_nds2_buffer(self):
-        return NotImplemented
-
 
 # -- StateTimeSeriesDict ------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes #862 by adding a new `classmethod` for `TimeSeriesBaseDict`.