### PR TITLE
Protect against KeyError in has_tex()

### DIFF
--- a/gwpy/plot/tex.py
+++ b/gwpy/plot/tex.py
@@ -48,7 +48,7 @@ def has_tex():
     for exe in ('latex', 'pdflatex', 'dvipng'):
         try:
             which(exe)
-        except ValueError:
+        except (ValueError, KeyError):
             return False
     return True
 


### PR DESCRIPTION
This PR patches `gwpy.plot.tex.has_tex` to catch `KeyError`s, so that no `PATH` variable doesn't crash the plotter, but just disables TeX.