### PR TITLE
Fix normalization for whitening and FIR filter design

### DIFF
--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -252,7 +252,7 @@ def fir_from_transfer(transfer, ntaps, window='hanning', ncorner=None):
     impulse = npfft.irfft(transfer)
     impulse = truncate_impulse(impulse, ntaps=ntaps, window=window)
     # wrap around and normalise to construct the filter
-    out = numpy.roll(impulse, int(ntaps/2 - 1))[0:ntaps] / impulse.size
+    out = numpy.roll(impulse, int(ntaps/2 - 1))[0:ntaps] * ntaps/2
     return out
 
 

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -238,7 +238,7 @@ def fir_from_transfer(transfer, ntaps, window='hanning', ncorner=None):
 
     Notes
     -----
-    The final FIR filter will be consistent with `~numpy` FFT normalisation.
+    The final FIR filter will use `~numpy.fft.rfft` FFT normalisation.
 
     If `ncorner` is not `None`, then `ncorner` extra samples will be zeroed
     on the left as a hard highpass filter.

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -238,6 +238,8 @@ def fir_from_transfer(transfer, ntaps, window='hanning', ncorner=None):
 
     Notes
     -----
+    The final FIR filter will be consistent with `~numpy` FFT normalisation.
+
     If `ncorner` is not `None`, then `ncorner` extra samples will be zeroed
     on the left as a hard highpass filter.
 
@@ -252,7 +254,7 @@ def fir_from_transfer(transfer, ntaps, window='hanning', ncorner=None):
     impulse = npfft.irfft(transfer)
     impulse = truncate_impulse(impulse, ntaps=ntaps, window=window)
     # wrap around and normalise to construct the filter
-    out = numpy.roll(impulse, int(ntaps/2 - 1))[0:ntaps] * ntaps/2
+    out = numpy.roll(impulse, int(ntaps/2 - 1))[0:ntaps]
     return out
 
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -830,6 +830,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
         assert whitened.size == noise.size
         nptest.assert_almost_equal(whitened.mean().value, 0.0, decimal=4)
+        nptest.assert_almost_equal(whitened.std().value, 1.0, decimal=4)
 
         tmax = whitened.times[whitened.argmax()]
         nptest.assert_almost_equal(tmax.value, glitchtime)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1493,7 +1493,8 @@ class TimeSeries(TimeSeriesBase):
         Returns
         -------
         out : `TimeSeries`
-            a whitened version of the input data
+            a whitened version of the input data with zero mean and unit
+            variance
 
         See Also
         --------
@@ -1511,6 +1512,9 @@ class TimeSeries(TimeSeriesBase):
 
         Due to filter settle-in, a segment of length `0.5*fduration` will be
         corrupted at the beginning and end of the output.
+
+        The input is detrended to give the whitened `TimeSeries` zero mean,
+        and the output is normalised to give it unit variance.
 
         For more on inverse spectrum truncation, see arXiv:gr-qc/0509116.
         """

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1533,7 +1533,7 @@ class TimeSeries(TimeSeriesBase):
         in_[-pad:] *= window[-pad:]
         out = type(self)(signal.fftconvolve(in_.value, tdw, mode='same'))
         out.__array_finalize__(self)
-        return out
+        return out / numpy.std(out.value)
 
     def detrend(self, detrend='constant'):
         """Remove the trend from this `TimeSeries`

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1533,7 +1533,7 @@ class TimeSeries(TimeSeriesBase):
         in_[-pad:] *= window[-pad:]
         out = type(self)(signal.fftconvolve(in_.value, tdw, mode='same'))
         out.__array_finalize__(self)
-        return out / numpy.std(out.value)
+        return out / out.value.std()
 
     def detrend(self, detrend='constant'):
         """Remove the trend from this `TimeSeries`


### PR DESCRIPTION
@duncanmmacleod, this PR adjusts the normali(s)ation in `signal.filter_design.fir_from_transfer` so that the resulting filter's frequency response has the same overall amplitude as the original transfer function. **Crucially, this means FIR filter design will use the `numpy` normalization.** To compensate for this, the PR also fixes normalization in `TimeSeries.whiten()` so that the output timeseries has zero mean and unit variance:

![150914_spectra_compare-2](https://user-images.githubusercontent.com/5273800/45451712-814b8480-b6a1-11e8-9670-a1cd89c17ae8.png)

![150914_compare](https://user-images.githubusercontent.com/5273800/45442803-a4b60580-b688-11e8-849b-55e158fec349.png)

![150914_spectra](https://user-images.githubusercontent.com/5273800/45451869-fe76f980-b6a1-11e8-8083-f32913180902.png)

First plot shows the original spectrum in blue and the frequency response of the filter in orange; second plot shows the original timeseries on top and the whitened timeseries (note the y-axis scale) on the bottom; third plot compares the original strain ASD to that of the whitened data.

This fixes #902.