### PR TITLE
Port LIGO_LW I/O to python-ligo-lw

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -79,7 +79,8 @@ apt-get -yqq install \
     ${PY_PREFIX}-lalframe \
     ${PY_PREFIX}-lalsimulation \
     ${PY_PREFIX}-ldas-tools-framecpp \
-    ${PY_PREFIX}-nds2-client
+    ${PY_PREFIX}-nds2-client \
+    ${PY_PREFIX}-ligo-lw
 
 # install ROOT for python2 only
 if [ "${PY_PREFIX}" == "python" ]; then

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -88,6 +88,7 @@ yum -y -q install \
     python2-ldas-tools-framecpp \
     python2-lalframe \
     python2-lalsimulation \
+    python-ligo-lw \
     texlive-dvipng-bin texlive-latex-bin-bin \
     texlive-type1cm texlive-collection-fontsrecommended
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -62,6 +62,9 @@
 .. |numpydoc| replace:: `numpydoc`
 .. _numpydoc: https://numpydoc.readthedocs.io/
 
+.. |python-ligo-lw| replace:: `python-ligo-lw`
+.. _python-ligo-lw: https://git.ligo.org/kipp.cannon/python-ligo-lw
+
 .. |pycbc| replace:: `pycbc`
 .. _pycbc: https://pycbc.org/
 

--- a/docs/segments/io.rst
+++ b/docs/segments/io.rst
@@ -21,11 +21,11 @@ The :meth:`read` and :meth:`write` methods take different arguments and keywords
 ``LIGO_LW`` XML
 ===============
 
-**Additional dependencies:** :mod:`glue.ligolw`
+**Additional dependencies:** |python-ligo-lw|_
 
 The LIGO Scientific Collaboration uses a custom scheme of XML in which to
-store tabular data, called the ``LIGO_LW`` scheme.
-Complementing the scheme is a python library - :mod:`glue.ligolw` - which
+store tabular data, called ``LIGO_LW``.
+Complementing the scheme is a python library - |python-ligo-lw|_ - which
 allows users to read and write all of the different types of tabular data
 produced by gravitational-wave searches.
 
@@ -81,6 +81,18 @@ To replace the segment tables in an existing file, while preserving other tables
 Extra attributes can be written to the tables via the ``attrs={}`` keyword, all attributes are set for all three of the segment-related tables::
 
     >>> f.write('new-table.xml', append=True, overwrite=True, attrs={'process_id': 0})
+
+.. note::
+
+   The |python-ligo-lw| library reads and writes files using an updated
+   version of the format compared to :mod:`glue.ligolw` used to. GWpy
+   should support both format versions natively when _reading_, but
+   when _writing_ you may need to explicitly pass the
+   ``ilwdchar_compat=True`` keyword in order to write using the old
+   format::
+
+       >>> f.write('new-table.xml', ilwdchar_compat=True)
+
 
 `DataQualityDict`
 -----------------

--- a/docs/segments/io.rst
+++ b/docs/segments/io.rst
@@ -85,8 +85,8 @@ Extra attributes can be written to the tables via the ``attrs={}`` keyword, all 
 .. note::
 
    The |python-ligo-lw| library reads and writes files using an updated
-   version of the format compared to :mod:`glue.ligolw` used to. GWpy
-   should support both format versions natively when _reading_, but
+   version of the ``LIGO_LW`` format compared to :mod:`glue.ligolw` used to.
+   GWpy should support both format versions natively when _reading_, but
    when _writing_ you may need to explicitly pass the
    ``ilwdchar_compat=True`` keyword in order to write using the old
    format::

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -45,15 +45,17 @@ but is **not** backported to for use with :meth:`Table.read`.
 ``LIGO_LW`` XML
 ===============
 
-**Additional dependencies:** :mod:`glue.ligolw`
+**Additional dependencies:** |python-ligo-lw|_
 
 The LIGO Scientific Collaboration uses a custom scheme of XML in which to
 store tabular data, called ``LIGO_LW``.
-Complementing the scheme is a python library - :mod:`glue.ligolw` - which
+Complementing the scheme is a python library - |python-ligo-lw|_ - which
 allows users to read and write all of the different types of tabular data
 produced by gravitational-wave searches.
 
-Reading and writing tables in ``LIGO_LW`` XML format is supported with ``format='ligolw', tablename=<tablename>'`` where ``<tablename>`` can be any of the supported LSC table names (see :mod:`glue.ligolw.lsctables`).
+Reading and writing tables in ``LIGO_LW`` XML format is supported with
+``format='ligolw', tablename=<tablename>'`` where ``<tablename>`` can be
+any of the supported LSC table names (see :mod:`ligo.lw.lsctables`).
 
 Reading
 -------
@@ -150,6 +152,18 @@ To write a table to an existing file, use ``append=True``::
 To replace an existing table of the given type in an existing file, while preserving other tables, use *both* ``append=True`` and ``overwrite=True``::
 
     >>> t.write('new-table.xml', format='ligolw', tablename='sngl_burst', append=True, overwrite=True)
+
+.. note::
+
+   The |python-ligo-lw| library reads and writes files using an updated
+   version of the format compared to :mod:`glue.ligolw` used to. GWpy
+   should support both format versions natively when _reading_, but
+   when _writing_ you may need to explicitly pass the
+   ``ilwdchar_compat=True`` keyword in order to write using the old
+   format::
+
+       >>> t.write('new-table.xml', format='ligolw', tablename='sngl_burst',
+       ...         ilwdchar_compat=True)
 
 
 .. _gwpy-table-io-ascii-cwb:

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -156,8 +156,8 @@ To replace an existing table of the given type in an existing file, while preser
 .. note::
 
    The |python-ligo-lw| library reads and writes files using an updated
-   version of the format compared to :mod:`glue.ligolw` used to. GWpy
-   should support both format versions natively when _reading_, but
+   version of the ``LIGO_LW`` format compared to :mod:`glue.ligolw` used to.
+   GWpy should support both format versions natively when _reading_, but
    when _writing_ you may need to explicitly pass the
    ``ilwdchar_compat=True`` keyword in order to write using the old
    format::

--- a/examples/table/rate.py
+++ b/examples/table/rate.py
@@ -33,7 +33,7 @@ __currentmodule__ = 'gwpy.table'
 
 # First, we import the `EventTable` object and read in a set of events from
 # a LIGO_LW-format XML file containing a
-# :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
+# :class:`sngl_burst <ligo.lw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz',
                          tablename='sngl_burst', columns=['peak', 'snr'])

--- a/examples/table/rate_binned.py
+++ b/examples/table/rate_binned.py
@@ -33,7 +33,7 @@ __currentmodule__ = 'gwpy.table'
 
 # First, we import the `EventTable` object and read in a set of events from
 # a LIGO_LW-format XML file containing a
-# :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
+# :class:`sngl_burst <ligo.lw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read('H1-LDAS_STRAIN-968654552-10.xml.gz',
                          tablename='sngl_burst', columns=['peak', 'snr'])

--- a/examples/table/tiles.py
+++ b/examples/table/tiles.py
@@ -32,7 +32,7 @@ __currentmodule__ = 'gwpy.table'
 
 # First, we import the `EventTable` object and read in a set of events from
 # a LIGO_LW-format XML file containing a
-# :class:`sngl_burst <glue.ligolw.lsctables.SnglBurstTable>` table
+# :class:`sngl_burst <ligo.lw.lsctables.SnglBurstTable>` table
 from gwpy.table import EventTable
 events = EventTable.read(
     'H1-LDAS_STRAIN-968654552-10.xml.gz', tablename='sngl_burst',

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -238,7 +238,7 @@ class TestFrequencySeries(_TestSeries):
             assert_equal=utils.assert_quantity_sub_equal,
             assert_kw={'exclude': ['name', 'channel', 'unit', 'epoch']})
 
-    @utils.skip_missing_dependency('glue.ligolw.utils.ligolw_add')
+    @utils.skip_missing_dependency('ligo.lw.utils.ligolw_add')
     def test_read_ligolw(self):
         with tempfile.NamedTemporaryFile(mode='w+') as fobj:
             fobj.write(LIGO_LW_ARRAY)

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -262,8 +262,8 @@ def read_ligolw(source, contenthandler=LIGOLWContentHandler, **kwargs):
                 return read_ligolw(
                     source,
                     contenthandler=contenthandler,
-                    verbose=verbose,
                     ilwdchar_compat=True,
+                    **kwargs
                 )
             except Exception:  # if fails for any reason, use original error
                 pass

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -23,25 +23,89 @@ an 'io' subdirectory of the containing directory for that class.
 """
 
 import os.path
+import re
 from contextlib import contextmanager
 from functools import wraps
+from importlib import import_module
+
+# note: because the "future" module provides a builtins namespace,
+# we need to do this the other way around compared to normal
+try:
+    import __builtin__ as builtins
+except ImportError:  # python >= 3
+    import builtins
 
 from six import string_types
 
 import numpy
 
+try:
+    from ligo.lw.ligolw import (
+        ElementError as LigolwElementError,
+        LIGOLWContentHandler,
+    )
+except ImportError:  # no ligo.lw
+    LigolwElementError = None
+    LIGOLWContentHandler = None
+
 from .utils import (file_list, FILE_LIKE)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+# record actual import function
+_real_import = builtins.__import__
+
+# XML elements
 XML_SIGNATURE = b'<?xml'
 LIGOLW_SIGNATURE = b'<!doctype ligo_lw'
 LIGOLW_ELEMENT = b'<ligo_lw>'
 
+LIGO_LW_MODULE_REGEX = re.compile(r"\Aligo.lw")
+
+# regex to catch all errors associated with reading an old-format file
+# with the new library
+_compat_errors = {
+    r"invalid Column \'process_id\'",
+    r"invalid type \'ilwd:char\'"
+}
+LIGO_LW_COMPAT_ERROR = re.compile("({})".format("|".join(_compat_errors)))
+
+
+# -- import hackery to support ligo.lw and glue.ligolw concurrently -----------
+
+def _ligolw_compat_import(name, *args, **kwargs):
+    name = LIGO_LW_MODULE_REGEX.sub("glue.ligolw", name)
+    return _real_import(name, *args, **kwargs)
+
+
+def _is_glue_ligolw_object(obj):
+    if not isinstance(obj, type):
+        obj = type(obj)
+    return str(obj.__module__).startswith("glue.ligolw")
+
+
+def ilwdchar_compat(func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        use_compat = kwargs.pop(
+            "ilwdchar_compat",
+            any(map(
+                _is_glue_ligolw_object,
+                list(args) + list(kwargs.values()),
+            )),
+        )
+        try:
+            if use_compat:
+                builtins.__import__ = _ligolw_compat_import
+            return func(*args, **kwargs)
+        finally:
+            builtins.__import__ = _real_import
+    return wrapped
+
 
 # -- hack around around TypeError from LIGOTimeGPS(numpy.int32(...)) ----------
 
-def _ligotimegps(s, ns):
+def _ligotimegps(s, ns=0):
     """Catch TypeError and cast `s` and `ns` to `int`
     """
     from lal import LIGOTimeGPS
@@ -52,72 +116,72 @@ def _ligotimegps(s, ns):
 
 
 @contextmanager
-def patch_ligotimegps():
+def patch_ligotimegps(module="ligo.lw.lsctables"):
     """Context manager to on-the-fly patch LIGOTimeGPS to accept all int types
     """
-    from glue.ligolw import lsctables
-    orig = lsctables.LIGOTimeGPS
-    lsctables.LIGOTimeGPS = _ligotimegps
-    yield
-    lsctables.LIGOTimeGPS = orig
+    module = import_module(module)
+    orig = module.LIGOTimeGPS
+    module.LIGOTimeGPS = _ligotimegps
+    try:
+        yield
+    finally:
+        module.LIGOTimeGPS = orig
 
 
 # -- content handling ---------------------------------------------------------
 
+@ilwdchar_compat
 def get_partial_contenthandler(element):
     """Build a `PartialLIGOLWContentHandler` to read only this element
 
     Parameters
     ----------
-    element : `type`
-        the element class to be read, subclass of
-        :class:`~glue.ligolw.ligolw.Element`
+    element : `type`, subclass of :class:`~ligo.lw.ligolw.Element`
+        the element class to be read,
 
     Returns
     -------
     contenthandler : `type`
-        a subclass of :class:`~glue.ligolw.ligolw.PartialLIGOLWContentHandler`
+        a subclass of :class:`~ligo.lw.ligolw.PartialLIGOLWContentHandler`
         to read only the given `element`
     """
-    from glue.ligolw.ligolw import PartialLIGOLWContentHandler
-    from glue.ligolw.table import Table
+    from ligo.lw.ligolw import PartialLIGOLWContentHandler
+    from ligo.lw.table import Table
 
     if issubclass(element, Table):
         def _element_filter(name, attrs):
-            # pylint: disable=unused-argument
             return element.CheckProperties(name, attrs)
     else:
-        def _element_filter(name, attrs):
-            # pylint: disable=unused-argument
+        def _element_filter(name, _):
             return name == element.tagName
 
     return build_content_handler(PartialLIGOLWContentHandler, _element_filter)
 
 
+@ilwdchar_compat
 def get_filtering_contenthandler(element):
     """Build a `FilteringLIGOLWContentHandler` to exclude this element
 
     Parameters
     ----------
-    element : `type`, subclass of :class:`~glue.ligolw.ligolw.Element`
+    element : `type`, subclass of :class:`~ligo.lw.ligolw.Element`
         the element to exclude (and its children)
 
     Returns
     -------
     contenthandler : `type`
         a subclass of
-        :class:`~glue.ligolw.ligolw.FilteringLIGOLWContentHandler` to
+        :class:`~ligo.lw.ligolw.FilteringLIGOLWContentHandler` to
         exclude an element and its children
     """
-    from glue.ligolw.ligolw import FilteringLIGOLWContentHandler
-    from glue.ligolw.table import Table
+    from ligo.lw.ligolw import FilteringLIGOLWContentHandler
+    from ligo.lw.table import Table
 
     if issubclass(element, Table):
         def _element_filter(name, attrs):
-            # pylint: disable=unused-argument
             return ~element.CheckProperties(name, attrs)
     else:
-        def _element_filter(name, attrs):
+        def _element_filter(name, _):
             # pylint: disable=unused-argument
             return name != element.tagName
 
@@ -125,10 +189,11 @@ def get_filtering_contenthandler(element):
                                  _element_filter)
 
 
+@ilwdchar_compat
 def build_content_handler(parent, filter_func):
     """Build a `~xml.sax.handler.ContentHandler` with a given filter
     """
-    from glue.ligolw.lsctables import use_in
+    from ligo.lw.lsctables import use_in
 
     class _ContentHandler(parent):
         # pylint: disable=too-few-public-methods
@@ -140,7 +205,8 @@ def build_content_handler(parent, filter_func):
 
 # -- reading ------------------------------------------------------------------
 
-def read_ligolw(source, contenthandler=None, verbose=False,
+@ilwdchar_compat
+def read_ligolw(source, contenthandler=LIGOLWContentHandler, verbose=False,
                 non_lsc_tables_ok=True):
     """Read one or more LIGO_LW format files
 
@@ -160,13 +226,13 @@ def read_ligolw(source, contenthandler=None, verbose=False,
 
     Returns
     -------
-    xmldoc : :class:`~glue.ligolw.ligolw.Document`
+    xmldoc : :class:`~ligo.lw.ligolw.Document`
         the document object as parsed from the file(s)
     """
-    from glue.ligolw.ligolw import (Document, LIGOLWContentHandler)
-    from glue.ligolw import types
-    from glue.ligolw.lsctables import use_in
-    from glue.ligolw.utils.ligolw_add import ligolw_add
+    from ligo.lw.ligolw import Document
+    from ligo.lw import types
+    from ligo.lw.lsctables import use_in
+    from ligo.lw.utils.ligolw_add import ligolw_add
 
     # mock ToPyType to link to numpy dtypes
     topytype = types.ToPyType.copy()
@@ -174,15 +240,28 @@ def read_ligolw(source, contenthandler=None, verbose=False,
         if key in types.ToNumPyType:
             types.ToPyType[key] = numpy.dtype(types.ToNumPyType[key]).type
 
-    # set default content handler
-    if contenthandler is None:
-        contenthandler = use_in(LIGOLWContentHandler)
+    contenthandler = use_in(contenthandler)
 
     # read one or more files into a single Document
     try:
         return ligolw_add(Document(), file_list(source),
                           contenthandler=contenthandler, verbose=verbose,
                           non_lsc_tables_ok=non_lsc_tables_ok)
+    except LigolwElementError as exc:
+        # failed to read with ligo.lw,
+        # try again with glue.ligolw (ilwdchar_compat)
+        if LIGO_LW_COMPAT_ERROR.search(str(exc)):
+            try:
+                return read_ligolw(
+                    source,
+                    contenthandler=contenthandler,
+                    verbose=verbose,
+                    non_lsc_tables_ok=non_lsc_tables_ok,
+                    ilwdchar_compat=True,
+                )
+            except Exception:  # if fails for any reason, us original error
+                pass
+        raise
     finally:  # replace ToPyType
         types.ToPyType = topytype
 
@@ -191,15 +270,16 @@ def with_read_ligolw(func=None, contenthandler=None):
     """Decorate a LIGO_LW-reading function to open a filepath if needed
 
     ``func`` should be written to presume a
-    :class:`~glue.ligolw.ligolw.Document` as the first positional argument
+    :class:`~ligo.lw.ligolw.Document` as the first positional argument
     """
     def decorator(func_):
         # pylint: disable=missing-docstring
         @wraps(func_)
         def decorated_func(source, *args, **kwargs):
             # pylint: disable=missing-docstring
-            from glue.ligolw.ligolw import Document
-            if not isinstance(source, Document):
+            from ligo.lw.ligolw import Document
+            from glue.ligolw.ligolw import Document as GlueDocument
+            if not isinstance(source, (Document, GlueDocument)):
                 read_kw = {
                     'contenthandler': kwargs.pop('contenthandler',
                                                  contenthandler),
@@ -218,16 +298,17 @@ def with_read_ligolw(func=None, contenthandler=None):
 
 # -- reading ------------------------------------------------------------------
 
+@ilwdchar_compat
 def read_table(source, tablename=None, columns=None, contenthandler=None,
                **kwargs):
-    """Read a :class:`~glue.ligolw.table.Table` from one or more LIGO_LW files
+    """Read a :class:`~ligo.lw.table.Table` from one or more LIGO_LW files
 
     Parameters
     ----------
     source : `Document`, `file`, `str`, `CacheEntry`, `list`
         object representing one or more files. One of
 
-        - a LIGO_LW :class:`~glue.ligolw.ligolw.Document`
+        - a LIGO_LW :class:`~ligo.lw.ligolw.Document`
         - an open `file`
         - a `str` pointing to a file path on disk
         - a formatted :class:`~lal.utils.CacheEntry` representing one file
@@ -247,15 +328,21 @@ def read_table(source, tablename=None, columns=None, contenthandler=None,
 
     Returns
     -------
-    table : :class:`~glue.ligolw.table.Table`
+    table : :class:`~ligo.lw.table.Table`
         `Table` of data
     """
-    from glue.ligolw.ligolw import Document
-    from glue.ligolw import (table, lsctables)
+    from ligo.lw.ligolw import Document
+    from ligo.lw import (table, lsctables)
+
+    # get ilwdchar_compat to pass to read_ligolw()
+    if Document.__module__.startswith("glue"):
+        kwargs["ilwdchar_compat"] = True
 
     # get content handler to read only this table (if given)
     if tablename is not None:
-        tableclass = lsctables.TableByName[table.Table.TableName(tablename)]
+        tableclass = lsctables.TableByName[
+            table.Table.TableName(tablename)
+        ]
         if contenthandler is None:
             contenthandler = get_partial_contenthandler(tableclass)
 
@@ -268,8 +355,9 @@ def read_table(source, tablename=None, columns=None, contenthandler=None,
     if isinstance(source, Document):
         xmldoc = source
     else:
+        if contenthandler is None:
+            contenthandler = lsctables.use_in(LIGOLWContentHandler)
         try:
-
             xmldoc = read_ligolw(source, contenthandler=contenthandler,
                                  **kwargs)
         finally:  # reinstate original set of loading column names
@@ -295,6 +383,7 @@ def read_table(source, tablename=None, columns=None, contenthandler=None,
 
 # -- writing ------------------------------------------------------------------
 
+@ilwdchar_compat
 def open_xmldoc(fobj, **kwargs):
     """Try and open an existing LIGO_LW-format file, or create a new Document
 
@@ -305,38 +394,53 @@ def open_xmldoc(fobj, **kwargs):
 
     **kwargs
         other keyword arguments to pass to
-        :func:`~glue.ligolw.utils.load_filename`, or
-        :func:`~glue.ligolw.utils.load_fileobj` as appropriate
+        :func:`~ligo.lw.utils.load_filename`, or
+        :func:`~ligo.lw.utils.load_fileobj` as appropriate
 
     Returns
     --------
-    xmldoc : :class:`~glue.ligolw.ligolw.Document`
+    xmldoc : :class:`~ligo.lw.ligolw.Document`
         either the `Document` as parsed from an existing file, or a new, empty
         `Document`
     """
-    from glue.ligolw.lsctables import use_in
-    from glue.ligolw.ligolw import (Document, LIGOLWContentHandler)
-    from glue.ligolw.utils import load_filename, load_fileobj
+    from ligo.lw.ligolw import (Document, LIGOLWContentHandler)
+    from ligo.lw.lsctables import use_in
+    from ligo.lw.utils import (load_filename, load_fileobj)
+
+    use_in(kwargs.setdefault('contenthandler', LIGOLWContentHandler))
+
     try:  # try and load existing file
         if isinstance(fobj, string_types):
-            kwargs.setdefault('contenthandler', use_in(LIGOLWContentHandler))
             return load_filename(fobj, **kwargs)
         if isinstance(fobj, FILE_LIKE):
-            kwargs.setdefault('contenthandler', use_in(LIGOLWContentHandler))
             return load_fileobj(fobj, **kwargs)[0]
     except (OSError, IOError):  # or just create a new Document
         return Document()
+    except LigolwElementError as exc:
+        if LIGO_LW_COMPAT_ERROR.search(str(exc)):
+            try:
+                return open_xmldoc(fobj, ilwdchar_compat=True, **kwargs)
+            except Exception:  # for any reason, raise original
+                pass
+        raise
 
 
 def get_ligolw_element(xmldoc):
     """Find an existing <LIGO_LW> element in this XML Document
     """
-    from glue.ligolw.ligolw import LIGO_LW
-    if isinstance(xmldoc, LIGO_LW):
+    from ligo.lw.ligolw import LIGO_LW
+    try:
+        from glue.ligolw.ligolw import LIGO_LW as LIGO_LW2
+    except ImportError:
+        ligolw_types = (LIGO_LW,)
+    else:
+        ligolw_types = (LIGO_LW, LIGO_LW2)
+
+    if isinstance(xmldoc, ligolw_types):
         return xmldoc
     else:
         for node in xmldoc.childNodes:
-            if isinstance(node, LIGO_LW):
+            if isinstance(node, ligolw_types):
                 return node
     raise ValueError("Cannot find LIGO_LW element in XML Document")
 
@@ -346,18 +450,18 @@ def write_tables_to_document(xmldoc, tables, overwrite=False):
 
     Parameters
     ----------
-    xmldoc : :class:`~glue.ligolw.ligolw.Document`
+    xmldoc : :class:`~ligo.lw.ligolw.Document`
         the document to write into
 
-    tables : `list` of :class:`~glue.ligolw.table.Table`
+    tables : `list` of :class:`~ligo.lw.table.Table`
         the set of tables to write
 
     overwrite : `bool`, optional, default: `False`
         if `True`, delete an existing instance of the table type, otherwise
         append new rows
     """
-    from glue.ligolw.ligolw import LIGO_LW
-    from glue.ligolw import lsctables
+    from ligo.lw.ligolw import LIGO_LW
+    from ligo.lw import lsctables
 
     # find or create LIGO_LW tag
     try:
@@ -388,10 +492,10 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
 
     Parameters
     ----------
-    target : `str`, `file`, :class:`~glue.ligolw.ligolw.Document`
+    target : `str`, `file`, :class:`~ligo.lw.ligolw.Document`
         the file or document to write into
 
-    tables : `list`, `tuple` of :class:`~glue.ligolw.table.Table`
+    tables : `list`, `tuple` of :class:`~ligo.lw.table.Table`
         the tables to write
 
     append : `bool`, optional, default: `False`
@@ -403,11 +507,11 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
 
     **kwargs
         other keyword arguments to pass to
-        :func:`~glue.ligolw.utils.load_filename`, or
-        :func:`~glue.ligolw.utils.load_fileobj` as appropriate
+        :func:`~ligo.lw.utils.load_filename`, or
+        :func:`~ligo.lw.utils.load_fileobj` as appropriate
     """
-    from glue.ligolw.ligolw import (Document, LIGO_LW, LIGOLWContentHandler)
-    from glue.ligolw import utils as ligolw_utils
+    from ligo.lw.ligolw import (Document, LIGO_LW, LIGOLWContentHandler)
+    from ligo.lw import utils as ligolw_utils
 
     # allow writing directly to XML
     if isinstance(target, (Document, LIGO_LW)):
@@ -444,7 +548,7 @@ def list_tables(source):
 
     Parameters
     ----------
-    source : `file`, `str`, :class:`~glue.ligolw.ligolw.Document`, `list`
+    source : `file`, `str`, :class:`~ligo.lw.ligolw.Document`, `list`
         one or more open files, file paths, or LIGO_LW `Document`s
 
     Examples
@@ -453,8 +557,15 @@ def list_tables(source):
     >>> print(list_tables('H1-LDAS_STRAIN-968654552-10.xml.gz'))
     ['process', 'process_params', 'sngl_burst', 'search_summary', 'segment_definer', 'segment_summary', 'segment']
     """  # noqa: E501
-    from glue.ligolw.ligolw import (Document, Stream)
-    from glue.ligolw.table import Table
+    from ligo.lw.ligolw import (Document, Stream)
+    from ligo.lw.table import Table
+    table_types = (Table,)
+    try:
+        from glue.ligolw.ligolw import Table as GlueTable
+    except ImportError:
+        pass
+    else:
+        table_types += (GlueTable,)
 
     # read file object
     if isinstance(source, Document):
@@ -466,11 +577,12 @@ def list_tables(source):
     # get list of table names
     tables = []
     for tbl in xmldoc.childNodes[0].childNodes:
-        if isinstance(tbl, Table):
+        if isinstance(tbl, table_types):
             tables.append(tbl.TableName(tbl.Name))
     return tables
 
 
+@ilwdchar_compat
 def to_table_type(val, cls, colname):
     """Cast a value to the correct type for inclusion in a LIGO_LW table
 
@@ -482,8 +594,8 @@ def to_table_type(val, cls, colname):
     val : `object`
         The input object to convert, of any type
 
-    cls : `type`
-        The sub-class of :class:`~glue.ligolw.table.Table` to map against
+    cls : `type`, subclass of :class:`~ligo.lw.table.Table`
+        the table class to map against
 
     colname : `str`
         The name of the mapping column
@@ -496,7 +608,7 @@ def to_table_type(val, cls, colname):
     Examples
     --------
     >>> from gwpy.io.ligolw import to_table_type as to_ligolw_type
-    >>> from glue.ligolw.lsctables import SnglBurstTable
+    >>> from ligo.lw.lsctables import SnglBurstTable
     >>> print(to_ligolw_type(1.0, SnglBurstTable, 'central_freq')))
     1.0
 
@@ -507,13 +619,15 @@ def to_table_type(val, cls, colname):
 
     Formatted fancy ILWD objects are left untouched:
 
-    >>> from glue.ligolw.ilwd import ilwdchar
+    >>> from ligo.lw.ilwd import ilwdchar
     >>> pid = ilwdchar('process:process_id:0')
     >>> print(to_ligolw_type(pid, SnglBurstTable, 'process_id')))
     process:process_id:1
     """
-    from glue.ligolw.types import (ToNumPyType as numpytypes,
-                                   ToPyType as pytypes)
+    from ligo.lw.types import (
+        ToNumPyType as numpytypes,
+        ToPyType as pytypes,
+    )
 
     # if nothing to do...
     if val is None or colname not in cls.validcolumns:
@@ -523,7 +637,8 @@ def to_table_type(val, cls, colname):
 
     # don't mess with formatted IlwdChar
     if llwtype == 'ilwd:char':
-        return _to_ilwd(val, cls.tableName, colname)
+        return _to_ilwd(val, cls.tableName, colname,
+                        ilwdchar_compat=_is_glue_ligolw_object(cls))
     # otherwise map to numpy or python types
     try:
         return numpy.typeDict[numpytypes[llwtype]](val)
@@ -531,9 +646,10 @@ def to_table_type(val, cls, colname):
         return pytypes[llwtype](val)
 
 
+@ilwdchar_compat
 def _to_ilwd(value, tablename, colname):
-    from glue.ligolw.ilwd import (ilwdchar, get_ilwdchar_class)
-    from glue.ligolw._ilwd import ilwdchar as IlwdChar
+    from ligo.lw.ilwd import (ilwdchar, get_ilwdchar_class)
+    from ligo.lw._ilwd import ilwdchar as IlwdChar
 
     if isinstance(value, IlwdChar) and value.column_name != colname:
         raise ValueError("ilwdchar '{0!s}' doesn't match column "
@@ -567,11 +683,16 @@ def is_ligolw(origin, filepath, fileobj, *args, **kwargs):
         finally:
             fileobj.seek(loc)
     try:
-        from glue.ligolw.ligolw import Element
+        from ligo.lw.ligolw import Element
     except ImportError:
         return False
+    try:
+        from glue.ligolw.ligolw import Element as GlueElement
+    except ImportError:
+        element_types = (Element,)
     else:
-        return len(args) > 0 and isinstance(args[0], Element)
+        element_types = (Element, GlueElement)
+    return len(args) > 0 and isinstance(args[0], element_types)
 
 
 def is_xml(origin, filepath, fileobj, *args, **kwargs):

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -425,6 +425,7 @@ def open_xmldoc(fobj, **kwargs):
         raise
 
 
+@ilwdchar_compat
 def get_ligolw_element(xmldoc):
     """Find an existing <LIGO_LW> element in this XML Document
     """
@@ -445,6 +446,7 @@ def get_ligolw_element(xmldoc):
     raise ValueError("Cannot find LIGO_LW element in XML Document")
 
 
+@ilwdchar_compat
 def write_tables_to_document(xmldoc, tables, overwrite=False):
     """Write the given LIGO_LW table into a :class:`Document`
 
@@ -487,6 +489,7 @@ def write_tables_to_document(xmldoc, tables, overwrite=False):
     return xmldoc
 
 
+@ilwdchar_compat
 def write_tables(target, tables, append=False, overwrite=False, **kwargs):
     """Write an LIGO_LW table to file
 
@@ -542,6 +545,7 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
 
 # -- utilities ----------------------------------------------------------------
 
+@ilwdchar_compat
 def list_tables(source):
     # pylint: disable=line-too-long
     """List the names of all tables in this file(s)
@@ -557,15 +561,10 @@ def list_tables(source):
     >>> print(list_tables('H1-LDAS_STRAIN-968654552-10.xml.gz'))
     ['process', 'process_params', 'sngl_burst', 'search_summary', 'segment_definer', 'segment_summary', 'segment']
     """  # noqa: E501
-    from ligo.lw.ligolw import (Document, Stream)
-    from ligo.lw.table import Table
-    table_types = (Table,)
     try:
-        from glue.ligolw.ligolw import Table as GlueTable
-    except ImportError:
-        pass
-    else:
-        table_types += (GlueTable,)
+        from ligo.lw.ligolw import (Document, Stream)
+    except ImportError:  # no python-ligo-lw
+        from glue.ligolw.ligolw import Document, Stream
 
     # read file object
     if isinstance(source, Document):
@@ -577,8 +576,10 @@ def list_tables(source):
     # get list of table names
     tables = []
     for tbl in xmldoc.childNodes[0].childNodes:
-        if isinstance(tbl, table_types):
+        try:
             tables.append(tbl.TableName(tbl.Name))
+        except AttributeError:  # not a table
+            continue
     return tables
 
 

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -27,6 +27,7 @@ import re
 from contextlib import contextmanager
 from functools import wraps
 from importlib import import_module
+from numbers import Integral
 
 # note: because the "future" module provides a builtins namespace,
 # we need to do this the other way around compared to normal
@@ -657,7 +658,7 @@ def _to_ilwd(value, tablename, colname):
                          "{1!r}".format(value, colname))
     if isinstance(value, IlwdChar):
         return value
-    if isinstance(value, int):
+    if isinstance(value, Integral):
         return get_ilwdchar_class(tablename, colname)(value)
     return ilwdchar(value)
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -552,7 +552,7 @@ class DataQualityFlag(object):
         --------
         >>> from gwpy.segments import DataQualityFlag
         >>> print(DataQualityFlag.fetch_open_data('H1_DATA', 'Jan 1 2010',
-        ...                                       'Jan 2 2010'))"
+        ...                                       'Jan 2 2010'))
         <DataQualityFlag('H1:DATA',
                          known=[[946339215 ... 946425615)],
                          active=[[946340946 ... 946351800)
@@ -640,7 +640,7 @@ class DataQualityFlag(object):
 
         Parameters
         ----------
-        veto : :class:`~glue.ligolw.lsctables.VetoDef`
+        veto : :class:`~ligo.lw.lsctables.VetoDef`
             veto definition to convert from
         """
         name = '%s:%s' % (veto.ifo, veto.name)
@@ -1406,13 +1406,13 @@ class DataQualityDict(OrderedDict):
 
         Parameters
         ----------
-        segmentdeftable : :class:`~glue.ligolw.lsctables.SegmentDefTable`
+        segmentdeftable : :class:`~ligo.lw.lsctables.SegmentDefTable`
             the ``segment_definer`` table to read
 
-        segmentsumtable : :class:`~glue.ligolw.lsctables.SegmentSumTable`
+        segmentsumtable : :class:`~ligo.lw.lsctables.SegmentSumTable`
             the ``segment_summary`` table to read
 
-        segmenttable : :class:`~glue.ligolw.lsctables.SegmentTable`
+        segmenttable : :class:`~ligo.lw.lsctables.SegmentTable`
             the ``segment`` table to read
 
         names : `list` of `str`, optional
@@ -1443,7 +1443,7 @@ class DataQualityDict(OrderedDict):
 
         # read segment definers and generate DataQualityFlag object
         for row in segmentdeftable:
-            ifos = row.get_ifos()
+            ifos = sorted(row.instruments)
             ifo = ''.join(ifos) if ifos else None
             tag = row.name
             version = row.version
@@ -1451,10 +1451,11 @@ class DataQualityDict(OrderedDict):
                              k is not None])
             if names is None or name in names:
                 out[name] = DataQualityFlag(name)
+                thisid = int(row.segment_def_id)
                 try:
-                    id_[name].append(row.segment_def_id)
+                    id_[name].append(thisid)
                 except (AttributeError, KeyError):
-                    id_[name] = [row.segment_def_id]
+                    id_[name] = [thisid]
 
         # verify all requested flags were found
         for flag in names or []:
@@ -1470,7 +1471,7 @@ class DataQualityDict(OrderedDict):
         for row in segmentsumtable:
             for flag in out:
                 # match row ID to list of IDs found for this flag
-                if row.segment_def_id in id_[flag]:
+                if int(row.segment_def_id) in id_[flag]:
                     out[flag].known.append(
                         Segment(*map(gpstype, row.segment)))
                     break
@@ -1478,40 +1479,59 @@ class DataQualityDict(OrderedDict):
         # read segment table as 'active'
         for row in segmenttable:
             for flag in out:
-                if row.segment_def_id in id_[flag]:
+                if int(row.segment_def_id) in id_[flag]:
                     out[flag].active.append(
                         Segment(*map(gpstype, row.segment)))
                     break
 
         return out
 
-    def to_ligolw_tables(self, **attrs):
+    def to_ligolw_tables(self, ilwdchar_compat=None, **attrs):
         """Convert this `DataQualityDict` into a trio of LIGO_LW segment tables
 
         Parameters
         ----------
+        ilwdchar_compat : `bool`, optional
+            whether to write in the old format, compatible with
+            ILWD characters (`True`), or to use the new format (`False`);
+            the current default is `True` to maintain backwards
+            compatibility, but this will change for gwpy-1.0.0.
+
         **attrs
             other attributes to add to all rows in all tables
             (e.g. ``'process_id'``)
 
         Returns
         -------
-        segmentdeftable : :class:`~glue.ligolw.lsctables.SegmentDefTable`
+        segmentdeftable : :class:`~ligo.lw.lsctables.SegmentDefTable`
             the ``segment_definer`` table
 
-        segmentsumtable : :class:`~glue.ligolw.lsctables.SegmentSumTable`
+        segmentsumtable : :class:`~ligo.lw.lsctables.SegmentSumTable`
             the ``segment_summary`` table
 
-        segmenttable : :class:`~glue.ligolw.lsctables.SegmentTable`
+        segmenttable : :class:`~ligo.lw.lsctables.SegmentTable`
             the ``segment`` table
         """
-        from glue.ligolw.lsctables import (SegmentTable, SegmentSumTable,
-                                           SegmentDefTable, New as new_table)
+        if ilwdchar_compat is None:
+            warnings.warn("ilwdchar_compat currently defaults to `True`, "
+                          "but this will change to `False` in the future, to "
+                          "maintain compatibility in future releases, "
+                          "manually specify `ilwdchar_compat=True`",
+                          PendingDeprecationWarning)
+            ilwdchar_compat = True
+
+        if ilwdchar_compat:
+            from glue.ligolw import lsctables
+        else:
+            from ligo.lw import lsctables
         from ..io.ligolw import to_table_type as to_ligolw_table_type
 
-        segdeftab = new_table(SegmentDefTable)
-        segsumtab = new_table(SegmentSumTable)
-        segtab = new_table(SegmentTable)
+        SegmentDefTable = lsctables.SegmentDefTable
+        SegmentSumTable = lsctables.SegmentSumTable
+        SegmentTable = lsctables.SegmentTable
+        segdeftab = lsctables.New(SegmentDefTable)
+        segsumtab = lsctables.New(SegmentSumTable)
+        segtab = lsctables.New(SegmentTable)
 
         def _write_attrs(table, row):
             for key, val in attrs.items():
@@ -1523,7 +1543,7 @@ class DataQualityDict(OrderedDict):
             segdef = segdeftab.RowType()
             for col in segdeftab.columnnames:  # default all columns to None
                 setattr(segdef, col, None)
-            segdef.set_ifos([flag.ifo])
+            segdef.instruments = {flag.ifo}
             segdef.name = flag.tag
             segdef.version = flag.version
             segdef.comment = flag.description
@@ -1538,7 +1558,7 @@ class DataQualityDict(OrderedDict):
                 for col in segsumtab.columnnames:  # default columns to None
                     setattr(segsum, col, None)
                 segsum.segment_def_id = segdef.segment_def_id
-                segsum.set(map(LIGOTimeGPS, vseg))
+                segsum.segment = map(LIGOTimeGPS, vseg)
                 segsum.comment = None
                 segsum.segment_sum_id = SegmentSumTable.get_next_id()
                 _write_attrs(segsumtab, segsum)
@@ -1550,7 +1570,7 @@ class DataQualityDict(OrderedDict):
                 for col in segtab.columnnames:  # default all columns to None
                     setattr(seg, col, None)
                 seg.segment_def_id = segdef.segment_def_id
-                seg.set(map(LIGOTimeGPS, aseg))
+                seg.segment = map(LIGOTimeGPS, aseg)
                 seg.segment_id = SegmentTable.get_next_id()
                 _write_attrs(segtab, seg)
                 segtab.append(seg)

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1467,22 +1467,22 @@ class DataQualityDict(OrderedDict):
                 else:
                     raise ValueError(msg)
 
+        # parse a table into the target DataQualityDict
+        def _parse_segments(table, listattr):
+            for row in table:
+                for flag in out:
+                    # match row ID to list of IDs found for this flag
+                    if int(row.segment_def_id) in id_[flag]:
+                        getattr(out[flag], listattr).append(
+                            Segment(*map(gpstype, row.segment)),
+                        )
+                        break
+
         # read segment summary table as 'known'
-        for row in segmentsumtable:
-            for flag in out:
-                # match row ID to list of IDs found for this flag
-                if int(row.segment_def_id) in id_[flag]:
-                    out[flag].known.append(
-                        Segment(*map(gpstype, row.segment)))
-                    break
+        _parse_segments(segmentsumtable, "known")
 
         # read segment table as 'active'
-        for row in segmenttable:
-            for flag in out:
-                if int(row.segment_def_id) in id_[flag]:
-                    out[flag].active.append(
-                        Segment(*map(gpstype, row.segment)))
-                    break
+        _parse_segments(segmenttable, "active")
 
         return out
 

--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -27,7 +27,7 @@ from . import utils
 # other readers are defined in their own modules, and are responsible
 # for applying the decorators themselves.
 from . import (
-    ligolw,  # glue.ligolw XML format
+    ligolw,  # ligo.lw XML format
     root,  # generic ROOT stuff
     omicron,  # Omicron ROOT format
     omega,  # Omega ASCII format

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -90,10 +90,7 @@ def _get_property_columns(tabletype, columns):
     # build list of real column names for fancy properties
     extracols = {}
     for key in columns:
-        try:
-            prop = rowvars[key]
-        except KeyError:
-            continue
+        prop = rowvars[key]
         if isinstance(prop, GpsProperty):
             extracols[key] = (prop.s_name, prop.ns_name)
     return extracols

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -61,7 +61,14 @@ except ImportError:
 else:
     from ligo.lw.ilwd import ilwdchar
     from ligo.lw._ilwd import ilwdchar as _ilwdchar
-    ilwdchar_types = (ilwdchar, _ilwdchar)
+    from glue.ligolw.ilwd import ilwdchar as glue_ilwdchar
+    from glue.ligolw._ilwd import ilwdchar as _glue_ilwdchar
+    ilwdchar_types = (
+        ilwdchar,
+        _ilwdchar,
+        glue_ilwdchar,
+        _glue_ilwdchar,
+    )
     NUMPY_TYPE_MAP[ilwdchar_types] = numpy.int_
     NUMPY_TYPE_MAP[LIGOTimeGPS] = numpy.float_
 

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -372,7 +372,7 @@ class EventTable(Table):
         """Return the `Column` with the given name
 
         This method is provided only for compatibility with the
-        :class:`glue.ligolw.table.Table`.
+        :class:`ligo.lw.table.Table`.
 
         Parameters
         ----------

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -30,12 +30,10 @@ from six.moves.urllib.error import URLError
 
 import pytest
 
-import numpy
-from numpy.testing import assert_array_equal
-
 import sqlparse
 
 from numpy import (random, isclose, dtype, asarray)
+from numpy.testing import assert_array_equal
 
 import h5py
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -32,7 +32,7 @@ import pytest
 
 import sqlparse
 
-from numpy import (random, isclose, dtype)
+from numpy import (random, isclose, dtype, asarray)
 
 import h5py
 
@@ -119,7 +119,7 @@ class TestTable(object):
 
     # -- test I/O -------------------------------
 
-    @utils.skip_missing_dependency('glue.ligolw.lsctables')
+    @utils.skip_missing_dependency('ligo.lw.lsctables')
     @pytest.mark.parametrize('ext', ['xml', 'xml.gz'])
     def test_read_write_ligolw(self, ext):
         table = self.create(
@@ -146,7 +146,7 @@ class TestTable(object):
             assert t2.meta.get('tablename', None) == 'sngl_burst'
 
             # check numpy type casting works
-            from glue.ligolw.lsctables import LIGOTimeGPS as LigolwGPS
+            from ligo.lw.lsctables import LIGOTimeGPS as LigolwGPS
             t3 = _read(columns=['peak'])
             assert isinstance(t3['peak'][0], LigolwGPS)
             t3 = _read(columns=['peak'], use_numpy_dtypes=True)
@@ -207,7 +207,7 @@ class TestTable(object):
             assert str(exc.value) == ('document must contain exactly '
                                       'one sngl_burst table')
 
-    @utils.skip_missing_dependency('glue.ligolw.lsctables')
+    @utils.skip_missing_dependency('ligo.lw.lsctables')
     def test_read_write_ligolw_property_columns(self):
         table = self.create(100, ['peak', 'snr', 'central_freq'],
                             ['f8', 'f4', 'f4'])
@@ -220,7 +220,10 @@ class TestTable(object):
             for col in ('peak_time', 'peak_time_ns'):
                 assert col in llw.columnnames
             with io_ligolw.patch_ligotimegps():
-                utils.assert_array_equal(llw.get_peak(), table['peak'])
+                utils.assert_array_equal(
+                    asarray([row.peak for row in llw]),
+                    table['peak'],
+                )
 
             # read table and assert gpsproperty was repacked properly
             t2 = self.TABLE.read(f, columns=table.colnames,

--- a/gwpy/types/io/ligolw.py
+++ b/gwpy/types/io/ligolw.py
@@ -29,7 +29,7 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 def series_contenthandler():
     """Build a `~xml.sax.handlers.ContentHandler` to read a LIGO_LW <Array>
     """
-    from glue.ligolw import (
+    from ligo.lw import (
         ligolw,
         array as ligolw_array,
         param as ligolw_param
@@ -50,7 +50,7 @@ def read_series(source, name, match=None):
 
     Parameters
     ----------
-    source : `file`, `str`, :class:`~glue.ligolw.ligolw.Document`
+    source : `file`, `str`, :class:`~ligo.lw.ligolw.Document`
         file path or open LIGO_LW-format XML file
 
     name : `str`
@@ -61,8 +61,8 @@ def read_series(source, name, match=None):
         this is useful if a single file contains multiple `LIGO_LW` elements
         with the same name
     """
-    from glue.ligolw.ligolw import (LIGO_LW, Time, Array, Dim)
-    from glue.ligolw.param import get_param
+    from ligo.lw.ligolw import (LIGO_LW, Time, Array, Dim)
+    from ligo.lw.param import get_param
 
     # read document
     xmldoc = read_ligolw(source, contenthandler=series_contenthandler())

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,4 +18,5 @@ psycopg2
 pycbc >= 1.13.4 ; python_version < '3' and sys_platform != 'win32'
 pymysql
 pyRXP
+python-ligo-lw >= 1.5.0 ; sys_platform != 'win32'
 sqlalchemy


### PR DESCRIPTION
This PR implements a backwards-compatible update to use the new `python-ligo-lw` library for `LIGO_LW` I/O, but with fallbacks to `glue.ligolw` when reading old files.

When reading there is now a try/except that should try and read with the new library, and if that fails, try and use the old library.

When writing:
- ...tables, the columns/datatypes in the table define the format version, so both libraries are tried (new first)
- ...segments, there is a new `ilwdchar_compat` keyword that currently defaults to `None`, which presents a warning that it will use `True` (old format), but will be switched to `False` for the 1.0.0 release (at which time the warning will be removed).

The upshot of this is that GWpy should now be able to seamlessly read LIGO_LW files written in either new or old formats.