### PR TITLE
Patched gwpy.segments to use standard multi-processed I/O

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -633,8 +633,8 @@ class DataQualityFlag(object):
             """
             out = flags[0]
             for flag in flags[1:]:
-                 out.known += flag.known
-                 out.active += flag.active
+                out.known += flag.known
+                out.active += flag.active
             if coalesce:
                 return out.coalesce()
             return out

--- a/gwpy/segments/io/segwizard.py
+++ b/gwpy/segments/io/segwizard.py
@@ -34,7 +34,7 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 # -- read ---------------------------------------------------------------------
 
-def from_segwizard(source, coalesce=True, gpstype=LIGOTimeGPS, strict=True,
+def from_segwizard(source, coalesce=False, gpstype=LIGOTimeGPS, strict=True,
                    nproc=1):
     """Read segments from a segwizard format file into a `SegmentList`
     """


### PR DESCRIPTION
This PR updates the `gwpy.segments` subpackage to use `gwpy.io.mp` to provide multi-processed I/O as standard.