### PR TITLE
Refactored tests of gwpy.cli to work with pytest-4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 env:
   global:
     # default environment variables
-    - PIP_FLAGS="--quiet"  # install with PIP quietly
+    - PIP_FLAGS=""
     # https://nedbatchelder.com/blog/201809/coveragepy_50a2_sqlite_storage.html
     - COVERAGE_STORAGE="json"
 
@@ -69,7 +69,7 @@ matrix:
     # test pre-release dependencies
     - python: '3.6'
       stage: Full tests
-      env: PIP_FLAGS="--upgrade --pre --quiet" INSTALL_CMD=". ./ci/install-pip.sh"
+      env: PIP_FLAGS="--upgrade --pre" INSTALL_CMD=". ./ci/install-pip.sh"
 
     # conda builds
     - python: '2.7'
@@ -115,7 +115,7 @@ matrix:
       env: INSTALL_CMD="${MACPORTS_INSTALL_CMD}" PYTHON_VERSION="3.7"
 
   allow_failures:
-    - env: PIP_FLAGS="--upgrade --pre --quiet"
+    - env: PIP_FLAGS="--upgrade --pre"
     - env: INSTALL_CMD="${MACPORTS_INSTALL_CMD}" PYTHON_VERSION="3.7"
 
 install:  # install package

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -96,9 +96,3 @@ if [ -d /usr/lib64/${PYTHON}/site-packages/LDAStools -a \
      ! -f /usr/lib64/${PYTHON}/site-packages/LDAStools/__init__.py ]; then
     touch /usr/lib64/${PYTHON}/site-packages/LDAStools/__init__.py
 fi
-
-# HACK: remove empty dist-info for python2-root
-_ROOT_DIST_INFO=$(rpm -ql python2-root | grep dist-info)
-if [ ! -s ${_ROOT_DIST_INFO} ]; then
-    rm -f ${_ROOT_DIST_INFO}
-fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -40,5 +40,8 @@ ${PIP} install "pip>=8.0.0" "setuptools>=20.2.2"
 # install test dependencies
 ${PIP} install ${PIP_FLAGS} -r requirements-test.txt
 
+# list all packages
+${PIP} list installed
+
 # run tests with coverage
 ${PYTHON} -m pytest --pyargs gwpy --cov=gwpy

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -40,6 +40,12 @@ ${PIP} install "pip>=8.0.0" "setuptools>=20.2.2"
 # install test dependencies
 ${PIP} install ${PIP_FLAGS} -r requirements-test.txt
 
+# try and install pytest-cov again, which forces pip to make sure
+# that the right version of pytest is installed
+if grep -q "pytest-cov" requirements-test.txt; then
+    ${PIP} install ${PIP_FLAGS} pytest-cov
+fi
+
 # list all packages
 ${PIP} list installed
 

--- a/gwpy/cli/tests/base.py
+++ b/gwpy/cli/tests/base.py
@@ -118,11 +118,11 @@ class _TestCliProduct(object):
         if prod.plot:
             prod.plot.close()
 
-    @classmethod
-    @pytest.fixture
-    def dataprod(cls, prod):
-        """Returns a `CliProduct` with data
-        """
+    @staticmethod
+    def _prod_add_data(prod):
+        # we need this method separate, rather than in dataprod, so that
+        # we can have classes override the dataprod fixture with extra
+        # stuff properly
         dur = prod.duration
         fs = 512
 
@@ -138,9 +138,20 @@ class _TestCliProduct(object):
 
     @classmethod
     @pytest.fixture
+    def dataprod(cls, prod):
+        """Returns a `CliProduct` with data
+        """
+        return cls._prod_add_data(prod)
+
+    @staticmethod
+    def _plotprod_init(prod):
+        prod.plot = pyplot.figure(FigureClass=Plot)
+        return prod
+
+    @classmethod
+    @pytest.fixture
     def plotprod(cls, dataprod):
-        dataprod.plot = pyplot.figure(FigureClass=Plot)
-        return dataprod
+        return cls._plotprod_init(dataprod)
 
     # -- tests ----------------------------------
 
@@ -261,7 +272,7 @@ class _TestImageProduct(_TestCliProduct):
     @classmethod
     @pytest.fixture
     def plotprod(cls, dataprod):
-        super(_TestImageProduct, cls).plotprod(dataprod)
+        cls._plotprod_init(dataprod)
         dataprod.plot.gca().pcolormesh(dataprod.result)
         return dataprod
 
@@ -296,7 +307,7 @@ class _TestFrequencyDomainProduct(_TestCliProduct):
     @classmethod
     @pytest.fixture
     def dataprod(cls, prod):
-        super(_TestFrequencyDomainProduct, cls).dataprod(prod)
+        cls._prod_add_data(prod)
         fftlength = prod.args.secpfft
         for i, ts in enumerate(prod.timeseries):
             nsamp = int(fftlength * 512 / 2.) + 1

--- a/gwpy/cli/tests/test_spectrogram.py
+++ b/gwpy/cli/tests/test_spectrogram.py
@@ -33,7 +33,7 @@ class TestCliSpectrogram(_TestFFTMixin, _TestTimeDomainProduct,
     @classmethod
     @pytest.fixture
     def dataprod(cls, prod):
-        super(TestCliSpectrogram, cls).dataprod(prod)
+        cls._prod_add_data(prod)
         prod.result = prod.get_spectrogram()
         return prod
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 # requirements for GWpy tests
-pytest >= 3.1, < 4.0a0
+pytest >= 3.1
 pytest-cov
 mock ; python_version < '3'
 freezegun >= 0.2.3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 # requirements for GWpy tests
 pytest >= 3.1
-pytest-cov
+pytest-cov >= 2.4.0
 mock ; python_version < '3'
 freezegun >= 0.2.3
 sqlparse >= 0.2.0

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ if not PEP_508 and (
 
 # test dependencies
 tests_require = [
-    'pytest>=3.1,<4.0a0',
+    'pytest>=3.1',
     'freezegun>=0.2.3',
     'sqlparse>=0.2.0',
     'beautifulsoup4',

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -211,7 +211,8 @@ class changelog(Command):
                 version,
                 build,
                 message,
-        ))
+            )
+        )
 
     @staticmethod
     def _format_entry_deb(name, version, build, author, email, message,
@@ -228,7 +229,8 @@ class changelog(Command):
                 email,
                 date.strftime('%a, %d %b %Y %H:%M:%S'),
                 int(-tzoffset / 3600. * 100),
-        ))
+            )
+        )
 
     @staticmethod
     def _tag_version(tag):

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -184,8 +184,9 @@ class changelog(Command):
             config = repo.config_reader()
             version = str(tag)
             build = 1000
-            author = config.get_value("user", "name")
-            email = config.get_value("user", "email")
+            author = config.get_value("user", "name", default="user")
+            email = config.get_value("user", "email",
+                                     default="<user@email.com>")
             message = 'Test build'
             date = datetime.datetime.now()
             tz = 0


### PR DESCRIPTION
This PR refactors the test suite for `gwpy.cli` to be compatible with `pytest-4.0.0`, mainly by removing direct calling of fixtures. The suite itself is now a little harder to read, but it runs. 