### PR TITLE
Skip failing test from bug in framecpp

### DIFF
--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -263,8 +263,12 @@ class TestTable(object):
             # check write
             try:
                 table.write(tmp, 'test_read_write_gwf')
-            except ImportError as e:
-                pytest.skip(str(e))
+            except ImportError as exc:  # no frameCPP
+                pytest.skip(str(exc))
+            except TypeError as exc:  # frameCPP broken (2.6.7)
+                if 'ParamList' in str(exc):
+                    pytest.skip("bug in python-ldas-tools-framecpp")
+                raise
 
             # check read gives back same table
             t2 = self.TABLE.read(tmp, 'test_read_write_gwf', columns=columns)


### PR DESCRIPTION
This PR works around a supposed bug in `python-ldas-tools-framecpp-2.6.7` by just skipping the test if the bug attacks, see [ldastools/LDAS_Tools#57](https://git.ligo.org/ldastools/LDAS_Tools/issues/57).