### PR TITLE
Fixed DeprecationWarnings in the test suite

### DIFF
--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -147,7 +147,7 @@ def write_channel_list_file(channels, fobj):
             out.add_section(group)
         for param, value in channel.params.items():
             out.set(group, param, value)
-        if channel.sample_rate:
+        if channel.sample_rate is not None:
             entry = '%s %s' % (str(channel),
                                str(channel.sample_rate.to('Hz').value))
         else:

--- a/gwpy/detector/io/omega.py
+++ b/gwpy/detector/io/omega.py
@@ -174,10 +174,10 @@ def print_omega_channel(channel, file=sys.stdout):
     params.setdefault('alwaysPlotFlag', int(params.pop('important', False)))
     if channel.frametype:
         params.setdefault('frameType', channel.frametype)
-    if channel.sample_rate:
+    if channel.sample_rate is not None:
         params.setdefault('sampleFrequency',
                           channel.sample_rate.to('Hz').value)
-    if channel.frequency_range:
+    if channel.frequency_range is not None:
         low, high = channel.frequency_range.to('Hz').value
         params.setdefault('searchFrequencyRange', (low, high))
     if 'qlow' in params or 'qhigh' in params:

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -125,7 +125,7 @@ class TestFrequencySeries(_TestSeries):
         # construct a TimeSeries, then check that it is unchanged by
         # the operation TimeSeries.fft().ifft()
         ts = TimeSeries([1.0, 0.0, -1.0, 0.0], sample_rate=1.0)
-        assert ts.fft().ifft() == ts
+        utils.assert_quantity_sub_equal(ts.fft().ifft(), ts)
         utils.assert_allclose(ts.fft().ifft().value, ts.value)
 
     def test_filter(self, array):

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -332,7 +332,7 @@ def average_spectrogram(timeseries, method_func, stride, *args, **kwargs):
 
     # define chunks
     tschunks = _chunk_timeseries(timeseries, nstride, noverlap)
-    if other:
+    if other is not None:
         otherchunks = _chunk_timeseries(other, nstride, noverlap)
         tschunks = zip(tschunks, otherchunks)
 

--- a/gwpy/signal/tests/test_fft.py
+++ b/gwpy/signal/tests/test_fft.py
@@ -155,9 +155,13 @@ class TestUI(object):
         """
         a = TimeSeries(numpy.arange(400))
         chunks = list(fft_ui._chunk_timeseries(a, 100, 50))
-        assert chunks == [
-            a[:150], a[75:225], a[175:325], a[250:400],
-        ]
+        for i, (idxa, idxb) in enumerate([
+                (None, 150),
+                (75, 225),
+                (175, 325),
+                (250, 400),
+        ]):
+            utils.assert_quantity_sub_equal(chunks[i], a[idxa:idxb])
 
     def test_fft_library(self):
         """Test :func:`gwpy.signal.fft.ui._fft_library`

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -405,7 +405,8 @@ class TestTimeSeriesBaseList(object):
         new = self.ENTRY_CLASS([1, 2, 3, 4, 5])
         a.append(new)
         b.extend([new])
-        assert a == b
+        for i in range(max(map(len, (a, b)))):
+            utils.assert_quantity_sub_equal(a[i], b[i])
 
     def test_coalesce(self):
         a = self.TEST_CLASS()

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1771,18 +1771,18 @@ class TimeSeries(TimeSeriesBase):
         from ..signal.qtransform import QTiling
 
         # condition data
-        if whiten:
-            if not isinstance(whiten, FrequencySeries):
-                window = asd_kw.pop('window', 'hann')
-                fftlength = asd_kw.pop('fftlength',
-                                       _fft_length_default(self.dt))
-                overlap = asd_kw.pop('overlap', None)
-                if overlap is None and fftlength == self.duration.value:
-                    asd_kw['method'] = 'scipy-welch'
-                    overlap = 0
-                elif overlap is None:
-                    overlap = recommended_overlap(window) * fftlength
-                whiten = self.asd(fftlength, overlap, window=window, **asd_kw)
+        if whiten is True:  # generate ASD dynamically
+            window = asd_kw.pop('window', 'hann')
+            fftlength = asd_kw.pop('fftlength',
+                                   _fft_length_default(self.dt))
+            overlap = asd_kw.pop('overlap', None)
+            if overlap is None and fftlength == self.duration.value:
+                asd_kw['method'] = 'scipy-welch'
+                overlap = 0
+            elif overlap is None:
+                overlap = recommended_overlap(window) * fftlength
+            whiten = self.asd(fftlength, overlap, window=window, **asd_kw)
+        if isinstance(whiten, FrequencySeries):
             # apply whitening (with errors on dividing by zero)
             with numpy.errstate(all='raise'):
                 data = self.whiten(asd=whiten, fduration=fduration,

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -194,6 +194,8 @@ class Array(Quantity):
         return super(Array, self).__getattribute__(attr)
 
     def __getitem__(self, item):
+        if isinstance(item, list):
+            item = tuple(item)
         new = super(Array, self).__getitem__(item)
 
         # return scalar as a Quantity


### PR DESCRIPTION
This PR fixes a number of `FutureWarning`s and `DeprecationWarning`s emitted when running the test suite, mainly from not correctly comparing `Quantity` objects to other things.