### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -158,7 +158,7 @@ To replace an existing table of the given type in an existing file, while preser
 Coherence WaveBurst ASCII (aka `EVENTS.txt`)
 ============================================
 
-The `Coherent WaveBurst <http://dx.doi.org/10.1088/0264-9381/25/11/114029>`_ analysis pipeline is used to detect generic gravitational-wave bursts, without using a signal model to restrict the analysis, and runs in both low-latency (online) and offline modes over current GWO data.
+The `Coherent WaveBurst <https://doi.org/10.1088/0264-9381/25/11/114029>`_ analysis pipeline is used to detect generic gravitational-wave bursts, without using a signal model to restrict the analysis, and runs in both low-latency (online) and offline modes over current GWO data.
 The analysis uses the ROOT framework for most data products, but also produces ASCII data in a custom format commonly written in a file called ``EVENTS.txt``.
 
 Reading

--- a/docs/timeseries/remote-access.rst
+++ b/docs/timeseries/remote-access.rst
@@ -26,7 +26,7 @@ Open data releases
 
 The `LIGO Open Science Center <https://losc.ligo.org/>`_ hosts a large quantity of open (meaning publicly-available) data from LIGO science runs, including the full strain record for the sixth LIGO science run (S6, 2009-2010) and short extracts of the strain record surrounding published GW observations from Advanced LIGO.
 
-To fetch 32 seconds of strain data around event `GW150914 <http://dx.doi.org/10.1103/PhysRevLett.116.061102>`_, you need to give the prefix of the relevant observatory (``'H1'`` for the LIGO Hanford Observatory, ``'L1'`` for LIGO Livingston), and the start and end times of your query:
+To fetch 32 seconds of strain data around event `GW150914 <https://doi.org/10.1103/PhysRevLett.116.061102>`_, you need to give the prefix of the relevant observatory (``'H1'`` for the LIGO Hanford Observatory, ``'L1'`` for LIGO Livingston), and the start and end times of your query:
 
 .. plot::
    :context: reset


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly, plus the code that generates new DOI links.

Cheers!