### PR TITLE
Close docs plots to prevent them showing up more than once

### DIFF
--- a/examples/frequencyseries/inject.py
+++ b/examples/frequencyseries/inject.py
@@ -59,6 +59,7 @@ from gwpy.plot import Plot
 plot = Plot(numpy.abs(noisefd), numpy.abs(injfd), separate=True,
             sharex=True, sharey=True, xscale='log', yscale='log')
 plot.show()
+plot.close()  # hide
 
 # Finally, for completeness we can visualize the effect before and after
 # injection back in the time domain:
@@ -67,6 +68,7 @@ inj = injfd.ifft()
 plot = Plot(noise, inj, separate=True, sharex=True, sharey=True,
             figsize=(12, 6))
 plot.show()
+plot.close()  # hide
 
 # We can see why sinusoids are easier to inject in the frequency domain:
 # they only require adding at a single frequency.

--- a/examples/timeseries/correlate.py
+++ b/examples/timeseries/correlate.py
@@ -62,6 +62,7 @@ plot = snr.crop(1172489782.07, 1172489784.07).plot()
 plot.axes[0].set_epoch(1172489783.07)
 plot.axes[0].set_ylabel('Signal-to-noise ratio', fontsize=16)
 plot.show()
+plot.close()  # hide
 
 # We can clearly see a loud spike (nearly SNR 40!) at GPS second 1172489783.07,
 # which we interpret as evidence that the PSL channel is witnessing the same
@@ -80,6 +81,7 @@ ax.set_ylabel('Frequency [Hz]')
 ax.grid(True, axis='y', which='both')
 ax.colorbar(cmap='viridis', label='Normalized energy', clim=[0, 25])
 plot.show()
+plot.close()  # hide
 
 # and the same for the PSL channel:
 qaux = waux.q_transform(whiten=False, qrange=(93.1, 93.1))
@@ -93,6 +95,7 @@ ax.set_ylabel('Frequency [Hz]')
 ax.grid(True, axis='y', which='both')
 ax.colorbar(cmap='viridis', label='Normalized energy', clim=[0, 25])
 plot.show()
+plot.close()  # hide
 
 # Sure enough, both channels record a clear whistle glitch at this time,
 # although the PSL channel sees it with much greater signal energy relative


### PR DESCRIPTION
@duncanmmacleod, this PR corrects an issue I noticed with [**the build version**](https://ldas-jobs.ligo.caltech.edu/~duncan.macleod/gwpy/testing/977/examples/timeseries/correlate.html) of the cross-correlation example for the GWPy docs.