### PR TITLE
Removed debian Jessie CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,13 +42,6 @@ jobs:
           paths:
             - gwpy-*.tar.*
 
-  debian:jessie:2.7:
-    <<: *debian-build
-    docker:
-      - image: ligo/base:jessie
-    environment:
-      PYTHON_VERSION: "2.7"
-
   debian:stretch:2.7:
     <<: *debian-build
     docker:
@@ -75,9 +68,6 @@ workflows:
   build_and_test:
     jobs:
       - sdist
-      - debian:jessie:2.7:
-          requires:
-            - sdist
       - debian:stretch:2.7:
           requires:
             - sdist

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -45,8 +45,8 @@ Debian Linux
 
     $ apt-get install python3-gwpy
 
-Supported python versions: 2.7 (all), 3.4 (Jessie), 3.5 (Stretch), 3.6 (Buster),
-`click here <https://wiki.ligo.org/DASWG/SoftwareOnDebian>`__ for
+Supported python versions: 2.7 (all), 3.5 (Stretch), 3.6 (Buster),
+`click here <https://wiki.ligo.org/Computing/DASWG/SoftwareOnDebian>`__ for
 instructions on how to add the required repositories.
 
 


### PR DESCRIPTION
This PR removes the Debian 8 (Jessie) CI build. The LIGO repositories haven't been updated in ages, and none of the LIGO Data Grid clusters run this distro anyway.