### PR TITLE
Fixed error reading GWF from unicode file path

### DIFF
--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -86,7 +86,7 @@ def open_data_source(source):
 
     # read single file
     if isinstance(source, string_types):
-        return lalframe.FrStreamOpen(*os.path.split(source))
+        return lalframe.FrStreamOpen(*map(str, os.path.split(source)))
 
     raise ValueError("Don't know how to open data source of type %r"
                      % type(source))

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -24,6 +24,7 @@ import os.path
 from itertools import (chain, product)
 from ssl import SSLError
 
+import six
 from six.moves.urllib.error import URLError
 
 import pytest
@@ -165,8 +166,12 @@ class TestTimeSeries(_TestTimeSeriesBase):
             array.write(tmp)
 
             def read_(**kwargs):
-                return type(array).read(tmp, array.name, format='gwf',
+                return type(array).read(tmp, array.name, format=fmt,
                                         **kwargs)
+
+            # test reading unicode (python2)
+            if six.PY2:
+                type(array).read(six.u(tmp), array.name, format=fmt)
 
             # test start, end
             start, end = array.span.contract(10)


### PR DESCRIPTION
This PR fixes a problem reading data from GWF using `lalframe` when the filepath is `unicode`.

cc: @scottcoughlin2014 