### PR TITLE
Added timeseries/io section on GWOSC HDF5

### DIFF
--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -133,6 +133,10 @@ HDF5
 
 GWpy allows storing data in HDF5 format files, using a custom specification for storage of metadata.
 
+.. warning::
+
+   To read GWOSC (LOSC) data from HDF5, please see
+   :ref:`gwpy-timeseries-io-hdf5-gwosc`.
 
 Reading
 -------
@@ -172,6 +176,33 @@ To write a `TimeSeries` to an existing file, use ``append=True``::
 To replace an existing dataset in an existing file, while preserving other data, use *both* ``append=True`` and ``overwrite=True``::
 
     >>> data.write('output.hdf', append=True, overwrite=True)
+
+.. _gwpy-timeseries-io-hdf5-gwosc:
+
+============
+HDF5 (GWOSC)
+============
+
+The `Gravitational Wave Open Science Center (GWOSC)
+<https://www.gw-openscience.org>` write data in HDF5 using a custom schema
+that is incompatible with the `format='hdf5'`.
+
+-------
+Reading
+-------
+
+GWpy can read data from GWOSC (LOSC) HDF5 files using the `format='hdf5.losc'`
+keyword::
+
+   >>> data = TimeSeries.read('H-H1_GWOSC_16KHZ_R1-1187056280-4096.hdf5',
+   ...                        format='hdf5.losc')
+
+By default, `TimeSeries.read` will return the contents of the
+``/strain/Strain`` dataset, while `StateVector.read` will return those of
+``/quality/simple``.
+
+As with regular HDF5, the ``start`` and ``end`` keyword arguments can be used to downselect data to a specific ``[start, end)`` time segment when reading.
+
 
 .. _gwpy-timeseries-io-wav:
 


### PR DESCRIPTION
This PR adds a documentation on how to read GWOSC data from their HDF5 files using `format='hdf5.losc'`.