### PR TITLE
Fixed bug in assert_dict_equal in the test suite

### DIFF
--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -101,7 +101,7 @@ KNOWNACTIVE = _as_segmentlist(
 
 # 'active' set contracted by 0.1 seconds
 ACTIVE_CONTRACTED = _as_segmentlist(
-    (1.1, 1.9), (3.1, 3.9))
+    (1.1, 1.9), (3.1, 3.9), (5.1, 6.9))
 
 # 'active' seg protracted by 0.1 seconts
 ACTIVE_PROTRACTED = _as_segmentlist(
@@ -321,8 +321,9 @@ class TestDataQualityFlag(object):
 
         # sub
         x = a - b
-        utils.assert_segmentlist_equal(x.active, a.active - b.active)
         utils.assert_segmentlist_equal(x.known, a.known & b.known)
+        utils.assert_segmentlist_equal(x.active,
+                                       (a.active - b.active) & x.known)
 
         # or
         x = a | b

--- a/gwpy/tests/utils.py
+++ b/gwpy/tests/utils.py
@@ -25,6 +25,7 @@ from contextlib import contextmanager
 from importlib import import_module
 
 from six import PY2
+from six.moves import zip_longest
 
 import pytest
 
@@ -177,7 +178,7 @@ def assert_table_equal(a, b, is_copy=True, meta=False, check_types=True,
 def assert_segmentlist_equal(a, b):
     """Assert that two `SegmentList`s contain the same data
     """
-    for aseg, bseg in zip(a, b):
+    for aseg, bseg in zip_longest(a, b):
         assert aseg == bseg
 
 


### PR DESCRIPTION
This PR fixes a bug in the test suite utilities (`gwpy.tests`) that was hiding bad test results.