### PR TITLE
Added support for applying ADC scaling from NDS2 buffers

### DIFF
--- a/gwpy/testing/mocks.py
+++ b/gwpy/testing/mocks.py
@@ -114,15 +114,19 @@ def segdb_query_segments(result):
 
 # -- NDS2 ---------------------------------------------------------------------
 
-def nds2_buffer(channel, data, epoch, sample_rate, unit):
+def nds2_buffer(channel, data, epoch, sample_rate, unit,
+                name=None, slope=1, offset=0):
     import nds2
     epoch = LIGOTimeGPS(epoch)
     ndsbuffer = mock.create_autospec(nds2.buffer)
     ndsbuffer.length = len(data)
     ndsbuffer.channel = nds2_channel(channel, sample_rate, unit)
+    ndsbuffer.name = name or ndsbuffer.channel.name
     ndsbuffer.sample_rate = sample_rate
     ndsbuffer.gps_seconds = epoch.gpsSeconds
     ndsbuffer.gps_nanoseconds = epoch.gpsNanoSeconds
+    ndsbuffer.signal_slope = slope
+    ndsbuffer.signal_offset = offset
     ndsbuffer.data = data
     return ndsbuffer
 

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -89,8 +89,8 @@ def set_parameter(connection, parameter, value, verbose=False):
 
 @io_nds2.open_connection
 def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
-          connection=None, host=None, port=None, pad=None, verbose=False,
-          series_class=TimeSeries):
+          connection=None, host=None, port=None, pad=None, scaled=True,
+          verbose=False, series_class=TimeSeries):
     # host and port keywords are used by the decorator only
     # pylint: disable=unused-argument
     """Fetch a dict of data series from NDS2
@@ -159,7 +159,11 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
             total = 0.
             for buffers in connection.iterate(int(seg[0]), int(seg[1]), names):
                 for buffer_, chan in zip(buffers, channels):
-                    series = series_class.from_nds2_buffer(buffer_)
+                    series = series_class.from_nds2_buffer(
+                        buffer_,
+                        scaled=scaled,
+                        copy=chan not in out,  # only copy if first buffer
+                    )
                     out.append({chan: series}, pad=pad, gap=gap)
                 new = buffer_.length / buffer_.channel.sample_rate
                 total += new

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -156,8 +156,6 @@ class TestTimeSeriesBase(_TestSeries):
         assert isinstance(a, self.TEST_CLASS)
         assert not shares_memory(a.value, nds_buffer.data)
         utils.assert_array_equal(a.value, nds_buffer.data * 2 + 1)
-        if not type(a).__name__.startswith('State'):  # states don't have units
-            assert a.unit == units.m
         assert a.t0 == 1000000000 * units.s
         assert a.dt == units.s / nds_buffer.data.shape[0]
         assert a.name == 'test'

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -31,7 +31,7 @@ from astropy import units
 
 from ...detector import Channel
 from ...time import (Time, LIGOTimeGPS)
-from ...testing import utils
+from ...testing import (mocks, utils)
 from ...types import Array2D
 from .. import (StateVector, StateVectorDict, StateVectorList,
                 StateTimeSeries, StateTimeSeriesDict, Bits)
@@ -104,6 +104,21 @@ class TestStateTimeSeries(_TestTimeSeriesBase):
         a2 = array ** 2
         assert a2.dtype is numpy.dtype(bool)
         utils.assert_array_equal(array.value, a2.value)
+
+    @utils.skip_missing_dependency('nds2')
+    def test_from_nds2_buffer(self):
+        # build fake buffer
+        nds_buffer = mocks.nds2_buffer(
+            'X1:TEST',
+            self.data,
+            1000000000,
+            self.data.shape[0],
+            'm',
+            name='test',
+        )
+        array = self.TEST_CLASS.from_nds2_buffer(nds_buffer)
+        assert array.unit is units.dimensionless_unscaled
+        assert array.dtype is numpy.dtype(bool)
 
     def test_to_dqflag(self, array):
         flag = array.to_dqflag()
@@ -314,6 +329,19 @@ class TestStateVector(_TestTimeSeriesBase):
                         bits=LOSC_GW150914_DQ_BITS[format]),
             exclude=['channel'])
 
+    @utils.skip_missing_dependency('nds2')
+    def test_from_nds2_buffer(self):
+        # build fake buffer
+        nds_buffer = mocks.nds2_buffer(
+            'X1:TEST',
+            self.data,
+            1000000000,
+            self.data.shape[0],
+            '',
+            name='test',
+        )
+        array = self.TEST_CLASS.from_nds2_buffer(nds_buffer)
+        assert array.unit is units.dimensionless_unscaled
 
 # -- StateVectorDict ----------------------------------------------------------
 


### PR DESCRIPTION
This PR adds two new keywords to `TimeSeriesBase.from_nds2_buffer`:

- `scaled=True`, whether to apply ADC scale and bias settings
- `copy=True`, whether to copy the data array to new memory

and exposes these keywords through all `TimeSeries*.{fetch,find,get}` methods.

This now means that we almost have a consistent interface for auto-applying ADC calibration, since NDS2 and frameCPP access will support it identically. Its just lalframe that doesn't, but I still plan to remove that interface in the near future anyway.