### PR TITLE
Address issues with whitening defaults

### DIFF
--- a/examples/timeseries/whiten.py
+++ b/examples/timeseries/whiten.py
@@ -55,4 +55,7 @@ plot.axes[1].set_ylabel('Whitened amplitude', fontsize=16)
 plot.show()
 
 # Here we see two large spikes that are completely undetected in the raw
-# `TimeSeries`, but are very obvious in the whitened data.
+# `TimeSeries`, but are very obvious in the whitened data. We can also see
+# tapering effects at the boundaries as the whitening filter settles in,
+# meaning that the first and last ~second of data are corrupted and should
+# be discarded before further processing.

--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -50,8 +50,8 @@ class TestCliQtransform(_TestCliSpectrogram):
         assert prod.qxfrm_args['qrange'] == (100., 110.)
 
     def test_get_title(self, dataprod):
-        t = ('Q=22.63, whitened, calc f-range=[45.02, 161.52], '
-             'calc e-range=[-0.09, 14.38]')
+        t = ('Q=45.25, whitened, calc f-range=[36.01, 161.51], '
+             'calc e-range=[-0.10, 16.02]')
         assert dataprod.get_title() == t
 
     def test_get_suptitle(self, prod):

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -90,6 +90,19 @@ def test_truncate():
     utils.assert_allclose(trunc2[5:59], numpy.zeros(54))
 
 
+def test_fir_from_transfer():
+    frequencies = numpy.arange(0, 64)
+    fseries = numpy.cos(2*numpy.pi*frequencies)
+
+    # prepare the time domain filter
+    fir = filter_design.fir_from_transfer(fseries, ntaps=10)
+
+    # test the filter
+    assert abs(fir[0] / fir.max()) <= 1e-2
+    assert abs(fir[-1] / fir.max()) <= 1e-2
+    assert fir.size == 10
+
+
 def test_notch_design():
     # test simple notch
     zpk = filter_design.notch(60, 16384)

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -818,21 +818,21 @@ class TestTimeSeries(_TestTimeSeriesBase):
             numpy.random.normal(loc=1, size=16384 * 10), sample_rate=16384,
             epoch=-5).zpk([], [0], 1)
         glitchtime = 0.5
-        glitch = signal.gausspulse(noise.times.value + glitchtime,
+        glitch = signal.gausspulse(noise.times.value - glitchtime,
                                    bw=100) * 1e-4
         data = noise + glitch
 
         # whiten and test that the max amplitude is recovered at the glitch
         tmax = data.times[data.argmax()]
-        assert not numpy.isclose(tmax.value, -glitchtime)
+        assert not numpy.isclose(tmax.value, glitchtime)
 
         whitened = data.whiten(2, 1)
 
-        assert whitened.size == noise.size - 2*noise.sample_rate.value
+        assert whitened.size == noise.size
         nptest.assert_almost_equal(whitened.mean().value, 0.0, decimal=4)
 
         tmax = whitened.times[whitened.argmax()]
-        nptest.assert_almost_equal(tmax.value, -glitchtime)
+        nptest.assert_almost_equal(tmax.value, glitchtime)
 
     def test_detrend(self, losc):
         assert not numpy.isclose(losc.value.mean(), 0.0, atol=1e-21)
@@ -871,9 +871,9 @@ class TestTimeSeries(_TestTimeSeriesBase):
         # test simple q-transform
         qspecgram = losc.q_transform(method='scipy-welch', fftlength=2)
         assert isinstance(qspecgram, Spectrogram)
-        assert qspecgram.shape == (2000, 2222)
+        assert qspecgram.shape == (4000, 2403)
         assert qspecgram.q == 5.65685424949238
-        nptest.assert_almost_equal(qspecgram.value.max(), 60.77958301153789)
+        nptest.assert_almost_equal(qspecgram.value.max(), 86.969865242376287)
 
         # test whitening args
         asd = losc.asd(2, 1, method='scipy-welch')
@@ -890,7 +890,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         with pytest.warns(UserWarning):
             qspecgram = losc.q_transform(method='scipy-welch',
                                          frange=(0, 10000))
-            nptest.assert_almost_equal(qspecgram.yspan[1], 1291.0632632314212)
+            nptest.assert_almost_equal(qspecgram.yspan[1], 1291.5316316157107)
 
         # test other normalisations work (or don't)
         q2 = losc.q_transform(method='scipy-welch', norm='median')

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1446,7 +1446,7 @@ class TimeSeries(TimeSeriesBase):
 
     def whiten(self, fftlength=None, overlap=0, method='scipy-welch',
                window='hanning', detrend='constant', asd=None,
-               fduration=1, highpass=None, **kwargs):
+               fduration=2, highpass=None, **kwargs):
         """Whiten this `TimeSeries` using inverse spectrum truncation
 
         Parameters
@@ -1479,7 +1479,7 @@ class TimeSeries(TimeSeriesBase):
 
         fduration : `float`, optional
             duration (in seconds) of the time-domain FIR whitening filter,
-            defaults to fftlength
+            must be no longer than `fftlength`, default: 2 seconds
 
         highpass : `float`, optional
             highpass corner frequency (in Hz) of the FIR whitening filter,
@@ -1499,40 +1499,41 @@ class TimeSeries(TimeSeriesBase):
         --------
         TimeSeries.asd
             for details on the ASD calculation
-        numpy.fft
-            for details on the Fourier transform algorithm used her
-        scipy.signal
+        scipy.signal.fftconvolve
+            for details on the convolution algorithm used here
+        gwpy.signal.filter_design.fir_from_transfer
+            for FIR filter design through spectrum truncation
 
         Notes
         -----
-        The `window` argument is used in both ASD estimation and FIR filter
-        design.
+        The `window` argument is used in ASD estimation, FIR filter design,
+        and in preventing spectral leakage in the output.
 
-        Due to filter corruption at the boundaries, a segment of length
-        `fduration` will automatically be cropped from the beginning and
-        end of the output.
+        Due to filter settle-in, a segment of length `0.5*fduration` will be
+        corrupted at the beginning and end of the output.
 
         For more on inverse spectrum truncation, see arXiv:gr-qc/0509116.
         """
-        # build whitener
+        # compute the ASD
         fftlength = fftlength if fftlength else _fft_length_default(self.dt)
         if asd is None:
             asd = self.asd(fftlength, overlap=overlap,
                            method=method, window=window, **kwargs)
         asd = asd.interpolate(1./self.duration.decompose().value)
-        # truncate the edges and apply a hard highpass
+        # design whitening filter, with highpass if requested
         ncorner = int(highpass / asd.df.decompose().value) if highpass else 0
-        invasd = filter_design.truncate_transfer(1./asd.value, ncorner=ncorner)
-        # truncate and window in the time domain
-        tdw = npfft.irfft(invasd)
         ntaps = int((fduration * self.sample_rate).decompose().value)
-        tdw = filter_design.truncate_impulse(tdw, ntaps=ntaps, window=window)
-        # filter in the frequency domain, enforcing zero-phase
-        invasd = (self.duration.value/2) * numpy.abs(npfft.rfft(tdw))
-        in_ = self.detrend(detrend)
-        out = type(self)(npfft.irfft(in_.fft().value * invasd))
+        tdw = filter_design.fir_from_transfer(1/asd.value, ntaps=ntaps,
+                                              window=window, ncorner=ncorner)
+        # condition the input data and apply the whitening filter
+        in_ = self.copy().detrend(detrend)
+        pad = int(numpy.ceil(tdw.size/2))
+        window = signal.get_window(window, tdw.size)
+        in_[:pad] *= window[:pad]
+        in_[-pad:] *= window[-pad:]
+        out = type(self)(signal.fftconvolve(in_.value, tdw, mode='same'))
         out.__array_finalize__(self)
-        return out.crop(*out.xspan.contract(fduration))
+        return out
 
     def detrend(self, detrend='constant'):
         """Remove the trend from this `TimeSeries`


### PR DESCRIPTION
@duncanmmacleod, this PR includes the following changes:

* Window the first and last half-filter-length of input data before convolving, and return a `TimeSeries` the same length as the input (this is mostly to stay more in line with the behavior of the old whitener)
* Update the documentation’s whitening example to reflect this
* Change default whitening filter length to 2 seconds, which better reproduces the published GW150914 Q-spectrogram
* Refactor FIR filter design into its own function, `signal.filter_design.fir_from_transfer()`, including a unit test
* Use `scipy.signal.fftconvolve()` to apply the whitening filter, anticipating #883
* Edit unit tests affected by changes to `TimeSeries.whiten()`

This fixes #890.