### PR TITLE
Don't apply null ADC scaling

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -651,7 +651,8 @@ class TimeSeriesBase(Series):
         # unwrap data
         slope = buffer_.signal_slope
         offset = buffer_.signal_offset
-        if scaled and (slope != 1 or offset != 0):
+        null_scaling = slope == 1. and offset == 0.
+        if scaled and not null_scaling:
             data = buffer_.data.copy() * slope + offset
             copy = False
         else:

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -334,6 +334,9 @@ def read_frdata(frdata, epoch, start, end, name=None, scaled=True,
     except AttributeError:  # not FrAdcData
         slope = None
         bias = None
+        null_scaling = True
+    else:
+        null_scaling = slope == 1. and bias == 0.
 
     out = None
     for j in range(frdata.data.size()):
@@ -345,11 +348,12 @@ def read_frdata(frdata, epoch, start, end, name=None, scaled=True,
         except _Skip:
             continue
 
-        # apply ADC scaling
-        if slope is not None and scaled:
+        # apply ADC scaling (only if interesting; this prevents unnecessary
+        #                                         type-casting errors)
+        if scaled and not null_scaling:
             new *= slope
             new += bias
-        elif slope is not None:
+        if slope is not None:
             # user has deliberately disabled the ADC calibration, so
             # the stored engineering unit is not valid, revert to 'counts':
             new.override_unit('count')


### PR DESCRIPTION
This PR modifies `gwpy.timeseries` to only apply ADC scaling if its mathematically interesting (`scale != 1. or bias != 0`); this helps to prevent unnecessary type-casting (e.g. for `uint` data).