### PR TITLE
Improved pycbc import protection in tests

### DIFF
--- a/gwpy/signal/tests/test_spectral_pycbc.py
+++ b/gwpy/signal/tests/test_spectral_pycbc.py
@@ -26,7 +26,7 @@ import pytest
 
 from ..spectral import _pycbc as fft_pycbc
 
-pytest.importorskip('pycbc')
+pytest.importorskip('pycbc.psd')
 
 
 def test_welch(noisy_sinusoid):


### PR DESCRIPTION
This PR should hopefully fix the [current CI failures](https://travis-ci.com/gwpy/gwpy/builds/101769964) by improving the import protection in the test suite for `gwpy.signal`.