### PR TITLE
Use dqsegdb2 for segment queries

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,8 @@ Depends: ${misc:Depends},
          python-ldas-tools-framecpp (>= 2.6.0),
          python-lal (>= 6.14.0),
          python-tqdm (>= 4.10.0),
-         python-gwosc (>= 0.3.1)
+         python-gwosc (>= 0.3.1),
+         python-dqsegdb2
 Suggests: python-pymysql,
           python-gwdatafind,
           python-dqsegdb,
@@ -60,7 +61,8 @@ Depends: ${misc:Depends},
          python3-lal (>= 6.14.0),
          python3-ligo-segments,
          python3-tqdm (>= 4.10.0),
-         python3-gwosc (>= 0.3.1)
+         python3-gwosc (>= 0.3.1),
+         python3-dqsegdb2
 Suggests: python3-pymysql,
           python3-gwdatafind,
           python3-dqsegdb,

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -21,6 +21,9 @@
 .. |gwosc| replace:: `gwosc`
 .. _gwosc: http://gwosc.readthedocs.io/en/stable/
 
+.. |dqsegdb2| replace:: `dqsegdb2`
+.. _dqsegdb2: https://dqsegdb2.readthedocs.io
+
 .. |h5py| replace:: `h5py`
 .. _h5py: http://docs.h5py.org/en/latest/
 
@@ -37,9 +40,6 @@
 .. _ligotimegps: https://github.com/gwpy/ligotimegps/
 
 .. -- Extra software ----------------------------
-
-.. |dqsegdb| replace:: `dqsegdb`
-.. _dqsegdb: https://wiki.ligo.org/DASWG/DQSEGDB
 
 .. |LDAStools.frameCPP| replace:: `LDAStools.frameCPP`
 .. _LDAStools.frameCPP: https://ldas-jobs.ligo.caltech.edu/~emaros/share/doc/ldas-tools/framecpp/html/

--- a/docs/segments/dqsegdb.rst
+++ b/docs/segments/dqsegdb.rst
@@ -1,26 +1,43 @@
 .. currentmodule:: gwpy.segments
 
-.. _gwpy-segments-dqsegdb:
+.. _gwpy-segments-dqsegdb2:
 
 ####################
 The Segment Database
 ####################
 
-**Additional dependencies**: :mod:`glue`, |dqsegdb|_
+.. warning::
 
-The LIGO and Virgo instruments utilise hundreds of data-quality flags to record instrumental state on a daily basis.
-These flags are stored in a joint segment database - a queryable database recording each flag, its valid and active segment lists, and all metadata associated with its generation.
-The segment database is the primary access point for users to study data-quality flags and apply them in any analysis.
+   Access to the GW segment database is reserved for members of
+   the LIGO-Virgo-KAGRA collaborations.
 
-The `DataQualityFlag` object includes the :meth:`~DataQualityFlag.query` classmethod with which to access segments stored in any segment database::
+
+The LIGO and Virgo instruments utilise hundreds of data-quality flags
+to record instrumental state on a daily basis.
+These flags are stored in a joint segment database - a queryable database
+recording each flag, its valid and active segment lists, and all metadata
+associated with its generation.
+The segment database is the primary access point for users to study
+data-quality flags and apply them in any analysis.
+
+The `DataQualityFlag` object includes the :meth:`~DataQualityFlag.query`
+`classmethod` with which to access segments stored in any segment database::
 
     >>> from gwpy.segments import DataQualityFlag
-    >>> segs = DataQualityFlag.query('L1:DMT-ANALYSIS_READY:1', 'Sep 14 2015', 'Sep 15 2015')
+    >>> segs = DataQualityFlag.query('L1:DMT-ANALYSIS_READY:1',
+    ...                              'Sep 14 2015', 'Sep 15 2015')
 
-The above command will return the complete record for the LIGO-Livingston Observatory (``L1``) observing segments for the day of September 14 2015 (all times should be given in UTC or GPS).
+The above command will return the complete record for the
+LIGO-Livingston Observatory (``L1``) observing segments for the day of
+September 14 2015 (all times should be given in UTC or GPS).
 
 .. note::
 
-    Members of the LIGO Scientific Collaboration or the Virgo Collaboration
-    can also go to https://segments-web.ligo.org to search for segments
-    using their browser.
+    :meth:`DataQuality.query` calls out to `dqsegdb2`, see its documentation
+    for more information and extra functions you can use to interact with
+    the segment database.
+
+.. note::
+
+    Members of LIGO-Virgo-KAGRA can also go to https://segments-web.ligo.org
+    to search for segments using their browser.

--- a/docs/segments/index.rst
+++ b/docs/segments/index.rst
@@ -6,13 +6,26 @@
 Data-quality segments
 #####################
 
-In order to successfully search data for gravitational-wave signals, precise records of when each observatory was operating, and in a particular configuration, are kept to enable search teams to pick the best data to analyse.
+In order to successfully search data for gravitational-wave signals, precise
+records of when each observatory was operating, and in which configuration,
+are kept to enable search teams to pick the best data to analyse.
 
-Time segments are recorded denoting when each observatory was taking science-quality data and when the calibration was nominal, as well as during times of possible problems - electronics glitches or severe weather, for example.
+Time segments are recorded denoting when each observatory was taking
+observation-quality data and when the calibration was nominal, as well as
+during times of possible problems - electronics glitches or severe weather,
+for example.
 
-The international collaboration operates using the GPS time standard (seconds since the GPS epoch of midnight on January 6th 1980), and records such times as semi-open GPS ``[start, stop)`` segments.
+The international collaboration operates using the GPS time standard
+(seconds since the GPS epoch of midnight on January 6th 1980), and records
+such times as semi-open GPS ``[start, stop)`` segments.
 
-GWpy provides a number of classes for generating and manipulating such segments, inherited most functionality from the :mod:`ligo.segments` package.
+=============================================
+The :class:`Segment` and :class:`SegmentList`
+=============================================
+
+GWpy provides a number of classes for generating and manipulating such
+segments, enhancing the functionality provided by the (excellent)
+:mod:`ligo.segments` package.
 All credits for their usefulness go to the authors of that package.
 
 These basic objects are as follows:
@@ -22,18 +35,26 @@ These basic objects are as follows:
 
    Segment
    SegmentList
-   SegmentListDict
 
-While these objects are key to representing core data segments, they are usually applied to analyses of data as a `DataQualityFlag`.
+While these objects are key to representing core data segments,
+they are usually applied to analyses of data as a `DataQualityFlag`.
 
 ============================
 The :class:`DataQualityFlag`
 ============================
 
-A `DataQualityFlag` is an annotated set of segments that indicate something about instrumental operation.
-Each flag is defined by applying some algorithm on data and generating a :class:`SegmentList` that indicates some good or bad condition has been met during those times.
-For example, the times during which the LIGO interferometers are operating under observing conditions are recorded as the 'analysis-ready' flag, which are used by data analysis groups to define periods of data over which to run their pipelines.
-Conversely, high seismic noise around the observatory buildings is recorded in a data-quality flag used by analysis groups to veto periods of analysis as a result of sub-standard data.
+A `DataQualityFlag` is an annotated set of segments that indicate something
+about instrumental operation.
+Each flag is defined by applying some algorithm on data and generating a
+:class:`SegmentList` that indicates some good or bad condition has been met
+during those times.
+For example, the times during which the LIGO interferometers are operating
+under observing conditions are recorded as the '*analysis-ready*' flag, which
+is used by data analysis groups to define periods of data over which to search
+for gravitational-wave signals.
+Conversely, high seismic noise around the observatory buildings is recorded
+in a data-quality flag used by those groups to veto periods of analysis as
+a result of sub-standard data.
 
 Each `DataQualityFlag` has some key attributes:
 
@@ -43,7 +64,12 @@ Each `DataQualityFlag` has some key attributes:
    ~DataQualityFlag.known
    ~DataQualityFlag.active
 
-By convention, the :attr:`~DataQualityFlag.name` is typically constructed of three colon-separated components: the :attr:`~DataQualityFlag.ifo`, :attr:`~DataQualityFlag.tag`, and :attr:`~DataQualityFlag.version`, e.g. ``L1:DMT-ANALYSIS_READY:1``.
+By convention, the :attr:`~DataQualityFlag.name` is typically constructed of
+three colon-separated components: the
+:attr:`~DataQualityFlag.ifo`,
+:attr:`~DataQualityFlag.tag`, and
+:attr:`~DataQualityFlag.version`,
+e.g. ``L1:DMT-ANALYSIS_READY:1``.
 
 =============================
 Combining `DataQualityFlag`\s

--- a/etc/Portfile.template
+++ b/etc/Portfile.template
@@ -43,7 +43,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-lal \
                         port:py${python.version}-ligo-segments \
                         port:py${python.version}-tqdm \
-                        port:py${python.version}-gwosc
+                        port:py${python.version}-gwosc \
+                        port:py${python.version}-dqsegdb2
 
     if {${python.version} < 34} {
         depends_lib-append port:py${python.version}-enum34

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -40,6 +40,7 @@ Requires:       python2-lal >= 6.14.0
 Requires:       python2-ligo-segments >= 1.0.0
 Requires:       python2-tqdm >= 4.10.0
 Requires:       python2-gwosc
+Requires:       python2-dqsegdb2
 
 %{?python_provide:%python_provide python2-%{srcname}}
 

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -32,7 +32,6 @@ from collections import (namedtuple, OrderedDict)
 from gzip import GzipFile
 
 from six import string_types
-from six.moves import StringIO
 from six.moves.urllib.parse import urlparse
 
 try:
@@ -342,7 +341,7 @@ def file_name(fobj):
     """
     if isinstance(fobj, string_types):
         return fobj
-    if isinstance(fobj, FILE_LIKE) and not isinstance(fobj, StringIO):
+    if (isinstance(fobj, FILE_LIKE) and hasattr(fobj, 'name')):
         return fobj.name
     if HAS_CACHEENTRY and isinstance(fobj, CacheEntry):
         return fobj.path

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -429,6 +429,9 @@ class DataQualityFlag(object):
             A new `DataQualityFlag`, with the `known` and `active` lists
             filled appropriately.
         """
+        warnings.warn("query_segdb is deprecated and will be removed in a "
+                      "future release", DeprecationWarning)
+
         # parse arguments
         qsegs = _parse_query_segments(args, cls.query_segdb)
 
@@ -1112,6 +1115,9 @@ class DataQualityDict(OrderedDict):
             An ordered `DataQualityDict` of (name, `DataQualityFlag`)
             pairs.
         """
+        warnings.warn("query_segdb is deprecated and will be removed in a "
+                      "future release", DeprecationWarning)
+
         # parse segments
         qsegs = _parse_query_segments(args, cls.query_segdb)
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -34,7 +34,7 @@ import operator
 import os
 import re
 import warnings
-from io import StringIO
+from io import BytesIO
 from collections import OrderedDict
 from copy import (copy as shallowcopy, deepcopy)
 from math import (floor, ceil)
@@ -52,6 +52,8 @@ from astropy.utils.data import get_readable_fileobj
 
 from gwosc import timeline
 
+from dqsegdb2.query import query_segments
+
 from ..io.mp import read_multi as io_read_multi
 from ..time import to_gps, LIGOTimeGPS
 from ..utils.misc import if_not_none
@@ -68,8 +70,8 @@ re_TAG_VERSION = re.compile(r"\A(?P<tag>[^/]+):(?P<version>\d+)\Z")
 DEFAULT_SEGMENT_SERVER = os.getenv('DEFAULT_SEGMENT_SERVER',
                                    'https://segments.ligo.org')
 
-# -- utilities ----------------------------------------------------------------
 
+# -- utilities ----------------------------------------------------------------
 
 def _select_query_method(cls, url):
     """Select the correct query method based on the URL
@@ -473,14 +475,11 @@ class DataQualityFlag(object):
             A new `DataQualityFlag`, with the `known` and `active` lists
             filled appropriately.
         """
-        from dqsegdb import apicalls
-
         # parse arguments
         qsegs = _parse_query_segments(args, cls.query_dqsegdb)
 
         # get server
-        protocol, server = kwargs.pop(
-            'url', DEFAULT_SEGMENT_SERVER).split('://', 1)
+        url = kwargs.pop('url', DEFAULT_SEGMENT_SERVER)
 
         # parse flag
         out = cls(name=flag)
@@ -488,36 +487,26 @@ class DataQualityFlag(object):
             raise ValueError("Cannot parse ifo or tag (name) for flag %r"
                              % flag)
 
-        # other keyword arguments
-        request = kwargs.pop('request', 'metadata,active,known')
-
         # process query
         for start, end in qsegs:
+            # handle infinities
             if float(end) == +inf:
                 end = to_gps('now').seconds
-            if out.version is None:
-                data, versions, _ = apicalls.dqsegdbCascadedQuery(
-                    protocol, server, out.ifo, out.tag, request,
-                    int(start), int(end))
-                data['metadata'] = versions[-1]['metadata']
-            else:
-                try:
-                    data, _ = apicalls.dqsegdbQueryTimes(
-                        protocol, server, out.ifo, out.tag, out.version,
-                        request, int(start), int(end))
-                except HTTPError as exc:
-                    if exc.code == 404:  # if not found, annotate flag name
-                        exc.msg += ' [{0}]'.format(flag)
-                    raise
-            # read from json buffer
+
+            # query
             try:
-                new = cls.read(StringIO(json.dumps(data)), format='json')
-            except TypeError as exc:
-                if 'initial_value must be unicode' in str(exc):  # python2
-                    new = cls.read(StringIO(json.dumps(data).decode('utf-8')),
-                                   format='json')
-                else:
-                    raise
+                data = query_segments(flag, int(start), int(end), host=url)
+            except HTTPError as exc:
+                if exc.code == 404:  # if not found, annotate flag name
+                    exc.msg += ' [{0}]'.format(flag)
+                raise
+
+            # read from json buffer
+            new = cls.read(
+                BytesIO(json.dumps(data).encode('utf-8')),
+                format='json',
+            )
+
             # restrict to query segments
             segl = SegmentList([Segment(start, end)])
             new.known &= segl

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,6 @@ pymysql
 pyRXP
 lscsoft-glue ; sys_platform != 'win32'
 lalsuite ; sys_platform != 'win32'
-dqsegdb
 gwdatafind
 pycbc >= 1.10.1 ; python_version == '2.7' and sys_platform != 'win32'
 git+https://github.com/duncanmmacleod/ligo.org.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ligo-segments >= 1.0.0
 tqdm >= 4.10.0
 ligotimegps >= 1.2.1
 gwosc >= 0.3.1
+dqsegdb2

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ install_requires = [
     'tqdm >= 4.10.0',
     'ligotimegps >= 1.2.1',
     'gwosc >= 0.3.1',
+    'dqsegdb2',
 ]
 
 # if setuptools is too old and we are building an EL7 or Debian 8


### PR DESCRIPTION
This PR modifies the `gwpy.segments` sub-package to use the [`dqsegdb2`](https://dqsegdb2.readthedocs.io) library for segment queries, instead of `dqsegdb`.

`dqsegdb2` is added as a first-class dependency, so segment queries should now be considered a standard part of GWpy's capability.