### PR TITLE
Fixed some warnings in testing

### DIFF
--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -144,7 +144,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
             specgram = self.get_spectrogram()
 
             # there may be data that can't be processed
-            if specgram:
+            if specgram is not None:  # <-DMM: why is this here?
                 # apply normalisation
                 if args.norm:
                     specgram = specgram.ratio(args.norm)

--- a/gwpy/cli/tests/base.py
+++ b/gwpy/cli/tests/base.py
@@ -192,7 +192,11 @@ class _TestCliProduct(object):
             mocker.return_value = conn
             prod.get_data()
 
-        assert prod.timeseries[0] == data[0]
+        utils.assert_quantity_sub_equal(
+            prod.timeseries[0],
+            data[0],
+            exclude=("channel",),
+        )
 
     @pytest.mark.parametrize('ftype, filt', [
         ('highpass', {'highpass': 10}),


### PR DESCRIPTION
This PR fixes some warnings emitted during testing `gwpy.cli`; one can't directly compare quantities, or get their 'truth' value, need to use fancier methods or compare against `None`.