### PR TITLE
Added DataQualityDict.coalesce method

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1541,6 +1541,20 @@ class DataQualityDict(OrderedDict):
         -----"""
         return io_registry.write(self, target, *args, **kwargs)
 
+    def coalesce(self):
+        """Coalesce all segments lists in this `DataQualityDict`.
+
+        **This method modifies this object in-place.**
+
+        Returns
+        -------
+        self
+            a view of this flag, not a copy.
+        """
+        for flag in self:
+            self[flag].coalesce()
+        return self
+
     def populate(self, source=DEFAULT_SEGMENT_SERVER,
                  segments=None, pad=True, on_error='raise', **kwargs):
         """Query the segment database for each flag's active segments.

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -856,3 +856,9 @@ class TestDataQualityDict(object):
                 vdf3[flag].known, QUERY_RESULTC[flag].known & span)
             utils.assert_segmentlist_equal(
                 vdf3[flag].active, QUERY_RESULTC[flag].active & span)
+
+    def test_coalesce(self):
+        instance = self.create()
+        instance.coalesce()
+        value = instance['X1:TEST-FLAG:1']
+        utils.assert_segmentlist_equal(value.active, KNOWNACTIVE)


### PR DESCRIPTION
This PR adds a new `.coalesce()` method to the `DataQualityDict`. This just calls `DataQualityFlag.coalesce()` for all values.