### PR TITLE
Modified strain unit definition to be an alias for dimensionless

### DIFF
--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -174,7 +174,7 @@ units.def_unit(['NONE', 'undef'], namespace=_ns,
                doc='No unit has been defined for these data')
 
 # other dimenionless units
-units.def_unit('strain', namespace=_ns)
+units.def_unit('strain', represents=units.Unit(''), namespace=_ns)
 units.def_unit('coherence', namespace=_ns)
 
 # alias for 'second' but with prefices


### PR DESCRIPTION
This PR modifies the definition of the custom `'strain'` unit to be represent `dimensionless_unscaled`, this used to be defined like this, but was removed in cffd06c738f7482e52a8574e7d8bc7179b90fb40 for some reason; fixes #958.