### PR TITLE
Implemented TimeSeriesDict.span

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -61,7 +61,6 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 __all__ = ['TimeSeriesBase', 'TimeSeriesBaseDict', 'TimeSeriesBaseList']
 
-ASTROPY_2_0 = astropy_version >= '2.0'
 
 _UFUNC_STRING = {
     'less': '<',
@@ -739,7 +738,7 @@ class TimeSeriesBase(Series):
 
     # -- TimeSeries operations ------------------
 
-    if ASTROPY_2_0:
+    if astropy_version >= '2.0.0':  # remove _if_ when we pin astropy >= 2.0.0
         def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
             # this is new in numpy 1.13, astropy 2.0 adopts it, we need to
             # work out how to handle this and __array_wrap__ together properly

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -51,9 +51,10 @@ from astropy import units
 from astropy import __version__ as astropy_version
 from astropy.io import registry as io_registry
 
-from ..types import (Array2D, Series)
+from ..types import Series
 from ..detector import (Channel, ChannelList)
 from ..io import datafind as io_datafind
+from ..segments import SegmentList
 from ..time import (Time, LIGOTimeGPS, gps_types, to_gps)
 from ..utils import gprint
 
@@ -811,6 +812,24 @@ class TimeSeriesBaseDict(OrderedDict):
     data access methods.
     """
     EntryClass = TimeSeriesBase
+
+    @property
+    def span(self):
+        """The GPS ``[start, stop)`` extent of data in this `dict`
+
+        :type: `~gwpy.segments.Segment`
+        """
+        span = SegmentList()
+        for value in self.values():
+            span.append(value.span)
+        try:
+            return span.extent()
+        except ValueError as exc:  # empty list
+            exc.args = (
+                'cannot calculate span for empty {0}'.format(
+                    type(self).__name__),
+            )
+            raise
 
     @classmethod
     def read(cls, source, *args, **kwargs):

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -34,10 +34,10 @@ from six.moves import range
 
 import numpy
 
-from astropy import units
+from astropy import (units, __version__ as astropy_version)
 
 from .core import (TimeSeriesBase, TimeSeriesBaseDict, TimeSeriesBaseList,
-                   as_series_dict_class, ASTROPY_2_0)
+                   as_series_dict_class)
 from ..types import Array2D
 from ..detector import Channel
 from ..time import Time
@@ -198,7 +198,7 @@ class StateTimeSeries(TimeSeriesBase):
 
     # -- math handling (always boolean) ---------
 
-    if ASTROPY_2_0:
+    if astropy_version >= '2.0.0':  # remove _if_ when we pin astropy >= 2.0.0
         def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
             return super(StateTimeSeries, self).__array_ufunc__(
                 ufunc, method, *inputs, **kwargs).view(bool)

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -27,7 +27,7 @@ import pytest
 import numpy
 try:
     from numpy import shares_memory
-except ImportError:  # old numpy
+except ImportError:  # numpy < 1.11.0
     from numpy import may_share_memory as shares_memory
 
 from matplotlib import rc_context

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -19,7 +19,8 @@
 """Unit test for timeseries module
 """
 
-import os
+import operator
+from functools import reduce
 from io import BytesIO
 
 import pytest
@@ -240,6 +241,15 @@ class TestTimeSeriesBaseDict(object):
     def test_series_link(self):
         assert self.ENTRY_CLASS.DictClass is self.TEST_CLASS
         assert self.TEST_CLASS.EntryClass is self.ENTRY_CLASS
+
+    def test_span(self, instance):
+        assert isinstance(instance.span, Segment)
+        assert instance.span == reduce(
+            operator.or_, (ts.span for ts in instance.values()), Segment(0, 0),
+        )
+        with pytest.raises(ValueError) as exc:
+            self.TEST_CLASS().span
+        assert 'cannot calculate span for empty ' in str(exc.value)
 
     def test_copy(self, instance):
         copy = instance.copy()


### PR DESCRIPTION
This PR fixes #864 by implementing a `span` property for the `TimeSeriesDict`, essentially just the logical OR of all `span`s for contained `TimeSeries`.