### PR TITLE
Introducing a TimeSeries.convolve() method based on the overlap-save algorithm

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -835,6 +835,17 @@ class TestTimeSeries(_TestTimeSeriesBase):
         tmax = whitened.times[whitened.argmax()]
         nptest.assert_almost_equal(tmax.value, glitchtime)
 
+    def test_convolve(self):
+        data = self.TEST_CLASS(
+            signal.hann(1024), sample_rate=512, epoch=-1
+        )
+        filt = numpy.array([1, 0])
+
+        # check that the 'valid' data are unchanged by this filter
+        convolved = data.convolve(filt)
+        assert convolved.size == data.size
+        utils.assert_allclose(convolved.value[1:-1], data.value[1:-1])
+
     def test_detrend(self, losc):
         assert not numpy.isclose(losc.value.mean(), 0.0, atol=1e-21)
         detrended = losc.detrend()


### PR DESCRIPTION
@duncanmmacleod, this PR introduces a `TimeSeries.convolve()` method which efficiently applies an FIR filter to a long timeseries using the [overlap-save](https://en.wikipedia.org/wiki/Overlap–save_method) algorithm. It also adds a unit test for `TimeSeries.convolve()` which prepares a timeseries and then checks that the input data are unchanged by convolving with a delta function.

@andrew-lundgren, this fixes #451.