### PR TITLE
Fixed usage of deprecated_call to fix failing test

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  precision: 2
+  range: 50..100
+  round: nearest
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1
+    patch:
+      default:
+        target: 90
+

--- a/gwpy/signal/tests/test_spectral_median_mean.py
+++ b/gwpy/signal/tests/test_spectral_median_mean.py
@@ -52,16 +52,24 @@ def test_median_mean(lal_func, pycbc_func):
     # first call goes to pycbc
     with pytest.deprecated_call() as record:
         fft_median_mean.median_mean(1, 2, 3)
-    assert len(record) == 2  # once for pycbc, once for mm
-    assert "pycbc_median_mean" in record[-1].message.args[0]
-    assert pycbc_func.called_with(1, 2, 3)
+    try:
+        assert len(record) == 2  # once for pycbc, once for mm
+    except TypeError:  # pytest < 3.9.1
+        pass
+    else:
+        assert "pycbc_median_mean" in record[-1].message.args[0]
+        assert pycbc_func.called_with(1, 2, 3)
 
     # second call goes to lal
     with pytest.deprecated_call() as record:
         fft_median_mean.median_mean(1, 2, 3)
-    assert len(record) == 3  # once for pycbc, once for lal, once for mm
-    assert "lal_median_mean" in record[-1].message.args[0]
-    assert lal_func.called_with(1, 2, 3)
+    try:
+        assert len(record) == 3  # once for pycbc, once for lal, once for mm
+    except TypeError:  # pytest < 3.9.1
+        pass
+    else:
+        assert "lal_median_mean" in record[-1].message.args[0]
+        assert lal_func.called_with(1, 2, 3)
 
     # third call errors
     with pytest.deprecated_call(), pytest.raises(KeyError):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ maya
 pandas ; python_version != '3.4'
 pandas < 0.21 ; python_version == '3.4'
 psycopg2
-pycbc >= 1.10.1 ; python_version == '2.7' and sys_platform != 'win32'
+pycbc >= 1.13.4 ; sys_platform != 'win32'
 pymysql
 pyRXP
 sqlalchemy


### PR DESCRIPTION
This PR fixes a failing test based on using `pytest.deprecated_call` with `pytest < 3.9.1`.