### PR TITLE
Renamed and moved a couple of I/O utility functions

### DIFF
--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -74,8 +74,7 @@ from six.moves import configparser
 from numpy import inf
 
 from ...io import registry
-from ...io.utils import identify_factory
-from ...io.cache import (file_list, FILE_LIKE)
+from ...io.utils import (FILE_LIKE, file_list, identify_factory)
 from .. import (Channel, ChannelList)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -30,7 +30,7 @@ from six import string_types
 
 import numpy
 
-from .cache import (file_list, FILE_LIKE)
+from .utils import (file_list, FILE_LIKE)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -30,8 +30,8 @@ from six import string_types
 from astropy.io.registry import (read as io_read)
 from astropy.utils.data import get_readable_fileobj
 
-from .cache import (FILE_LIKE, file_list)
 from .registry import get_read_format
+from .utils import file_list
 from ..utils import mp as mp_utils
 
 

--- a/gwpy/io/registry.py
+++ b/gwpy/io/registry.py
@@ -34,7 +34,7 @@ from astropy.io.registry import (  # pylint: disable=unused-import
 )
 from astropy.utils.data import get_readable_fileobj
 
-from .cache import (file_list, FILE_LIKE)
+from .utils import (file_list, FILE_LIKE)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 

--- a/gwpy/io/tests/test_cache.py
+++ b/gwpy/io/tests/test_cache.py
@@ -30,7 +30,7 @@ import numpy
 import pytest
 
 from ...segments import (Segment, SegmentList)
-from ...testing.utils import (skip_missing_dependency, TemporaryFilename)
+from ...testing.utils import skip_missing_dependency
 from .. import cache as io_cache
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -142,66 +142,6 @@ def test_is_cache_entry():
         assert io_cache.is_cache_entry(e)
 
 
-def test_file_list(cache):
-
-    # test file -> [file.name]
-    with tempfile.NamedTemporaryFile() as f:
-        assert io_cache.file_list(f) == [f.name]
-
-    try:
-        from lal.utils import CacheEntry
-    except ImportError:
-        pass
-    else:
-        # test CacheEntry -> [CacheEntry.path]
-        lcache = list(map(CacheEntry.from_T050017, cache))
-        assert io_cache.file_list(lcache[0]) == [cache[0]]
-
-        # test cache object -> pfnlist
-        assert io_cache.file_list(lcache) == cache
-
-        # test cache file -> pfnlist()
-        with tempfile.NamedTemporaryFile(suffix='.lcf', mode='w') as f:
-            io_cache.write_cache(lcache, f)
-            f.seek(0)
-            assert io_cache.file_list(f.name) == cache
-
-    # test comma-separated list -> list
-    assert io_cache.file_list('A,B,C,D') == ['A', 'B', 'C', 'D']
-
-    # test list -> list
-    assert io_cache.file_list(['A', 'B', 'C', 'D']) == ['A', 'B', 'C', 'D']
-
-    # otherwise error
-    with pytest.raises(ValueError):
-        io_cache.file_list(1)
-
-
-def test_file_name(cache):
-
-    # check file_name(<str>)
-    assert io_cache.file_name('test.txt') == 'test.txt'
-
-    # check file_name(<file>)
-    with tempfile.NamedTemporaryFile() as f:
-        assert io_cache.file_name(f) == f.name
-
-    # check file_name(<CacheEntry>)
-    try:
-        from lal.utils import CacheEntry
-    except ImportError:
-        pass
-    else:
-        assert io_cache.file_name(
-            CacheEntry.from_T050017(cache[0])) == cache[0]
-
-    # check that anything else fails
-    with pytest.raises(ValueError):
-        io_cache.file_name(1)
-    with pytest.raises(ValueError):
-        io_cache.file_name(['test.txt'])
-
-
 def test_cache_segments(cache, segments):
     """Test :func:`gwpy.io.cache.cache_segments`
     """
@@ -271,3 +211,13 @@ def test_sieve(cache, segments):
 
     segments.coalesce()
     assert io_cache.sieve(cache, segments[0]) == cache[:2]
+
+
+def test_file_list():
+    with pytest.warns(DeprecationWarning):
+        assert io_cache.file_list("1,2,3") == ["1", "2", "3"]
+
+
+def test_file_name():
+    with pytest.warns(DeprecationWarning):
+        assert io_cache.file_name("123") == "123"

--- a/gwpy/io/tests/test_utils.py
+++ b/gwpy/io/tests/test_utils.py
@@ -20,13 +20,18 @@
 """
 
 import gzip
-import os.path
 import tempfile
 
-from six import PY2
+import pytest
 
-from ...testing.utils import TemporaryFilename
-from .. import utils as io_utils
+from ...testing.utils import (TemporaryFilename, skip_missing_dependency)
+from .. import (
+    cache as io_cache,
+    utils as io_utils,
+)
+
+# not required, just a reminder where the fixture lives:
+from .test_cache import cache
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -57,3 +62,67 @@ def test_identify_factory():
     assert id_func(None, 'test.blah', None) is True
     assert id_func(None, 'test.blah2', None) is True
     assert id_func(None, 'test.blah2x', None) is False
+
+
+def test_file_list_file(cache):
+    # test file -> [file.name]
+    with tempfile.NamedTemporaryFile() as f:
+        assert io_utils.file_list(f) == [f.name]
+
+
+@skip_missing_dependency("lal")
+def test_file_list_cache(cache):
+    from lal.utils import CacheEntry
+    # test CacheEntry -> [CacheEntry.path]
+    lcache = list(map(CacheEntry.from_T050017, cache))
+    assert io_utils.file_list(lcache[0]) == [cache[0]]
+
+    # test cache object -> pfnlist
+    assert io_utils.file_list(lcache) == cache
+
+    # test cache file -> pfnlist()
+    with tempfile.NamedTemporaryFile(suffix='.lcf', mode='w') as f:
+        io_cache.write_cache(lcache, f)
+        f.seek(0)
+        assert io_utils.file_list(f.name) == cache
+
+
+def test_file_list_str():
+    # test comma-separated list -> list
+    assert io_utils.file_list('A,B,C,D') == ['A', 'B', 'C', 'D']
+
+    # test list -> list
+    assert io_utils.file_list(['A', 'B', 'C', 'D']) == ['A', 'B', 'C', 'D']
+
+
+def test_file_list_error():
+    with pytest.raises(ValueError):
+        io_utils.file_list(1)
+
+
+def test_file_path():
+    # check file_path(<str>)
+    assert io_utils.file_path('test.txt') == 'test.txt'
+
+    # check file_path(<file>)
+    with tempfile.NamedTemporaryFile() as f:
+        assert io_utils.file_path(f) == f.name
+
+
+def test_file_path_url():
+    assert io_utils.file_path("file:///test/path.txt") == "/test/path.txt"
+
+
+def test_file_path_errors():
+    # check that anything else fails
+    with pytest.raises(ValueError):
+        io_utils.file_path(1)
+    with pytest.raises(ValueError):
+        io_utils.file_path(['test.txt'])
+
+
+@skip_missing_dependency("lal")
+def test_file_path_cacheentry():
+    from lal.utils import CacheEntry
+    path = "/path/to/A-B-0-1.txt"
+    assert io_utils.file_path(CacheEntry.from_T050017(path)) == path

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -30,7 +30,7 @@ import numpy
 from LDAStools import frameCPP
 
 from ....io import gwf as io_gwf
-from ....io.cache import file_list
+from ....io.utils import file_list
 from ....segments import Segment
 from ....time import LIGOTimeGPS
 from ... import TimeSeries

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -34,7 +34,8 @@ import lal
 from lal.utils import CacheEntry
 
 
-from ....io import cache as io_cache
+from ....io.cache import is_cache
+from ....io.utils import (FILE_LIKE, file_list)
 from ....utils import lal as lalutils
 from ... import TimeSeries
 
@@ -63,7 +64,7 @@ def open_data_source(source):
     ValueError
         If the input format cannot be identified.
     """
-    if isinstance(source, io_cache.FILE_LIKE):
+    if isinstance(source, FILE_LIKE):
         source = source.name
     if isinstance(source, CacheEntry):
         source = source.path
@@ -74,9 +75,9 @@ def open_data_source(source):
         return lalframe.FrStreamCacheOpen(lal.CacheImport(source))
 
     # read glue cache object
-    if isinstance(source, list) and io_cache.is_cache(source):
+    if isinstance(source, list) and is_cache(source):
         cache = lal.Cache()
-        for entry in io_cache.file_list(source):
+        for entry in file_list(source):
             cache = lal.CacheMerge(cache, lal.CacheGlob(*os.path.split(entry)))
         return lalframe.FrStreamCacheOpen(cache)
 


### PR DESCRIPTION
This PR renames/relocates the following methods and variables:

- `gwpy.io.cache.FILE_LIKE` -> `gwpy.io.utils.FILE_LIKE`
- `gwpy.io.cache.file_name` -> `gwpy.io.utils.file_path`
- `gwpy.io.cache.file_list` -> `gwpy.io.utils.file_list`

and updates their usage and tests throughout the package. This is backwards compatible (the new names are imported to their old locations, with appropriate `DeprecationWarnings`).