### PR TITLE
Pin to pytest<4.0.0 for now

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 # requirements for GWpy tests
-pytest >= 3.1
+pytest >= 3.1, < 4.0a0
 pytest-cov
 mock ; python_version < '3'
 freezegun >= 0.2.3

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ if not PEP_508 and (
 
 # test dependencies
 tests_require = [
-    'pytest>=3.1',
+    'pytest>=3.1,<4.0a0',
     'freezegun>=0.2.3',
     'sqlparse>=0.2.0',
     'beautifulsoup4',


### PR DESCRIPTION
This PR pins out pytest requirement to `< 4.0a0` - this new major version has been released, but we can't use it until pytest-dev/pytest#4401 has been resolved.