### PR TITLE
Q-transform fix min search length

### DIFF
--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -187,8 +187,8 @@ class Qtransform(Spectrogram):
             bits.append(('whitened',))
         bits.extend([
             ('f-range', fformat(self.result.yspan)),
-            ('e-range', '{:.3g}, {:.3g}]'.format(self.result.min(),
-                                                 self.result.max())),
+            ('e-range', '[{:.3g}, {:.3g}]'.format(self.result.min(),
+                                                  self.result.max())),
         ])
         return ', '.join([': '.join(bit) for bit in bits])
 

--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -114,7 +114,7 @@ class Qtransform(Spectrogram):
         search = args.search
         # ensure we have enough data for filter settling
         max_plot = max(args.plot)
-        search = max(search, max_plot * 2 + 6)
+        search = max(search, max_plot * 2 + 8)
         args.search = search
         self.log(3, "Search window: {0:.0f} sec, max plot window {1:.0f}".
                  format(search, max_plot))

--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -211,7 +211,7 @@ class Qtransform(Spectrogram):
             # processed and the time resolution needed to create a good
             # image. NB:For each time span specified
             # NB: the timeseries h enough data for the longest plot
-            inseg = outseg.protract(-4) & self.timeseries[0].span
+            inseg = outseg.protract(4) & self.timeseries[0].span
             proc_ts = self.timeseries[0].crop(*inseg)
 
             #  time resolution is calculated to provide about 4 times

--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -20,6 +20,7 @@
 """
 
 import os
+import re
 
 from ... import cli
 from ...testing.compat import mock
@@ -50,9 +51,18 @@ class TestCliQtransform(_TestCliSpectrogram):
         assert prod.qxfrm_args['qrange'] == (100., 110.)
 
     def test_get_title(self, dataprod):
-        t = ('Q: 45.25, tres: 0.000208, whitened, f-range: [51.45, 161.45], '
-             'e-range: -0.134, 16.5]')
-        assert dataprod.get_title() == t
+        _float_reg = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
+        title_reg = re.compile(
+            r"\A"
+            r"q: {float}, "
+            r"tres: {float}, "
+            r"whitened, "
+            r"f-range: \[{float}, {float}\], "
+            r"e-range: \[{float}, {float}\]"
+            r"\Z".format(float=_float_reg),
+            re.I,
+        )
+        assert title_reg.match(dataprod.get_title())
 
     def test_get_suptitle(self, prod):
         assert prod.get_suptitle() == 'Q-transform: {0}'.format(


### PR DESCRIPTION
I had the sign  of protract wrong. Plus align reading pad with calculation padding