### PR TITLE
Restore grid after pcolormesh

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -80,6 +80,24 @@ def xlim_as_gps(func):
     return wrapped_func
 
 
+def restore_grid(func):
+    """Wrap ``func`` to preserve the Axes current grid settings.
+    """
+    @wraps(func)
+    def wrapped_func(self, *args, **kwargs):
+        grid = (self.xaxis._gridOnMinor, self.xaxis._gridOnMajor,
+                self.yaxis._gridOnMinor, self.yaxis._gridOnMajor)
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            # reset grid
+            self.xaxis.grid(grid[0], which="minor")
+            self.xaxis.grid(grid[1], which="major")
+            self.yaxis.grid(grid[2], which="minor")
+            self.yaxis.grid(grid[3], which="major")
+    return wrapped_func
+
+
 # -- new Axes -----------------------------------------------------------------
 
 class Axes(_Axes):
@@ -236,6 +254,7 @@ class Axes(_Axes):
         return self.imshow(array.value.T, origin=origin, aspect=aspect,
                            interpolation=interpolation, **kwargs)
 
+    @restore_grid
     @log_norm
     def pcolormesh(self, *args, **kwargs):
         """Create a pseudocolor plot with a non-regular rectangular grid.
@@ -246,6 +265,11 @@ class Axes(_Axes):
 
         In all other usage, all ``args`` and ``kwargs`` are passed directly
         to :meth:`~matplotlib.axes.Axes.pcolormesh`.
+
+        Notes
+        -----
+        Unlike the upstream :meth:`matplotlib.axes.Axes.pcolormesh`,
+        this method respects the current grid settings.
 
         See Also
         --------

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -93,10 +93,18 @@ class TestAxes(AxesTestBase):
 
     def test_pcolormesh(self, ax):
         array = Array2D(numpy.random.random((10, 10)), dx=.1, dy=.2)
+        ax.grid(True, which="both", axis="both")
         mesh = ax.pcolormesh(array)
         utils.assert_array_equal(mesh.get_array(), array.T.flatten())
         utils.assert_array_equal(mesh.get_paths()[-1].vertices[2],
                                  (array.xspan[1], array.yspan[1]))
+        # check that restore_grid decorator did its job
+        assert all((
+            ax.xaxis._gridOnMajor,
+            ax.xaxis._gridOnMinor,
+            ax.yaxis._gridOnMajor,
+            ax.yaxis._gridOnMinor,
+        ))
 
     def test_hist(self, ax):
         x = numpy.random.random(100) + 1


### PR DESCRIPTION
`matplotlib`'s `Axes.pcolormesh` method sets `ax.grid(False)` for some reason:

https://github.com/matplotlib/matplotlib/blob/v3.0.2/lib/matplotlib/axes/_axes.py#L6007

so this PR adds a decorator to `gwpy.plot.axes` that can be used to restore the grid settings after an `Axes` call to what they were before, and applies it to the `pcolormesh` override method.