### PR TITLE
Improved EventTable I/O with decorators

### DIFF
--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -19,7 +19,14 @@
 """Input/output methods for tabular data.
 """
 
-from . import (  # pylint: disable=unused-import
+# utils.py provides some decorators, but importantly applies those
+# decorators _automatically_ to the existing registered readers
+# provided by astropy, so this needs to come first.
+from . import utils
+
+# other readers are defined in their own modules, and are responsible
+# for applying the decorators themselves.
+from . import (
     ligolw,  # glue.ligolw XML format
     root,  # generic ROOT stuff
     omicron,  # Omicron ROOT format

--- a/gwpy/table/io/cwb.py
+++ b/gwpy/table/io/cwb.py
@@ -25,6 +25,7 @@ from astropy.io.ascii import core
 
 from ...io import registry
 from .. import (Table, EventTable)
+from .utils import decorate_registered_reader
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -115,6 +116,13 @@ class Cwb(core.BaseReader):
     data_class = CwbData
 
 
-# register ascii.cwb for EventTable
+# register for EventTable
 registry.register_reader(
-    'ascii.cwb', EventTable, registry.get_reader('ascii.cwb', Table))
+    "ascii.cwb",
+    EventTable,
+    registry.get_reader("ascii.cwb", Table),
+)
+decorate_registered_reader(
+    "ascii.cwb",
+    EventTable,
+)

--- a/gwpy/table/io/omega.py
+++ b/gwpy/table/io/omega.py
@@ -25,6 +25,7 @@ from astropy.io.ascii import core
 
 from ...io import registry
 from .. import (Table, EventTable)
+from .utils import decorate_registered_reader
 
 
 class OmegaHeader(core.BaseHeader):
@@ -80,6 +81,14 @@ class Omega(core.BaseReader):
     data_class = OmegaData
 
 
-# register ascii.omega for EventTable
+# register for EventTable
+# (to populate that object's docstring)
 registry.register_reader(
-    'ascii.omega', EventTable, registry.get_reader('ascii.omega', Table))
+    'ascii.omega',
+    EventTable,
+    registry.get_reader("ascii.omega", Table),
+)
+decorate_registered_reader(
+    "ascii.omega",
+    EventTable,
+)

--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -19,8 +19,6 @@
 """Read events from ROOT trees into Tables
 """
 
-import warnings
-
 from six import string_types
 
 from ...io import registry
@@ -31,21 +29,10 @@ from .. import (Table, EventTable)
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
-def table_from_root(source, treename=None, include_names=None, **kwargs):
+def table_from_root(source, treename=None, columns=None, **kwargs):
     """Read a Table from a ROOT tree
     """
     import root_numpy
-
-    if include_names is None:
-        try:
-            include_names = kwargs.pop('columns')
-        except KeyError:
-            pass
-        else:
-            warnings.warn("Keyword argument `columns` has been renamed to "
-                          "`include_names` to better match default "
-                          "astropy.table.Table.read kwargs, please update "
-                          "your call.", DeprecationWarning)
 
     # parse column filters into tree2array ``selection`` keyword
     # NOTE: not all filters can be passed directly to root_numpy, so we store
@@ -84,8 +71,12 @@ def table_from_root(source, treename=None, include_names=None, **kwargs):
                              % (source, ', '.join(map(repr, trees))))
 
     # read, filter, and return
-    t = Table(root_numpy.root2array(source, treename,
-                                    branches=include_names, **kwargs))
+    t = Table(root_numpy.root2array(
+        source,
+        treename,
+        branches=columns,
+        **kwargs
+    ))
     if filters:
         return filter_table(t, *filters)
     return t

--- a/gwpy/table/io/utils.py
+++ b/gwpy/table/io/utils.py
@@ -19,25 +19,49 @@
 """Utilities for Table I/O
 """
 
-from functools import wraps
+import functools
 
+from astropy.io import registry
+
+from .. import EventTable
 from ..filter import filter_table
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+def _safe_wraps(wrapper, func):
+    try:
+        return functools.update_wrapper(wrapper, func)
+    except AttributeError:  # func is partial
+        return wrapper
+
+
+def read_with_columns(func):
+    """Decorate a Table read method to use the ``columns`` keyword
+    """
+    def wrapper(*args, **kwargs):
+        # parse columns argument
+        columns = kwargs.pop("columns", None)
+
+        # read table
+        tab = func(*args, **kwargs)
+
+        # filter on columns
+        if columns is None:
+            return tab
+        return tab[columns]
+
+    return _safe_wraps(wrapper, func)
+
+
 def read_with_selection(func):
     """Decorate a Table read method to apply ``selection`` keyword
     """
-    @wraps(func)
-    def decorated_func(*args, **kwargs):
+    def wrapper(*args, **kwargs):
         """Execute a function, then apply a selection filter
         """
         # parse selection
-        try:
-            selection = kwargs.pop('selection')
-        except KeyError:
-            selection = []
+        selection = kwargs.pop('selection', None) or []
 
         # read table
         tab = func(*args, **kwargs)
@@ -48,4 +72,45 @@ def read_with_selection(func):
 
         return tab
 
-    return decorated_func
+    return _safe_wraps(wrapper, func)
+
+
+# override astropy's readers with decorated versions that accept our
+# "selection" keyword argument,
+# this is bit hacky, and someone should probably come up with something
+# better
+
+def decorate_registered_reader(
+        name,
+        data_class=EventTable,
+        columns=True,
+        selection=True,
+):
+    """Wrap an existing registered reader to use GWpy's input decorators
+
+    Parameters
+    ----------
+    name : `str`
+        the name of the registered format
+
+    data_class : `type`, optional
+        the class for whom the format is registered
+
+    columns : `bool`, optional
+        use the `read_with_columns` decorator
+
+    selection : `bool`, optional
+        use the `read_with_selection` decorator
+    """
+    reader = registry.get_reader(name, data_class)
+    wrapped = (  # nopep8
+        read_with_columns(  # use ``columns``
+        read_with_selection(  # use ``selection``
+            reader
+        ))
+    )
+    return registry.register_reader(name, data_class, wrapped, force=True)
+
+
+for row in registry.get_formats(data_class=EventTable, readwrite="Read"):
+    decorate_registered_reader(row["Format"], data_class=EventTable)

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -46,12 +46,6 @@ def inherit_io_registrations(cls):
     parent = cls.__mro__[1]
     for row in registry.get_formats(data_class=parent):
         name = row["Format"]
-        # dont inherit deprecated names
-        try:
-            if row["Deprecated"].lower() == "yes":
-                continue
-        except KeyError:
-            pass
         # read
         if row["Read"].lower() == "yes":
             registry.register_reader(

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -555,7 +555,8 @@ class TestEventTable(TestTable):
             utils.assert_table_equal(table, t2)
 
             # assert processed colums works
-            t2 = self.TABLE.read(fp,
+            t2 = self.TABLE.read(
+                fp,
                 format="hdf5.pycbc_live",
                 ifo="X1",
                 columns=["mchirp", "new_snr"],

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -564,10 +564,18 @@ class TestEventTable(TestTable):
                 table['mass1'] + table['mass2']) ** (1/5.)
             utils.assert_array_equal(t2['mchirp'], mchirp)
 
-            # test with selection
-            t2 = self.TABLE.read(fp, format='hdf5.pycbc_live',
-                                 ifo='X1', selection='snr>.5')
-            utils.assert_table_equal(filter_table(table, 'snr>.5'), t2)
+            # test with selection and columns
+            t2 = self.TABLE.read(
+                fp,
+                format='hdf5.pycbc_live',
+                ifo='X1',
+                selection='snr>.5',
+                columns=("a", "b", "mass1"),
+            )
+            utils.assert_table_equal(
+                t2,
+                filter_table(table, 'snr>.5')[("a", "b", "mass1")],
+            )
         finally:
             if os.path.isdir(os.path.dirname(fp)):
                 shutil.rmtree(os.path.dirname(fp))

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -423,24 +423,62 @@ class TestEventTable(TestTable):
 
     # -- test I/O -------------------------------
 
+    def test_read_write_hdf5(self, table):
+        # check that our overrides of astropy's H5 reader
+        # didn't break everything
+        with utils.TemporaryFilename(suffix=".h5") as tmp:
+            table.write(tmp, path="/data")
+            t2 = self.TABLE.read(tmp, path="/data")
+            utils.assert_table_equal(t2, table)
+
+            t2 = self.TABLE.read(
+                tmp,
+                path="/data",
+                selection="frequency>500",
+                columns=["time", "snr"],
+            )
+            utils.assert_table_equal(
+                t2,
+                filter_table(table, "frequency>500")[("time", "snr")],
+            )
+
     @pytest.mark.parametrize('fmtname', ('Omega', 'cWB'))
     def test_read_write_ascii(self, table, fmtname):
-        fmt = 'ascii.%s' % fmtname.lower()
+        fmt = 'ascii.{}'.format(fmtname.lower())
         with utils.TemporaryFilename(suffix='.txt') as tmp:
             # check write/read returns the same table
             with open(tmp, 'w') as fobj:
                 table.write(fobj, format=fmt)
-            utils.assert_table_equal(table, self.TABLE.read(tmp, format=fmt),
-                                     almost_equal=True)
+            t2 = self.TABLE.read(tmp, format=fmt)
+            utils.assert_table_equal(table, t2, almost_equal=True)
 
+            # check that we can use selections and column filtering
+            t2 = self.TABLE.read(
+                tmp,
+                format=fmt,
+                selection="frequency>500",
+                columns=["time", "snr"],
+            )
+            utils.assert_table_equal(
+                t2,
+                filter_table(table, "frequency>500")[("time", "snr")],
+                almost_equal=True,
+            )
+
+    @pytest.mark.parametrize('fmtname', ('Omega', 'cWB'))
+    def test_read_write_ascii_error(self, table, fmtname):
         with utils.TemporaryFilename(suffix='.txt') as tmp:
             with open(tmp, 'w') as f:
                 pass  # write empty file
             # assert reading blank file doesn't work with column name error
             with pytest.raises(InconsistentTableError) as exc:
-                self.TABLE.read(tmp, format=fmt)
-            assert str(exc.value) == ('No column names found in %s header'
-                                      % fmtname)
+                self.TABLE.read(
+                    tmp,
+                    format="ascii.{}".format(fmtname.lower()),
+                )
+            assert str(exc.value) == (
+                'No column names found in {} header'.format(fmtname)
+            )
 
     def test_read_pycbc_live(self):
         table = self.create(
@@ -460,22 +498,25 @@ class TestEventTable(TestTable):
                 group['psd'].attrs['delta_f'] = psd.df.to('Hz').value
 
             # check that we can read
-            t2 = self.TABLE.read(fp)
+            t2 = self.TABLE.read(fp, format="hdf5.pycbc_live")
             utils.assert_table_equal(table, t2)
             # and check metadata was recorded correctly
             assert t2.meta['ifo'] == 'X1'
 
             # check keyword arguments result in same table
-            t2 = self.TABLE.read(fp, format='hdf5.pycbc_live')
-            utils.assert_table_equal(table, t2)
             t2 = self.TABLE.read(fp, format='hdf5.pycbc_live', ifo='X1')
+            utils.assert_table_equal(table, t2)
 
             # assert loudest works
-            t2 = self.TABLE.read(fp, loudest=True)
+            t2 = self.TABLE.read(fp, format="hdf5.pycbc_live", loudest=True)
             utils.assert_table_equal(table.filter('snr > 500'), t2)
 
             # check extended_metadata=True works (default)
-            t2 = self.TABLE.read(fp, extended_metadata=True)
+            t2 = self.TABLE.read(
+                fp,
+                format="hdf5.pycbc_live",
+                extended_metadata=True,
+            )
             utils.assert_table_equal(table, t2)
             utils.assert_array_equal(t2.meta['loudest'], loudest)
             utils.assert_quantity_sub_equal(
@@ -483,11 +524,20 @@ class TestEventTable(TestTable):
                 exclude=['name', 'channel', 'unit', 'epoch'])
 
             # check extended_metadata=False works
-            t2 = self.TABLE.read(fp, extended_metadata=False)
+            t2 = self.TABLE.read(
+                fp,
+                format="hdf5.pycbc_live",
+                extended_metadata=False,
+            )
             assert t2.meta == {'ifo': 'X1'}
 
             # double-check that loudest and extended_metadata=False work
-            t2 = self.TABLE.read(fp, loudest=True, extended_metadata=False)
+            t2 = self.TABLE.read(
+                fp,
+                format="hdf5.pycbc_live",
+                loudest=True,
+                extended_metadata=False,
+            )
             utils.assert_table_equal(table.filter('snr > 500'), t2)
             assert t2.meta == {'ifo': 'X1'}
 
@@ -496,7 +546,7 @@ class TestEventTable(TestTable):
             with h5py.File(fp) as h5f:
                 h5f.create_group('Z1')
             with pytest.raises(ValueError) as exc:
-                self.TABLE.read(fp)
+                self.TABLE.read(fp, format="hdf5.pycbc_live")
             assert str(exc.value).startswith(
                 'PyCBC live HDF5 file contains dataset groups')
 
@@ -505,7 +555,11 @@ class TestEventTable(TestTable):
             utils.assert_table_equal(table, t2)
 
             # assert processed colums works
-            t2 = self.TABLE.read(fp, ifo='X1', columns=['mchirp', 'new_snr'])
+            t2 = self.TABLE.read(fp,
+                format="hdf5.pycbc_live",
+                ifo="X1",
+                columns=["mchirp", "new_snr"],
+            )
             mchirp = (table['mass1'] * table['mass2']) ** (3/5.) / (
                 table['mass1'] + table['mass2']) ** (1/5.)
             utils.assert_array_equal(t2['mchirp'], mchirp)


### PR DESCRIPTION
This PR attempts to improve the `EventTable` I/O system, mainly to make the keyword arguments more consistent across formats.

All readers (including those inherited from astropy) now accept the `columns` and `selection` keywords, mainly thanks to the new `gwpy.table.io.utils.decorate_registered_reader` function.

This is technically backwards incompatible since it registers the 'hdf5' reader for the `EventTable`, meaning PyCBC HDF5 files cannot be distinguished from normal HDF5 files, which in turns means the `format` keyword now needs to be explicitly given when reading either PyCBC Live files.