### PR TITLE
Fixed issues with automagic gap handling in TimeSeries data access methods

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -262,17 +262,9 @@ class TimeSeriesBase(Series):
             number of parallel processes to use, serial process by
             default.
 
-        gap : `str`, optional
-            how to handle gaps in the cache, one of
-
-            - 'ignore': do nothing, let the undelying reader method handle it
-            - 'warn': do nothing except print a warning to the screen
-            - 'raise': raise an exception upon finding a gap (default)
-            - 'pad': insert a value to fill the gaps
-
         pad : `float`, optional
-            value with which to fill gaps in the source data, only used if
-            gap is not given, or `gap='pad'` is given
+            value with which to fill gaps in the source data,
+            by default gaps will result in a `ValueError`.
 
         Notes
         -----"""
@@ -484,8 +476,8 @@ class TimeSeriesBase(Series):
             for containing frame types if necessary
 
         pad : `float`, optional
-            value with which to fill gaps in the source data, only used if
-            gap is not given, or `gap='pad'` is given
+            value with which to fill gaps in the source data,
+            by default gaps will result in a `ValueError`.
 
         nproc : `int`, optional, default: `1`
             number of parallel processes to use, serial process by
@@ -530,8 +522,8 @@ class TimeSeriesBase(Series):
             any input parseable by `~gwpy.time.to_gps` is fine
 
         pad : `float`, optional
-            value with which to fill gaps in the source data, default to
-            'don't fill gaps'
+            value with which to fill gaps in the source data,
+            by default gaps will result in a `ValueError`.
 
         dtype : `numpy.dtype`, `str`, `type`, or `dict`
             numeric data type for returned data, e.g. `numpy.float`, or
@@ -834,17 +826,9 @@ class TimeSeriesBaseDict(OrderedDict):
             number of parallel processes to use, serial process by
             default.
 
-        gap : `str`, optional
-            how to handle gaps in the cache, one of
-
-            - 'ignore': do nothing, let the undelying reader method handle it
-            - 'warn': do nothing except print a warning to the screen
-            - 'raise': raise an exception upon finding a gap (default)
-            - 'pad': insert a value to fill the gaps
-
         pad : `float`, optional
-            value with which to fill gaps in the source data, only used if
-            gap is not given, or `gap='pad'` is given
+            value with which to fill gaps in the source data,
+            by default gaps will result in a `ValueError`.
 
         Returns
         -------

--- a/gwpy/timeseries/io/core.py
+++ b/gwpy/timeseries/io/core.py
@@ -37,8 +37,8 @@ def read(cls, source, *args, **kwargs):
                                  end=kwargs.get('end'))
 
     # get join arguments
-    gap = kwargs.pop('gap', 'raise')
-    pad = kwargs.pop('pad', 0.)
+    pad = kwargs.pop('pad', None)
+    gap = kwargs.pop('gap', 'raise' if pad is None else 'pad')
     joiner = _join_factory(cls, gap, pad)
 
     # read

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -19,6 +19,8 @@
 """NDS2 data query routines for the TimeSeries
 """
 
+from __future__ import division
+
 import operator
 import warnings
 
@@ -124,15 +126,14 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
     span = SegmentList([Segment(start, end)])
     if pad is None:
         qsegs = span
-        gap = None
+        gap = 'raise'
     else:
         print_verbose("Querying for data availability...", end=' ',
                       verbose=verbose)
+        pad = float(pad)
         gap = 'pad'
-        qsegs = io_nds2.get_availability(
-            ndschannels, start, end, connection=connection).intersection()
-        qsegs &= span
-        print_verbose('done\nFound {0} viable segments of data with {1}%% '
+        qsegs = _get_data_segments(ndschannels, start, end, connection) & span
+        print_verbose('done\nFound {0} viable segments of data with {1:.2f}% '
                       'coverage'.format(len(qsegs),
                                         abs(qsegs) / abs(span) * 100),
                       verbose=verbose)
@@ -162,3 +163,11 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
                     connection.get_host(), seg))
 
     return out
+
+
+def _get_data_segments(channels, start, end, connection):
+    """Get available data segments for the given channels
+    """
+    allsegs = io_nds2.get_availability(channels, start, end,
+                                       connection=connection)
+    return allsegs.intersection(allsegs.keys())

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -144,12 +144,10 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
 
     # query for each segment
     out = series_class.DictClass()
-    for seg in qsegs:
-        duration = seg[1] - seg[0]
-        msg = 'Downloading data'
-        total = 0.
-        with progress_bar(total=duration, desc=msg, unit='s',
-                          disable=not bool(verbose)) as bar:
+    with progress_bar(total=float(abs(qsegs)), desc='Downloading data',
+                      unit='s', disable=not bool(verbose)) as bar:
+        for seg in qsegs:
+            total = 0.
             for buffers in connection.iterate(int(seg[0]), int(seg[1]), names):
                 for buffer_, chan in zip(buffers, channels):
                     series = series_class.from_nds2_buffer(buffer_)


### PR DESCRIPTION
This PR fixes some issues with handling gaps in source data in `TimeSeries.read` and `TimeSeries.fetch`.

Fixes #810.