### PR TITLE
Switch coverage to codecov, and update CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,6 @@ environment:
   matrix:
     - MINICONDA: C:\Miniconda-x64
       PYTHON_VERSION: 2.7
-    - MINICONDA: C:\Miniconda35-x64
-      PYTHON_VERSION: 3.5
     - MINICONDA: C:\Miniconda36-x64
       PYTHON_VERSION: 3.6
     - MINICONDA: C:\Miniconda37-x64
@@ -25,4 +23,10 @@ install:
 build_script:
   - python -m pip install .
 test_script:
-  - python -m pytest --pyargs gwpy --cov gwpy
+  - python -m pytest --pyargs gwpy --cov gwpy --junitxml=junit.xml
+after_test:
+  - "set _PYV=%PYTHON_VERSION:.=%"
+  - python -m pip install codecov
+  - python -m codecov --flags Windows python%_PYV% conda
+on_finish:
+  - ps: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\junit.xml))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,33 @@
 version: 2
 
-machine:
-  environment:
-    PIP_FLAGS: "--progress-bar off"
-
 # -- templates --------------
 
 aliases:
   - &attach_workspace
       attach_workspace:
         at: .
+
+  - &set_python_environment
+      name: Set Python environment
+      command: |
+        export PIP_FLAGS=${PIP_FLAGS:-"--progress-bar=off"}
+        echo "export PIP_FLAGS=\"${PIP_FLAGS}\"" >> ${BASH_ENV}
+        echo "Set PIP_FLAGS=\"${PIP_FLAGS}\""
+        export PYTHON_VERSION=${CIRCLE_JOB##*:}
+        echo "export PYTHON_VERSION=\"${PYTHON_VERSION}\"" >> ${BASH_ENV}
+        echo "Set PYTHON_VERSION=\"${PYTHON_VERSION}\""
+
+  - &run-tests
+      name: Test
+      command: bash -ex ci/test.sh
+
+  - &codecov
+      name: Submit coverage to codecov
+      command: bash -ex ci/codecov.sh
+
+  - &coveralls
+      name: Submit coverage to coveralls
+      command: bash -ex ci/coveralls.sh
 
   - &store_test_results
       store_test_results:
@@ -19,20 +37,18 @@ aliases:
       store_artifacts:
         path: test-reports
 
-  - &run-tests
-      name: Test
-      command: bash -ex ci/test.sh
-
   - &python-build
       docker:
         - image: python
       steps:
         - checkout
         - *attach_workspace
+        - run: *set_python_environment
         - run:
             name: Install
-            command: python -m pip install gwpy-*.tar.*
+            command: python -m pip install ${PIP_FLAGS} gwpy-*.tar.*
         - run: *run-tests
+        - run: *codecov
         - store_test_results:
             path: test-reports
         - store_artifacts:
@@ -45,10 +61,12 @@ aliases:
         - checkout
         - restore_cache:
             key: v1-gwpy-{{ .Environment.CIRCLE_JOB }}
+        - run: *set_python_environment
         - run:
             name: Install
             command: bash -ex ci/install-pip.sh
         - run: *run-tests
+        - run: *codecov
         - save_cache:
             key: v1-gwpy-{{ .Environment.CIRCLE_JOB }}
             paths:
@@ -64,16 +82,17 @@ aliases:
         - checkout
         - *attach_workspace
         - restore_cache:
-            key: v1-gwpy-{{ .Environment.CIRCLE_JOB }}
+            key: v3-gwpy-{{ .Environment.CIRCLE_JOB }}
+        - run: *set_python_environment
         - run:
             name: Install
             command: bash -ex ci/install-conda.sh
         - run: *run-tests
+        - run: *codecov
         - save_cache:
-            key: v1-gwpy-{{ .Environment.CIRCLE_JOB }}
+            key: v3-gwpy-{{ .Environment.CIRCLE_JOB }}
             paths:
-              - "/opt/conda/envs/gwpyci/bin"
-              - "/opt/conda/envs/gwpyci/lib"
+              - "/opt/conda/envs/gwpyci"
         - *store_test_results
         - *store_test_artifacts
 
@@ -81,10 +100,12 @@ aliases:
       steps:
         - checkout
         - *attach_workspace
+        - run: *set_python_environment
         - run:
             name: Build
             command: bash -ex ci/install-debian.sh
         - run: *run-tests
+        - run: *codecov
         - *store_test_results
         - *store_test_artifacts
 
@@ -92,10 +113,12 @@ aliases:
       steps:
         - checkout
         - *attach_workspace
+        - run: *set_python_environment
         - run:
             name: Build
             command: bash -ex ci/install-el.sh
         - run: *run-tests
+        - run: *codecov
         - *store_test_results
         - *store_test_artifacts
         - store_artifacts:
@@ -145,36 +168,26 @@ jobs:
     <<: *python-build
     docker:
       - image: python:2.7
-    environment:
-      PYTHON_VERSION: "2.7"
 
   python:3.4:
     <<: *python-build
     docker:
       - image: python:3.4
-    environment:
-      PYTHON_VERSION: "3.4"
 
   python:3.5:
     <<: *python-build
     docker:
       - image: python:3.5
-    environment:
-      PYTHON_VERSION: "3.5"
 
   python:3.6:
     <<: *python-build
     docker:
       - image: python:3.6
-    environment:
-      PYTHON_VERSION: "3.6"
 
   python:3.7:
     <<: *python-build
     docker:
       - image: python:3.7
-    environment:
-      PYTHON_VERSION: "3.7"
 
   # -- pip ------------------
 
@@ -182,44 +195,33 @@ jobs:
     <<: *pip-build
     docker:
       - image: python:2.7
-    environment:
-      PYTHON_VERSION: "2.7"
 
   pip:3.4:
     <<: *pip-build
     docker:
       - image: python:3.4
-    environment:
-      PYTHON_VERSION: "3.4"
 
   pip:3.5:
     <<: *pip-build
     docker:
       - image: python:3.5
-    environment:
-      PYTHON_VERSION: "3.5"
 
   pip:3.6:
     <<: *pip-build
     docker:
       - image: python:3.6
-    environment:
-      PYTHON_VERSION: "3.6"
 
   pip:3.7:
     <<: *pip-build
     docker:
       - image: python:3.7
-    environment:
-      PYTHON_VERSION: "3.7"
 
-  pip:3.7:pre:
+  pip:pre:3.7:
     <<: *pip-build
     docker:
       - image: python:3.7
     environment:
       PIP_FLAGS: "--progress-bar off --upgrade --pre"
-      PYTHON_VERSION: "3.7"
 
   # -- conda ----------------
 
@@ -227,18 +229,12 @@ jobs:
     <<: *conda-build
     docker:
       - image: continuumio/miniconda2
-    environment:
-      PYTHON_VERSION: "2.7"
 
   conda:3.6:
     <<: *conda-build
-    environment:
-      PYTHON_VERSION: "3.6"
 
   conda:3.7:
     <<: *conda-build
-    environment:
-      PYTHON_VERSION: "3.7"
 
   # -- debian ---------------
 
@@ -247,14 +243,14 @@ jobs:
     docker:
       - image: ligo/base:stretch
     environment:
-      PYTHON_VERSION: "2.7"
+      PIP_FLAGS: " "
 
   debian:stretch:3.5:
     <<: *debian-build
     docker:
       - image: ligo/base:stretch
     environment:
-      PYTHON_VERSION: "3.5"
+      PIP_FLAGS: " "
 
   # -- rhel -----------------
 
@@ -263,7 +259,7 @@ jobs:
     docker:
       - image: ligo/base:el7
     environment:
-      PYTHON_VERSION: "2.7"
+      PIP_FLAGS: " "
 
 # -- workflow ---------------
 
@@ -307,7 +303,7 @@ workflows:
       - pip:3.7:
           requires:
             - python:3.7
-      - pip:3.7:pre:
+      - pip:pre:3.7:
           requires:
             - python:3.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,17 @@ matrix:
     - python: '2.7'
       language: minimal
       stage: Distribution tests
+      name: "conda:2.7"
       env: INSTALL_CMD=". ./ci/install-conda.sh" PYTHON_VERSION="2.7"
     - python: '3.6'
       language: minimal
       stage: Distribution tests
+      name: "conda:3.6"
       env: INSTALL_CMD=". ./ci/install-conda.sh" PYTHON_VERSION="3.6"
     - python: '3.7'
       language: minimal
       stage: Distribution tests
+      name: "conda:3.7"
       env: INSTALL_CMD=". ./ci/install-conda.sh" PYTHON_VERSION="3.7"
 
 install:  # install package
@@ -54,8 +57,8 @@ install:  # install package
 script:  # run tests
   - ${TEST_CMD}
 
-after_success:  # submit coverage results
-  - . ./ci/coveralls.sh
+after_success:
+  - bash -ex ci/codecov.sh
 
 before_deploy:
   - git clean -dfX

--- a/README.md
+++ b/README.md
@@ -18,15 +18,18 @@ step.
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/gwpy.svg)](https://travis-ci.org/gwpy/gwpy)
 [![Research software impact](http://depsy.org/api/package/pypi/gwpy/badge.svg)](http://depsy.org/package/python/gwpy)
 
-[![Unix](https://img.shields.io/travis/gwpy/gwpy/master.svg?label=Unix)](https://travis-ci.org/gwpy/gwpy)
+[![Linux](https://img.shields.io/circleci/project/github/gwpy/gwpy/master.svg?label=Linux)](https://circleci.com/gh/gwpy/gwpy)
+[![OSX](https://img.shields.io/travis/gwpy/gwpy/master.svg?label=macOS)](https://travis-ci.org/gwpy/gwpy)
 [![Windows](https://img.shields.io/appveyor/ci/gwpy/gwpy/master.svg?label=Windows)](https://ci.appveyor.com/project/gwpy/gwpy/branch/master)
-[![Coverage Status](https://coveralls.io/repos/github/gwpy/gwpy/badge.svg?branch=master)](https://coveralls.io/github/gwpy/gwpy?branch=master)
+[![codecov](https://codecov.io/gh/gwpy/gwpy/branch/master/graph/badge.svg)](https://codecov.io/gh/gwpy/gwpy)
 
 # Development status
 
-[![Unix dev](https://img.shields.io/travis/gwpy/gwpy/develop.svg?label=Unix)](https://travis-ci.org/gwpy/gwpy)
-[![Windows dev](https://img.shields.io/appveyor/ci/gwpy/gwpy/develop.svg?label=Windows)](https://ci.appveyor.com/project/gwpy/gwpy/branch/master)
-[![Coverage Status dev](https://coveralls.io/repos/github/gwpy/gwpy/badge.svg?branch=develop)](https://coveralls.io/github/gwpy/gwpy?branch=develop)
+
+[![Linux dev](https://img.shields.io/circleci/project/github/gwpy/gwpy/develop.svg?label=Linux)](https://circleci.com/gh/gwpy/gwpy)
+[![OSX dev](https://img.shields.io/travis/gwpy/gwpy/develop.svg?label=macOS)](https://travis-ci.org/gwpy/gwpy)
+[![Windows dev](https://img.shields.io/appveyor/ci/gwpy/gwpy/develop.svg?label=Windows)](https://ci.appveyor.com/project/gwpy/gwpy/branch/develop)
+[![codecov dev](https://codecov.io/gh/gwpy/gwpy/branch/develop/graph/badge.svg)](https://codecov.io/gh/gwpy/gwpy)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2cf14445b3e070133745/maintainability)](https://codeclimate.com/github/gwpy/gwpy/maintainability)
 
 # Installation

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2017-2019)
+# Copyright (C) Duncan Macleod (2019)
 #
 # This file is part of GWpy.
 #
@@ -20,15 +20,23 @@ set -ex
 trap 'set +ex' RETURN
 
 #
-# Submit coverage data to coveralls.io
+# Submit coverage data to codecov.io
 #
 
-# get path to python and pip
-PYTHON=$(which "python${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}")
-PYTHON_PREFIX=$(${PYTHON} -c "import sys; print(sys.prefix)")
-PIP="${PYTHON} -m pip"
+# reactivate environmennt
+if [ -n ${CIRCLECI} ] && [ -d /opt/conda/envs ]; then
+    conda activate gwpyci || source activate gwpyci
+fi
 
-${PIP} install --quiet coveralls
+# get path to python
+PYTHON_VERSION=$(echo "${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}" | cut -d. -f-2)
+PYTHON=$(which "python${PYTHON_VERSION}")
+
+# install codecov
+${PYTHON} -m pip install ${PIP_FLAGS} coverage codecov
+
+# find job name
+_JOBNAME=${CIRCLE_JOB:-${TRAVIS_JOB_NAME}}
 
 # submit coverage results
-${PYTHON} -m coveralls
+${PYTHON} -m codecov --flags $(uname) python${PYTHON_VERSION/./} ${_JOBNAME%%:*}

--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -23,7 +23,7 @@ trap 'set +ex' RETURN
 # Install GWpy and dependencies using Conda
 #
 
-PYTHON_VERSION=${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}
+PYTHON_VERSION=$(echo "${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}" | cut -d. -f-2)
 
 if ! which conda 1> /dev/null; then
     # install conda
@@ -56,7 +56,7 @@ conda update --quiet conda
 conda info --all
 
 # create environment for tests (if needed)
-if [ ! -d ${CONDA_PATH}/envs/gwpyci ]; then
+if [ ! -f ${CONDA_PATH}/envs/gwpyci/conda-meta/history ]; then
     conda create --name gwpyci python=${PYTHON_VERSION} gwpy
 fi
 conda activate gwpyci || source activate gwpyci
@@ -70,12 +70,12 @@ rm -f conda-reqs.txt  # clean up
 
 # install other conda packages that aren't represented in the requirements file
 conda install --name gwpyci --quiet --yes \
-    lscsoft-glue \
     python-lal \
     python-lalframe \
     python-lalsimulation \
     python-ldas-tools-framecpp \
-    python-nds2-client
+    python-nds2-client \
+    root_numpy
 
 # install gwpy into this environment
 ${PYTHON} -m pip install ${PIP_FLAGS} . --ignore-installed --no-deps

--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -62,9 +62,7 @@ dpkg --install ${GWPY_DEB} || { \
 }
 
 # install extras
-# NOTE: git is needed for coveralls
 apt-get -yqq install \
-    git \
     ${PY_PREFIX}-pip \
     libkrb5-dev krb5-user \
     dvipng texlive-latex-base texlive-latex-extra \
@@ -80,6 +78,7 @@ apt-get -yqq install \
     ${PY_PREFIX}-lal \
     ${PY_PREFIX}-lalframe \
     ${PY_PREFIX}-lalsimulation \
+    ${PY_PREFIX}-ldas-tools-framecpp \
     ${PY_PREFIX}-nds2-client
 
 # install ROOT for python2 only

--- a/ci/install-pip.sh
+++ b/ci/install-pip.sh
@@ -23,7 +23,8 @@ trap 'set +ex' RETURN
 # Install GWpy and all optional dependencies with pip
 #
 
-PYTHON=$(which python)
+PYTHON_VERSION=$(echo "${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}" | cut -d. -f-2)
+PYTHON=$(which "python${PYTHON_VERSION}")
 
 # install myriad testing dependencies
 ${PYTHON} -m pip install ${PIP_FLAGS} -r requirements-dev.txt

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -29,11 +29,12 @@ if [ -n ${CIRCLECI} ] && [ -d /opt/conda/envs ]; then
 fi
 
 # get path to python and pip
-PYTHON=$(which "python${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}")
+PYTHON_VERSION=$(echo "${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}" | cut -d. -f-2)
+PYTHON=$(which "python${PYTHON_VERSION}")
 PIP="${PYTHON} -m pip"
 
 # upgrade setuptools in order to understand environment markers
-${PIP} install "pip>=8.0.0" "setuptools>=20.2.2"
+${PIP} install ${PIP_FLAGS} "pip>=8.0.0" "setuptools>=20.2.2"
 
 # install test dependencies
 ${PIP} install ${PIP_FLAGS} -r requirements-test.txt


### PR DESCRIPTION
This PR does one big thing, and a few small things.

## The main event

This switches the coverage reporting from coveralls to codecov, mainly because it natively supports multiple coverage providers. The reporting is also very nice.

## The other bits

- use test reports properly in appveyor
- removed python3.5 build for appveyor - it just adds time and not useful information
- fixed some bugs in the CI scripts, mainly conda related
- fixed caching of conda builds in circleci