### PR TITLE
Fixed fetching 'online' data with the NDS2 client

### DIFF
--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -399,7 +399,7 @@ class Channel(object):
     def ndsname(self):
         """Name of this channel as stored in the NDS database
         """
-        if self.type not in [None, 'raw', 'reduced']:
+        if self.type not in [None, 'raw', 'reduced', 'online']:
             return '%s,%s' % (self.name, self.type)
         return self.name
 

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -435,7 +435,6 @@ def find_channels(channels, connection=None, host=None, port=None,
         else:
             ctype = Nds2ChannelType.find(ctype).value
         found = connection.find_channels(name, ctype, dtype, *sample_rate)
-        ctypes = [c.channel_type for c in found]
         # if two results, remove 'online' copy (if present)
         #    (if no online channels present, this does nothing)
         if unique and len(found) == 2:

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -410,6 +410,12 @@ def find_channels(channels, connection=None, host=None, port=None,
     --------
     nds2.connection.find_channels
         for documentation on the underlying query method
+
+    Examples
+    --------
+    >>> from gwpy.io.nds2 import find_channels
+    >>> find_channels(['G1:DER_DATA_H'], host='nds.ligo.caltech.edu')
+    [<G1:DER_DATA_H (16384Hz, RDS, FLOAT64)>]
     """
     # set epoch
     if isinstance(epoch, tuple):
@@ -426,24 +432,72 @@ def find_channels(channels, connection=None, host=None, port=None,
     # query for channels
     out = []
     for name in _get_nds2_names(channels):
-        try:
-            name, ctype = name.rsplit(',', 1)
-        except ValueError:
-            ctype = type
-        else:
-            ctype = Nds2ChannelType.find(ctype).value
-        found = connection.find_channels(name, ctype, dtype, *sample_rate)
-        # if two results, remove 'online' copy (if present)
-        #    (if no online channels present, this does nothing)
-        if unique and len(found) == 2:
-            found = [c for c in found if
-                     c.channel_type != Nds2ChannelType.ONLINE.value]
-        # if not unique result, panic
-        if unique and len(found) != 1:
-            raise ValueError("unique NDS2 channel match not found for %r"
-                             % name)
-        out.extend(found)
+        out.extend(_find_channel(connection, name, type, dtype, sample_rate,
+                                 unique=unique))
     return out
+
+
+def _find_channel(connection, name, ctype, dtype, sample_rate, unique=False):
+    """Internal method to find a single channel
+
+    Parameters
+    ----------
+    connection : `nds2.connection`, optional
+        open NDS2 connection to use for query
+
+    name : `str`
+        the name of the channel to find
+
+    ctype : `int`
+        the NDS2 channel type to match
+
+    dtype : `int`
+        the NDS2 data type to match
+
+    sample_rate : `tuple`
+        a pre-formatted rate tuple (see `find_channels`)
+
+    unique : `bool`, optional, default: `False`
+        require one (and only one) match per channel
+
+    Returns
+    -------
+    channels : `list` of `nds2.channel`
+        list of NDS2 channel objects, if `unique=True` is given the list
+        is guaranteed to have only one element.
+
+    See also
+    --------
+    nds2.connection.find_channels
+        for documentation on the underlying query method
+    """
+    # parse channel type from name (e.g. 'L1:GDS-CALIB_STRAIN,reduced')
+    try:
+        name, ctype = name.rsplit(',', 1)
+    except ValueError:
+        pass
+    else:
+        ctype = Nds2ChannelType.find(ctype).value
+
+    # query NDS2
+    found = connection.find_channels(name, ctype, dtype, *sample_rate)
+
+    # if don't care about defaults, just return now
+    if not unique:
+        return found
+
+    # if two results, remove 'online' copy (if present)
+    #    (if no online channels present, this does nothing)
+    if len(found) == 2:
+        found = [c for c in found if
+                 c.channel_type != Nds2ChannelType.ONLINE.value]
+
+    # if not unique result, panic
+    if len(found) != 1:
+        raise ValueError("unique NDS2 channel match not found for %r"
+                         % name)
+
+    return found
 
 
 @open_connection

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -423,8 +423,6 @@ def find_channels(channels, connection=None, host=None, port=None,
     elif sample_rate is None:
         sample_rate = tuple()
 
-    online = Nds2ChannelType.ONLINE.value
-
     # query for channels
     out = []
     for name in _get_nds2_names(channels):
@@ -438,7 +436,8 @@ def find_channels(channels, connection=None, host=None, port=None,
         # if two results, remove 'online' copy (if present)
         #    (if no online channels present, this does nothing)
         if unique and len(found) == 2:
-            found = [c for c in found if c.channel_type != online]
+            found = [c for c in found if
+                     c.channel_type != Nds2ChannelType.ONLINE.value]
         # if not unique result, panic
         if unique and len(found) != 1:
             raise ValueError("unique NDS2 channel match not found for %r"

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -423,6 +423,8 @@ def find_channels(channels, connection=None, host=None, port=None,
     elif sample_rate is None:
         sample_rate = tuple()
 
+    online = Nds2ChannelType.ONLINE.value
+
     # query for channels
     out = []
     for name in _get_nds2_names(channels):
@@ -433,6 +435,12 @@ def find_channels(channels, connection=None, host=None, port=None,
         else:
             ctype = Nds2ChannelType.find(ctype).value
         found = connection.find_channels(name, ctype, dtype, *sample_rate)
+        ctypes = [c.channel_type for c in found]
+        # if two results, remove 'online' copy (if present)
+        #    (if no online channels present, this does nothing)
+        if unique and len(found) == 2:
+            found = [c for c in found if c.channel_type != online]
+        # if not unique result, panic
         if unique and len(found) != 1:
             raise ValueError("unique NDS2 channel match not found for %r"
                              % name)

--- a/gwpy/tests/mocks.py
+++ b/gwpy/tests/mocks.py
@@ -30,6 +30,7 @@ from six.moves.urllib.error import HTTPError
 
 import pytest
 
+from gwpy.detector import Channel
 from gwpy.time import LIGOTimeGPS
 from gwpy.segments import (Segment, SegmentList)
 
@@ -143,7 +144,7 @@ def nds2_channel(name, sample_rate, unit):
     channel.sample_rate = sample_rate
     channel.signal_units = unit
     channel.channel_type = 2
-    channel.channel_type_to_string.return_value = 'raw'
+    channel.channel_type_to_string = nds2.channel.channel_type_to_string
     channel.data_type = 8
     for attr, value in inspect.getmembers(
             nds2.channel, predicate=lambda x: isinstance(x, int)):
@@ -166,9 +167,7 @@ def nds2_connection(host='nds.test.gwpy', port=31200, buffers=[]):
         if not buffers:
             return []
         return [[b for b in buffers if
-                 '%s,%s' % (b.channel.name,
-                            b.channel.channel_type_to_string(b.channel_type))
-                 in names]]
+                 Channel.from_nds2(b.channel).ndsname in names]]
 
     NdsConnection.iterate = iterate
 

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -43,7 +43,7 @@ def print_verbose(*args, **kwargs):
 def _parse_nds_enum_dict_param(channels, key, value):
     if key == 'type':
         enum = io_nds2.Nds2ChannelType
-        default = enum.any() - enum.ONLINE.value
+        default = enum.any()
     else:
         enum = io_nds2.Nds2DataType
         default = enum.any()

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -24,6 +24,7 @@ import warnings
 
 from six.moves import reduce
 
+from ...detector import Channel
 from ...io import nds2 as io_nds2
 from ...segments import (Segment, SegmentList)
 from ...utils import gprint
@@ -107,8 +108,8 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
     ndschannels = io_nds2.find_channels(channels, connection=connection,
                                         type=utype, dtype=udtype, unique=True,
                                         epoch=(start, end))
-    names = ['%s,%s' % (c.name, c.channel_type_to_string(c.channel_type)) for
-             c in ndschannels]
+
+    names = [Channel.from_nds2(c).ndsname for c in ndschannels]
     print_verbose('done', verbose=verbose)
 
     # handle minute trend timing


### PR DESCRIPTION
This PR fixes some problems seen when trying to fetch data from `'ONLINE'` channels, especially from NDS1 servers.