### PR TITLE
Allow reading caches and GWFs from file:// URLs

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -29,6 +29,7 @@ from gzip import GzipFile
 
 from six import string_types
 from six.moves import StringIO
+from six.moves.urllib.parse import urlparse
 
 try:
     from lal.utils import CacheEntry
@@ -87,7 +88,7 @@ def read_cache(lcf, coltype=LIGOTimeGPS):
 
     # open file
     if not isinstance(lcf, FILE_LIKE):
-        with open(lcf, 'r') as fobj:
+        with open(urlparse(lcf).path, 'r') as fobj:
             return read_cache(fobj, coltype=coltype)
 
     # read file

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -236,8 +236,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
             try:
                 connection = reconnect(connection)
                 path = _find_latest_url(connection, ifo, ftype,
-                                          gpstime=gpstime,
-                                          allow_tape=allow_tape)
+                                        gpstime=gpstime, allow_tape=allow_tape)
             except (RuntimeError, IOError):  # something went wrong
                 continue
 

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -25,6 +25,8 @@ one or more frametypes that contain data for that channel.
 import os.path
 import re
 
+from six.moves.urllib.parse import urlparse
+
 from ..time import to_gps
 from .cache import cache_segments
 from .gwf import (num_channels, iter_channel_names)
@@ -233,7 +235,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
             # find instance of this frametype
             try:
                 connection = reconnect(connection)
-                path = _find_latest_frame(connection, ifo, ftype,
+                path = _find_latest_url(connection, ifo, ftype,
                                           gpstime=gpstime,
                                           allow_tape=allow_tape)
             except (RuntimeError, IOError):  # something went wrong
@@ -400,27 +402,27 @@ def on_tape(*files):
 
 # -- utilities ----------------------------------------------------------------
 
-def _find_latest_frame(connection, ifo, frametype, gpstime=None,
-                       allow_tape=False):
-    """Find the latest framepath for a given frametype
+def _find_latest_url(connection, ifo, frametype, gpstime=None,
+                     allow_tape=False):
+    """Find the latest ``file://` URL for a given frametype
     """
     ifo = ifo[0]
     if gpstime is not None:
         gpstime = int(to_gps(gpstime))
     try:
         if gpstime is None:
-            path = connection.find_latest(ifo, frametype, urltype='file')[0]
+            url = connection.find_latest(ifo, frametype, urltype='file')[0]
         else:
-            path = connection.find_urls(ifo, frametype, gpstime, gpstime,
-                                        urltype='file', on_gaps='ignore')[0]
+            url = connection.find_urls(ifo, frametype, gpstime, gpstime,
+                                       urltype='file', on_gaps='ignore')[0]
     except (IndexError, RuntimeError):
         raise RuntimeError("No files found for {}-{}".format(ifo, frametype))
-    else:
-        if not os.access(path, os.R_OK):
-            raise IOError("Latest file for {}-{} is unreadable: "
-                          "{}".format(ifo, frametype, path))
-        if not allow_tape and on_tape(path):
-            raise IOError("Latest file for {}-{} is on tape "
-                          "(pass allow_tape=True to force): "
-                          "{}".format(ifo, frametype, path))
-        return path
+    path = urlparse(url).path
+    if not os.access(path, os.R_OK):
+        raise IOError("Latest file for {}-{} is unreadable: "
+                      "{}".format(ifo, frametype, path))
+    if not allow_tape and on_tape(path):
+        raise IOError("Latest file for {}-{} is on tape "
+                      "(pass allow_tape=True to force): "
+                      "{}".format(ifo, frametype, path))
+    return url

--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -21,6 +21,8 @@
 
 import six
 
+from six.moves.urllib.parse import urlparse
+
 from ..time import to_gps
 from ..utils import shell
 from .cache import read_cache
@@ -87,6 +89,7 @@ def open_gwf(filename, mode='r'):
     if mode not in ('r', 'w'):
         raise ValueError("mode must be either 'r' or 'w'")
     from LDAStools import frameCPP
+    filename = urlparse(filename).path  # strip file://localhost or similar
     if mode == 'r':
         return frameCPP.IFrameFStream(str(filename))
     return frameCPP.OFrameFStream(str(filename))

--- a/gwpy/io/tests/test_gwf.py
+++ b/gwpy/io/tests/test_gwf.py
@@ -19,6 +19,8 @@
 """Unit tests for :mod:`gwpy.io.gwf`
 """
 
+from six.moves.urllib.parse import urljoin
+
 import pytest
 
 from ...tests.utils import (TEST_GWF_FILE, skip_missing_dependency,
@@ -45,6 +47,10 @@ def test_open_gwf():
     assert isinstance(io_gwf.open_gwf(TEST_GWF_FILE), frameCPP.IFrameFStream)
     with TemporaryFilename() as tmp:
         assert isinstance(io_gwf.open_gwf(tmp, mode='w'),
+                          frameCPP.OFrameFStream)
+        # check that we can use a file:// URL as well
+        url = urljoin('file:', tmp)
+        assert isinstance(io_gwf.open_gwf(url, mode='w'),
                           frameCPP.OFrameFStream)
     with pytest.raises(ValueError):
         io_gwf.open_gwf('test', mode='a')


### PR DESCRIPTION
This PR fixes a few failures when trying to read (mainly `open()`) local files using `file://localhost` style URLs, mainly by calling `urlparse(...).path`.

This is necessary because the updated `gwdatafind` package returns file URLs, rather than cache objects.