### PR TITLE
Removed latex macros from examples

### DIFF
--- a/examples/frequencyseries/percentiles.py
+++ b/examples/frequencyseries/percentiles.py
@@ -60,7 +60,7 @@ from gwpy.plot import Plot
 plot = Plot()
 ax = plot.gca(xscale='log', xlim=(10, 1500), xlabel='Frequency [Hz]',
               yscale='log', ylim=(3e-24, 2e-20),
-              ylabel=r'Strain noise [1/\rtHz]')
+              ylabel=r'Strain noise [1/$\sqrt{\mathrm{Hz}}$]')
 ax.plot_mmm(median, low, high, color='gwpy:ligo-hanford')
 ax.set_title('LIGO-Hanford strain noise variation around GW170817',
              fontsize=16)

--- a/examples/frequencyseries/rayleigh.py
+++ b/examples/frequencyseries/rayleigh.py
@@ -56,7 +56,7 @@ asdax, rayax = plot.axes
 
 asdax.set_yscale('log')
 asdax.set_ylim(5e-24, 1e-21)
-asdax.set_ylabel(r'[strain/\rtHz]')
+asdax.set_ylabel(r'[strain/$\sqrt{\mathrm{Hz}}$]')
 
 rayax.set_ylim(0, 2)
 rayax.set_ylabel('Rayleigh statistic')

--- a/examples/frequencyseries/variance.py
+++ b/examples/frequencyseries/variance.py
@@ -55,7 +55,7 @@ ax.grid()
 ax.set_xlim(20, 1500)
 ax.set_ylim(1e-24, 1e-20)
 ax.set_xlabel('Frequency [Hz]')
-ax.set_ylabel(r'[strain/\rtHz]')
+ax.set_ylabel(r'[strain/$\sqrt{\mathrm{Hz}}$]')
 ax.set_title('LIGO-Livingston sensitivity variance')
 plot.show()
 

--- a/examples/miscellaneous/open-data-spectrogram.py
+++ b/examples/miscellaneous/open-data-spectrogram.py
@@ -75,6 +75,6 @@ ax.set_yscale('log')
 ax.set_ylabel('Frequency [Hz]')
 ax.set_title('LIGO-Hanford strain data')
 ax.colorbar(cmap='viridis', norm='log', clim=(1e-23, 1e-19),
-            label=r'Strain noise [1/\rtHz]')
+            label=r'Strain noise [1/$\sqrt{\mathrm{Hz}}$]')
 plot.add_segments_bar(h1segs)
 plot.show()

--- a/examples/spectrogram/spectrogram2.py
+++ b/examples/spectrogram/spectrogram2.py
@@ -63,7 +63,7 @@ plot = specgram.plot(norm='log', cmap='viridis', yscale='log')
 ax = plot.gca()
 ax.set_title('LIGO-Hanford strain data around GW150914')
 ax.set_xlim(1126259462, 1126259463)
-ax.colorbar(label=r'Strain ASD [1/\rtHz]')
+ax.colorbar(label=r'Strain ASD [1/$\sqrt{\mathrm{Hz}}$]')
 plot.show()
 
 # Here we can see the trace of a high-mass binary black hole system,

--- a/examples/timeseries/filter.py
+++ b/examples/timeseries/filter.py
@@ -64,7 +64,7 @@ plot = Plot(whiteasd, dispasd, separate=True, sharex=True,
 # Finally, we prettify our plot with some limits, and some labels:
 plot.text(0.95, 0.05, 'Preliminary', fontsize=40, color='gray', ha='right', rotation=45, va='bottom', alpha=0.5)  # hide
 plot.axes[0].set_ylabel('ASD [whitened]')
-plot.axes[1].set_ylabel(r'ASD [m/\rtHz]')
+plot.axes[1].set_ylabel(r'ASD [m/$\sqrt{\mathrm{Hz}}$]')
 plot.axes[1].set_xlabel('Frequency [Hz]')
 plot.axes[1].set_ylim(1e-20, 1e-15)
 plot.axes[1].set_xlim(5, 4000)


### PR DESCRIPTION
This PR removes the use of the `\rtHz` TeX macro from the examples; we don't use TeX for the documentation any more, so we can't use the macros.

This reminds me, we should document that you _can_ use TeX for formatting, and it looks good.