### PR TITLE
Fixed symlinks of XML files

### DIFF
--- a/docs/examples/table/H1-LDAS_STRAIN-968654552-10.xml.gz
+++ b/docs/examples/table/H1-LDAS_STRAIN-968654552-10.xml.gz
@@ -1,1 +1,1 @@
-../../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz
+../../../gwpy/testing/data/H1-LDAS_STRAIN-968654552-10.xml.gz

--- a/docs/table/H1-LDAS_STRAIN-968654552-10.xml.gz
+++ b/docs/table/H1-LDAS_STRAIN-968654552-10.xml.gz
@@ -1,1 +1,1 @@
-../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz
+../../gwpy/testing/data/H1-LDAS_STRAIN-968654552-10.xml.gz

--- a/examples/table/H1-LDAS_STRAIN-968654552-10.xml.gz
+++ b/examples/table/H1-LDAS_STRAIN-968654552-10.xml.gz
@@ -1,1 +1,1 @@
-../../gwpy/tests/data/H1-LDAS_STRAIN-968654552-10.xml.gz
+../../gwpy/testing/data/H1-LDAS_STRAIN-968654552-10.xml.gz


### PR DESCRIPTION
This PR fixes the broken symlinks for XML files, this was missed when I moved `gwpy.tests -> gwpy.testing` (#993).