### PR TITLE
Copy all metadata in Array.copy

### DIFF
--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -27,8 +27,10 @@ critical to being able to view data with this class, used when copying and
 transforming instances of the class.
 """
 
-from math import modf
+import copy
 from decimal import Decimal
+from functools import wraps
+from math import modf
 
 import numpy
 
@@ -471,3 +473,12 @@ class Array(Quantity):
         <Quantity [1., 2., 3., 4.] m>
         """
         return super(Array, self).flatten(order=order).view(Quantity)
+
+    @wraps(Quantity.copy)
+    def copy(self, order='C'):
+        out = super(Array, self).copy(order=order)
+        for slot in self._metadata_slots:
+            old = getattr(self, slot, None)
+            if old is not None:
+                setattr(out, slot, copy.copy(old))
+        return out

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -29,7 +29,6 @@ transforming instances of the class.
 
 import copy
 from decimal import Decimal
-from functools import wraps
 from math import modf
 
 import numpy
@@ -474,7 +473,6 @@ class Array(Quantity):
         """
         return super(Array, self).flatten(order=order).view(Quantity)
 
-    @wraps(Quantity.copy)
     def copy(self, order='C'):
         out = super(Array, self).copy(order=order)
         for slot in self._metadata_slots:
@@ -482,3 +480,5 @@ class Array(Quantity):
             if old is not None:
                 setattr(out, slot, copy.copy(old))
         return out
+
+    copy.__doc__ = Quantity.copy.__doc__

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -476,7 +476,7 @@ class Array(Quantity):
     def copy(self, order='C'):
         out = super(Array, self).copy(order=order)
         for slot in self._metadata_slots:
-            old = getattr(self, slot, None)
+            old = getattr(self, '_{0}'.format(slot), None)
             if old is not None:
                 setattr(out, slot, copy.copy(old))
         return out

--- a/gwpy/types/tests/test_array.py
+++ b/gwpy/types/tests/test_array.py
@@ -215,8 +215,11 @@ class TestArray(object):
         assert arraysq.epoch == array.epoch
         assert arraysq.channel == array.channel
 
-    def test_copy(self, array):
-        utils.assert_quantity_sub_equal(array, array.copy())
+    def test_copy(self):
+        array = self.create(channel='X1:TEST')
+        copy = array.copy()
+        utils.assert_quantity_sub_equal(array, copy)
+        assert copy.channel is not array.channel
 
     def test_repr(self, array):
         # just test that it runs


### PR DESCRIPTION
This PR fixes #919 by augmenting `Array.copy` to `copy.copy` all metadata attributes declared in `_metadata_slots`.