### PR TITLE
Removed dependencies on glue.segmentsUtils library

### DIFF
--- a/gwpy/segments/io/segwizard.py
+++ b/gwpy/segments/io/segwizard.py
@@ -19,76 +19,141 @@
 """Read SegmentLists from seg-wizard format ASCII files
 """
 
-import warnings
+from __future__ import print_function
+
+import re
 
 from six import string_types
 
-from .. import (Segment, SegmentList, DataQualityFlag)
+from .. import (Segment, SegmentList)
 from ...io import registry
 from ...io.utils import identify_factory
-from ...io.cache import file_list
 from ...time import LIGOTimeGPS
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
+_FLOAT_PAT = r'([\d.+-eE]+)'
+# simple two-column (gpsstart, gpsend)
+TWO_COL_REGEX = re.compile(
+    r'\A\s*{float}\s+{float}\s*\Z'.format(float=_FLOAT_PAT))
+# three column (gpsstart, gpsend, duration)
+THREE_COL_REGEX = re.compile(
+    r'\A\s*{float}\s+{float}\s+{float}\s*\Z'.format(float=_FLOAT_PAT))
+# four column (index, gpsstart, gpsend, duration)
+FOUR_COL_REGEX = re.compile(
+    r'\A\s*([\d]+)\s+{float}\s+{float}\s+{float}\s*\Z'.format(
+        float=_FLOAT_PAT))
+
 
 # -- read ---------------------------------------------------------------------
 
-def from_segwizard(source, coalesce=False, gpstype=LIGOTimeGPS, strict=True,
-                   nproc=1):
+def from_segwizard(source, gpstype=LIGOTimeGPS, strict=True):
     """Read segments from a segwizard format file into a `SegmentList`
+
+    Parameters
+    ----------
+    source : `file`, `str`
+        An open file, or file path, from which to read
+
+    gpstype : `type`, optional
+        The numeric type to which to cast times (from `str`) when reading.
+
+    strict : `bool`, optional
+        Check that recorded duration matches ``end-start`` for all segments;
+        only used when reading from a 3+-column file.
+
+    Returns
+    -------
+    segments : `~gwpy.segments.SegmentList`
+        The list of segments as parsed from the file.
+
+    Notes
+    -----
+    This method is adapted from original code written by Kipp Cannon and
+    distributed under GPLv3.
     """
-    from glue import segmentsUtils
+    # read file path
+    if isinstance(source, string_types):
+        with open(source, 'r') as fobj:
+            return from_segwizard(fobj, gpstype=gpstype, strict=strict)
 
-    if nproc != 1:
-        return SegmentList.read(source, coalesce=coalesce, gpstype=gpstype,
-                                strict=strict, nproc=nproc, format='cache')
+    # read file object
+    out = SegmentList()
+    fmt_pat = None
+    for line in source:
+        if line.startswith(('#', ';')):  # comment
+            continue
+        # determine line format
+        if fmt_pat is None:
+            fmt_pat = _line_format(line)
+        # parse line
+        tokens, = fmt_pat.findall(line)
+        out.append(_format_segment(tokens[-3:], gpstype=gpstype))
+    return out
 
-    # format list of files and read in serial
-    files = file_list(source)
-    segs = SegmentList()
-    for file_ in files:
-        with open(file_, 'r') as fobj:
-            raw = segmentsUtils.fromsegwizard(fobj, coltype=gpstype,
-                                              strict=strict)
-            segs.extend(SegmentList(map(Segment, raw)))
-    if coalesce:
-        segs.coalesce()
-    return segs
+
+def _line_format(line):
+    """Determine the column format pattern for a line in an ASCII segment file.
+    """
+    for pat in (FOUR_COL_REGEX, THREE_COL_REGEX, TWO_COL_REGEX):
+        if pat.match(line):
+            return pat
+    raise ValueError("unable to parse segment from line {!r}".format(line))
+
+
+def _format_segment(tokens, strict=True, gpstype=LIGOTimeGPS):
+    """Format a list of tokens parsed from an ASCII file into a segment.
+    """
+    try:
+        start, end, dur = tokens
+    except ValueError:  # two-columns
+        return Segment(map(gpstype, tokens))
+    seg = Segment(gpstype(start), gpstype(end))
+    if strict and abs(seg) != gpstype(dur):
+        raise ValueError("segment {0!r} has incorrect duration".format(seg))
+    return seg
 
 
 # -- write --------------------------------------------------------------------
 
-def to_segwizard(segs, fobj, header=True, coltype=int):
-    """Write the given `SegmentList` to the file object fobj
+# pylint: disable=inconsistent-return-statements
+def to_segwizard(segs, target, header=True, coltype=LIGOTimeGPS):
+    """Write the given `SegmentList` to a file in SegWizard format.
 
     Parameters
     ----------
-    segs : :class:`~gwpy.segments.segments.SegmentList`
-        segmentlist to print
-    fobj : `file`, `str`
-        open file object, or file path, to write to
+    segs : :class:`~gwpy.segments.SegmentList`
+        The list of segments to write.
+
+    target : `file`, `str`
+        An open file, or file path, to which to write.
+
     header : `bool`, optional
-        print header into the file, default: `True`
+        Print a column header into the file, default: `True`.
+
     coltype : `type`, optional
-        numerical type in which to cast times before printing
+        The numerical type in which to cast times before printing.
 
-    See Also
-    --------
-    glue.segmentsUtils
-        for definition of the segwizard format, and the to/from functions
-        used in this GWpy module
+    Notes
+    -----
+    This method is adapted from original code written by Kipp Cannon and
+    distributed under GPLv3.
     """
-    from glue import segmentsUtils
+    # write file path
+    if isinstance(target, string_types):
+        with open(target, 'w') as fobj:
+            return to_segwizard(segs, fobj, header=header, coltype=coltype)
 
-    if isinstance(fobj, string_types):
-        close = True
-        fobj = open(fobj, 'w')
-    else:
-        close = False
-    segmentsUtils.tosegwizard(fobj, segs, header=header, coltype=coltype)
-    if close:
-        fobj.close()
+    # write file object
+    if header:
+        print('# seg\tstart\tstop\tduration', file=target)
+    for i, seg in enumerate(segs):
+        print(
+            '\t'.join(map(
+                str, (i, coltype(seg[0]), coltype(seg[1]), coltype(abs(seg))),
+            )), file=target,
+        )
+
 
 # -- register -----------------------------------------------------------------
 

--- a/gwpy/segments/tests/test_segments.py
+++ b/gwpy/segments/tests/test_segments.py
@@ -25,8 +25,7 @@ import tempfile
 
 import pytest
 
-from ...tests.utils import (assert_segmentlist_equal, skip_missing_dependency,
-                            TemporaryFilename)
+from ...tests.utils import (assert_segmentlist_equal, TemporaryFilename)
 from ...time import LIGOTimeGPS
 from .. import (Segment, SegmentList)
 
@@ -78,7 +77,6 @@ class TestSegmentList(object):
 
     # -- test I/O -------------------------------
 
-    @skip_missing_dependency('glue.segmentsUtils')
     def test_read_write_segwizard(self, segmentlist):
         with TemporaryFilename(suffix='.txt') as tmp:
             # check write/read returns the same list

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -94,7 +94,12 @@ def _bool_segments(array, start=0, delta=1, minlen=1):
     array = iter(array)
     i = 0
     while True:
-        if next(array):  # start of new segment
+        try:  # get next value
+            val = next(array)
+        except StopIteration:  # end of array
+            return
+
+        if val:  # start of new segment
             n = 1  # count consecutive True
             try:
                 while next(array):  # run until segment will end

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -49,6 +49,65 @@ __all__ = ['StateTimeSeries', 'StateTimeSeriesDict',
            'StateVector', 'StateVectorDict', 'StateVectorList', 'Bits']
 
 
+# -- utilities ----------------------------------------------------------------
+
+def _bool_segments(array, start=0, delta=1, minlen=1):
+    """Yield segments of consecutive `True` values in a boolean array
+
+    Parameters
+    ----------
+    array : `iterable`
+        An iterable of boolean-castable values.
+
+    start : `float`
+        The value of the first sample on the indexed axis
+        (e.g.the GPS start time of the array).
+
+    delta : `float`
+        The step size on the indexed axis (e.g. sample duration).
+
+    minlen : `int`, optional
+        The minimum number of consecutive `True` values for a segment.
+
+    Yields
+    ------
+    segment : `tuple`
+        ``(start + i * delta, start + (i + n) * delta)`` for a sequence
+        of ``n`` consecutive True values starting at position ``i``.
+
+    Notes
+    -----
+    This method is adapted from original code written by Kipp Cannon and
+    distributed under GPLv3.
+
+    The datatype of the values returned will be the larger of the types
+    of ``start`` and ``delta``.
+
+    Examples
+    --------
+    >>> print(list(_bool_segments([0, 1, 0, 0, 0, 1, 1, 1, 0, 1]))
+    [(1, 2), (5, 8), (9, 10)]
+    >>> print(list(_bool_segments([0, 1, 0, 0, 0, 1, 1, 1, 0, 1]
+    ...                           start=100., delta=0.1))
+    [(100.1, 100.2), (100.5, 100.8), (100.9, 101.0)]
+    """
+    array = iter(array)
+    i = 0
+    while True:
+        if next(array):  # start of new segment
+            n = 1  # count consecutive True
+            try:
+                while next(array):  # run until segment will end
+                    n += 1
+            except StopIteration:  # have reached the end
+                return  # stop
+            finally:  # yield segment (including at StopIteration)
+                if n >= minlen:  # ... if long enough
+                    yield (start + i * delta, start + (i + n) * delta)
+            i += n
+        i += 1
+
+
 # -- StateTimeSeries ----------------------------------------------------------
 
 class StateTimeSeries(TimeSeriesBase):
@@ -165,7 +224,7 @@ class StateTimeSeries(TimeSeriesBase):
 
     def to_dqflag(self, name=None, minlen=1, dtype=None, round=False,
                   label=None, description=None):
-        """Convert this series into a `~gwpy.segments.DataQualityFlag`
+        """Convert this series into a `~gwpy.segments.DataQualityFlag`.
 
         Each contiguous set of `True` values are grouped as a
         `~gwpy.segments.Segment` running from the GPS time the first
@@ -174,7 +233,7 @@ class StateTimeSeries(TimeSeriesBase):
 
         Parameters
         ----------
-        minlen : `int`, optional, default: 1
+        minlen : `int`, optional
             minimum number of consecutive `True` values to identify as a
             `~gwpy.segments.Segment`. This is useful to ignore single
             bit flips, for example.
@@ -184,9 +243,17 @@ class StateTimeSeries(TimeSeriesBase):
             casting, or a callable function that accepts a float and returns
             another numeric type, defaults to the `dtype` of the time index
 
-        round : `bool`, optional, default: False
+        round : `bool`, optional
             choose to round each `~gwpy.segments.Segment` to its
             inclusive integer boundaries
+
+        label : `str`, optional
+            the :attr:`~gwpy.segments.DataQualityFlag.label` for the
+            output flag.
+
+        description : `str`, optional
+            the :attr:`~gwpy.segments.DataQualityFlag.description` for the
+            output flag.
 
         Returns
         -------
@@ -195,28 +262,27 @@ class StateTimeSeries(TimeSeriesBase):
             defines the `known` segments, while the contiguous `True`
             sets defined each of the `active` segments
         """
-        from glue.segmentsUtils import from_bitstream
         from ..segments import (Segment, SegmentList, DataQualityFlag)
 
         # format dtype
         if dtype is None:
-            dtype = self.t0.dtype.type
-        elif isinstance(dtype, numpy.dtype):
+            dtype = self.t0.dtype
+        if isinstance(dtype, numpy.dtype):  # use callable dtype
             dtype = dtype.type
-        start = dtype(self.t0.value)  # <-- sets the dtype for the segments
-        dt = self.dt.value
+        start = dtype(self.t0.value)
+        dt = dtype(self.dt.value)
 
-        # build segmentlists
-        active = from_bitstream(self.value, start, dt, minlen=int(minlen))
-        known = SegmentList([Segment(*map(dtype, self.span))])
+        # build segmentlists (can use simple objects since DQFlag converts)
+        active = _bool_segments(self.value, start, dt, minlen=int(minlen))
+        known = [tuple(map(dtype, self.span))]
 
         # build flag and return
         out = DataQualityFlag(name=name or self.name, active=active,
                               known=known, label=label or self.name,
                               description=description)
         if round:
-            out = out.round()
-        return out.coalesce()
+            return out.round()
+        return out
 
     def to_lal(self, *args, **kwargs):
         """Bogus function inherited from superclass, do not use.

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -258,7 +258,6 @@ class TestStateVector(_TestTimeSeriesBase):
             array.get_bit_series(['blah'])
         assert str(exc.value) == "Bit 'blah' not found in StateVector"
 
-    @utils.skip_missing_dependency('glue.segmentsUtils')
     def test_plot(self, array):
         with rc_context(rc={'text.usetex': False}):
             plot = array.plot()

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -30,7 +30,7 @@ from matplotlib import rc_context
 from astropy import units
 
 from ...detector import Channel
-from ...time import Time
+from ...time import (Time, LIGOTimeGPS)
 from ...tests import utils
 from ...types import Array2D
 from .. import (StateVector, StateVectorDict, StateVectorList,
@@ -104,6 +104,27 @@ class TestStateTimeSeries(_TestTimeSeriesBase):
         a2 = array ** 2
         assert a2.dtype is numpy.dtype(bool)
         utils.assert_array_equal(array.value, a2.value)
+
+    def test_to_dqflag(self, array):
+        flag = array.to_dqflag()
+        utils.assert_segmentlist_equal(
+            flag.active, [(1, 4), (7, 8), (10, 13), (14, 15), (16, 20)],
+        )
+        utils.assert_segmentlist_equal(flag.known, [array.span])
+        assert flag.name == array.name
+        assert flag.label == array.name
+        assert flag.description is None
+
+        flag = array.to_dqflag(minlen=2, dtype=LIGOTimeGPS, name='Test flag',
+                               round=True, label='Label',
+                               description='Description')
+        utils.assert_segmentlist_equal(
+            flag.active, [(1, 4), (10, 13), (16, 20)],
+        )
+        assert isinstance(flag.active[0][0], LIGOTimeGPS)
+        assert flag.name == 'Test flag'
+        assert flag.label == 'Label'
+        assert flag.description == 'Description'
 
     def test_override_unit(self):
         return NotImplemented


### PR DESCRIPTION
This PR removes any dependencies on the `glue.segmentsUtils` module, mainly be adapting the necessary code directly into the calling gwpy modules, with credits.