### PR TITLE
Fixed HDF5 DeprecationWarning

### DIFF
--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -200,7 +200,7 @@ def read_losc_hdf5(h5f, path='strain/Strain',
     """
     dataset = io_hdf5.find_dataset(h5f, path)
     # read data
-    nddata = dataset.value
+    nddata = dataset[()]
     # read metadata
     xunit = parse_unit(dataset.attrs['Xunits'])
     epoch = dataset.attrs['Xstart']

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,6 @@
 # requirements for GWpy tests
+# pytest needs more-itertools, we need it to work on python2.7
+more-itertools < 6.0a0 ; python_version < '3'
 pytest >= 3.3.0
 pytest-cov >= 2.4.0
 mock ; python_version < '3'


### PR DESCRIPTION
This PR fixes a simple `DeprecationWarning` in `gwpy.timeseries.io.losc` when reading HDF5 data.