### PR TITLE
Patched DataQualityFlag.round() to preserve type

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -804,11 +804,11 @@ class DataQualityFlag(object):
         """
         def _round(seg):
             if contract:  # round inwards
-                a = ceil(seg[0])
-                b = floor(seg[1])
+                a = type(seg[0])(ceil(seg[0]))
+                b = type(seg[1])(floor(seg[1]))
             else:  # round outwards
-                a = floor(seg[0])
-                b = ceil(seg[1])
+                a = type(seg[0])(floor(seg[0]))
+                b = type(seg[1])(ceil(seg[1]))
             if a >= b:  # if segment is too short, return 'null' segment
                 return type(seg)(0, 0)  # will get coalesced away
             return type(seg)(a, b)


### PR DESCRIPTION
This PR modifies `DataQualityFlag.round()` to preserve the type of the numbers contained within each segment list. For python3, the `math.floor` and `math.ceil` return `Integral` types, rather than floats, meaning type was being lost.