### PR TITLE
Avoid pytest-3.8.0 on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - conda config --add channels conda-forge
   - conda install --yes "pip" "setuptools>=27.3"
   - conda install --yes "six>=1.5" "python-dateutil" "numpy>=1.7.1" "scipy>=0.12.1" "matplotlib>=1.2.0" "astropy>=1.1.1" "h5py>=1.3" "ligo-segments>=1.0.1" "tqdm>=4.10.0" "ligotimegps"
-  - conda install --yes "pytest>=3.1" "pytest-runner" "coverage>=4.0.0" "freezegun>=0.2.3" "sqlparse>=0.2.0" "beautifulsoup4"
+  - conda install --yes "pytest>=3.1,!=3.8.0" "pytest-runner" "coverage>=4.0.0" "freezegun>=0.2.3" "sqlparse>=0.2.0" "beautifulsoup4"
 build_script:
   - python -m pip install .
 test_script:


### PR DESCRIPTION
This PR works around the failing unit tests on windows by excluding pytest-3.8.0 from the build, it seems that version introduced a change. See #894 for progress on actually fixing it.