### PR TITLE
Update setuptools for LDG builds on CI

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -54,9 +54,7 @@ GWPY_VERSION=$(python -c "import versioneer; print(versioneer.get_version())")
 GWPY_RELEASE=${GWPY_VERSION%%+*}
 
 # upgrade setuptools for development builds only to prevent version munging
-if [[ "${GWPY_VERSION}" == *"+"* ]]; then
-    pip install --quiet "setuptools>=25"
-fi
+pip install "setuptools>=25"
 
 # upgrade GitPython (required for git>=2.15.0)
 #     since we link the git clone from travis, the dependency is actually

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -44,9 +44,7 @@ yum -y -q install \
 GWPY_VERSION=$(python -c "import versioneer; print(versioneer.get_version())")
 
 # upgrade setuptools for development builds only to prevent version munging
-if [[ "${GWPY_VERSION}" == *"+"* ]]; then
-    pip install "setuptools>=25"
-fi
+pip install "setuptools>=25"
 
 # -- build and install --------------------------------------------------------
 


### PR DESCRIPTION
This PR updates `setuptools` for all CI builds on LDG references OSs. This should fix release build failures such as [this one](https://travis-ci.com/gwpy/gwpy/jobs/140405017).