### PR TITLE
Moved PyPI deploy to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,12 +133,18 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install dependencies
+          command: |
+            set -ex
+            python -m pip install "setuptools>=20.2.0" "wheel"
+      - run:
           name: Build tarball
-          command: python setup.py --quiet sdist --dist-dir .
+          command: python setup.py --quiet sdist --dist-dir . bdist_wheel --universal --dist-dir .
       - persist_to_workspace:
           root: .
           paths:
             - gwpy-*.tar.*
+            - gwpy-*-none-any.whl
 
   flake8:
     docker:
@@ -261,6 +267,19 @@ jobs:
     environment:
       PIP_FLAGS: " "
 
+  # -- deploy ---------------
+
+  deploy:
+    docker:
+      - image: python
+    steps:
+      - run:
+          name: Twine upload
+          command: |
+            # TWINE_USERNAME and TWINE_PASSWORD are set in repo settings
+            python -m pip install twine
+            python -m twine upload gwpy-*.tar.* gwpy-*-none-any.whl
+
 # -- workflow ---------------
 
 workflows:
@@ -328,3 +347,18 @@ workflows:
       - el7:2.7:
           requires:
             - sdist
+
+      # deploy
+      - deploy:
+          requires:
+            - conda:2.7
+            - conda:3.6
+            - conda:3.7
+            - debian:stretch:2.7
+            - debian:stretch:3.5
+            - el7:2.7
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,19 +63,6 @@ after_success:
 before_deploy:
   - git clean -dfX
 
-deploy:
-  - provider: pypi
-    user: duncanmmacleod
-    password: ${PYPI_PASSWD}
-    distributions: sdist bdist_wheel
-    on:
-      condition: -z "${DOCKER_IMAGE}"
-      branch: master
-      tags: true
-      python: '3.6'
-      repo: gwpy/gwpy
-      skip_existing: true
-
 notifications:
   slack:
     secure: jQdoSpwNbUnq0Eo7o6Ko7vuhu58LQdfy8jFKxLUnUjv/GLezK/PPAQCU9SgmyDPh1yD8sb5Xa8UtbNfGtpYdwBAGwZxPHz3oQQAflivFwcF6UP7/NlAB9muSOOnL0QfQyX1I4sIKOkX+gkl+TBciX4v58B8NUU02dDkwDqTLUqQ=


### PR DESCRIPTION
This PR moves the automatic PyPI deployment to CircleCI, which is better suited to it. This is impossible to actually test in CI as part of a pull request, unfortunately.