### PR TITLE
Introducing a TimeSeries.correlate() method

### DIFF
--- a/examples/timeseries/correlate.py
+++ b/examples/timeseries/correlate.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Cross-correlating two `TimeSeries`
+
+.. warning::
+
+   This example requires LIGO.ORG credentials for data access.
+
+Gravitational wave detectors are very sensitive astronomical instruments, but
+they are also susceptible to transient noise events called _glitches_. In
+order to reliably detect gravitational waves and improve detector performance,
+we must distinguish glitches from astrophysical signals and, if possible,
+identify their cause.
+
+Fortunately there are also tens of thousands of auxiliary sensors at various
+parts of the detector, closely monitoring mechanical subsystems and
+environmental conditions. We can cross-correlate data from these sensors with
+the primary gravitational wave data to look for evidence of terrestrial noise.
+
+We demonstrate below a prominent 'whistle glitch' in the gravitational wave
+channel, which is also witnessed by a photodiode in the Pre-Stabilized Laser
+(PSL) chamber. This example uses data from the LIGO Livingston detector during
+Advanced LIGO's second observing run.
+"""
+
+__author__ = "Alex Urban <alexander.urban@ligo.org>"
+__currentmodule__ = 'gwpy.timeseries'
+
+# First, we import the `TimeSeries` and :meth:`~TimeSeries.get` the data:
+from gwpy.timeseries import TimeSeries
+hoft = TimeSeries.get('L1:GDS-CALIB_STRAIN', 1172489751, 1172489815)
+aux = TimeSeries.get('L1:PSL-ISS_PDA_REL_OUT_DQ', 1172489751, 1172489815)
+
+# Next, we should `~TimeSeries.whiten` the data to enhance the higher-frequency
+# content and make a more faithful comparison between data streams.
+whoft = hoft.whiten(8, 4)
+waux = aux.whiten(8, 4)
+
+ # We can now cross-correlate these channels:
+mfilter = waux.crop(1172489782.57, 1172489783.57)
+snr = whoft.correlate(mfilter).abs()
+
+# and plot the resulting normalised signal-to-noise ratio:
+plot = snr.crop(1172489782.07, 1172489784.07).plot()
+plot.axes[0].set_epoch(1172489783.07)
+plot.axes[0].set_ylabel('Signal-to-noise ratio', fontsize=16)
+plot.show()
+
+# We can clearly see a loud spike (nearly SNR 40!) at GPS second 1172489783.07,
+# which we interpret as evidence that the PSL channel is witnessing the same
+# glitch as the gravitational wave channel.
+
+# It's now worth checking out the time-frequency morphology in both channels
+# using :meth:`~TimeSeries.q_transform`:
+qhoft = whoft.q_transform(whiten=False, qrange=(93.1, 93.1))
+plot = qhoft.crop(1172489782.57, 1172489783.57).plot(figsize=[8, 4])
+ax = plot.gca()
+ax.set_xscale('seconds')
+ax.set_yscale('log')
+ax.set_epoch(1172489783.07)
+ax.set_ylim(20, 5000)
+ax.set_ylabel('Frequency [Hz]')
+ax.grid(True, axis='y', which='both')
+ax.colorbar(cmap='viridis', label='Normalized energy', clim=[0, 25])
+plot.show()
+
+# and the same for the PSL channel:
+qaux = waux.q_transform(whiten=False, qrange=(93.1, 93.1))
+plot = qaux.crop(1172489782.57, 1172489783.57).plot(figsize=[8, 4])
+ax = plot.gca()
+ax.set_xscale('seconds')
+ax.set_yscale('log')
+ax.set_epoch(1172489783.07)
+ax.set_ylim(20, 5000)
+ax.set_ylabel('Frequency [Hz]')
+ax.grid(True, axis='y', which='both')
+ax.colorbar(cmap='viridis', label='Normalized energy', clim=[0, 25])
+plot.show()
+
+# Sure enough, both channels record a clear whistle glitch at this time,
+# although the PSL channel sees it with much greater signal energy relative
+# to its background noise.

--- a/examples/timeseries/index.rst
+++ b/examples/timeseries/index.rst
@@ -11,6 +11,7 @@
    public
    filter
    whiten
+   correlate
    blrms
    statevector
    qscan

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -828,23 +828,26 @@ class TestTimeSeries(_TestTimeSeriesBase):
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz
         noise = self.TEST_CLASS(
-            numpy.random.normal(loc=1, size=16384 * 10), sample_rate=16384,
-            epoch=-5).zpk([], [0], 1)
+            numpy.random.normal(loc=1, scale=.5, size=16384 * 64),
+            sample_rate=16384, epoch=-32).zpk([], [0], 1)
         glitchtime = 0.5
         glitch = signal.gausspulse(noise.times.value - glitchtime,
                                    bw=100) * 1e-4
         data = noise + glitch
 
-        # whiten and test that the max amplitude is recovered at the glitch
+        # when the input is stationary Gaussian noise, the output should have
+        # zero mean and unit variance
+        whitened = noise.whiten(detrend='linear')
+        assert whitened.size == noise.size
+        nptest.assert_almost_equal(whitened.mean().value, 0.0, decimal=2)
+        nptest.assert_almost_equal(whitened.std().value, 1.0, decimal=2)
+
+        # when a loud signal is present, the max amplitude should be recovered
+        # at the time of that signal
         tmax = data.times[data.argmax()]
         assert not numpy.isclose(tmax.value, glitchtime)
 
-        whitened = data.whiten(2, 1)
-
-        assert whitened.size == noise.size
-        nptest.assert_almost_equal(whitened.mean().value, 0.0, decimal=4)
-        nptest.assert_almost_equal(whitened.std().value, 1.0, decimal=4)
-
+        whitened = data.whiten(detrend='linear')
         tmax = whitened.times[whitened.argmax()]
         nptest.assert_almost_equal(tmax.value, glitchtime)
 
@@ -858,6 +861,30 @@ class TestTimeSeries(_TestTimeSeriesBase):
         convolved = data.convolve(filt)
         assert convolved.size == data.size
         utils.assert_allclose(convolved.value[1:-1], data.value[1:-1])
+
+    def test_correlate(self):
+        # create noise and a glitch template at 1000 Hz
+        noise = self.TEST_CLASS(
+            numpy.random.normal(size=16384 * 64), sample_rate=16384, epoch=-32
+            ).zpk([], [1], 1)
+        glitchtime = -16.5
+        glitch = self.TEST_CLASS(
+            signal.gausspulse(numpy.arange(-1, 1, 1./16384), bw=100),
+            sample_rate=16384, epoch=glitchtime-1)
+
+        # check that, without a signal present, we only see background
+        snr = noise.correlate(glitch, whiten=True)
+        tmax = snr.times[snr.argmax()]
+        assert snr.size == noise.size
+        assert not numpy.isclose(tmax.value, glitchtime)
+        nptest.assert_almost_equal(snr.mean().value, 0.0, decimal=1)
+        nptest.assert_almost_equal(snr.std().value, 1.0, decimal=1)
+
+        # inject and recover the glitch
+        data = noise.inject(glitch * 1e-4)
+        snr = data.correlate(glitch, whiten=True)
+        tmax = snr.times[snr.argmax()]
+        nptest.assert_almost_equal(tmax.value, glitchtime)
 
     def test_detrend(self, losc):
         assert not numpy.isclose(losc.value.mean(), 0.0, atol=1e-21)


### PR DESCRIPTION
@duncanmmacleod, this pull request makes the following changes:

* Introduce a method, `TimeSeries.correlate()`, which convolves `self` with the phase reverse of a given signal, yielding the matched-filter SNR
* The new method whitens both the input and the matched-filter if requested, using an ASD of the input followed by two calls to `TimeSeries.whiten()`
* Add a unit test and documentation example for the new method (the latter requires `LIGO.ORG` credentials)
* Update `TimeSeries.whiten()` to normalize by expected standard deviation, rather than observed
* Update the unit test for `TimeSeries.whiten()`

Note, the SNR timeseries returned by `TimeSeries.correlate()` has the same length and timestamps as `self`. Both `self` and the matched-filter argument are detrended (to give the output zero mean), and the output SNR is normalized by its expected standard deviation (to give unit variance). Users will have to remember to take the absolute value of the output if they don't care about minus signs.

This should be considered a target for gwpy 0.13.0/1.0.0.

This fixes #892.