### PR TITLE
Silence some NDS2 host warnings

### DIFF
--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -266,7 +266,11 @@ def host_resolution_order(ifo, env='NDSSERVER', epoch='now',
         try:
             host, port = DEFAULT_HOSTS[difo]
         except KeyError:
-            warnings.warn('No default host found for ifo %r' % ifo)
+            # unknown default NDS2 host for detector, if we don't have
+            # hosts already defined (either by NDSSERVER or similar)
+            # we should warn the user
+            if not hosts:
+                warnings.warn('No default host found for ifo %r' % ifo)
         else:
             if (host, port) not in hosts:
                 hosts.append((host, port))

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -56,8 +56,10 @@ DEFAULT_HOSTS = OrderedDict([
     ('H0', ('nds.ligo-wa.caltech.edu', 31200)),
     ('L1', ('nds.ligo-la.caltech.edu', 31200)),
     ('L0', ('nds.ligo-la.caltech.edu', 31200)),
+    ('V1', ('nds.ligo.caltech.edu', 31200)),
     ('C1', ('nds40.ligo.caltech.edu', 31200)),
-    ('C0', ('nds40.ligo.caltech.edu', 31200))])
+    ('C0', ('nds40.ligo.caltech.edu', 31200)),
+])
 
 
 # -- enums --------------------------------------------------------------------

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -125,9 +125,13 @@ def test_nds2_host_order():
                    ('nds.ligo.caltech.edu', 31200)]
 
     # test warnings for unknown IFO
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning) as record:
+        # should produce warning
         hro = io_nds2.host_resolution_order('X1')
         assert hro == [('nds.ligo.caltech.edu', 31200)]
+        # should _not_ produce warning
+        hro = io_nds2.host_resolution_order('X1', env='TESTENV')
+    assert len(record) == 1  # make sure only one warning was emitted
 
 
 @skip_missing_dependency('nds2')


### PR DESCRIPTION
This PR silences the `no default host found for ifo 'V1'` style warnings when you try to dynamically `get` (`fetch`) data for a non-LIGO interferometer, as long as the `NDSSERVER` variable is set (meaning the user/admin has opted into selecting the default host for themselves).

Fixes #816.