### PR TITLE
gwpy/cli/timeseries.py: limit sample rate to 3 decimals in plot title

### DIFF
--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -57,7 +57,7 @@ class TimeSeries(TimeDomainProduct):
     def get_title(self):
         suffix = super(TimeSeries, self).get_title()
         # limit significant digits for minute trends
-        rates = {int((ts.sample_rate.value + 5e-4) * 1000) / 1000. * units.Hz
+        rates = {round(ts.sample_rate.value,3) * units.Hz
                  for ts in self.timeseries}
         fss = '({0})'.format('), ('.join(map(str, rates)))
         return ', '.join([

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -25,7 +25,6 @@
 from .cliproduct import TimeDomainProduct
 from ..plot import Plot
 from ..plot.tex import label_to_latex
-from astropy import units
 
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -57,7 +57,7 @@ class TimeSeries(TimeDomainProduct):
     def get_title(self):
         suffix = super(TimeSeries, self).get_title()
         # limit significant digits for minute trends
-        rates = {round(ts.sample_rate.value,3) * units.Hz
+        rates = {round(ts.sample_rate.value, 3) * units.Hz
                  for ts in self.timeseries}
         fss = '({0})'.format('), ('.join(map(str, rates)))
         return ', '.join([

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -25,6 +25,7 @@
 from .cliproduct import TimeDomainProduct
 from ..plot import Plot
 from ..plot.tex import label_to_latex
+from astropy import units
 
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 
@@ -55,7 +56,9 @@ class TimeSeries(TimeDomainProduct):
 
     def get_title(self):
         suffix = super(TimeSeries, self).get_title()
-        rates = {ts.sample_rate for ts in self.timeseries}
+        # limit sg digits for minute trends
+        rates = {int((ts.sample_rate.value + 5e-4) * 1000) / 1000. * units.Hz
+                 for ts in self.timeseries}
         fss = '({0})'.format('), ('.join(map(str, rates)))
         return ', '.join([
             'Fs: {0}'.format(fss),

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -57,8 +57,7 @@ class TimeSeries(TimeDomainProduct):
     def get_title(self):
         suffix = super(TimeSeries, self).get_title()
         # limit significant digits for minute trends
-        rates = {round(ts.sample_rate.value, 3) * units.Hz
-                 for ts in self.timeseries}
+        rates = {ts.sample_rate.round(3) for ts in self.timeseries}
         fss = '({0})'.format('), ('.join(map(str, rates)))
         return ', '.join([
             'Fs: {0}'.format(fss),

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -56,7 +56,7 @@ class TimeSeries(TimeDomainProduct):
 
     def get_title(self):
         suffix = super(TimeSeries, self).get_title()
-        # limit sg digits for minute trends
+        # limit significant digits for minute trends
         rates = {int((ts.sample_rate.value + 5e-4) * 1000) / 1000. * units.Hz
                  for ts in self.timeseries}
         fss = '({0})'.format('), ('.join(map(str, rates)))


### PR DESCRIPTION
I got tired of minute trends reporting Fs to 10 decimal digits.  I verified VIrgo sample rates are not slower than .001 Hz