### PR TITLE
Avoid pytest>=3.8 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - conda config --add channels conda-forge
   - conda install --yes "pip" "setuptools>=27.3"
   - conda install --yes "six>=1.5" "python-dateutil" "numpy>=1.7.1" "scipy>=0.12.1" "matplotlib>=1.2.0" "astropy>=1.1.1" "h5py>=1.3" "ligo-segments>=1.0.1" "tqdm>=4.10.0" "ligotimegps"
-  - conda install --yes "pytest>=3.1,!=3.8.0" "pytest-runner" "coverage>=4.0.0" "freezegun>=0.2.3" "sqlparse>=0.2.0" "beautifulsoup4"
+  - conda install --yes "pytest>=3.1,<3.8.0" "pytest-runner" "coverage>=4.0.0" "freezegun>=0.2.3" "sqlparse>=0.2.0" "beautifulsoup4"
 build_script:
   - python -m pip install .
 test_script:


### PR DESCRIPTION
This PR fixes the version pinning for `pytest` for Windows builds on Appveyor. See #894. 