### PR TITLE
Allow specifying verbose prefix for NDS fetch

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -321,7 +321,9 @@ class TimeSeriesBase(Series):
             open NDS connection to use
 
         verbose : `bool`, optional
-            print verbose output about NDS progress, useful for debugging
+            print verbose output about NDS progress, useful for debugging;
+            if ``verbose`` is specified as a string, this defines the
+            prefix for the progress meter
 
         type : `int`, optional
             NDS2 channel type integer
@@ -491,7 +493,9 @@ class TimeSeriesBase(Series):
             allow reading from frame files on (slow) magnetic tape
 
         verbose : `bool`, optional
-            print verbose output about NDS progress.
+            print verbose output about read progress, if ``verbose``
+            is specified as a string, this defines the prefix for the
+            progress meter
 
         **readargs
             any other keyword arguments to be passed to `.read()`
@@ -541,7 +545,9 @@ class TimeSeriesBase(Series):
             retrieving data from tape if required
 
         verbose : `bool`, optional
-            print verbose output about NDS progress.
+            print verbose output about data access progress, if ``verbose``
+            is specified as a string, this defines the prefix for the
+            progress meter
 
         **kwargs
             other keyword arguments to pass to either
@@ -979,7 +985,9 @@ class TimeSeriesBaseDict(OrderedDict):
             check channels exist in database before asking for data
 
         verbose : `bool`, optional
-            print verbose output about NDS progress.
+            print verbose output about NDS download progress, if ``verbose``
+            is specified as a string, this defines the prefix for the
+            progress meter
 
         connection : `nds2.connection`, optional
             open NDS connection to use.
@@ -1114,7 +1122,9 @@ class TimeSeriesBaseDict(OrderedDict):
             allow reading from frame files on (slow) magnetic tape
 
         verbose : `bool`, optional
-            print verbose output about NDS progress.
+            print verbose output about read progress, if ``verbose``
+            is specified as a string, this defines the prefix for the
+            progress meter
 
         **readargs
             any other keyword arguments to be passed to `.read()`
@@ -1223,7 +1233,9 @@ class TimeSeriesBaseDict(OrderedDict):
             retrieving data from tape if required
 
         verbose : `bool`, optional
-            print verbose output about NDS progress.
+            print verbose output about data access progress, if ``verbose``
+            is specified as a string, this defines the prefix for the
+            progress meter
 
         **kwargs
             other keyword arguments to pass to either

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -39,7 +39,7 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 def print_verbose(*args, **kwargs):
     """Utility to print something only if verbose=True is given
     """
-    if kwargs.pop('verbose', False):
+    if kwargs.pop('verbose', False) is True:
         gprint(*args, **kwargs)
 
 
@@ -78,9 +78,11 @@ def set_parameter(connection, parameter, value, verbose=False):
             'failed to set {}={!r}: {}'.format(parameter, value, str(exc)),
             io_nds2.NDSWarning)
     else:
-        if verbose:
-            print('    [{}] set {}={!r}'.format(connection.get_host(),
-                                                parameter, value))
+        print_verbose(
+            '    [{}] set {}={!r}'.format(
+                connection.get_host(), parameter, value),
+            verbose=verbose,
+        )
 
 
 @io_nds2.open_connection
@@ -148,7 +150,8 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
 
     # query for each segment
     out = series_class.DictClass()
-    with progress_bar(total=float(abs(qsegs)), desc='Downloading data',
+    desc = verbose if isinstance(verbose, str) else 'Downloading data'
+    with progress_bar(total=float(abs(qsegs)), desc=desc,
                       unit='s', disable=not bool(verbose)) as bar:
         for seg in qsegs:
             total = 0.


### PR DESCRIPTION
This PR modifies the behaviour of the `verbose` keyword to `TimeSeries.fetch` and friends, such that the user can now specify the prefix string for the tqdm progress bar. This has the impact of silencing all other output, mainly to enable convenient embedding of the progress bar into other contexts. This is useful for the LIGO summary pages.