### PR TITLE
Simplified travis builds and added new build for python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,67 +12,14 @@ matrix:
     # -- simple builds --------------------------
 
     - python: '2.7'
-      addons:
-        apt:
-          packages:
-            - gcc
-            - gfortran
-            - libblas-dev
-            - liblapack-dev
-            - texlive-latex-extra
-            - texlive-fonts-recommended
-            - dvipng
-            - libhdf5-serial-dev
     - python: '3.4'
-      addons:
-        apt:
-          packages:
-            - gcc
-            - gfortran
-            - libblas-dev
-            - liblapack-dev
-            - texlive-latex-extra
-            - texlive-fonts-recommended
-            - dvipng
-            - libhdf5-serial-dev
     - python: '3.5'
-      addons:
-        apt:
-          packages:
-            - gcc
-            - gfortran
-            - libblas-dev
-            - liblapack-dev
-            - texlive-latex-extra
-            - texlive-fonts-recommended
-            - dvipng
-            - libhdf5-serial-dev
     - python: '3.6'
-      addons:
-        apt:
-          packages:
-            - gcc
-            - gfortran
-            - libblas-dev
-            - liblapack-dev
-            - texlive-latex-extra
-            - texlive-fonts-recommended
-            - dvipng
-            - libhdf5-serial-dev
-
+    - python: '3.7'
+      sudo: required
+      dist: xenial
     - env: PIP_FLAGS="--upgrade --pre --quiet"
       python: '3.6'
-      addons:
-        apt:
-          packages:
-            - gcc
-            - gfortran
-            - libblas-dev
-            - liblapack-dev
-            - texlive-latex-extra
-            - texlive-fonts-recommended
-            - dvipng
-            - libhdf5-serial-dev
 
     # -- reference OS builds --------------------
 


### PR DESCRIPTION
This PR simplifies the `.travis.yml` configuration, removing the extra `apt` `addons`, and adds a python3.7 build using https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905.