### PR TITLE
Make interpolated Q-transform spectrograms single precision

### DIFF
--- a/examples/timeseries/qscan.py
+++ b/examples/timeseries/qscan.py
@@ -42,12 +42,16 @@ from gwpy.timeseries import TimeSeries
 data = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
 
 # Next, we generate the `~TimeSeries.q_transform` of these data:
-qspecgram = data.q_transform()
+qspecgram = data.q_transform(outseg=(1126259462.2, 1126259462.5))
 
-# Now, we can plot the resulting `~gwpy.spectrogram.Spectrogram`, focusing on a
-# specific window around the interesting time
+# .. note::
+#    We can save memory by focusing on a specific window around the
+#    interesting time. The ``outseg`` keyword argument returns a `Spectrogram`
+#    that is only as long as we need it to be.
 
-plot = qspecgram.crop(1126259462.2, 1126259462.5).plot(figsize=[8, 4])
+# Now, we can plot the resulting `~gwpy.spectrogram.Spectrogram`:
+
+plot = qspecgram.plot(figsize=[8, 4])
 ax = plot.gca()
 ax.set_xscale('seconds')
 ax.set_yscale('log')

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -518,7 +518,7 @@ class QGram(object):
 
         Notes
         -----
-        This method will return a `Spectrogram` of dtype ``float32``
+        This method will return a `Spectrogram` of dtype ``float32`` if
         ``norm`` is given, and ``float64`` otherwise.
 
         To optimize plot rendering with `~matplotlib.axes.Axes.pcolormesh`,

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -435,11 +435,12 @@ class QTile(QBase):
         if norm:
             norm = norm.lower() if isinstance(norm, string_types) else norm
             if norm in (True, 'median'):
-                return energy / energy.median()
+                narray = energy / energy.median()
             elif norm in ('mean',):
-                return energy / energy.mean()
+                narray = energy / energy.mean()
             else:
                 raise ValueError("Invalid normalisation %r" % norm)
+            return narray.astype("float32", casting="same_kind", copy=False)
         return energy
 
 
@@ -478,14 +479,15 @@ class QGram(object):
                 })
         return peak
 
-    def interpolate(self, tres=.001, fres="<default>",
-                    logf=False, outseg=None):
+    def interpolate(self, tres="<default>", fres="<default>", logf=False,
+                    outseg=None):
         """Interpolate this `QGram` over a regularly-gridded spectrogram
 
         Parameters
         ----------
         tres : `float`, optional
-            desired time resolution (seconds) of output `Spectrogram`
+            desired time resolution (seconds) of output `Spectrogram`,
+            default is `abs(outseg) / 1000.`
 
         fres : `float`, `int`, `None`, optional
             desired frequency resolution (Hertz) of output `Spectrogram`,
@@ -498,7 +500,8 @@ class QGram(object):
             log-sampled frequencies in the output `Spectrogram`
 
         outseg : `~gwpy.segments.Segment`, optional
-            GPS `[start, stop)` segment for output `Spectrogram`
+            GPS `[start, stop)` segment for output `Spectrogram`,
+            default is the full duration of the input
 
         Returns
         -------
@@ -515,6 +518,9 @@ class QGram(object):
 
         Notes
         -----
+        This method will return a `Spectrogram` of dtype ``float32``
+        ``norm`` is given, and ``float64`` otherwise.
+
         To optimize plot rendering with `~matplotlib.axes.Axes.pcolormesh`,
         the output `~gwpy.spectrogram.Spectrogram` can be given a log-sampled
         frequency axis by passing `logf=True` at runtime. The `fres` argument
@@ -532,6 +538,8 @@ class QGram(object):
         dtype = self.energies[0].dtype
         # build regular Spectrogram from peak-Q data by interpolating each
         # (Q, frequency) `TimeSeries` to have the same time resolution
+        if tres == "<default>":
+            tres = abs(Segment(outseg)) / 1000.
         xout = numpy.arange(*outseg, step=tres)
         nx = xout.size
         ny = frequencies.size
@@ -544,7 +552,8 @@ class QGram(object):
             xrow = numpy.arange(row.x0.value, (row.x0 + row.duration).value,
                                 row.dx.value)
             interp = InterpolatedUnivariateSpline(xrow, row.value)
-            out[:, i] = interp(xout)
+            out[:, i] = interp(xout).astype(dtype, casting="same_kind",
+                                            copy=False)
         if fres is None:
             return out
         # interpolate the spectrogram to increase its frequency resolution
@@ -555,7 +564,8 @@ class QGram(object):
             if fres == "<default>":
                 fres = .5
             outfreq = numpy.arange(
-                self.plane.frange[0], self.plane.frange[1], fres)
+                self.plane.frange[0], self.plane.frange[1], fres,
+                dtype=dtype)
         else:
             if fres == "<default>":
                 fres = 500
@@ -564,8 +574,11 @@ class QGram(object):
             logfmin = numpy.log10(self.plane.frange[0])
             logfmax = numpy.log10(self.plane.frange[1])
             outfreq = numpy.logspace(logfmin, logfmax, num=int(fres))
-        new = type(out)(interp(xout, outfreq).T,
-                        t0=outseg[0], dt=tres, frequencies=outfreq)
+        new = type(out)(
+            interp(xout, outfreq).T.astype(
+                dtype, casting="same_kind", copy=False),
+            t0=outseg[0], dt=tres, frequencies=outfreq,
+        )
         new.q = self.plane.q
         return new
 

--- a/gwpy/signal/tests/test_qtransform.py
+++ b/gwpy/signal/tests/test_qtransform.py
@@ -60,7 +60,17 @@ def test_q_scan():
     # test spectrogram output
     assert ts_qspecgram.q == QSPECGRAM.q
     assert ts_qspecgram.shape == QSPECGRAM.shape
+    assert ts_qspecgram.dtype == numpy.dtype('float32')
     nptest.assert_allclose(ts_qspecgram.value, QSPECGRAM.value)
+
+
+def test_unnormalised_q_scan():
+    # scan with norm=False
+    ts_qspecgram = DATA.q_transform(whiten=False, norm=False)
+
+    # test spectrogram output
+    assert ts_qspecgram.q == QSPECGRAM.q
+    assert ts_qspecgram.dtype == numpy.dtype('float64')
 
 
 def test_q_scan_fd():
@@ -74,8 +84,9 @@ def test_q_scan_fd():
     # test that the output is the same
     assert far == FAR
     assert fs_qspecgram.q == QSPECGRAM.q
+    assert fs_qspecgram.dtype == numpy.dtype('float32')
     assert fs_qspecgram.shape == QSPECGRAM.shape
-    nptest.assert_allclose(fs_qspecgram.value, QSPECGRAM.value)
+    nptest.assert_allclose(fs_qspecgram.value, QSPECGRAM.value, rtol=3e-2)
 
 
 def test_qtable():

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -907,15 +907,15 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert isinstance(qgram, EventTable)
         assert qgram.meta['q'] == 45.25483399593904
         assert qgram['energy'].min() >= 5.5**2 / 2
-        nptest.assert_almost_equal(qgram['energy'].max(), 10559.255014979768)
+        nptest.assert_almost_equal(qgram['energy'].max(), 10559.25, decimal=2)
 
     def test_q_transform(self, losc):
         # test simple q-transform
         qspecgram = losc.q_transform(method='scipy-welch', fftlength=2)
         assert isinstance(qspecgram, Spectrogram)
-        assert qspecgram.shape == (4000, 2403)
+        assert qspecgram.shape == (1000, 2403)
         assert qspecgram.q == 5.65685424949238
-        nptest.assert_almost_equal(qspecgram.value.max(), 156.43279233248313)
+        nptest.assert_almost_equal(qspecgram.value.max(), 155.93567, decimal=5)
 
         # test whitening args
         asd = losc.asd(2, 1, method='scipy-welch')
@@ -932,7 +932,8 @@ class TestTimeSeries(_TestTimeSeriesBase):
         with pytest.warns(UserWarning):
             qspecgram = losc.q_transform(method='scipy-welch',
                                          frange=(0, 10000))
-            nptest.assert_almost_equal(qspecgram.yspan[1], 1291.5316316157107)
+            nptest.assert_almost_equal(
+                qspecgram.yspan[1], 1291.5316, decimal=4)
 
         # test other normalisations work (or don't)
         q2 = losc.q_transform(method='scipy-welch', norm='median')
@@ -945,11 +946,11 @@ class TestTimeSeries(_TestTimeSeriesBase):
     def test_q_transform_logf(self, losc):
         # test q-transform with log frequency spacing
         qspecgram = losc.q_transform(method='scipy-welch', fftlength=2,
-                                     fres=500, logf=True)
+                                     logf=True)
         assert isinstance(qspecgram, Spectrogram)
-        assert qspecgram.shape == (4000, 500)
+        assert qspecgram.shape == (1000, 500)
         assert qspecgram.q == 5.65685424949238
-        nptest.assert_almost_equal(qspecgram.value.max(), 156.43222488296405)
+        nptest.assert_almost_equal(qspecgram.value.max(), 155.93774, decimal=5)
 
     def test_boolean_statetimeseries(self, array):
         comp = array >= 2 * array.unit

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1840,7 +1840,7 @@ class TimeSeries(TimeSeriesBase):
                     frange=qtransform.DEFAULT_FRANGE,
                     gps=None,
                     search=.5,
-                    tres=.001,
+                    tres="<default>",
                     fres="<default>",
                     logf=False,
                     norm='median',
@@ -1852,6 +1852,12 @@ class TimeSeries(TimeSeriesBase):
                     **asd_kw):
         """Scan a `TimeSeries` using the multi-Q transform and return an
         interpolated high-resolution spectrogram
+
+        By default, this method returns a high-resolution spectrogram in
+        both time and frequency, which can result in a large memory
+        footprint. If you know that you only need a subset of the output
+        for, say, a figure, consider using ``outseg`` and the other
+        keyword arguments to restrict the size of the returned data.
 
         Parameters
         ----------
@@ -1869,7 +1875,8 @@ class TimeSeries(TimeSeriesBase):
             used if `gps` is given
 
         tres : `float`, optional
-            desired time resolution (seconds) of output `Spectrogram`
+            desired time resolution (seconds) of output `Spectrogram`,
+            default is `abs(outseg) / 1000.`
 
         fres : `float`, `int`, `None`, optional
             desired frequency resolution (Hertz) of output `Spectrogram`,
@@ -1892,7 +1899,8 @@ class TimeSeries(TimeSeriesBase):
             maximum allowed fractional mismatch between neighbouring tiles
 
         outseg : `~gwpy.segments.Segment`, optional
-            GPS `[start, stop)` segment for output `Spectrogram`
+            GPS `[start, stop)` segment for output `Spectrogram`,
+            default is the full duration of the input
 
         whiten : `bool`, `~gwpy.frequencyseries.FrequencySeries`, optional
             boolean switch to enable (`True`) or disable (`False`) data
@@ -1927,6 +1935,9 @@ class TimeSeries(TimeSeriesBase):
 
         Notes
         -----
+        This method will return a `Spectrogram` of dtype ``float32`` if
+        ``norm`` is given, and ``float64`` otherwise.
+
         To optimize plot rendering with `~matplotlib.axes.Axes.pcolormesh`,
         the output `~gwpy.spectrogram.Spectrogram` can be given a log-sampled
         frequency axis by passing `logf=True` at runtime. The `fres` argument


### PR DESCRIPTION
This pull request ensures that interpolated Q-transform spectrograms are populated with single-precision floats, to save memory. It also slightly expands unit tests for the Q-transform, and fixes one of the documentation examples to use `outseg` rather than `crop`.

This fixes #1050.

cc @duncanmmacleod, @tjma12 