### PR TITLE
Removed urltype keyword from datafind find_*frametype functions

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -23,13 +23,22 @@ trap 'set +ex' RETURN
 # Run the test suite for GWpy on the current system
 #
 
+# get path to python and pip
 PYTHON="python${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}"
+PYTHON_PREFIX=$(${PYTHON} -c "import sys; print(sys.prefix)")
+
+# install with sudo on macports
+if [[ "${PYTHON_PREFIX}" =~ "/opt/local/"* ]]; then
+    PIP="sudo -H ${PYTHON} -m pip"
+else
+    PIP="${PYTHON} -m pip"
+fi
 
 # upgrade setuptools in order to understand environment markers
-${PYTHON} -m pip install "pip>=8.0.0" "setuptools>=20.2.2"
+${PIP} install "pip>=8.0.0" "setuptools>=20.2.2"
 
 # install test dependencies
-${PYTHON} -m pip install ${PIP_FLAGS} -r requirements-test.txt
+${PIP} install ${PIP_FLAGS} -r requirements-test.txt
 
 # run tests with coverage
 ${PYTHON} -m pytest --pyargs gwpy --cov=gwpy

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -331,7 +331,7 @@ def with_connection(func):
 @with_connection
 def find_frametype(channel, gpstime=None, frametype_match=None,
                    host=None, port=None, return_all=False, allow_tape=False,
-                   connection=None, urltype='file', on_gaps='error'):
+                   connection=None, on_gaps='error'):
     """Find the frametype(s) that hold data for a given channel
 
     Parameters
@@ -357,9 +357,6 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     allow_tape : `bool`, optional, default: `False`
         do not test types whose frame files are stored on tape (not on
         spinning disk)
-
-    urltype : `str`, optional
-        scheme of URL to return, default is ``'file'``
 
     on_gaps : `str`, optional
         action to take when gaps are discovered in datafind coverage,
@@ -536,7 +533,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
 
 
 @with_connection
-def find_best_frametype(channel, start, end, urltype='file',
+def find_best_frametype(channel, start, end,
                         frametype_match=None, allow_tape=True,
                         connection=None, host=None, port=None):
     """Intelligently select the best frametype from which to read this channel
@@ -553,9 +550,6 @@ def find_best_frametype(channel, start, end, urltype='file',
     end : `~gwpy.time.LIGOTimeGPS`, `float`, `str`
         GPS end time of period of interest,
         any input parseable by `~gwpy.time.to_gps` is fine
-
-    urltype : `str`, optional
-        scheme of URL to return, default is ``'file'``
 
     host : `str`, optional
         name of datafind host to use
@@ -590,15 +584,14 @@ def find_best_frametype(channel, start, end, urltype='file',
     try:
         return find_frametype(channel, gpstime=(start, end),
                               frametype_match=frametype_match,
-                              allow_tape=allow_tape, urltype=urltype,
-                              on_gaps='error', connection=connection,
-                              host=host, port=port)
+                              allow_tape=allow_tape, on_gaps='error',
+                              connection=connection, host=host, port=port)
     except RuntimeError:  # gaps (or something else went wrong)
         ftout = find_frametype(channel, gpstime=(start, end),
                                frametype_match=frametype_match,
                                return_all=True, allow_tape=allow_tape,
-                               urltype=urltype, on_gaps='ignore',
-                               connection=connection, host=host, port=port)
+                               on_gaps='ignore', connection=connection,
+                               host=host, port=port)
         try:
             if isinstance(ftout, dict):
                 return {key: ftout[key][0] for key in ftout}

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -279,7 +279,6 @@ def _type_priority(ifo, ftype, trend=None):
             SECOND_TREND_TYPE: 10,
     }.items():
         if reg.search(ftype):
-            print(ftype, reg.pattern)
             return prio, len(ftype)
 
     return 5, len(ftype)


### PR DESCRIPTION
This PR removes the `urltype` keyword argument from the `find_frametype` and `find_best_frametype` functions in `gwpy.io.datafind`. Only `'file'` URLs are supported, so we may as well not expose the option to change it.