### PR TITLE
Upgrade gwdatafind to first-class dependency

### DIFF
--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -77,7 +77,6 @@ yum -y -q install \
     python-beautifulsoup4 \
     python-sqlalchemy \
     python2-PyMySQL \
-    python2-gwdatafind \
     m2crypto \
     glue \
     dqsegdb \

--- a/ci/install-macports.sh
+++ b/ci/install-macports.sh
@@ -98,7 +98,6 @@ fi
 # install extras (see requirements-dev.txt)
 #sudo port -q install \
 #    kerberos5 \
-#    ${PY_PREFIX}-gwdatafind \
 #    ${PY_PREFIX}-lal \
 #    ${PY_PREFIX}-lalframe \
 #    ${PY_PREFIX}-lalsimulation \

--- a/debian/control
+++ b/debian/control
@@ -33,9 +33,9 @@ Depends: ${misc:Depends},
          python-lal (>= 6.14.0),
          python-tqdm (>= 4.10.0),
          python-gwosc (>= 0.3.1),
-         python-dqsegdb2
+         python-dqsegdb2,
+         python-gwdatafind
 Suggests: python-pymysql,
-          python-gwdatafind,
           python-dqsegdb,
           python-sqlalchemy,
           python-psycopg2,
@@ -62,9 +62,9 @@ Depends: ${misc:Depends},
          python3-ligo-segments,
          python3-tqdm (>= 4.10.0),
          python3-gwosc (>= 0.3.1),
-         python3-dqsegdb2
+         python3-dqsegdb2,
+         python3-gwdatafind
 Suggests: python3-pymysql,
-          python3-gwdatafind,
           python3-dqsegdb,
           python3-sqlalchemy,
           python3-psycopg2,

--- a/debian/control
+++ b/debian/control
@@ -20,26 +20,27 @@ Package: python-gwpy
 Architecture: all
 Depends: ${misc:Depends},
          ${python:Depends},
-         python-six (>= 1.5),
+         python-astropy (>= 1.1.1),
          python-dateutil,
+         python-dqsegdb2,
          python-enum34,
+         python-gwdatafind,
+         python-gwosc (>= 0.3.1),
+         python-h5py (>= 1.3),
+         python-lal (>= 6.14.0),
+         python-ligo-segments (>= 1.0.0),
+         python-matplotlib (>= 1.2.0),
          python-numpy (>= 1.7.1),
          python-scipy (>= 0.12.1),
-         python-astropy (>= 1.1.1),
-         python-h5py (>= 1.3),
-         python-matplotlib (>= 1.2.0),
-         python-ligo-segments (>= 1.0.0),
-         python-ldas-tools-framecpp (>= 2.6.0),
-         python-lal (>= 6.14.0),
-         python-tqdm (>= 4.10.0),
-         python-gwosc (>= 0.3.1),
-         python-dqsegdb2,
-         python-gwdatafind
-Suggests: python-pymysql,
-          python-dqsegdb,
-          python-sqlalchemy,
+         python-six (>= 1.5),
+         python-tqdm (>= 4.10.0)
+Suggests: python-glue (>= 1.60.0),
+          python-ldas-tools-framecpp (>= 2.6.0),
+          python-nds2-client,
+          python-pandas,
           python-psycopg2,
-          python-pandas
+          python-pymysql,
+          python-sqlalchemy
 Description: A python package for gravitational-wave astrophysics
  GWpy is a collaboration-driven Python package providing tools
  for studying data from ground-based gravitational-wave detectors.
@@ -50,25 +51,26 @@ Package: python3-gwpy
 Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
-         python3-six (>= 1.5),
-         python3-dateutil,
-         python3-numpy (>= 1.7.1),
-         python3-scipy (>= 0.12.0),
          python3-astropy (>= 1.1.1),
+         python3-dateutil,
+         python3-dqsegdb2,
+         python3-gwosc (>= 0.3.1),
+         python3-gwdatafind,
          python3-h5py (>= 1.3),
-         python3-matplotlib (>= 1.2.0),
-         python3-ldas-tools-framecpp (>= 2.6.0),
          python3-lal (>= 6.14.0),
          python3-ligo-segments,
-         python3-tqdm (>= 4.10.0),
-         python3-gwosc (>= 0.3.1),
-         python3-dqsegdb2,
-         python3-gwdatafind
-Suggests: python3-pymysql,
-          python3-dqsegdb,
-          python3-sqlalchemy,
+         python3-matplotlib (>= 1.2.0),
+         python3-numpy (>= 1.7.1),
+         python3-scipy (>= 0.12.0),
+         python3-six (>= 1.5),
+         python3-tqdm (>= 4.10.0)
+Suggests: python3-glue (>= 1.60.0),
+          python3-ldas-tools-framecpp (>= 2.6.0),
+          python3-nds2-client,
+          python3-pandas,
           python3-psycopg2,
-          python3-pandas
+          python3-pymysql,
+          python3-sqlalchemy
 Description: A python package for gravitational-wave astrophysics
  GWpy is a collaboration-driven Python package providing tools
  for studying data from ground-based gravitational-wave detectors.

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -87,26 +87,29 @@ Requirements
 GWpy has the following strict requirements:
 
 - `Python <https://python.org>`__ 2.7, or 3.4 or greater
-- |six|_ `>= 1.5.0`
+- |astropy|_ `>= 1.1.1`
 - |dateutil|_
+- |dqsegdb2|_
 - |enum34|_ (Python 2.7 only)
+- |gwdatafind|_
+- |gwosc| `>= 0.3.1`
+- |h5py|_ `>= 1.3.0`
+- |ligo-segments|_ `>= 1.0.0`
+- |ligotimegps|_ `>= 1.2.1`
+- |matplotlib|_ `>= 1.2.0`
 - |numpy|_ `>= 1.7.1`
 - |scipy|_ `>= 0.12.1`
-- |astropy|_ `>= 1.1.1`
-- |h5py|_ `>= 1.3.0`
-- |matplotlib|_ `>= 1.2.0`
-- |ligo-segments|_ `>= 1.0.0`
+- |six|_ `>= 1.5.0`
 - |tqdm|_ `>= 4.10.0`
-- |ligotimegps|_ `>= 1.2.1`
 
 All of these will be installed using any of the above install methods.
 
 GWpy also depends on the following other packages for optional features:
 
-- |dqsegdb|_: to query data from DQSEGDB (see :ref:`gwpy-segments-dqsegdb`)
-- |LDAStools.frameCPP|_ or |lalframe|_: to read/write data in GWF format
-- |LDAStools.frameCPP|_: to enable data discovery in GWF files
-- |lal|_: to power some FFT-based PSD estimation
-- |nds2|_: to provide remote data access for `TimeSeries` (see :ref:`gwpy-timeseries-remote`)
-- |pycbc|_: to power some FFT-based PSD estimation
-- |root_numpy|_: to read/write :class:`~gwpy.table.EventTable` with ROOT format (see :ref:`gwpy-table-io-root`)
+- :mod:`glue.ligolw`: to read/write :class:`~gwpy.table.EventTable` with
+  LIGO_LW XML format (see :ref:`gwpy-table-io-ligolw`)
+- |LDAStools.frameCPP|_: to read/write data in GWF format
+- |nds2|_: to provide remote data access for `TimeSeries`
+  (see :ref:`gwpy-timeseries-remote`)
+- |root_numpy|_: to read/write :class:`~gwpy.table.EventTable` with ROOT
+  format (see :ref:`gwpy-table-io-root`)

--- a/docs/segments/io.rst
+++ b/docs/segments/io.rst
@@ -140,7 +140,7 @@ Identical arguments should be used relative to the :meth:`DataQualityFlag.write`
 JSON
 ====
 
-The |dqsegdb|_ client uses JSON as the intermediate format for returning information during queries.
+The DQSEGDB server uses JSON as the intermediate format for returning information during queries.
 
 Reading
 -------

--- a/etc/Portfile.template
+++ b/etc/Portfile.template
@@ -31,24 +31,24 @@ python.default_version 27
 
 if {${name} ne ${subport}} {
 
-    depends_build-append port:py${python.version}-setuptools
+    depends_build-append    port:py${python.version}-setuptools
 
-    depends_lib-append  port:py${python.version}-six \
-                        port:py${python.version}-dateutil \
-                        port:py${python.version}-numpy \
-                        port:py${python.version}-scipy \
-                        port:py${python.version}-matplotlib \
-                        port:py${python.version}-astropy \
-                        port:py${python.version}-h5py \
-                        port:py${python.version}-lal \
-                        port:py${python.version}-ligo-segments \
-                        port:py${python.version}-tqdm \
-                        port:py${python.version}-gwosc \
-                        port:py${python.version}-dqsegdb2 \
-                        port:py${python.version}-gwdatafind
+    depends_lib-append      port:py${python.version}-astropy \
+                            port:py${python.version}-dateutil \
+                            port:py${python.version}-dqsegdb2 \
+                            port:py${python.version}-gwdatafind \
+                            port:py${python.version}-gwosc \
+                            port:py${python.version}-h5py \
+                            port:py${python.version}-ligo-segments \
+                            port:py${python.version}-ligotimegps \
+                            port:py${python.version}-matplotlib \
+                            port:py${python.version}-numpy \
+                            port:py${python.version}-scipy \
+                            port:py${python.version}-six \
+                            port:py${python.version}-tqdm
 
     if {${python.version} < 34} {
-        depends_lib-append port:py${python.version}-enum34
+        depends_lib-append  port:py${python.version}-enum34
     }
 
     if {${python.version} == 27} {
@@ -61,8 +61,5 @@ if {${name} ne ${subport}} {
             depends_lib-append port:py${python.version}-ldas-tools-framecpp
         }
 
-        variant dqsegdb description {Add DQSEGDB support} {
-            depends_lib-append port:dqsegdb
-        }
     }
 }

--- a/etc/Portfile.template
+++ b/etc/Portfile.template
@@ -44,7 +44,8 @@ if {${name} ne ${subport}} {
                         port:py${python.version}-ligo-segments \
                         port:py${python.version}-tqdm \
                         port:py${python.version}-gwosc \
-                        port:py${python.version}-dqsegdb2
+                        port:py${python.version}-dqsegdb2 \
+                        port:py${python.version}-gwdatafind
 
     if {${python.version} < 34} {
         depends_lib-append port:py${python.version}-enum34

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -41,6 +41,7 @@ Requires:       python2-ligo-segments >= 1.0.0
 Requires:       python2-tqdm >= 4.10.0
 Requires:       python2-gwosc
 Requires:       python2-dqsegdb2
+Requires:       python2-gwdatafind
 
 %{?python_provide:%python_provide python2-%{srcname}}
 

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -43,6 +43,8 @@ from functools import wraps
 
 from six.moves.urllib.parse import urlparse
 
+from gwdatafind import connect
+
 from ..segments import (Segment, SegmentList)
 from ..time import to_gps
 from .cache import (cache_segments, read_cache_entry, _iter_cache, _CacheEntry)
@@ -309,7 +311,6 @@ def on_tape(*files):
 
 def _choose_connection(**datafind_kw):
     if os.getenv('LIGO_DATAFIND_SERVER') or datafind_kw.get('host'):
-        from gwdatafind import connect
         return connect(**datafind_kw)
     if os.getenv('VIRGODATA'):
         return FflConnection()

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -30,9 +30,10 @@ from six.moves.http_client import HTTPConnection
 
 import pytest
 
+import gwdatafind
+
 from ...testing.compat import mock
-from ...testing.utils import (skip_missing_dependency, TEST_GWF_FILE,
-                              TemporaryFilename)
+from ...testing.utils import (TEST_GWF_FILE, TemporaryFilename)
 from .. import datafind as io_datafind
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -65,7 +66,6 @@ def teardown_module():
 # -- utilities ----------------------------------------------------------------
 
 def mock_connection(framefile):
-    import gwdatafind
     # create mock up of connection object
     conn = mock.create_autospec(gwdatafind.http.HTTPConnection)
     conn.find_types.return_value = [os.path.basename(framefile).split('-')[1]]
@@ -234,7 +234,6 @@ def test_reconnect():
         assert b.ffldir == a.ffldir
 
 
-@skip_missing_dependency('gwdatafind')
 @mock.patch('gwpy.io.datafind.iter_channel_names',
             return_value=['L1:LDAS-STRAIN', 'H1:LDAS-STRAIN'])
 @mock.patch('gwpy.io.datafind.num_channels', return_value=1)
@@ -281,7 +280,6 @@ def test_find_frametype(reconnect, num_channels, iter_channels, connection):
         assert '[files on tape have not been checked' in str(exc.value)
 
 
-@skip_missing_dependency('gwdatafind')
 @mock.patch('gwpy.io.datafind.iter_channel_names',
             return_value=['L1:LDAS-STRAIN'])
 @mock.patch('gwpy.io.datafind.num_channels', return_value=1)

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1200,8 +1200,6 @@ class TimeSeriesBaseDict(OrderedDict):
         **readargs
             any other keyword arguments to be passed to `.read()`
         """
-        import gwdatafind
-
         start = to_gps(start)
         end = to_gps(end)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,6 @@ pymysql
 pyRXP
 lscsoft-glue ; sys_platform != 'win32'
 lalsuite ; sys_platform != 'win32'
-gwdatafind
 pycbc >= 1.10.1 ; python_version == '2.7' and sys_platform != 'win32'
 git+https://github.com/duncanmmacleod/ligo.org.git
 sqlalchemy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,13 +8,13 @@
 -r requirements-doc.txt
 
 # extras
-pymysql
-pyRXP
-lscsoft-glue ; sys_platform != 'win32'
 lalsuite ; sys_platform != 'win32'
-pycbc >= 1.10.1 ; python_version == '2.7' and sys_platform != 'win32'
 git+https://github.com/duncanmmacleod/ligo.org.git
-sqlalchemy
-psycopg2
+lscsoft-glue ; sys_platform != 'win32'
 pandas ; python_version != '3.4'
 pandas < 0.21 ; python_version == '3.4'
+psycopg2
+pycbc >= 1.10.1 ; python_version == '2.7' and sys_platform != 'win32'
+pymysql
+pyRXP
+sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
 # GWpy core requirements
 #           [use requirements-dev.txt for a full development environment
 #            including docs and testing dependencies]
-six >= 1.5
-python-dateutil
-enum34 ; python_version < '3'
-numpy >= 1.7.1
-scipy >= 0.12.1
 astropy >= 1.1.1, < 3.0.0 ; python_version < '3'
 astropy >= 1.1.1 ; python_version >= '3'
-h5py >= 1.3
-matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
-ligo-segments >= 1.0.0
-tqdm >= 4.10.0
-ligotimegps >= 1.2.1
-gwosc >= 0.3.1
 dqsegdb2
+enum34 ; python_version < '3'
 gwdatafind
+gwosc >= 0.3.1
+h5py >= 1.3
+ligo-segments >= 1.0.0
+ligotimegps >= 1.2.1
+matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
+numpy >= 1.7.1
+python-dateutil
+scipy >= 0.12.1
+six >= 1.5
+tqdm >= 4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ tqdm >= 4.10.0
 ligotimegps >= 1.2.1
 gwosc >= 0.3.1
 dqsegdb2
+gwdatafind

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ install_requires = [
     'ligotimegps >= 1.2.1',
     'gwosc >= 0.3.1',
     'dqsegdb2',
+    'gwdatafind',
 ]
 
 # if setuptools is too old and we are building an EL7 or Debian 8

--- a/setup.py
+++ b/setup.py
@@ -49,21 +49,21 @@ setup_requires = get_setup_requires()
 
 # runtime dependencies
 install_requires = [
-    'six >= 1.5',
-    'python-dateutil',
-    'enum34 ; python_version < \'3\'',
-    'numpy >= 1.7.1',
-    'scipy >= 0.12.1',
-    'matplotlib >= 1.2.0, != 2.1.0, != 2.1.1',
     'astropy >= 1.1.1, < 3.0.0 ; python_version < \'3\'',
     'astropy >= 1.1.1 ; python_version >= \'3\'',
+    'dqsegdb2',
+    'enum34 ; python_version < \'3\'',
+    'gwdatafind',
+    'gwosc >= 0.3.1',
     'h5py >= 1.3',
     'ligo-segments >= 1.0.0',
-    'tqdm >= 4.10.0',
     'ligotimegps >= 1.2.1',
-    'gwosc >= 0.3.1',
-    'dqsegdb2',
-    'gwdatafind',
+    'matplotlib >= 1.2.0, != 2.1.0, != 2.1.1',
+    'numpy >= 1.7.1',
+    'python-dateutil',
+    'scipy >= 0.12.1',
+    'six >= 1.5',
+    'tqdm >= 4.10.0',
 ]
 
 # if setuptools is too old and we are building an EL7 or Debian 8


### PR DESCRIPTION
This PR upgrades `gwdatafind` to a first-class dependency. This was the case in practice already since `dqsegdb2` is a dependency and depends in turn on `gwdatafind`, but this allows us to clean up some imports.

I also took this chance to clean up the dependency lists as they exist across various files, now all alphabetically ordered, and rechecked.