### PR TITLE
Added basic gating as TimeSeries method

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -807,6 +807,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         utils.assert_allclose(new_data.value[ind], waveform.value)
         utils.assert_allclose(data.value, numpy.zeros(duration*sample_rate))
 
+    @utils.skip_minimum_version("scipy", "1.1.0")
     def test_gate(self):
         # generate Gaussian noise with std = 0.5
         noise = self.TEST_CLASS(numpy.random.normal(scale=0.5, size=16384*64),

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -807,6 +807,36 @@ class TestTimeSeries(_TestTimeSeriesBase):
         utils.assert_allclose(new_data.value[ind], waveform.value)
         utils.assert_allclose(data.value, numpy.zeros(duration*sample_rate))
 
+    def test_gate(self):
+        # generate Gaussian noise with std = 0.5
+        noise = self.TEST_CLASS(numpy.random.normal(scale=0.5, size=16384*64),
+                                sample_rate=16384, epoch=-32)
+        # generate a glitch with amplitude 20 at 1000 Hz
+        glitchtime = 0.0
+        glitch = signal.gausspulse(noise.times.value - glitchtime,
+                                   bw=100) * 20
+        data = noise + glitch
+
+        # check that the glitch is at glitchtime as expected
+        tmax = data.times.value[data.argmax()]
+        nptest.assert_almost_equal(tmax, glitchtime)
+
+        # gating method will be called with whiten = False to decouple
+        # whitening method from gating method
+        tzero = 1.0
+        tpad = 1.0
+        threshold = 10.0
+        gated = data.gate(tzero=tzero, tpad=tpad, threshold=threshold,
+                          whiten=False)
+
+        # check that the maximum value is not within the region set to zero
+        tleft = glitchtime - tzero
+        tright = glitchtime + tzero
+        assert not tleft < gated.times.value[gated.argmax()] < tright
+
+        # check that there are no remaining values above the threshold
+        assert gated.max() < threshold
+
     def test_whiten(self):
         # create noise with a glitch in it at 1000 Hz
         noise = self.TEST_CLASS(

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1635,7 +1635,7 @@ class TimeSeries(TimeSeriesBase):
         data = self.whiten(**whiten_kwargs) if whiten else self
         window_samples = cluster_window * data.sample_rate.value
         gates = find_peaks(abs(data.value), height=threshold,
-                                  distance=window_samples)[0]
+                           distance=window_samples)[0]
         out = self.copy()
 
         # Iterate over list of indices to gate and apply each one

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1626,6 +1626,12 @@ class TimeSeries(TimeSeriesBase):
         >>> ax.legend()
         >>> overlay.show()
         """
+        try:
+             from scipy.signal import find_peaks
+        except ImportError:
+             raise ImportError("Must have scipy>=1.1.0 to utilize "
+                               "this method.")
+
         # Find points to gate based on a threshold
         data = self.whiten(**whiten_kwargs) if whiten else self
         window_samples = cluster_window * data.sample_rate.value

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1634,7 +1634,7 @@ class TimeSeries(TimeSeriesBase):
         # Find points to gate based on a threshold
         data = self.whiten(**whiten_kwargs) if whiten else self
         window_samples = cluster_window * data.sample_rate.value
-        gates = signal.find_peaks(abs(data.value), height=threshold,
+        gates = find_peaks(abs(data.value), height=threshold,
                                   distance=window_samples)[0]
         out = self.copy()
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1627,10 +1627,10 @@ class TimeSeries(TimeSeriesBase):
         >>> overlay.show()
         """
         try:
-             from scipy.signal import find_peaks
+            from scipy.signal import find_peaks
         except ImportError:
-             raise ImportError("Must have scipy>=1.1.0 to utilize "
-                               "this method.")
+            raise ImportError("Must have scipy>=1.1.0 to utilize "
+                              "this method.")
 
         # Find points to gate based on a threshold
         data = self.whiten(**whiten_kwargs) if whiten else self

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1628,10 +1628,9 @@ class TimeSeries(TimeSeriesBase):
         """
         try:
             from scipy.signal import find_peaks
-        except ImportError:
-            raise ImportError("Must have scipy>=1.1.0 to utilize "
-                              "this method.")
-
+        except ImportError as exc:
+            exc.args = ("Must have scipy>=1.1.0 to utilize this method.",)
+            raise
         # Find points to gate based on a threshold
         data = self.whiten(**whiten_kwargs) if whiten else self
         window_samples = cluster_window * data.sample_rate.value

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1626,8 +1626,9 @@ class TimeSeries(TimeSeriesBase):
         """
         # Find points to gate based on a threshold
         data = self.whiten(**whiten_kwargs) if whiten else self
+        window_samples = cluster_window*data.sample_rate.value
         gates = signal.find_peaks(data.value, height=threshold,
-                       distance=cluster_window*data.sample_rate.value)[0]
+                                  distance=window_samples)[0]
         out = self.copy()
 
         # Iterate over list of indices to gate and apply each one


### PR DESCRIPTION
This PR adds gating as a `TimeSeries` class method. The method whitens the time series, marks all points above a threshold, clusters them within a time window, and applies inverse Planck windows to zero out the data. The **unwhitened**, gated time series is returned.

An example can be found here (behind LIGO.org auth): https://ldas-jobs.ligo.caltech.edu/~thomas.massinger/notebook/demonstrate-gwpy-gating.html

Whitening arguments can be passed to the underlying whitening used to locate gating points.