### PR TITLE
Updated copyright years for all files under our license

### DIFF
--- a/bin/gwpy-plot
+++ b/bin/gwpy-plot
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) Joseph Areeda (2015)
+# Copyright (C) Joseph Areeda (2015-2019)
 #
 # This file is part of GWpy.
 #

--- a/ci/coveralls.sh
+++ b/ci/coveralls.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/ci/install-macports.sh
+++ b/ci/install-macports.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/ci/install-pip.sh
+++ b/ci/install-pip.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Contact: Duncan Macleod <duncan.macleod@ligo.org>
 Source: https://git.ligo.org/gwpy/gwpy
 
 Files: *
-Copyright: 2018 Duncan Macleod <duncan.macleod@ligo.org>
+Copyright: 2018-2019 Duncan Macleod <duncan.macleod@ligo.org>
 License: GPL-3+
 
 License: GPL-3+

--- a/docs/_static/css/gwpy-sphinx.css
+++ b/docs/_static/css/gwpy-sphinx.css
@@ -1,4 +1,4 @@
-/* Copyright (C) Duncan Macleod (2014)
+/* Copyright (C) Duncan Macleod (2014-2019)
  *
  * This file is part of GWpy.
  *

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -24,7 +24,14 @@ Step-by-step
 
       $ git flow release start 1.0.0
 
-   and then ``publish`` it, allowing CI to run, and others to contribute:
+#. **Update the copyright:**
+
+   .. code-block:: bash
+
+      $ python -c "from setup_utils import update_all_copyright; update_all_copyright($(date +%Y))"
+      $ git commit -S . -m "Updated copyright for release"
+
+#. **``publish`` the release branch**, allowing CI to run, and others to contribute:
 
    .. code-block:: bash
 

--- a/docs/ex2rst.py
+++ b/docs/ex2rst.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/frequencyseries/coherence.py
+++ b/examples/frequencyseries/coherence.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/frequencyseries/hoff.py
+++ b/examples/frequencyseries/hoff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/frequencyseries/inject.py
+++ b/examples/frequencyseries/inject.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Alexander Urban (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/frequencyseries/percentiles.py
+++ b/examples/frequencyseries/percentiles.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/frequencyseries/rayleigh.py
+++ b/examples/frequencyseries/rayleigh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013-2015)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/frequencyseries/transfer_function.py
+++ b/examples/frequencyseries/transfer_function.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with GWpy.  If not, see <http://www.gnu.org/licenses/>"""GWpy Example: plotting a time-series
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """Plotting a transfer function
 

--- a/examples/frequencyseries/variance.py
+++ b/examples/frequencyseries/variance.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013-2015)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with GWpy.  If not, see <http://www.gnu.org/licenses/>
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """Calculating and plotting a `SpectralVariance` histogram
 

--- a/examples/miscellaneous/open-data-spectrogram.py
+++ b/examples/miscellaneous/open-data-spectrogram.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """Plotting a spectrogram of all open data for 1 day
 

--- a/examples/miscellaneous/range-timeseries.py
+++ b/examples/miscellaneous/range-timeseries.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """Generating an inspiral range timeseries
 

--- a/examples/segments/open-data.py
+++ b/examples/segments/open-data.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2018-2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 """Plotting observing segments for O1
 

--- a/examples/signal/gw150914.py
+++ b/examples/signal/gw150914.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright (C) Duncan Macleod (2016)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2016-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/signal/qscan.py
+++ b/examples/signal/qscan.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/spectrogram/coherence.py
+++ b/examples/spectrogram/coherence.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/spectrogram/plot.py
+++ b/examples/spectrogram/plot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/spectrogram/ratio.py
+++ b/examples/spectrogram/ratio.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/spectrogram/rayleigh.py
+++ b/examples/spectrogram/rayleigh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/spectrogram/spectrogram2.py
+++ b/examples/spectrogram/spectrogram2.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/table/histogram.py
+++ b/examples/table/histogram.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2014)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/table/rate.py
+++ b/examples/table/rate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2014)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/table/rate_binned.py
+++ b/examples/table/rate_binned.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2014)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/table/scatter.py
+++ b/examples/table/scatter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2014)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/table/tiles.py
+++ b/examples/table/tiles.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2014)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/blrms.py
+++ b/examples/timeseries/blrms.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013-2015)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/correlate.py
+++ b/examples/timeseries/correlate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/filter.py
+++ b/examples/timeseries/filter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/inject.py
+++ b/examples/timeseries/inject.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
-
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/public.py
+++ b/examples/timeseries/public.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/pycbc-snr.py
+++ b/examples/timeseries/pycbc-snr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2017)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/qscan.py
+++ b/examples/timeseries/qscan.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/statevector.py
+++ b/examples/timeseries/statevector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/examples/timeseries/whiten.py
+++ b/examples/timeseries/whiten.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-
-# Copyright (C) Duncan Macleod (2013)
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/__init__.py
+++ b/gwpy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/astro/__init__.py
+++ b/gwpy/astro/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/astro/tests/__init__.py
+++ b/gwpy/astro/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/__init__.py
+++ b/gwpy/cli/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (C) Joseph Areeda (2015)
+# Copyright (C) Joseph Areeda (2015-2019)
 #
 # This file is part of GWpy.
 #
@@ -17,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Base class for CLI (`gwpy-plot`) products.
 """

--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (C) Joseph Areeda (2015)
+# Copyright (C) Joseph Areeda (2015-2019)
 #
 # This file is part of GWpy.
 #
@@ -17,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Coherence plots
 """

--- a/gwpy/cli/coherencegram.py
+++ b/gwpy/cli/coherencegram.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (C) Joseph Areeda (2015)
+# Copyright (C) Joseph Areeda (2015-2019)
 #
 # This file is part of GWpy.
 #
@@ -17,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Coherence spectrogram
 """

--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (C) Joseph Areeda (2017)
+# Copyright (C) Joseph Areeda (2017-2019)
 #
 # This file is part of GWpy.
 #
@@ -17,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """ Q-transform plots
 """

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (C) Joseph Areeda (2015)
+# Copyright (C) Joseph Areeda (2015-2019)
 #
 # This file is part of GWpy.
 #
@@ -17,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """ Spectrogram plots
 """

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (C) Joseph Areeda (2015)
+# Copyright (C) Joseph Areeda (2015-2019)
 #
 # This file is part of GWpy.
 #
@@ -17,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """Spectrum plots
 """

--- a/gwpy/cli/tests/__init__.py
+++ b/gwpy/cli/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/tests/base.py
+++ b/gwpy/cli/tests/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/tests/test_coherence.py
+++ b/gwpy/cli/tests/test_coherence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/tests/test_coherencegram.py
+++ b/gwpy/cli/tests/test_coherencegram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/tests/test_spectrogram.py
+++ b/gwpy/cli/tests/test_spectrogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/tests/test_spectrum.py
+++ b/gwpy/cli/tests/test_spectrum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/tests/test_timeseries.py
+++ b/gwpy/cli/tests/test_timeseries.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (C) Joseph Areeda (2015)
+# Copyright (C) Joseph Areeda (2015-2019)
 #
 # This file is part of GWpy.
 #
@@ -17,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
-#
 
 """The timeseries CLI product
 """

--- a/gwpy/conftest.py
+++ b/gwpy/conftest.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/detector/__init__.py
+++ b/gwpy/detector/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/detector/io/__init__.py
+++ b/gwpy/detector/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/detector/io/cis.py
+++ b/gwpy/detector/io/cis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2015-)
+# Copyright (C) Duncan Macleod (2015-2019)
 #
-# This file is part of the GWpy python package.
+# This file is part of GWpy.
 #
 # GWpy is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gwpy/detector/io/omega.py
+++ b/gwpy/detector/io/omega.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2015)
+# Copyright (C) Duncan Macleod (2015-2019)
 #
-# This file is part of the GWpy python package.
+# This file is part of GWpy.
 #
 # GWpy is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/gwpy/detector/tests/__init__.py
+++ b/gwpy/detector/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/detector/tests/test_channel.py
+++ b/gwpy/detector/tests/test_channel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/detector/tests/test_units.py
+++ b/gwpy/detector/tests/test_units.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013-2015)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/__init__.py
+++ b/gwpy/frequencyseries/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/_fdcommon.py
+++ b/gwpy/frequencyseries/_fdcommon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/io/__init__.py
+++ b/gwpy/frequencyseries/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/io/ascii.py
+++ b/gwpy/frequencyseries/io/ascii.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/io/hdf5.py
+++ b/gwpy/frequencyseries/io/hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/io/ligolw.py
+++ b/gwpy/frequencyseries/io/ligolw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/tests/__init__.py
+++ b/gwpy/frequencyseries/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/__init__.py
+++ b/gwpy/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
-
+#
 # GWpy is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
-
+#
 # GWpy is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/gwpy/io/hdf5.py
+++ b/gwpy/io/hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/kerberos.py
+++ b/gwpy/io/kerberos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/registry.py
+++ b/gwpy/io/registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/tests/__init__.py
+++ b/gwpy/io/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/tests/test_cache.py
+++ b/gwpy/io/tests/test_cache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/tests/test_gwf.py
+++ b/gwpy/io/tests/test_gwf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/tests/test_kerberos.py
+++ b/gwpy/io/tests/test_kerberos.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/tests/test_ligolw.py
+++ b/gwpy/io/tests/test_ligolw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/tests/test_utils.py
+++ b/gwpy/io/tests/test_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/__init__.py
+++ b/gwpy/plot/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/bode.py
+++ b/gwpy/plot/bode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/colorbar.py
+++ b/gwpy/plot/colorbar.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/colors.py
+++ b/gwpy/plot/colors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/log.py
+++ b/gwpy/plot/log.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/rc.py
+++ b/gwpy/plot/rc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/segments.py
+++ b/gwpy/plot/segments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/__init__.py
+++ b/gwpy/plot/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_bode.py
+++ b/gwpy/plot/tests/test_bode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_colors.py
+++ b/gwpy/plot/tests/test_colors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_gps.py
+++ b/gwpy/plot/tests/test_gps.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_log.py
+++ b/gwpy/plot/tests/test_log.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_rc.py
+++ b/gwpy/plot/tests/test_rc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_segments.py
+++ b/gwpy/plot/tests/test_segments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_tex.py
+++ b/gwpy/plot/tests/test_tex.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/test_text.py
+++ b/gwpy/plot/tests/test_text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tests/utils.py
+++ b/gwpy/plot/tests/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/tex.py
+++ b/gwpy/plot/tex.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/text.py
+++ b/gwpy/plot/text.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/units.py
+++ b/gwpy/plot/units.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/plot/utils.py
+++ b/gwpy/plot/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/__init__.py
+++ b/gwpy/segments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/io/__init__.py
+++ b/gwpy/segments/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/io/hdf5.py
+++ b/gwpy/segments/io/hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/io/json.py
+++ b/gwpy/segments/io/json.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/io/segwizard.py
+++ b/gwpy/segments/io/segwizard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/segments.py
+++ b/gwpy/segments/segments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/tests/__init__.py
+++ b/gwpy/segments/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/segments/tests/test_segments.py
+++ b/gwpy/segments/tests/test_segments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/__init__.py
+++ b/gwpy/signal/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2016)
+# Copyright (C) Duncan Macleod (2016-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/fft/__init__.py
+++ b/gwpy/signal/fft/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/fft/basic.py
+++ b/gwpy/signal/fft/basic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/fft/lal.py
+++ b/gwpy/signal/fft/lal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/fft/pycbc.py
+++ b/gwpy/signal/fft/pycbc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/fft/registry.py
+++ b/gwpy/signal/fft/registry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/fft/scipy.py
+++ b/gwpy/signal/fft/scipy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/fft/ui.py
+++ b/gwpy/signal/fft/ui.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/fft/utils.py
+++ b/gwpy/signal/fft/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2016)
+# Copyright (C) Duncan Macleod (2016-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/tests/__init__.py
+++ b/gwpy/signal/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/tests/test_fft.py
+++ b/gwpy/signal/tests/test_fft.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/tests/test_qtransform.py
+++ b/gwpy/signal/tests/test_qtransform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Alex Urban (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/tests/test_window.py
+++ b/gwpy/signal/tests/test_window.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/signal/window.py
+++ b/gwpy/signal/window.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/spectrogram/__init__.py
+++ b/gwpy/spectrogram/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/spectrogram/coherence.py
+++ b/gwpy/spectrogram/coherence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/spectrogram/io/__init__.py
+++ b/gwpy/spectrogram/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/spectrogram/io/hdf5.py
+++ b/gwpy/spectrogram/io/hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/spectrogram/spectrogram.py
+++ b/gwpy/spectrogram/spectrogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/spectrogram/tests/__init__.py
+++ b/gwpy/spectrogram/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/__init__.py
+++ b/gwpy/table/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/filters.py
+++ b/gwpy/table/filters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/gravityspy.py
+++ b/gwpy/table/gravityspy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Scott Coughlin (2017)
+# Copyright (C) Scott Coughlin (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/cwb.py
+++ b/gwpy/table/io/cwb.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/fetch.py
+++ b/gwpy/table/io/fetch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/gravityspy.py
+++ b/gwpy/table/io/gravityspy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Scott Coughlin (2017)
+# Copyright (C) Scott Coughlin (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/gwf.py
+++ b/gwpy/table/io/gwf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/hacr.py
+++ b/gwpy/table/io/hacr.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013-2016)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/omega.py
+++ b/gwpy/table/io/omega.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/omicron.py
+++ b/gwpy/table/io/omicron.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/sql.py
+++ b/gwpy/table/io/sql.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Scott Coughlin (2017)
+# Copyright (C) Scott Coughlin (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/utils.py
+++ b/gwpy/table/io/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/tests/__init__.py
+++ b/gwpy/table/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/testing/__init__.py
+++ b/gwpy/testing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/testing/compat.py
+++ b/gwpy/testing/compat.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/testing/fixtures.py
+++ b/gwpy/testing/fixtures.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/testing/mocks.py
+++ b/gwpy/testing/mocks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/time/__init__.py
+++ b/gwpy/time/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/time/__main__.py
+++ b/gwpy/time/__main__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/time/tests/__init__.py
+++ b/gwpy/time/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/time/tests/test_time.py
+++ b/gwpy/time/tests/test_time.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/__init__.py
+++ b/gwpy/timeseries/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/__init__.py
+++ b/gwpy/timeseries/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/ascii.py
+++ b/gwpy/timeseries/io/ascii.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/core.py
+++ b/gwpy/timeseries/io/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/hdf5.py
+++ b/gwpy/timeseries/io/hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/io/wav.py
+++ b/gwpy/timeseries/io/wav.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/tests/__init__.py
+++ b/gwpy/timeseries/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/__init__.py
+++ b/gwpy/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013-2016)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013-2016)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013-2016)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013-2016)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/io/__init__.py
+++ b/gwpy/types/io/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/io/ascii.py
+++ b/gwpy/types/io/ascii.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/io/hdf5.py
+++ b/gwpy/types/io/hdf5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/io/ligolw.py
+++ b/gwpy/types/io/ligolw.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013-2016)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/tests/__init__.py
+++ b/gwpy/types/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/tests/test_array.py
+++ b/gwpy/types/tests/test_array.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/tests/test_index.py
+++ b/gwpy/types/tests/test_index.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/__init__.py
+++ b/gwpy/utils/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/env.py
+++ b/gwpy/utils/env.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/mp.py
+++ b/gwpy/utils/mp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/progress.py
+++ b/gwpy/utils/progress.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/shell.py
+++ b/gwpy/utils/shell.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/sphinx/__init__.py
+++ b/gwpy/utils/sphinx/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/sphinx/zenodo.py
+++ b/gwpy/utils/sphinx/zenodo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/tests/__init__.py
+++ b/gwpy/utils/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/tests/test_decorators.py
+++ b/gwpy/utils/tests/test_decorators.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/tests/test_env.py
+++ b/gwpy/utils/tests/test_env.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018)
+# Copyright (C) Duncan Macleod (2018-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/tests/test_lal.py
+++ b/gwpy/utils/tests/test_lal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/tests/test_misc.py
+++ b/gwpy/utils/tests/test_misc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/tests/test_mp.py
+++ b/gwpy/utils/tests/test_mp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/utils/tests/test_shell.py
+++ b/gwpy/utils/tests/test_shell.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2013)
+# Copyright (C) Duncan Macleod (2014-2019)
 #
 # This file is part of GWpy.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2016)
+# Copyright (C) Duncan Macleod (2016-2019)
 #
 # This file is part of GWpy.
 #

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -26,6 +26,7 @@ import datetime
 import glob
 import hashlib
 import os
+import re
 import subprocess
 import shutil
 import sys
@@ -35,6 +36,7 @@ from distutils.command.clean import (clean as orig_clean, log, remove_tree)
 from distutils.command.bdist_rpm import bdist_rpm as distutils_bdist_rpm
 from distutils.errors import DistutilsArgError
 from distutils.version import (LooseVersion, StrictVersion)
+from itertools import groupby
 
 from setuptools.command.bdist_rpm import bdist_rpm as _bdist_rpm
 from setuptools.command.sdist import sdist as _sdist
@@ -45,6 +47,7 @@ CMDCLASS = versioneer.get_cmdclass()
 SETUP_REQUIRES = {
     'test': ['pytest_runner'],
 }
+COPYRIGHT_REGEX = re.compile(r"Copyright[\S ]+(?P<years>\d\d\d\d([, \d-]+)?)")
 
 # -- documentation builder ----------------------------------------------------
 
@@ -516,3 +519,74 @@ def get_scripts(scripts_dir='bin'):
     for (dirname, _, filenames) in os.walk(scripts_dir):
         scripts.extend([os.path.join(dirname, fn) for fn in filenames])
     return scripts
+
+
+def _parse_years(years):
+    """Parse string of ints include ranges into a `list` of `int`
+
+    Source: https://stackoverflow.com/a/6405228/1307974
+    """
+    result = []
+    for part in years.split(','):
+        if '-' in part:
+            a, b = part.split('-')
+            a, b = int(a), int(b)
+            result.extend(range(a, b + 1))
+        else:
+            a = int(part)
+            result.append(a)
+    return result
+
+
+def _format_years(years):
+    """Format a list of ints into a string including ranges
+
+    Source: https://stackoverflow.com/a/9471386/1307974
+    """
+    def sub(x):
+        return x[1] - x[0]
+
+    ranges = []
+    for k, iterable in groupby(enumerate(sorted(years)), sub):
+        rng = list(iterable)
+        if len(rng) == 1:
+            s = str(rng[0][1])
+        else:
+            s = "{}-{}".format(rng[0][1], rng[-1][1])
+        ranges.append(s)
+    return ", ".join(ranges)
+
+
+def update_copyright(path, year):
+    """Update a file's copyright statement to include the given year
+    """
+    with open(path, "r") as fobj:
+        text = fobj.read().rstrip()
+    match = COPYRIGHT_REGEX.search(text)
+    x = match.start("years")
+    y = match.end("years")
+    if text[y-1] == " ":  # don't strip trailing whitespace
+        y -= 1
+    yearstr = match.group("years")
+    years = set(_parse_years(yearstr)) | {year}
+    with open(path, "w") as fobj:
+        print(text[:x] + _format_years(years) + text[y:], file=fobj)
+
+
+def update_all_copyright(year):
+    files = subprocess.check_output([
+        "git", "grep", "-l", "-E", r"(\#|\*) Copyright",
+    ]).strip().splitlines()
+    ignore = {
+        "gwpy/utils/sphinx/epydoc.py",
+        "docs/_static/js/copybutton.js",
+    }
+    for path in files:
+        if path.decode() in ignore:
+            continue
+        try:
+            update_copyright(path, year)
+        except AttributeError:
+            raise RuntimeError(
+                "failed to update copyright for {!r}".format(path),
+            )

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017)
+# Copyright (C) Duncan Macleod (2017-2019)
 #
 # This file is part of GWpy.
 #


### PR DESCRIPTION
This PR modifies essentially every file in the repo to update the years of copyright, which should match any year there has been a release: 2014-2019.

I also added a utility to automatically update the copyright statements, and documented that this should be run for each release, it should have no impact when run for a year that is already included in the copyright.

@alurban, @areeda, @scottcoughlin2014, you are listed as copyright holders for one or more files, so I need explicit approval from each of you.