### PR TITLE
Use pytest-xdist to run tests in parallel

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ install:
 build_script:
   - python -m pip install .
 test_script:
-  - python -m pytest --pyargs gwpy --cov gwpy --junitxml=junit.xml
+  - python -m pytest --pyargs gwpy --cov gwpy --junitxml=junit.xml --numprocesses=2
 after_test:
   - "set _PYV=%PYTHON_VERSION:.=%"
   - python -m pip install codecov

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -53,4 +53,4 @@ else
 fi
 
 # run tests with coverage
-${PYTHON} -m pytest --pyargs gwpy --cov=gwpy --junitxml=test-reports/junit.xml
+${PYTHON} -m pytest --pyargs gwpy --cov=gwpy --junitxml=test-reports/junit.xml --numprocesses=2

--- a/gwpy/plot/tests/test_gps.py
+++ b/gwpy/plot/tests/test_gps.py
@@ -141,7 +141,9 @@ class TestInverseGpsTransform(TestGpsTransform):
 
 
 @pytest.mark.parametrize(
-    'scale', filter(lambda x: x != 'auto-gps', plot_gps.GPS_SCALES))
+    'scale',
+    sorted(filter(lambda x: x != 'auto-gps', plot_gps.GPS_SCALES)),
+)
 def test_gps_scale(scale):
     u = Unit(scale[:-1])
 

--- a/gwpy/utils/tests/test_env.py
+++ b/gwpy/utils/tests/test_env.py
@@ -55,7 +55,8 @@ BOOL_ENV.update(BOOL_FALSE)
 @mock.patch.dict('os.environ', values=BOOL_ENV)
 @pytest.mark.parametrize(
     'env, result',
-    [(k, True) for k in BOOL_TRUE] + [(k, False) for k in BOOL_FALSE],
+    [(k, True) for k in sorted(BOOL_TRUE)] +
+    [(k, False) for k in sorted(BOOL_FALSE)],
 )
 def test_bool_env(env, result):
     """Test :meth:`gwpy.utils.env.bool_env` _without_ the `default` keyword

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,7 @@
 more-itertools < 6.0a0 ; python_version < '3'
 pytest >= 3.3.0
 pytest-cov >= 2.4.0
+pytest-xdist
 mock ; python_version < '3'
 freezegun >= 0.2.3
 sqlparse >= 0.2.0


### PR DESCRIPTION
This PR adds `pytest-xdist` to the CI configuration to try and run the tests in parallel, ideally speeding things up.