### PR TITLE
Fix interpolation domain in FrequencySeries.interpolate()

### DIFF
--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -270,7 +270,7 @@ class FrequencySeries(Series):
         """
         return self.filter(zeros, poles, gain, analog=analog)
 
-    def interpolate(self, df, left=0, right=0):
+    def interpolate(self, df):
         """Interpolate this `FrequencySeries` to a new resolution.
 
         Parameters
@@ -279,12 +279,6 @@ class FrequencySeries(Series):
             desired frequency resolution of the interpolated `FrequencySeries`,
             in Hz
 
-        left : `float`
-            value to return for f < flow, default: 0
-
-        right : `float`
-            value to return for f > fhigh, default: 0
-
         Returns
         -------
         out : `FrequencySeries`
@@ -292,14 +286,16 @@ class FrequencySeries(Series):
 
         See Also
         --------
-        :func:`numpy.interp`
+        numpy.interp
             for the underlying 1-D linear interpolation scheme
         """
+        f0 = self.f0.decompose().value
         N = (self.size - 1) * (self.df.decompose().value / df) + 1
-        fsamples = numpy.arange(0, numpy.rint(N)) * df
-        out = numpy.interp(fsamples, self.frequencies.value, self.value,
-                           left=left, right=right).view(type(self))
+        fsamples = numpy.arange(0, numpy.rint(N)) * df + f0
+        out = type(self)(numpy.interp(fsamples, self.frequencies.value,
+                                      self.value))
         out.__array_finalize__(self)
+        out.f0 = f0
         out.df = df
         return out
 

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -168,7 +168,7 @@ class TestFrequencySeries(_TestSeries):
         # create a simple FrequencySeries
         df, nyquist = 1, 256
         nsamp = int(nyquist/df) + 1
-        fseries = FrequencySeries(numpy.ones(nsamp), f0=0, df=df, unit='')
+        fseries = FrequencySeries(numpy.ones(nsamp), f0=1, df=df, unit='')
 
         # create an interpolated FrequencySeries
         newf = fseries.interpolate(df/2.)
@@ -176,6 +176,8 @@ class TestFrequencySeries(_TestSeries):
         # check that the interpolated series is what was expected
         assert newf.unit == fseries.unit
         assert newf.size == 2*(fseries.size - 1) + 1
+        assert newf.df == fseries.df / 2.
+        assert newf.f0 == fseries.f0
         utils.assert_allclose(newf.value, numpy.ones(2*int(nyquist/df) + 1))
 
     @utils.skip_missing_dependency('lal')


### PR DESCRIPTION
This PR fixes a bug in `FrequencySeries.interpolate()` so that the output of that method is interpolated properly only over the domain of the input. As a consequence, the `left` and `right` arguments have been removed, since they are redundant.

A more complete unit test for `FrequencySeries.interpolate()` is also added.

This fixes #932. (Note, the first attempt at doing this was in #940.)