### PR TITLE
Qxfm min search

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -151,13 +151,15 @@ class CliProduct(object):
     action = None
 
     def __init__(self, args):
-        self._finalize_arguments(args)  # post-process args
 
         #: input argument Namespace
         self.args = args
 
         #: verbosity
         self.verbose = 0 if args.silent else args.verbose
+
+        #NB: finalizing may want to log if we're being verbose
+        self._finalize_arguments(args)  # post-process args
 
         if args.style:  # apply custom styling
             try:

--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -112,6 +112,11 @@ class Qtransform(Spectrogram):
         """
         gps = args.gps
         search = args.search
+        # ennsure we have enough data for filter settling
+        max_plot = max(args.plot)
+        search = max(search, max_plot * 2 + 6)
+        self.log(3, "Search window: {0:.0f} sec, max plot window {1:.0f}".
+                 format(search, max_plot))
 
         args.start = [[int(gps - search/2)]]
         if args.epoch is None:


### PR DESCRIPTION
This addresses issue #956 
Simply forces a minimum search window based on maximum plot window.
Also a minor reordering in __init__ to make logging available earlier