### PR TITLE
Added tests for frameCPP errors and fixed a bug

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -47,7 +47,7 @@ FRERR_NO_FRAME_AT_NUM = re.compile(
     r'0 through (?P<nframes>\d+)\Z',
 )
 FRERR_NO_CHANNEL_OF_TYPE = re.compile(
-    r'\ANo Fr(Adc|Proc|Sim)Data structures with the name (?P<channel>\S+)\Z',
+    r'\ANo Fr(Adc|Proc|Sim)Data structures with the name ',
 )
 
 # get frameCPP type mapping
@@ -261,7 +261,7 @@ def _get_frdata(stream, num, name, ctype=None):
             if FRERR_NO_CHANNEL_OF_TYPE.match(str(exc)):
                 continue
             raise
-    raise ValueError("no Fr{Adc,Proc,Sim}Data structures with the "
+    raise ValueError("no Fr{{Adc,Proc,Sim}}Data structures with the "
                      "name {0}".format(name))
 
 


### PR DESCRIPTION
This PR adds a `test_read_write_gwf_errors` test method that exposed a failure, and corrects said failure in error reporting.