### PR TITLE
Updated licensing information to GPLv3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ You can test your installation, and its version by
 ```
 python -c "import gwpy; print(gwpy.__version__)"
 ```
+
+# License
+
+GWpy is released under the GNU General Public License v3.0 or later, see [here](https://choosealicense.com/licenses/gpl-3.0/) for a description of this license, or see [LICENSE](https://github.com/gwpy/gwpy/blob/master/LICENSE) file for the full text.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,24 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Contact: Duncan Macleod <duncan.macleod@ligo.org>
+Source: https://git.ligo.org/gwpy/gwpy
+
+Files: *
+Copyright: 2018 Duncan Macleod <duncan.macleod@ligo.org>
+License: GPL-3+
+
+License: GPL-3+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU General
+ Public License version 3 can be found in `/usr/share/common-licenses/GPL-3'.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,16 @@ and frequency-domain data produced by the `LIGO <http://www.ligo.org>`_ and
 `Virgo <http://www.ego-gw.it>`_ instruments and their analysis,
 with easy-to-follow tutorials at each step.
 
+.. image:: https://badge.fury.io/py/gwpy.svg
+    :target: https://badge.fury.io/py/gwpy
+    :alt: GWpy PyPI release badge
+.. image:: https://zenodo.org/badge/9979119.svg
+    :target: https://zenodo.org/badge/latestdoi/9979119
+    :alt: GWpy DOI badge
+.. image:: https://img.shields.io/pypi/l/gwpy.svg
+    :target: https://choosealicense.com/licenses/gpl-3.0/
+    :alt: GWpy license badge
+
 First steps
 ~~~~~~~~~~~
 

--- a/etc/Portfile.template
+++ b/etc/Portfile.template
@@ -11,7 +11,7 @@ categories-append   science
 maintainers         {ligo.org:duncan.macleod @duncanmmacleod} openmaintainer
 
 platforms           darwin
-license             GPL-3
+license             GPL-3+
 
 description         A python package for gravitational-wave astrophysics
 long_description    GWpy is a collaboration-driven Python package providing \

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     long_description_content_type='text/markdown',
     author='Duncan Macleod',
     author_email='duncan.macleod@ligo.org',
-    license='GPLv3',
+    license='GPLv3+',
     url='https://github.com/gwpy/gwpy',
 
     # package content
@@ -128,6 +128,7 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: Unix',
         'Operating System :: MacOS',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'License :: OSI Approved :: '
+        'GNU General Public License v3 or later (GPLv3+)',
     ],
 )


### PR DESCRIPTION
This PR updates the license for GWpy to GPLv3+ and improves the inclusion of licensing information in distributions.