### PR TITLE
Moved TimeSeries.shift upstream to Series

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -561,32 +561,6 @@ class TimeSeriesBase(Series):
 
     # -- utilities ------------------------------
 
-    def shift(self, delta):
-        """Shift this `TimeSeries` forward in time by ``delta``
-
-        This modifies the series in-place.
-
-        Parameters
-        ----------
-        delta : `float`, `~astropy.units.Quantity`, `str`
-            The amount by which to shift (in seconds if `float`), give
-            a negative value to shift backwards in time
-
-        Examples
-        --------
-        >>> from gwpy.timeseries import TimeSeries
-        >>> a = TimeSeries([1, 2, 3, 4, 5], t0=0, dt=1)
-        >>> print(a.t0)
-        0.0 s
-        >>> a.shift(5)
-        >>> print(a.t0)
-        5.0 s
-        >>> a.shift('-1 hour')
-        -3595.0 s
-        """
-        delta = units.Quantity(delta, 's')
-        self.t0 += delta
-
     def plot(self, method='plot', figsize=(12, 4), xscale='auto-gps',
              **kwargs):
         """Plot the data for this timeseries

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -126,21 +126,6 @@ class TestTimeSeriesBase(_TestSeries):
 
     # -- test methods ---------------------------
 
-    def test_shift(self):
-        a = self.create()
-        t0 = a.t0.copy()
-        a.shift(5)
-        assert a.t0 == t0 + 5 * t0.unit
-
-        a.shift('1 hour')
-        assert a.t0 == t0 + 3605 * t0.unit
-
-        a.shift(-0.007)
-        assert a.t0 == t0 + (3604.993) * t0.unit
-
-        with pytest.raises(ValueError):
-            a.shift('1 Hz')
-
     def test_plot(self, array):
         with rc_context(rc={'text.usetex': False}):
             plot = array.plot()

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -437,6 +437,31 @@ class Series(Array):
 
     # -- series methods -------------------------
 
+    def shift(self, delta):
+        """Shift this `Series` forward on the X-axis by ``delta``
+
+        This modifies the series in-place.
+
+        Parameters
+        ----------
+        delta : `float`, `~astropy.units.Quantity`, `str`
+            The amount by which to shift (in x-axis units if `float`), give
+            a negative value to shift backwards in time
+
+        Examples
+        --------
+        >>> from gwpy.types import Series
+        >>> a = Series([1, 2, 3, 4, 5], x0=0, dx=1, xunit='m')
+        >>> print(a.x0)
+        0.0 m
+        >>> a.shift(5)
+        >>> print(a.x0)
+        5.0 m
+        >>> a.shift('-1 km')
+        -995.0 m
+        """
+        self.x0 = self.x0 + Quantity(delta, self.xunit)
+
     def value_at(self, x):
         """Return the value of this `Series` at the given `xindex` value
 

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -351,7 +351,7 @@ class TestSeries(_TestArray):
                 self.data[3] * ts1.unit)
 
     def test_shift(self):
-        a = self.create(xunit='s')
+        a = self.create(x0=0, dx=1, xunit='s')
         x0 = a.x0.copy()
         a.shift(5)
         assert a.x0 == x0 + 5 * x0.unit

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -349,3 +349,18 @@ class TestSeries(_TestArray):
         elif ts1.xunit == units.Hz:
             assert ts1.value_at(1500 * units.milliHertz) == (
                 self.data[3] * ts1.unit)
+
+    def test_shift(self):
+        a = self.create(xunit='s')
+        x0 = a.x0.copy()
+        a.shift(5)
+        assert a.x0 == x0 + 5 * x0.unit
+
+        a.shift('1 hour')
+        assert a.x0 == x0 + 3605 * x0.unit
+
+        a.shift(-0.007)
+        assert a.x0 == x0 + (3604.993) * x0.unit
+
+        with pytest.raises(ValueError):
+            a.shift('1 Hz')


### PR DESCRIPTION
This PR moves the `TimeSeries.shift` method upstream to the `Series` object, exposing it to `FrequencySeries` and friends. Also, I fixed a bug in the implementation where `shift()` would have no effect if the `xindex` had already been created.