### PR TITLE
Updated defaults for spectrogram2

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -634,16 +634,16 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
     def test_spectrogram2(self, losc):
         # test defaults
-        sg = losc.spectrogram2(1)
+        sg = losc.spectrogram2(1, overlap=0)
         utils.assert_quantity_sub_equal(
             sg, losc.spectrogram(1, fftlength=1, overlap=0,
-                                 method='scipy-welch', window='boxcar'))
+                                 method='scipy-welch', window='hann'))
 
         # test fftlength
         sg = losc.spectrogram2(0.5)
-        assert sg.shape == (8, 0.5 * losc.sample_rate.value // 2 + 1)
+        assert sg.shape == (16, 0.5 * losc.sample_rate.value // 2 + 1)
         assert sg.df == 2 * units.Hertz
-        assert sg.dt == 0.5 * units.second
+        assert sg.dt == 0.25 * units.second
         # test overlap
         sg = losc.spectrogram2(fftlength=0.25, overlap=0.24)
         assert sg.shape == (399, 0.25 * losc.sample_rate.value // 2 + 1)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -437,7 +437,7 @@ class TimeSeries(TimeSeriesBase):
                                           fftlength=fftlength, overlap=overlap,
                                           window=window, **kwargs)
 
-    def spectrogram2(self, fftlength, overlap=0, **kwargs):
+    def spectrogram2(self, fftlength, overlap=None, window='hann', **kwargs):
         """Calculate the non-averaged power `Spectrogram` of this `TimeSeries`
 
         Parameters
@@ -489,7 +489,7 @@ class TimeSeries(TimeSeriesBase):
         # run
         return fft_ui.spectrogram(self, signal.periodogram,
                                   fftlength=fftlength, overlap=overlap,
-                                  **kwargs)
+                                  window=window, **kwargs)
 
     def fftgram(self, fftlength, overlap=None, window='hann', **kwargs):
         """Calculate the Fourier-gram of this `TimeSeries`.


### PR DESCRIPTION
This PR updates the defaults for `TimeSeries.spectrogram2` to better match `TimeSeries.spectrogram` as follows:

- window, was `None`, now `hann`
- overlap, was `0`, now `None` (defaults to `recommended_overlap` output)
