### PR TITLE
Added new gwpy.utils.env module

### DIFF
--- a/docs/env.rst
+++ b/docs/env.rst
@@ -1,0 +1,33 @@
+#####################################
+Configuring GWpy from the environment
+#####################################
+
+GWpy can be configured by setting environment variables at run time.
+Each of the variables are boolean switches, meaning they just tell GWpy to
+do something, or not to do something. The following values match as `True`:
+
+- ``'y'``
+- ``'yes'``
+- ``'1'``
+- ``'true'``
+
+And these match as `False`:
+
+- ``'n'``
+- ``'no'``
+- ``'0'``
+- ``'false'``
+
+The matching is **case-independent**, so, for example, ``'TRUE'`` will
+match as `True`.
+
+The following variables are defined:
+
++---------------------+---------+---------------------------------------------+
+| Variable            | Default | Purpose                                     |
++=====================+=========+=============================================+
+| ``GWPY_CACHE``      | `False` | Whether to cache downloaded files from      |
+|                     |         | GWOSC to prevent repeated downloads         |
++---------------------+---------+---------------------------------------------+
+| ``GWPY_USETEX``     | `True`  | Whether to use LaTeX when rendering images  |
++---------------------+---------+---------------------------------------------+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,6 +92,7 @@ Working with data
    detector/channel
    time/index
    astro/index
+   env
 
 **Developer notes**
 

--- a/gwpy/plot/rc.py
+++ b/gwpy/plot/rc.py
@@ -26,6 +26,7 @@ from matplotlib.figure import SubplotParams
 
 from . import tex
 from .colors import DEFAULT_COLORS
+from ..utils.env import bool_env
 
 # record matplotlib's original rcParams
 MPL_RCPARAMS = rc_params()
@@ -64,10 +65,7 @@ DEFAULT_PARAMS = {
 }
 
 # select tex formatting (or not)
-try:  # allow user to override from environment
-    _USETEX = os.environ['GWPY_USETEX'].lower() in ['1', 'true', 'yes', 'y']
-except KeyError:  # 'or' means default to tex
-    _USETEX = rcParams['text.usetex'] or tex.has_tex()
+_USETEX = bool_env('GWPY_USETEX', rcParams['text.usetex'] or tex.has_tex())
 
 # set latex options
 rcParams['text.latex.preamble'].extend(tex.MACROS)

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -40,6 +40,7 @@ from ...io.cache import (cache_segments, file_segment)
 from ...detector.units import parse_unit
 from ...segments import (Segment, SegmentList)
 from ...time import to_gps
+from ...utils.env import bool_env
 
 # ASCII parsing globals
 LOSC_ASCII_HEADER_REGEX = re.compile(
@@ -64,9 +65,7 @@ LOSC_VERSION_RE = re.compile(r'V\d+')
 
 def _download_file(url, cache=None, verbose=False):
     if cache is None:
-        cache = os.getenv('GWPY_CACHE', 'no').lower() in (
-            '1', 'true', 'yes', 'y',
-        )
+        cache = bool_env('GWPY_CACHE', False)
     return get_readable_fileobj(url, cache=cache, show_progress=verbose)
 
 

--- a/gwpy/utils/env.py
+++ b/gwpy/utils/env.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2018)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Environment utilities for GWpy
+"""
+
+import os
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+TRUE = (
+    '1',
+    'y',
+    'yes',
+    'true',
+)
+
+
+def bool_env(key, default=False):
+    """Parse an environment variable as a boolean switch
+
+    `True` is returned if the variable value matches one of the following:
+
+    - ``'1'``
+    - ``'y'``
+    - ``'yes'``
+    - ``'true'``
+
+    The match is case-insensitive (so ``'Yes'`` will match as `True`)
+
+    Parameters
+    ----------
+    key : `str`
+        the name of the environment variable to find
+
+    default : `bool`
+        the default return value if the key is not found
+
+    Returns
+    -------
+    True
+        if the environment variable matches as 'yes' or similar
+    False
+        otherwise
+
+    Examples
+    --------
+    >>> import os
+    >>> from gwpy.utils.env import bool_env
+    >>> os.environ['GWPY_VALUE'] = 'yes'
+    >>> print(bool_env('GWPY_VALUE'))
+    True
+    >>> os.environ['GWPY_VALUE'] = 'something else'
+    >>> print(bool_env('GWPY_VALUE'))
+    False
+    >>> print(bool_env('GWPY_VALUE2'))
+    False
+    """
+    try:
+        return os.environ[key].lower() in TRUE
+    except KeyError:
+        return default

--- a/gwpy/utils/tests/test_env.py
+++ b/gwpy/utils/tests/test_env.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2018)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwpy.utils.env`
+"""
+
+try:
+    from unittest import mock
+except ImportError:  # python < 3
+    import mock
+
+import pytest
+
+from .. import env as utils_env
+
+BOOL_TRUE = {
+    'TEST_y': 'y',
+    'TEST_Y': 'Y',
+    'TEST_yes': 'yes',
+    'TEST_Yes': 'Yes',
+    'TEST_YES': 'YES',
+    'TEST_ONE': '1',
+    'TEST_true': 'true',
+    'TEST_True': 'True',
+    'TEST_TRUE': 'TRUE',
+}
+BOOL_FALSE = {
+    'TEST_no': 'no',
+    'TEST_No': 'No',
+    'TEST_ZERO': '0',
+    'TEST_false': 'false',
+    'TEST_False': 'False',
+    'TEST_FALSE': 'FALSE',
+    'TEST_OTHER': 'blah',
+}
+BOOL_ENV = BOOL_TRUE.copy()
+BOOL_ENV.update(BOOL_FALSE)
+
+
+@mock.patch.dict('os.environ', values=BOOL_ENV)
+@pytest.mark.parametrize(
+    'env, result',
+    [(k, True) for k in BOOL_TRUE] + [(k, False) for k in BOOL_FALSE],
+)
+def test_bool_env(env, result):
+    """Test :meth:`gwpy.utils.env.bool_env` _without_ the `default` keyword
+    """
+    assert utils_env.bool_env(env) is result
+
+
+@mock.patch.dict('os.environ', values=BOOL_TRUE)
+@pytest.mark.parametrize('env, default, result', [
+    ('TEST_YES', False, True),
+    ('TEST_MISSING', True, True),
+])
+def test_bool_env_default(env, default, result):
+    """Test :meth:`gwpy.utils.env.bool_env` _with_ the `default` keyword
+    """
+    assert utils_env.bool_env(env, default=default) is result


### PR DESCRIPTION
This PR adds the `gwpy.utils.env` module, which currently provides just a single function `bool_env` - which parses an environment variable as a boolean switch. I updated the two blocks in the library that would use it.