### PR TITLE
Fixed bug reading two-col segments

### DIFF
--- a/gwpy/segments/io/segwizard.py
+++ b/gwpy/segments/io/segwizard.py
@@ -108,7 +108,7 @@ def _format_segment(tokens, strict=True, gpstype=LIGOTimeGPS):
     try:
         start, end, dur = tokens
     except ValueError:  # two-columns
-        return Segment(map(gpstype, tokens))
+        return Segment(*map(gpstype, tokens))
     seg = Segment(gpstype(start), gpstype(end))
     if strict and not float(abs(seg)) == float(dur):
         raise ValueError(

--- a/gwpy/segments/tests/test_segments.py
+++ b/gwpy/segments/tests/test_segments.py
@@ -112,6 +112,14 @@ class TestSegmentList(object):
             sl = self.TEST_CLASS.read(tmp, strict=False, format='segwizard')
             assert_segmentlist_equal(sl, [(0, 1)])
 
+    def test_read_write_segwizard_twocol(self):
+        with TemporaryFilename(suffix='.txt') as tmp:
+            with open(tmp, "w") as tmpf:
+                print("0 1", file=tmpf)
+                print("2 3", file=tmpf)
+            sl = self.TEST_CLASS.read(tmp, format='segwizard')
+            assert_segmentlist_equal(sl, [(0, 1), (2, 3)])
+
     @pytest.mark.parametrize('ext', ('.hdf5', '.h5'))
     def test_read_write_hdf5(self, segmentlist, ext):
         with TemporaryFilename(suffix=ext) as fp:


### PR DESCRIPTION
This PR fixes a bug in `gwpy.segments.io.segwizard` when reading segments from a two-column ASCII file (python3 only).