### PR TITLE
Fixed crop warnings in TimeSeries.q_transform

### DIFF
--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1734,6 +1734,10 @@ class TimeSeries(TimeSeriesBase):
         if outseg is None:
             outseg = span
 
+        # truncate search window to available data
+        if gps is not None:  # search is only used if gps is given
+            search = Segment(gps-search, gps+search) & span
+
         # generate tiling
         planes = QTiling(abs(span), self.sample_rate.value,
                          qrange=qrange, frange=frange)
@@ -1751,7 +1755,7 @@ class TimeSeries(TimeSeriesBase):
                 if gps is None:
                     peak = ts.value.max()
                 else:
-                    peak = ts.crop(gps-search, gps+search).value.max()
+                    peak = ts.crop(*search).value.max()
                 if peak > peakenergy:
                     peakenergy = peak
                     peakq = plane.q


### PR DESCRIPTION
This PR fixes a lot of `UserWarning`s in `TimeSeries.q_transform` introduced when the new whitening was merged (#868) - since the output of the new whitening is a truncated `TimeSeries`, the default `search` window in `gwpy.cli.qtransform` overflows the available data and causes warnings, so we just truncate the search window to match the output of the whitener.

cc: @areeda, @alurban