### PR TITLE
Removed macports scipy install hack

### DIFF
--- a/ci/install-macports.sh
+++ b/ci/install-macports.sh
@@ -81,9 +81,6 @@ wvbpid=$!
 disown
 set -x
 
-# install scipy with openblas to fix symbols error
-sudo port -q install ${PY_PREFIX}-scipy +openblas
-
 # install py-gwpy
 sudo port -q install ${PY_PREFIX}-gwpy
 


### PR DESCRIPTION
This PR removes the manual install of `scipy` with macports, hopefully this has been fixed upstream.