### PR TITLE
Fixed linking of CSS and JS in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -506,17 +506,19 @@ def write_citing_rst(_):
 
 # -- add css and js files -----------------------------------------------------
 
-CSS_DIR = os.path.join(html_static_path[0], 'css')
-JS_DIR = os.path.join(html_static_path[0], 'js')
 
 def setup_static_content(app):
+    staticdir = os.path.join(SPHINX_DIR, html_static_path[0])
+
     # add stylesheets
-    for cssf in glob.glob(os.path.join(CSS_DIR, '*.css')):
-        app.add_stylesheet(cssf.split(os.path.sep, 1)[1])
+    cssdir = os.path.join(staticdir, 'css')
+    for cssf in glob.glob(os.path.join(cssdir, '*.css')):
+        app.add_stylesheet(os.path.sep.join(cssf.rsplit(os.path.sep, 2)[-2:]))
 
     # add custom javascript
-    for jsf in glob.glob(os.path.join(JS_DIR, '*.js')):
-        app.add_javascript(jsf.split(os.path.sep, 1)[1])
+    jsdir = os.path.join(staticdir, 'js')
+    for jsf in glob.glob(os.path.join(jsdir, '*.js')):
+        app.add_javascript(os.path.sep.join(jsf.rsplit(os.path.sep, 2)[-2:]))
 
 
 # -- setup --------------------------------------------------------------------

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,5 @@
 # requirements for GWpy docs
-sphinx >= 1.6.1
+sphinx >= 1.7.6
 numpydoc >= 0.8.0
 sphinx-bootstrap-theme >= 0.6
 sphinxcontrib-programoutput


### PR DESCRIPTION
This PR fixes how the extra CSS and JS files are linked into the output documentation HTML pages for the relevant version of sphinx that auto-creates the docs.