### PR TITLE
Fixed lingering references to gwpy.tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE README.md MANIFEST.in
-recursive-include gwpy/tests/data *gwf *xml.gz *txt *hdf
+recursive-include gwpy/testing/data *gwf *xml.gz *txt *hdf
 recursive-include examples *py
 include setup_utils.py
 include versioneer.py

--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -66,7 +66,7 @@ To read data from a GWF file, pass the input file path (or paths) and the name o
 
 .. note::
 
-   The ``HLV-HW100916-968654552-1.gwf`` file is included with the GWpy source under `/gwpy/tests/data/ <https://github.com/gwpy/gwpy/tree/master/gwpy/tests/data>`_.
+   The ``HLV-HW100916-968654552-1.gwf`` file is included with the GWpy source under `/gwpy/testing/data/ <https://github.com/gwpy/gwpy/tree/master/gwpy/testing/data>`_.
 
 Reading a `StateVector` uses the same syntax::
 


### PR DESCRIPTION
This PR fixes the last lingering references to `gwpy.tests` that are currently causing conda builds to fail.