### PR TITLE
Fixed error with multiple deployments from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,8 +139,9 @@ deploy:
       condition: -z "${DOCKER_IMAGE}"
       branch: master
       tags: true
-      python: '2.7'
+      python: '3.6'
       repo: gwpy/gwpy
+      skip_existing: true
 
 notifications:
   slack:


### PR DESCRIPTION
This PR fixes the problem of multiple competing deployments from travis for tags by adding the `skip_existing: true` key to the `deploy` configuration.