### PR TITLE
Added tconvert-like command-line interface for gwpy.time

### DIFF
--- a/gwpy/time/__main__.py
+++ b/gwpy/time/__main__.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2013)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Primitive command-line interface to `gwpy.time.tconvert`.
+
+Either pass a GPS time to convert to a date string, or a date string
+to convert to a GPS time.
+"""
+
+import argparse
+import datetime
+import sys
+
+from dateutil import tz
+
+from .. import __version__
+from . import tconvert
+
+
+def main(args=None):
+    """Parse command-line arguments, tconvert inputs, and print
+    """
+    # define command line arguments
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-V", "--version", action="version",
+                        version=__version__,
+                        help="show version number and exit")
+    parser.add_argument("-l", "--local", action="store_true", default=False,
+                        help="print datetimes in local timezone")
+    parser.add_argument("-f", "--format", type=str, action="store",
+                        default=r"%Y-%m-%d %H:%M:%S.%f %Z",
+                        help="output datetime format (default: %(default)r)")
+    parser.add_argument("input", help="GPS or datetime string to convert",
+                        nargs="*")
+
+    # parse and convert
+    args = parser.parse_args(args)
+    input_ = " ".join(args.input)
+    output = tconvert(input_)
+
+    # print (now with timezones!)
+    if isinstance(output, datetime.datetime):
+        output = output.replace(tzinfo=tz.tzutc())
+        if args.local:
+            output = output.astimezone(tz.tzlocal())
+        print(output.strftime(args.format))
+    else:
+        print(output)
+
+
+if __name__ == "__main__":  # pragma: no-cover
+    sys.exit(main())

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -23,6 +23,7 @@ Peter Shawhan.
 """
 
 import datetime
+import warnings
 from decimal import Decimal
 
 from six import string_types
@@ -230,19 +231,32 @@ DATE_STRINGS = {
 def _str_to_datetime(datestr):
     """Convert `str` to `datetime.datetime`.
     """
-    try:  # try known string
+    # try known string
+    try:
         return DATE_STRINGS[str(datestr).lower()]()
     except KeyError:  # any other string
-        try:  # use maya
-            import maya
-            return maya.when(datestr).datetime()
-        except ImportError:
-            try:  # use dateutil.parse
-                return dateparser.parse(datestr)
-            except (ValueError, TypeError) as exc:  # improve error reporting
-                exc.args = ("Cannot parse date string {0!r}: {1}".format(
-                    datestr, exc.args[0]),)
-                raise
+        pass
+
+    # use maya
+    try:
+        import maya
+        return maya.when(datestr).datetime()
+    except ImportError:
+        pass
+
+    # use dateutil.parse
+    with warnings.catch_warnings():
+        # don't allow lazy passing of time-zones
+        warnings.simplefilter("error", RuntimeWarning)
+        try:
+            return dateparser.parse(datestr)
+        except RuntimeWarning as exc:
+            raise ValueError("Cannot parse date string with timezone "
+                             "without maya, please install maya")
+        except (ValueError, TypeError) as exc:  # improve error reporting
+            exc.args = ("Cannot parse date string {0!r}: {1}".format(
+                datestr, exc.args[0]),)
+            raise
 
 
 def _datetime_to_time(dtm):

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -233,12 +233,16 @@ def _str_to_datetime(datestr):
     try:  # try known string
         return DATE_STRINGS[str(datestr).lower()]()
     except KeyError:  # any other string
-        try:
-            return dateparser.parse(datestr)
-        except (ValueError, TypeError) as exc:
-            exc.args = ("Cannot parse date string {0!r}: {1}".format(
-                datestr, exc.args[0]),)
-            raise
+        try:  # use maya
+            import maya
+            return maya.when(datestr).datetime()
+        except ImportError:
+            try:  # use dateutil.parse
+                return dateparser.parse(datestr)
+            except (ValueError, TypeError) as exc:  # improve error reporting
+                exc.args = ("Cannot parse date string {0!r}: {1}".format(
+                    datestr, exc.args[0]),)
+                raise
 
 
 def _datetime_to_time(dtm):

--- a/gwpy/time/tests/test_main.py
+++ b/gwpy/time/tests/test_main.py
@@ -19,7 +19,14 @@
 """Tests for the `gwpy.time` command-line interface
 """
 
+import datetime
+try:
+    from unittest import mock
+except ImportError:  # python < 3
+    import mock
+
 import pytest
+from dateutil import tz
 
 from .. import __main__ as gwpy_time_cli
 
@@ -27,11 +34,11 @@ from .. import __main__ as gwpy_time_cli
 @pytest.mark.parametrize('args, result', [
     (['Jan 1 2010'], 946339215),
     (['Jan', '1', '2010'], 946339215),
-    (['Oct 30 2016 12:34 CST'], 1161887657),
     (['946339215'], '2010-01-01 00:00:00.000000 UTC'),
-    (['1161887657'], '2016-10-30 18:34:00.000000 UTC'),
+    (['1161887657', '--local'], '2016-10-30 13:34:00.000000 CDT'),
 ])
-def test_main(args, result, capsys):
+@mock.patch('dateutil.tz.tzlocal', return_value=tz.gettz('America/Chicago'))
+def test_main(tzlocal, args, result, capsys):
     gwpy_time_cli.main(args)
     out, err = capsys.readouterr()
     assert not err

--- a/gwpy/time/tests/test_main.py
+++ b/gwpy/time/tests/test_main.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the `gwpy.time` command-line interface
+"""
+
+import pytest
+
+from .. import __main__ as gwpy_time_cli
+
+
+@pytest.mark.parametrize('args, result', [
+    (['Jan 1 2010'], 946339215),
+    (['Jan', '1', '2010'], 946339215),
+    (['Oct 30 2016 12:34 CST'], 1161887657),
+    (['946339215'], '2010-01-01 00:00:00.000000 UTC'),
+    (['1161887657'], '2016-10-30 18:34:00.000000 UTC'),
+])
+def test_main(args, result, capsys):
+    gwpy_time_cli.main(args)
+    out, err = capsys.readouterr()
+    assert not err
+    assert out.rstrip() == str(result)

--- a/gwpy/time/tests/test_time.py
+++ b/gwpy/time/tests/test_time.py
@@ -33,6 +33,7 @@ from astropy.time import Time
 from astropy.units import (UnitConversionError, Quantity)
 
 from ... import time
+from ...testing.utils import skip_missing_dependency
 from .. import LIGOTimeGPS
 
 try:
@@ -44,8 +45,6 @@ else:
     HAS_GLUE = True
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-
-skipglue = pytest.mark.skipif(not HAS_GLUE, reason='no module named glue')
 
 GW150914 = LIGOTimeGPS(1126259462, 391000000)
 GW150914_DT = datetime(2015, 9, 14, 9, 50, 45, 391000)
@@ -88,7 +87,7 @@ def _test_with_errors(func, in_, out):
     (Quantity(1167264018, 's'), 1167264018),
     (Decimal('1126259462.391000000'), GW150914),
     pytest.param(GlueGPS(GW150914.gpsSeconds, GW150914.gpsNanoSeconds),
-                 GW150914, marks=skipglue),
+                 GW150914, marks=skip_missing_dependency('glue')),
     (numpy.int32(NOW), NOW),  # fails with lal-6.18.0
     ('now', NOW),
     ('today', TODAY),
@@ -96,6 +95,8 @@ def _test_with_errors(func, in_, out):
     ('yesterday', YESTERDAY),
     (Quantity(1, 'm'), UnitConversionError),
     ('random string', (ValueError, TypeError)),
+    pytest.param('Oct 30 2016 12:34 CST', 1161887657,
+                 marks=skip_missing_dependency('maya')),
 ])
 def test_to_gps(in_, out):
     """Test :func:`gwpy.time.to_gps`
@@ -109,7 +110,7 @@ def test_to_gps(in_, out):
     (1126259462.391, datetime(2015, 9, 14, 9, 50, 45, 391000)),
     ('1.13e9', datetime(2015, 10, 27, 16, 53, 3)),
     pytest.param(GlueGPS(GW150914.gpsSeconds, GW150914.gpsNanoSeconds),
-                 GW150914_DT, marks=skipglue),
+                 GW150914_DT, marks=skip_missing_dependency('glue')),
     ('test', ValueError),
 ])
 def test_from_gps(in_, out):
@@ -122,7 +123,8 @@ def test_from_gps(in_, out):
     (float(GW150914), GW150914_DT),
     (GW150914, GW150914_DT),
     (GW150914_DT, GW150914),
-    pytest.param(GlueGPS(float(GW150914)), GW150914_DT, marks=skipglue),
+    pytest.param(GlueGPS(float(GW150914)), GW150914_DT,
+                 marks=skip_missing_dependency('glue')),
     ('now', NOW),
     ('today', TODAY),
     ('tomorrow', TOMORROW),


### PR DESCRIPTION
This PR adds a command-line interface to `gwpy.time` to replicate `tconvert` functionality, used as follows:

```shell
$ python -m gwpy.time 1161887657
2016-10-30 18:34:00.000000 UTC
```

This also improves the functionality of `gwpy.time._str_to_datetime` by optionally using [`maya`](https://pypi.org/project/maya/) to parse datetime strings, its a little better than `dateutil`.