### PR TITLE
Fixed error testing gwpy.io.nds2 when NDSSERVER is set on the host

### DIFF
--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -167,7 +167,7 @@ def test_host_resolution_order_warning():
     # test warnings for unknown IFO
     with pytest.warns(UserWarning) as record:
         # should produce warning
-        hro = io_nds2.host_resolution_order('X1')
+        hro = io_nds2.host_resolution_order('X1', env=None)
         assert hro == [('nds.ligo.caltech.edu', 31200)]
         # should _not_ produce warning
         hro = io_nds2.host_resolution_order('X1', env='TESTENV')


### PR DESCRIPTION
This PR fixes a minor testing failure when NDSSERVER is inherited from the environment (LDG).