### PR TITLE
Minor improvements to correlate.py

### DIFF
--- a/examples/timeseries/correlate.py
+++ b/examples/timeseries/correlate.py
@@ -70,8 +70,12 @@ plot.close()  # hide
 
 # It's now worth checking out the time-frequency morphology in both channels
 # using :meth:`~TimeSeries.q_transform`:
-qhoft = whoft.q_transform(whiten=False, qrange=(93.1, 93.1))
-plot = qhoft.crop(1172489782.57, 1172489783.57).plot(figsize=[8, 4])
+qhoft = whoft.q_transform(
+    whiten=False,  # already white
+    qrange=(4, 150),  # wider Q-transform range
+    outseg=(1172489782.57, 1172489783.57),  # region of interest
+)
+plot = qhoft.imshow(figsize=[8, 4])
 ax = plot.gca()
 ax.set_xscale('seconds')
 ax.set_yscale('log')
@@ -84,8 +88,12 @@ plot.show()
 plot.close()  # hide
 
 # and the same for the PSL channel:
-qaux = waux.q_transform(whiten=False, qrange=(93.1, 93.1))
-plot = qaux.crop(1172489782.57, 1172489783.57).plot(figsize=[8, 4])
+qaux = waux.q_transform(
+    whiten=False,  # already white
+    qrange=(4, 150),  # wider Q-transform range
+    outseg=(1172489782.57, 1172489783.57),  # region of interest
+)
+plot = qaux.imshow(figsize=[8, 4])
 ax = plot.gca()
 ax.set_xscale('seconds')
 ax.set_yscale('log')


### PR DESCRIPTION
This PR makes a few 'improvements' to the `correlate` example, mainly so that my laptop doesn't explode when I run it:

- use `outseg` to reduce memory usage in interpolation
- use wider `qrange`, rather than specific Q (which we would have to document)
- explicitly use `imshow`