### PR TITLE
Allow users to save time and memory computing Q-scans

### DIFF
--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -51,7 +51,7 @@ class TestCliQtransform(_TestCliSpectrogram):
 
     def test_get_title(self, dataprod):
         t = ('Q=45.25, whitened, calc f-range=[36.01, 161.51], '
-             'calc e-range=[-0.14, 21.18]')
+             'calc e-range=[-0.13, 21.50]')
         assert dataprod.get_title() == t
 
     def test_get_suptitle(self, prod):

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -929,7 +929,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert isinstance(qspecgram, Spectrogram)
         assert qspecgram.shape == (4000, 2403)
         assert qspecgram.q == 5.65685424949238
-        nptest.assert_almost_equal(qspecgram.value.max(), 156.0411964254892)
+        nptest.assert_almost_equal(qspecgram.value.max(), 156.43279233248313)
 
         # test whitening args
         asd = losc.asd(2, 1, method='scipy-welch')
@@ -955,6 +955,15 @@ class TestTimeSeries(_TestTimeSeriesBase):
         losc.q_transform(method='scipy-welch', norm=False)
         with pytest.raises(ValueError):
             losc.q_transform(method='scipy-welch', norm='blah')
+
+    def test_q_transform_logf(self, losc):
+        # test q-transform with log frequency spacing
+        qspecgram = losc.q_transform(method='scipy-welch', fftlength=2,
+                                     fres=500, logf=True)
+        assert isinstance(qspecgram, Spectrogram)
+        assert qspecgram.shape == (4000, 500)
+        assert qspecgram.q == 5.65685424949238
+        nptest.assert_almost_equal(qspecgram.value.max(), 156.43222488296405)
 
     def test_boolean_statetimeseries(self, array):
         comp = array >= 2 * array.unit


### PR DESCRIPTION
This PR gives users the option to sample Q-scan spectrograms logarithmically in frequency, so that they can render Qscan plots more quickly (and using less memory) by invoking `Spectrogram.pcolormesh()` with a much smaller input array.

Other memory-saving changes in this PR include:
* Define an `ndarray` x-index proxy for interpolating Q-tiles, as this will use less memory than explicit calls to `series.times`
* Add a unit test for the `logf=True` use case
* Minor tweaks to unit tests affected by these changes

cc @duncanmmacleod, @areeda, @tjma12