### PR TITLE
Refactor TimeSeries.q_transform() to support eventgrams

### DIFF
--- a/examples/signal/index.rst
+++ b/examples/signal/index.rst
@@ -9,3 +9,4 @@ Signal processing examples
    :numbered:
 
    gw150914
+   qscan

--- a/examples/signal/qscan.py
+++ b/examples/signal/qscan.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Compute the raw Q-transform of a `TimeSeries`
+
+One of the most useful tools for visualising short-duration features in a
+`TimeSeries` is the `Q-transform
+<https://en.wikipedia.org/wiki/Constant-Q_transform>`_.
+This tool is routinely used by data analysts to produce time-frequency maps of
+both transient noise (glitches) and astrophysical signals from ground-based
+gravitational-wave detectors.
+
+Below we use this algorithm to visualise GW170817, a gravitational-wave
+signal from two merging neutron stars. In the LIGO-Livingston (L1) detector,
+the end of this signal coincides with a very loud glitch (`Phys. Rev. Lett.
+vol. 119, p. 161101 <http://doi.org/10.1103/PhysRevLett.119.161101>`_).
+"""
+
+__author__ = "Alex Urban <alexander.urban@ligo.org>"
+__currentmodule__ = 'gwpy.timeseries'
+
+# First, we need to download the `TimeSeries` record of L1 strain measurements
+# from `GWOSC <http://gw-openscience.org>`_:
+
+from gwosc import datasets
+from gwpy.timeseries import TimeSeries
+gps = datasets.event_gps('GW170817')
+data = TimeSeries.fetch_open_data('L1', gps-34, gps+34, tag='C00')
+
+# We can Q-transform these data and scan over time-frequency planes to
+# find the one with the most significant tile near the time of merger:
+
+from gwpy.segments import Segment
+search = Segment(gps-0.25, gps+0.25)
+qgram = data.q_gram(qrange=(4, 150), search=search, mismatch=0.35)
+
+# .. note::
+#
+#    To recover as much signal as possible, in practice we should suppress
+#    background noise by whitening the data before the Q-transform. This
+#    can be done with :meth:`TimeSeries.whiten`.
+
+# Finally, we can plot the loudest time-frequency plane, focusing on a
+# specific window around the merger time:
+
+from matplotlib.cm import get_cmap
+cmap = get_cmap('viridis')
+plot = qgram.tile('time', 'frequency', 'duration', 'bandwidth',
+                  color='energy', figsize=[8, 4], linewidth=0.1,
+                  edgecolor=cmap(0), antialiased=True)
+ax = plot.gca()
+ax.set_xscale('seconds')
+ax.set_xlim(gps-6, gps+1)
+ax.set_epoch(gps)
+ax.set_yscale('log')
+ax.set_ylim(16, 1024)
+ax.set_ylabel('Frequency [Hz]')
+ax.grid(True, axis='y', which='both')
+ax.colorbar(cmap='viridis', label='Normalized energy', clim=[0, 25])
+cmap = get_cmap('viridis')
+ax.set_facecolor(cmap(0))
+plot.show()
+
+# Here we can clearly see the trace of a binary neutron star merger, sweeping
+# up in frequency through a loud saturation glitch in the foreground.
+# For more details on this result, please see
+# https://www.gw-openscience.org/catalog/GWTC-1-confident/single/GW170817/.

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -34,12 +34,16 @@ from six.moves import xrange
 import numpy
 from numpy import fft as npfft
 
+from ..segments import Segment
 from ..timeseries import TimeSeries
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-__credits__ = 'Scott Coughlin <scott.coughlin@ligo.org>'
-__all__ = ['QTiling', 'QPlane', 'QTile']
+__credits__ = 'Scott Coughlin <scott.coughlin@ligo.org>, ' \
+              'Alex Urban <alexander.urban@ligo.org>'
+__all__ = ['QTiling', 'QPlane', 'QTile', 'QGram', 'q_scan']
 
+
+# -- object class definitions -------------------------------------------------
 
 class QObject(object):
     """Base class for Q-transform objects
@@ -89,12 +93,16 @@ class QTiling(QObject):
     ----------
     duration : `float`
         the duration of the data to be Q-transformed
+
     qrange : `tuple` of `float`
         `(low, high)` pair of Q extrema
+
     frange : `tuple` of `float`
         `(low, high)` pair of frequency extrema
+
     sampling : `float`
         sampling rate (in Hertz) of data to be Q-transformed
+
     mismatch : `float`
         maximum fractional mismatch between neighbouring tiles
     """
@@ -149,6 +157,44 @@ class QTiling(QObject):
             yield QPlane(q, self.frange, self.duration, self.sampling,
                          mismatch=self.mismatch)
 
+    def transform(self, fseries, **kwargs):
+        """Compute the time-frequency plane at fixed Q with the most
+        significant tile
+
+        Parameters
+        ----------
+        fseries : `~gwpy.timeseries.FrequencySeries`
+            the complex FFT of a time-series data set
+
+        **kwargs
+            other keyword arguments to pass to `QPlane.transform`
+
+        Returns
+        -------
+        out : `QGram`
+            signal energies over the time-frequency plane containing the most
+            significant tile
+
+        N : `int`
+            estimated number of statistically independent tiles
+
+        See Also
+        --------
+        QPlane.transform
+            compute the Q-transform over a single time-frequency plane
+        """
+        weight = 1 + numpy.log10(self.qrange[1]/self.qrange[0]) / numpy.sqrt(2)
+        nind, nplanes, peak, result = (0, 0, 0, None)
+        # identify the plane with the loudest tile
+        for plane in self:
+            nplanes += 1
+            nind += sum([1 + row.ntiles * row.deltam for row in plane])
+            result = plane.transform(fseries, **kwargs)
+            if result.peak['energy'] > peak:
+                out = result
+                peak = out.peak['energy']
+        return (out, nind * weight / nplanes)
+
 
 class QPlane(QBase):
     """Iterable representation of a Q-transform plane
@@ -160,12 +206,16 @@ class QPlane(QBase):
     ----------
     q : `float`
         the Q-value for this plane
+
     frange : `tuple` of `float`
         `(low, high)` range of frequencies for this plane
+
     duration : `float`
         the duration of the data to be Q-transformed
+
     sampling : `float`
         sampling rate (in Hertz) of data to be Q-transformed
+
     mismatch : `float`
         maximum fractional mismatch between neighbouring tiles
     """
@@ -226,41 +276,45 @@ class QPlane(QBase):
         """
         return 2 ** (round(log(self.q / (2 * self.frange[0]), 2)))
 
-    def transform(self, fseries, norm=True, epoch=None):
-        """Calculate the energy `TimeSeries` for the given fseries
+    def transform(self, fseries, norm=True, epoch=None, search=None):
+        """Calculate the energy `TimeSeries` for the given `fseries`
 
         Parameters
         ----------
         fseries : `~gwpy.frequencyseries.FrequencySeries`
             the complex FFT of a time-series data set
+
         norm : `bool`, `str`, optional
             normalize the energy of the output by the median (if `True` or
             ``'median'``) or the ``'mean'``, if `False` the output
             is the complex `~numpy.fft.ifft` output of the Q-tranform
+
         epoch : `~gwpy.time.LIGOTimeGPS`, `float`, optional
             the epoch of these data, only used for metadata in the output
             `TimeSeries`, and not requires if the input `fseries` has the
             epoch populated.
 
+        search : `~gwpy.segments.Segment`, optional
+            search window of interest to determine the loudest Q-plane
+
         Returns
         -------
-        frequencies : `numpy.ndarray`
-            array of frequencies for this `QPlane`
-        transforms : `list` of `~gwpy.timeseries.TimeSeries`
+        results : `QGram`
             the complex energies of the Q-transform of the input `fseries`
             at each frequency
 
         See Also
         --------
         QTile.transform
-            for details on the transform for a single `(Q, frequency)` tile
+            for details on the transform over a row of `(Q, frequency)` tiles
+        QGram
+            an object with energies populated over time-frequency tiles
         """
         out = []
         for qtile in self:
             # get energy from transform
-            out.append(qtile.transform(fseries, norm=norm,
-                                       epoch=epoch))
-        return self.frequencies, out
+            out.append(qtile.transform(fseries, norm=norm, epoch=epoch))
+        return QGram(self, out, search)
 
 
 class QTile(QBase):
@@ -337,10 +391,12 @@ class QTile(QBase):
         ----------
         fseries : `~gwpy.frequencyseries.FrequencySeries`
             the complex FFT of a time-series data set
+
         norm : `bool`, `str`, optional
             normalize the energy of the output by the median (if `True` or
             ``'median'``) or the ``'mean'``, if `False` the output
             is the energy (power) of the Q-tranform
+
         epoch : `~gwpy.time.LIGOTimeGPS`, `float`, optional
             the epoch of these data, only used for metadata in the output
             `TimeSeries`, and not requires if the input `fseries` has the
@@ -377,7 +433,227 @@ class QTile(QBase):
         return energy
 
 
+class QGram(object):
+    """Store tile energies over an irregularly gridded plane
+
+    Parameters
+    ----------
+    plane : `QPlane`
+        the time-frequency plane over which to populate
+
+    energies : `list` of `TimeSeries`
+        a list of signal energies for each row of tiles
+
+    search : `~gwpy.segments.Segment`, optional
+        search window of interest to determine the loudest tile
+    """
+    def __init__(self, plane, energies, search):
+        self.plane = plane
+        self.energies = energies
+        self.peak = self._find_peak(search)
+
+    def _find_peak(self, search):
+        peak = {'energy': 0, 'snr': None, 'time': None, 'frequency': None}
+        for freq, energy in zip(self.plane.frequencies, self.energies):
+            if search is not None:
+                energy = energy.crop(*search)
+            maxidx = energy.value.argmax()
+            maxe = energy.value[maxidx]
+            if maxe > peak['energy']:
+                peak.update({
+                    'energy': maxe,
+                    'snr': (2 * maxe) ** (1/2.),
+                    'time': energy.t0.value + energy.dt.value * maxidx,
+                    'frequency': freq,
+                })
+        return peak
+
+    def interpolate(self, tres=.001, fres=.5, logf=False, outseg=None):
+        """Interpolate this `QGram` over a regularly-gridded spectrogram
+
+        Parameters
+        ----------
+        tres : `float`, optional
+            desired time resolution (seconds) of output `Spectrogram`
+
+        fres : `float`, `int`, `None`, optional
+            desired frequency resolution (Hertz) of output `Spectrogram`,
+            give `None` to skip this step and return the original resolution
+
+        logf : `bool`, optional
+            boolean switch to enable (`True`) or disable (`False`) use of
+            log-sampled frequencies in the output `Spectrogram`,
+            if `True` then `fres` is interpreted as number of frequency
+            samples, default: `False`
+
+        outseg : `~gwpy.segments.Segment`, optional
+            GPS `[start, stop)` segment for output `Spectrogram`
+
+        Returns
+        -------
+        out : `~gwpy.spectrogram.Spectrogram`
+            output `Spectrogram` of normalised Q energy
+
+        See Also
+        --------
+        scipy.interpolate
+            this method uses `~scipy.interpolate.InterpolatedUnivariateSpline`
+            to cast all frequency rows to a common time-axis, and then
+            `~scipy.interpolate.interp2d` to apply the desired frequency
+            resolution across the band
+
+        Notes
+        -----
+        To optimize plot rendering with `~matplotlib.axes.Axes.pcolormesh`,
+        the output `~gwpy.spectrogram.Spectrogram` can be given a log-sampled
+        frequency axis by passing `logf=True` at runtime. The `fres` argument
+        is then the number of points on the frequency axis. Note, this is
+        incompatible with `~matplotlib.axes.Axes.imshow`.
+
+        It is also highly recommended to use the `outseg` keyword argument
+        when only a small window around a given GPS time is of interest.
+        """
+        from scipy.interpolate import (interp2d, InterpolatedUnivariateSpline)
+        from ..spectrogram import Spectrogram
+        if outseg is None:
+            outseg = self.energies[0].span
+        frequencies = self.plane.frequencies
+        dtype = self.energies[0].dtype
+        # build regular Spectrogram from peak-Q data by interpolating each
+        # (Q, frequency) `TimeSeries` to have the same time resolution
+        xout = numpy.arange(*outseg, step=tres)
+        nx = xout.size
+        ny = frequencies.size
+        out = Spectrogram(numpy.empty((nx, ny), dtype=dtype),
+                          t0=outseg[0], dt=tres, frequencies=frequencies)
+        # record Q in output
+        out.q = self.plane.q
+        # interpolate rows
+        for i, row in enumerate(self.energies):
+            xrow = numpy.arange(row.x0.value, (row.x0 + row.duration).value,
+                                row.dx.value)
+            interp = InterpolatedUnivariateSpline(xrow, row.value)
+            out[:, i] = interp(xout)
+        if fres is None:
+            return out
+        # interpolate the spectrogram to increase its frequency resolution
+        # --- this is done because Duncan doesn't like interpolated images
+        #     since they don't support log scaling
+        interp = interp2d(xout, frequencies, out.value.T, kind='cubic')
+        if not logf:
+            outfreq = numpy.arange(
+                self.plane.frange[0], self.plane.frange[1], fres)
+        else:
+            # using `~numpy.logspace` here to support numpy-1.7.1 for EPEL7,
+            # but numpy-1.12.0 introduced the function `~numpy.geomspace`
+            logfmin = numpy.log10(self.plane.frange[0])
+            logfmax = numpy.log10(self.plane.frange[1])
+            outfreq = numpy.logspace(logfmin, logfmax, fres)
+        new = type(out)(interp(xout, outfreq).T,
+                        t0=outseg[0], dt=tres, frequencies=outfreq)
+        new.q = self.plane.q
+        return new
+
+    def table(self, snrthresh=5.5):
+        """Represent this `QPlane` as an `EventTable`
+
+        Parameters
+        ----------
+        snrthresh : `float`, optional
+            lower inclusive threshold on individual tile SNR to keep in the
+            table, default: 5.5
+
+        Returns
+        -------
+        out : `~gwpy.table.EventTable`
+            a table of time-frequency tiles on this `QPlane`
+
+        Notes
+        -----
+        Only tiles with signal energy greater than or equal to
+        `snrthresh ** 2 / 2` will be stored in the output `EventTable`.
+        """
+        from ..table import EventTable
+        # get plane properties
+        freqs = self.plane.frequencies
+        bws = 2 * (freqs - self.plane.farray)
+        # collect table data as a recarray
+        names = ('time', 'frequency', 'duration', 'bandwidth', 'energy')
+        rec = numpy.recarray((0,), names=names, formats=['f8'] * len(names))
+        for f, bw, row in zip(freqs, bws, self.energies):
+            ind, = (row.value >= snrthresh ** 2 / 2.).nonzero()
+            new = ind.size
+            if new > 0:
+                rec.resize((rec.size + new,), refcheck=False)
+                rec['time'][-new:] = row.times.value[ind]
+                rec['frequency'][-new:] = f
+                rec['duration'][-new:] = row.dt.to('s').value
+                rec['bandwidth'][-new:] = bw
+                rec['energy'][-new:] = row.value[ind]
+        # save to a table
+        out = EventTable(rec, copy=False)
+        out.meta['q'] = self.plane.q
+        return out
+
+
+# -- utilities ----------------------------------------------------------------
+
 def next_power_of_two(x):
     """Return the smallest power of two greater than or equal to `x`
     """
     return 2**(ceil(log(x, 2)))
+
+
+def q_scan(data, mismatch=0.2, qrange=(4, 64), frange=(0, float('inf')),
+           duration=None, sampling=None, **kwargs):
+    """Transform data by scanning over a `QTiling`
+
+    This utility is provided mainly to allow direct manipulation of the
+    `QTiling.transform` output. Most users probably just want to use
+    :meth:`~gwpy.timeseries.TimeSeries.q_transform`, which wraps around this.
+
+    Parameters
+    ----------
+    data : `~gwpy.timeseries.TimeSeries` or `ndarray`
+        the time- or frequency-domain input data
+
+    mismatch : `float`, optional
+        maximum allowed fractional mismatch between neighbouring tiles,
+        default: 0.2
+
+    qrange : `tuple` of `float`, optional
+        `(low, high)` range of Qs to scan
+
+    frange : `tuple` of `float`, optional
+        `(low, high)` range of frequencies to scan
+
+    duration : `float`, optional
+        duration (seconds) of input, required if `data` is not a `TimeSeries`
+
+    sampling : `float`, optional
+        sample rate (Hertz) of input, required if `data` is not a `TimeSeries`
+
+    **kwargs
+        other keyword arguments to be passed to :meth:`QTiling.transform`,
+        including ``'epoch'`` and ``'search'``
+
+    Returns
+    -------
+    qgram : `QGram`
+        the raw output of :meth:`QTiling.transform`
+
+    far : `float`
+        expected false alarm rate (Hertz) of white Gaussian noise with the
+        same peak energy and total duration as `qgram`
+    """
+    # prepare input
+    if isinstance(data, TimeSeries):
+        duration = abs(data.span)
+        sampling = data.sample_rate.to('Hz').value
+        kwargs.update({'epoch': data.epoch.value})
+        data = data.fft().value
+    # return a raw Q-transform and its significance
+    qgram, N = QTiling(duration, sampling, mismatch=mismatch, qrange=qrange,
+                       frange=frange).transform(data, **kwargs)
+    far = 1.5 * N * numpy.exp(-qgram.peak['energy']) / duration
+    return (qgram, far)

--- a/gwpy/signal/tests/test_qtransform.py
+++ b/gwpy/signal/tests/test_qtransform.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for :mod:`gwpy.signal.qtransform`
+"""
+
+import numpy
+from numpy import testing as nptest
+from scipy.signal import gausspulse
+
+from .. import qtransform
+from ...table import EventTable
+from ...segments import Segment
+from ...timeseries import TimeSeries
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+
+# -- global variables ---------------------------------------------------------
+
+# create noise and a glitch template at 1000 Hz
+NOISE = TimeSeries(
+    numpy.random.normal(size=4096 * 10), sample_rate=4096, epoch=-5)
+GLITCH = TimeSeries(
+    gausspulse(NOISE.times.value, fc=500)*10, sample_rate=4096)
+DATA = NOISE + GLITCH
+
+# global test objects
+SEARCH = Segment(-0.25, 0.25)
+QGRAM, FAR = qtransform.q_scan(DATA, search=SEARCH)
+QSPECGRAM = QGRAM.interpolate()
+
+
+# -- test utilities -----------------------------------------------------------
+
+def test_far():
+    # test that FAR is better than 1 / Hubble time
+    assert FAR < 1 / (1.37e10 * 365 * 86400)
+
+
+def test_q_scan():
+    # scan with the TimeSeries method
+    ts_qspecgram = DATA.q_transform(whiten=False)
+
+    # test spectrogram output
+    assert ts_qspecgram.q == QSPECGRAM.q
+    assert ts_qspecgram.shape == QSPECGRAM.shape
+    nptest.assert_allclose(ts_qspecgram.value, QSPECGRAM.value)
+
+
+def test_q_scan_fd():
+    # create test object from frequency-domain input
+    fdata = DATA.fft()
+    fs_qgram, far = qtransform.q_scan(
+        fdata, duration=abs(DATA.span), sampling=DATA.sample_rate.value,
+        search=SEARCH, epoch=fdata.epoch.value)
+    fs_qspecgram = fs_qgram.interpolate()
+
+    # test that the output is the same
+    assert far == FAR
+    assert fs_qspecgram.q == QSPECGRAM.q
+    assert fs_qspecgram.shape == QSPECGRAM.shape
+    nptest.assert_allclose(fs_qspecgram.value, QSPECGRAM.value)
+
+
+def test_qtable():
+    # test EventTable output
+    qtable = QGRAM.table()
+    imax = qtable['energy'].argmax()
+    assert isinstance(qtable, EventTable)
+    assert qtable.meta['q'] == QGRAM.plane.q
+    nptest.assert_almost_equal(qtable['time'][imax], QGRAM.peak['time'])
+    nptest.assert_almost_equal(qtable['duration'][imax], 1/1638.4)
+    nptest.assert_almost_equal(qtable['frequency'][imax],
+                               QGRAM.peak['frequency'])
+    nptest.assert_almost_equal(
+        qtable['bandwidth'][imax],
+        2 * numpy.pi ** (1/2.) * qtable['frequency'][imax] / QGRAM.plane.q)
+    nptest.assert_almost_equal(qtable['energy'][imax], QGRAM.peak['energy'])
+
+    # it's enough to check consistency between the shape of time and
+    # frequency columns, because of the way they're calculated
+    assert qtable['time'].shape == qtable['frequency'].shape
+
+    # test that too high an SNR threshold returns an empty table
+    assert len(QGRAM.table(snrthresh=1e9)) == 0

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -39,6 +39,7 @@ from astropy import units
 from ...frequencyseries import (FrequencySeries, SpectralVariance)
 from ...segments import Segment
 from ...signal import filter_design
+from ...table import EventTable
 from ...spectrogram import Spectrogram
 from ...testing import (mocks, utils)
 from ...testing.compat import mock
@@ -918,6 +919,14 @@ class TestTimeSeries(_TestTimeSeriesBase):
         # test breaks when you try and 'fir' notch
         with pytest.raises(NotImplementedError):
             losc.notch(10, type='fir')
+
+    def test_q_gram(self, losc):
+        # test simple q-transform
+        qgram = losc.q_gram()
+        assert isinstance(qgram, EventTable)
+        assert qgram.meta['q'] == 45.25483399593904
+        assert qgram['energy'].min() >= 5.5**2 / 2
+        nptest.assert_almost_equal(qgram['energy'].max(), 10559.255014979768)
 
     def test_q_transform(self, losc):
         # test simple q-transform

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1749,11 +1749,65 @@ class TimeSeries(TimeSeriesBase):
                                   type=type, **kwargs)
         return self.filter(*zpk, filtfilt=filtfilt)
 
+    def q_gram(self, qrange=(4, 64), frange=(0, float('inf')), mismatch=0.2,
+               snrthresh=5.5, **kwargs):
+        """Scan a `TimeSeries` using the multi-Q transform and return an
+        `EventTable` of the most significant tiles
+
+        Parameters
+        ----------
+        qrange : `tuple` of `float`, optional
+            `(low, high)` range of Qs to scan
+
+        frange : `tuple` of `float`, optional
+            `(low, high)` range of frequencies to scan
+
+        mismatch : `float`, optional
+            maximum allowed fractional mismatch between neighbouring tiles,
+            default: 0.2
+
+        snrthresh : `float`, optional
+            lower inclusive threshold on individual tile SNR to keep in the
+            table, default: 5.5
+
+        **kwargs
+            other keyword arguments to be passed to :meth:`QTiling.transform`,
+            including ``'epoch'`` and ``'search'``
+
+        Returns
+        -------
+        qgram : `EventTable`
+            a table of time-frequency tiles on the most significant `QPlane`
+
+        See Also
+        --------
+        TimeSeries.q_transform
+            for a method to interpolate the raw Q-transform over a regularly
+            gridded spectrogram
+        gwpy.signal.qtransform
+            for code and documentation on how the Q-transform is implemented
+        gwpy.table.EventTable.tile
+            to render this `EventTable` as a collection of polygons
+
+        Notes
+        -----
+        Only tiles with signal energy greater than or equal to
+        `snrthresh ** 2 / 2` will be stored in the output `EventTable`. The
+        table columns are ``'time'``, ``'duration'``, ``'frequency'``,
+        ``'bandwidth'``, and ``'energy'``.
+        """
+        from ..signal.qtransform import q_scan
+        qscan, _ = q_scan(self, mismatch=mismatch, qrange=qrange,
+                          frange=frange, **kwargs)
+        qgram = qscan.table(snrthresh=snrthresh)
+        return qgram
+
     def q_transform(self, qrange=(4, 64), frange=(0, numpy.inf),
                     gps=None, search=.5, tres=.001, fres=.5, logf=False,
-                    norm='median', outseg=None, whiten=True, fduration=2,
-                    highpass=None, **asd_kw):
-        """Scan a `TimeSeries` using a multi-Q transform
+                    norm='median', mismatch=0.2, outseg=None, whiten=True,
+                    fduration=2, highpass=None, **asd_kw):
+        """Scan a `TimeSeries` using the multi-Q transform and return an
+        interpolated high-resolution spectrogram
 
         Parameters
         ----------
@@ -1789,6 +1843,10 @@ class TimeSeries(TimeSeriesBase):
             default: `True` (``'median'``), other options: `False`,
             ``'mean'``
 
+        mismatch : `float`
+            maximum allowed fractional mismatch between neighbouring tiles,
+            default: 0.2
+
         outseg : `~gwpy.segments.Segment`, optional
             GPS `[start, stop)` segment for output `Spectrogram`
 
@@ -1811,7 +1869,7 @@ class TimeSeries(TimeSeriesBase):
 
         Returns
         -------
-        specgram : `~gwpy.spectrogram.Spectrogram`
+        out : `~gwpy.spectrogram.Spectrogram`
             output `Spectrogram` of normalised Q energy
 
         See Also
@@ -1822,12 +1880,6 @@ class TimeSeries(TimeSeriesBase):
             for documentation on how the whitening is done
         gwpy.signal.qtransform
             for code and documentation on how the Q-transform is implemented
-        scipy.interpolate
-            for details on how the interpolation is implemented. This method
-            uses `~scipy.interpolate.InterpolatedUnivariateSpline` to
-            cast all frequency rows to the same time-axis, and then
-            `~scipy.interpolate.interpd` to apply the desired frequency
-            resolution across the band.
 
         Notes
         -----
@@ -1867,11 +1919,8 @@ class TimeSeries(TimeSeriesBase):
         >>> ax.set_epoch(0)
         >>> plot.show()
         """  # nopep8
-        from scipy.interpolate import (interp2d, InterpolatedUnivariateSpline)
+        from ..signal.qtransform import q_scan
         from ..frequencyseries import FrequencySeries
-        from ..spectrogram import Spectrogram
-        from ..signal.qtransform import QTiling
-
         # condition data
         if whiten is True:  # generate ASD dynamically
             window = asd_kw.pop('window', 'hann')
@@ -1885,85 +1934,21 @@ class TimeSeries(TimeSeriesBase):
                 overlap = recommended_overlap(window) * fftlength
             whiten = self.asd(fftlength, overlap, window=window, **asd_kw)
         if isinstance(whiten, FrequencySeries):
-            # apply whitening (with errors on dividing by zero)
+            # apply whitening (with error on division by zero)
             with numpy.errstate(all='raise'):
                 data = self.whiten(asd=whiten, fduration=fduration,
                                    highpass=highpass)
         else:
             data = self
-
-        # perform FFT to feed into Q-transform
-        fdata = data.fft().value
-
-        # metadata
-        epoch = data.x0
-        span = data.span
-        if outseg is None:
-            outseg = span
-
-        # truncate search window to available data
-        if gps is not None:  # search is only used if gps is given
-            search = Segment(gps-search, gps+search) & span
-
-        # generate tiling
-        planes = QTiling(abs(span), self.sample_rate.value,
-                         qrange=qrange, frange=frange)
-
-        # set up results
-        peakq = None
-        peakenergy = 0
-
-        # Q-transform data for each `(Q, frequency)` tile
-        for plane in planes:
-            freqs, normenergies = plane.transform(fdata, norm=norm,
-                                                  epoch=epoch)
-            # find peak energy in this plane and record if loudest
-            for ts in normenergies:
-                if gps is None:
-                    peak = ts.value.max()
-                else:
-                    peak = ts.crop(*search).value.max()
-                if peak > peakenergy:
-                    peakenergy = peak
-                    peakq = plane.q
-                    norms = normenergies
-                    frequencies = freqs
-
-        # build regular Spectrogram from peak-Q data by interpolating each
-        # (Q, frequency) `TimeSeries` to have the same time resolution
-        nx = int(abs(Segment(*outseg)) / tres)
-        ny = frequencies.size
-        out = Spectrogram(numpy.zeros((nx, ny)), x0=outseg[0], dx=tres,
-                          frequencies=frequencies)
-        # record Q in output
-        out.q = peakq
-        # interpolate rows
-        xout = numpy.arange(outseg[0], outseg[1], tres)
-        for i, row in enumerate(norms):
-            xrow = numpy.arange(row.x0.value, (row.x0 + row.duration).value,
-                                row.dx.value)
-            interp = InterpolatedUnivariateSpline(xrow, row.value)
-            out[:, i] = interp(xout)
-
-        if fres is None:
-            return out
-
-        # then interpolate the spectrogram to increase the frequency resolution
-        # --- this is done because duncan doesn't like interpolated images
-        #     because they don't support log scaling
-        interp = interp2d(xout, frequencies, out.value.T, kind='cubic')
-        if not logf:
-            outfreq = numpy.arange(planes.frange[0], planes.frange[1], fres)
-        else:
-            # using `~numpy.logspace` here to support numpy-1.7.1 for EPEL7,
-            # but numpy-1.12.0 introduced the function `~numpy.geomspace`
-            logfmin = numpy.log10(planes.frange[0])
-            logfmax = numpy.log10(planes.frange[1])
-            outfreq = numpy.logspace(logfmin, logfmax, fres)
-        new = Spectrogram(interp(xout, outfreq).T,
-                          x0=outseg[0], dx=tres, frequencies=outfreq)
-        new.q = peakq
-        return new
+        # determine search window
+        if gps is None:
+            search = None
+        elif search is not None:
+            search = Segment(gps-search/2, gps+search/2) & self.span
+        qgram, _ = q_scan(data, frange=frange, qrange=qrange, norm=norm,
+                          mismatch=mismatch, search=search)
+        return qgram.interpolate(
+            tres=tres, fres=fres, logf=logf, outseg=outseg)
 
 
 @as_series_dict_class(TimeSeries)


### PR DESCRIPTION
This PR substantially refactors `TimeSeries.q_transform()` to support eventgrams, a feature ported over from [**`gwdetchar-omega`**](https://github.com/gwdetchar/gwdetchar/blob/master/bin/gwdetchar-omega#L166-L254). To simplify review, here is a summary of changes made:

**New Features**
* Introduce a new object class, `~gwpy.signal.qtransform.QGram`, to support eventgrams
* Introduce a new function, `~gwpy.signal.qtransform.q_scan()`, which identifies the time-frequency plane at fixed Q with the most significant tile within a given (optional) search window. This method returns an instance of `QGram` along with the estimated false alarm rate from white Gaussian noise.
* Include a method, `QGram.table()`, which converts a populated `QGram` object to an `EventTable` so that it can be rendered with matplotlib. Table columns are `'time'`, `'duration'`, `'frequency'`, `'bandwidth'`, and `'energy'`. The only argument is an SNR threshold, which selects for tiles with energy greater than or equal `snrthresh**2/2`.
* Introduce a `TimeSeries.q_gram` method to wrap around `QGram.table`.
* Add a `mismatch` argument for `q_scan()` and `TimeSeries.q_transform()`.
* Add a unit test for the `QGram` object under `gwpy/signal/tests/test_qtransform.py`.
* Add an example for the docs under `examples/signal/qscan.py`.

**Refactor Existing Features**
* Refactor spectrogram interpolation into `~gwpy.signal.qtransform.QGram.interpolate()`. This reduces the cyclomatic complexity of `TimeSeries.q_transform()` to a level acceptable to CodeClimate.

This fixes #922 and fixes #995.

cc @duncanmmacleod, @areeda, @scottcoughlin2014 