### PR TITLE
Corrected pytest version requirement

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 # requirements for GWpy tests
-pytest >= 3.1
+pytest >= 3.3.0
 pytest-cov >= 2.4.0
 mock ; python_version < '3'
 freezegun >= 0.2.3

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ if not PEP_508 and (
 
 # test dependencies
 tests_require = [
-    'pytest>=3.1',
+    'pytest>=3.3.0',
     'freezegun>=0.2.3',
     'sqlparse>=0.2.0',
     'beautifulsoup4',


### PR DESCRIPTION
This PR fixes the minimum `pytest` version we require; parsing `capsys.readouterr()` as a namedtuple is only available in `pytest>=3.3.0`.