### PR TITLE
Error on interactive prompts in non-interactive sessions for kinit()

### DIFF
--- a/gwpy/io/kerberos.py
+++ b/gwpy/io/kerberos.py
@@ -125,12 +125,14 @@ def kinit(username=None, password=None, realm=None, exe=None, keytab=None,
             else:
                 keytab = None
 
-    # set verbose if prompting for input
-    if verbose is None and (
-        username is None or
-        (not keytab and password is None)
+    # refuse to prompt if we can't get an answer
+    if not sys.stdout.isatty() and (
+            username is None or
+            (not keytab and password is None)
     ):
-        verbose = True
+        raise KerberosError("cannot generate kerberos ticket in a "
+                            "non-interactive session, please manually create "
+                            "a ticket, or consider using a keytab file")
 
     # get credentials
     if realm is None:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1038,6 +1038,7 @@ class TimeSeriesBaseDict(OrderedDict):
             else:
                 tapes = [allow_tape]
             for allow_tape_ in tapes:
+                error = ""  # container for error message from cls.fetch()
                 for host_, port_ in hostlist:
                     try:
                         return cls.fetch(channels, start, end, host=host_,
@@ -1045,12 +1046,13 @@ class TimeSeriesBaseDict(OrderedDict):
                                          type=type, dtype=dtype, pad=pad,
                                          allow_tape=allow_tape_)
                     except (RuntimeError, ValueError) as exc:
-                        warnings.warn(str(exc).split('\n')[0],
+                        error = str(exc)  # need to assign to take out of scope
+                        warnings.warn(error.split('\n', 1)[0],
                                       io_nds2.NDSWarning)
 
                 # if failing occurred because of data on tape, don't try
                 # reading channels individually, the same error will occur
-                if not allow_tape_ and 'Requested data is on tape' in str(exc):
+                if not allow_tape_ and 'Requested data is on tape' in error:
                     continue
 
                 # if we got this far, we can't get all channels in one go

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -406,10 +406,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
                                      frametype_match='C01\Z')
         except (ImportError, RuntimeError) as e:
             pytest.skip(str(e))
-        except IOError as exc:
-            if 'reading from stdin' in str(exc):
-                pytest.skip(str(exc))
-            raise
         utils.assert_quantity_sub_equal(ts, losc_16384,
                                         exclude=['name', 'channel', 'unit'])
 


### PR DESCRIPTION
This PR fixes #838 by patching `gwpy.io.kerberos.kinit` to raise an exception whenever it is about to try and prompt for a username or password in a session that won't allow a response from the user.

I also took an opportunity to clean up the test suite for the containing `gwpy.io.kerberos` module.