### PR TITLE
WIP: Fix for failed tests on windows with pytest-3.8.0

### DIFF
--- a/gwpy/utils/tests/test_mp.py
+++ b/gwpy/utils/tests/test_mp.py
@@ -29,10 +29,9 @@ from ..misc import null_context
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-pytestmark = pytest.mark.filterwarnings(
-    'always:multiprocessing is currently not supported on Windws')
 
-
+@pytest.mark.filterwarnings(
+    'always:multiprocessing is currently not supported on Windows')
 @pytest.mark.parametrize('verbose', [False, True, 'Test'])
 @pytest.mark.parametrize('nproc', [1, 2])
 def test_multiprocess_with_queues(capsys, nproc, verbose):


### PR DESCRIPTION
This PR attempts to fix the failing tests on appveyor when using pytest-3.8.0. Something changed with the way warnings are collected...