### PR TITLE
Update to whitening defaults in TimeSeries.q_transform

### DIFF
--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -51,7 +51,7 @@ class TestCliQtransform(_TestCliSpectrogram):
 
     def test_get_title(self, dataprod):
         t = ('Q=45.25, whitened, calc f-range=[36.01, 161.51], '
-             'calc e-range=[-0.10, 16.02]')
+             'calc e-range=[-0.14, 21.18]')
         assert dataprod.get_title() == t
 
     def test_get_suptitle(self, prod):

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -873,7 +873,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert isinstance(qspecgram, Spectrogram)
         assert qspecgram.shape == (4000, 2403)
         assert qspecgram.q == 5.65685424949238
-        nptest.assert_almost_equal(qspecgram.value.max(), 86.969865242376287)
+        nptest.assert_almost_equal(qspecgram.value.max(), 156.0411964254892)
 
         # test whitening args
         asd = losc.asd(2, 1, method='scipy-welch')

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1594,7 +1594,7 @@ class TimeSeries(TimeSeriesBase):
 
     def q_transform(self, qrange=(4, 64), frange=(0, numpy.inf),
                     gps=None, search=.5, tres=.001, fres=.5, norm='median',
-                    outseg=None, whiten=True, fduration=1, highpass=None,
+                    outseg=None, whiten=True, fduration=2, highpass=None,
                     **asd_kw):
         """Scan a `TimeSeries` using a multi-Q transform
 
@@ -1636,7 +1636,7 @@ class TimeSeries(TimeSeriesBase):
 
         fduration : `float`, optional
             duration (in seconds) of the time-domain FIR whitening filter,
-            only used if `whiten` is not `False`, defaults to 1 second
+            only used if `whiten` is not `False`, defaults to 2 seconds
 
         highpass : `float`, optional
             highpass corner frequency (in Hz) of the FIR whitening filter,


### PR DESCRIPTION
@duncanmmacleod, this PR updates whitening defaults (and affected unit tests) under `TimeSeries.q_transform`. This was missed in #891, but will properly restore the low-frequency content in the GW150914 spectrogram when run with default values, and should be released with GWPy 0.12.1.