### PR TITLE
Preserve epoch in add_segments_bar

### DIFF
--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -468,6 +468,12 @@ class Plot(figure.Figure):
         if axes_kw['sharex'] is ax and not ax.get_autoscalex_on():
             axes_kw['xlim'] = ax.get_xlim()
 
+        # if axes uses GPS scaling, copy the epoch as well
+        try:
+            axes_kw['epoch'] = ax.get_epoch()
+        except AttributeError:
+            pass
+
         # add new axes
         if ax.get_axes_locator():
             divider = ax.get_axes_locator()._axes_divider

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -126,13 +126,16 @@ class TestPlot(FigureTestBase):
         assert cbar.mappable is image
 
     def test_add_segments_bar(self, fig):
-        ax = fig.gca(xscale='auto-gps')
+        ax = fig.gca(xscale='auto-gps', epoch=150)
         ax.set_xlim(100, 200)
         ax.set_xlabel('test')
         segs = SegmentList([Segment(10, 110), Segment(150, 400)])
         segax = fig.add_segments_bar(segs)
         assert segax._sharex is ax
         assert ax.get_xlabel() == ''
+        for ax_ in (ax, segax):
+            assert ax_.get_xlim() == (100, 200)
+            assert ax_.get_epoch() == 150.
 
         # check that it works again
         segax = fig.add_segments_bar(segs, ax=ax)


### PR DESCRIPTION
This PR fixes an issue with `gwpy.plot.Plot.add_segments_bar` where the `epoch` of the parent axes would be unset when creating the segments bar axes.

cc: @alurban