### PR TITLE
Added functionality for matplotlib inline backend

### DIFF
--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -127,11 +127,10 @@ class Plot(figure.Figure):
         try:
             manager = backend_mod.new_figure_manager_given_figure(num, self)
         except AttributeError:
+            canvas = backend_mod.FigureCanvas(self)
             if 'inline' in backend_mod.__name__:
-                canvas = backend_mod.FigureCanvas(self)
                 manager = backend_mod.new_figure_manager(1)
             else:
-                canvas = backend_mod.FigureCanvas(self)
                 manager = backend_mod.FigureManagerBase(canvas, 1)
         manager._cidgcf = manager.canvas.mpl_connect(
             'button_press_event',

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -127,8 +127,12 @@ class Plot(figure.Figure):
         try:
             manager = backend_mod.new_figure_manager_given_figure(num, self)
         except AttributeError:
-            canvas = backend_mod.FigureCanvas(self)
-            manager = backend_mod.FigureManagerBase(canvas, 1)
+            if 'inline' in backend_mod.__name__:
+                canvas = backend_mod.FigureCanvas(self)
+                manager = backend_mod.new_figure_manager(1)
+            else:
+                canvas = backend_mod.FigureCanvas(self)
+                manager = backend_mod.FigureManagerBase(canvas, 1)
         manager._cidgcf = manager.canvas.mpl_connect(
             'button_press_event',
             lambda ev: _pylab_helpers.Gcf.set_active(manager))

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -127,11 +127,10 @@ class Plot(figure.Figure):
         try:
             manager = backend_mod.new_figure_manager_given_figure(num, self)
         except AttributeError:
-            canvas = backend_mod.FigureCanvas(self)
-            if 'inline' in backend_mod.__name__:
-                manager = backend_mod.new_figure_manager(1)
-            else:
-                manager = backend_mod.FigureManagerBase(canvas, 1)
+            upstream_mod = importlib.import_module(
+                pyplot.new_figure_manager.__module__)
+            canvas = upstream_mod.FigureCanvasBase(self)
+            manager = upstream_mod.FigureManagerBase(canvas, 1)
         manager._cidgcf = manager.canvas.mpl_connect(
             'button_press_event',
             lambda ev: _pylab_helpers.Gcf.set_active(manager))


### PR DESCRIPTION
The `%matplotlib inline` functionality in Jupyter notebooks was not working because the matplotlib inline backend doesn't have a `FigureManagerBase` class. This PR adds a check to use the correct methods if the inline backend is called. I tested this in a jupyterhub notebook and was able to render inline figures.

Fixes #964.

@duncanmmacleod @alurban 