### PR TITLE
Refactored default parameters for Q-transform as module-level variables

### DIFF
--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -225,7 +225,8 @@ class QPlane(QBase):
     mismatch : `float`
         maximum fractional mismatch between neighbouring tiles
     """
-    def __init__(self, q, frange, duration, sampling, mismatch=DEFAULT_MISMATCH):
+    def __init__(self, q, frange, duration, sampling,
+                 mismatch=DEFAULT_MISMATCH):
         super(QPlane, self).__init__(q, duration, sampling, mismatch=mismatch)
         self.frange = [float(frange[0]), float(frange[1])]
 
@@ -326,7 +327,8 @@ class QPlane(QBase):
 class QTile(QBase):
     """Representation of a tile with fixed Q and frequency
     """
-    def __init__(self, q, frequency, duration, sampling, mismatch=DEFAULT_MISMATCH):
+    def __init__(self, q, frequency, duration, sampling,
+                 mismatch=DEFAULT_MISMATCH):
         super(QTile, self).__init__(q, duration, sampling, mismatch=mismatch)
         self.frequency = frequency
 
@@ -476,7 +478,8 @@ class QGram(object):
                 })
         return peak
 
-    def interpolate(self, tres=.001, fres="<default>", logf=False, outseg=None):
+    def interpolate(self, tres=.001, fres="<default>",
+                    logf=False, outseg=None):
         """Interpolate this `QGram` over a regularly-gridded spectrogram
 
         Parameters

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -35,7 +35,6 @@ import numpy
 from numpy import fft as npfft
 
 from ..segments import Segment
-from ..timeseries import TimeSeries
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Scott Coughlin <scott.coughlin@ligo.org>, ' \
@@ -415,6 +414,8 @@ class QTile(QBase):
             a `TimeSeries` of the energy from the Q-transform of
             this tile against the data.
         """
+        from ..timeseries import TimeSeries
+
         windowed = fseries[self.get_data_indices()] * self.get_window()
         # pad data, move negative frequencies to the end, and IFFT
         padded = numpy.pad(windowed, self.padding, mode='constant')
@@ -657,6 +658,7 @@ def q_scan(data, mismatch=DEFAULT_MISMATCH, qrange=DEFAULT_QRANGE,
         expected false alarm rate (Hertz) of white Gaussian noise with the
         same peak energy and total duration as `qgram`
     """
+    from gwpy.timeseries import TimeSeries
     # prepare input
     if isinstance(data, TimeSeries):
         duration = abs(data.span)


### PR DESCRIPTION
This PR refactors the defaults for the Q-transform as module level variables of `gwpy.signal.qtransform`:

https://github.com/duncanmmacleod/gwpy/blob/334c3ccf01b5aa05a1ab860e74371e9a3b5b07aa/gwpy/signal/qtransform.py#L44-L47

and updates `gwpy.timeseries.timeseries` to match. This doesn't change any of the defaults.