### PR TITLE
Swap the defaults for applying ADC bias and slope calibration

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -291,7 +291,7 @@ class TimeSeriesBase(Series):
     @classmethod
     def fetch(cls, channel, start, end, host=None, port=None, verbose=False,
               connection=None, verify=False, pad=None, allow_tape=None,
-              scaled=True, type=None, dtype=None):
+              scaled=False, type=None, dtype=None):
         """Fetch data from NDS
 
         Parameters
@@ -461,7 +461,7 @@ class TimeSeriesBase(Series):
 
     @classmethod
     def find(cls, channel, start, end, frametype=None, pad=None,
-             scaled=True, dtype=None, nproc=1, verbose=False, **readargs):
+             scaled=False, dtype=None, nproc=1, verbose=False, **readargs):
         """Find and read data from frames for a channel
 
         Parameters
@@ -520,7 +520,7 @@ class TimeSeriesBase(Series):
         )[str(channel)]
 
     @classmethod
-    def get(cls, channel, start, end, pad=None, scaled=True,
+    def get(cls, channel, start, end, pad=None, scaled=False,
             dtype=None, verbose=False, allow_tape=None, **kwargs):
         """Get data for this channel from frames or NDS
 
@@ -610,7 +610,7 @@ class TimeSeriesBase(Series):
         return super(TimeSeriesBase, self).plot(method=method, **kwargs)
 
     @classmethod
-    def from_nds2_buffer(cls, buffer_, scaled=True, copy=True, **metadata):
+    def from_nds2_buffer(cls, buffer_, scaled=False, copy=True, **metadata):
         """Construct a new series from an `nds2.buffer` object
 
         **Requires:** |nds2|_
@@ -1016,7 +1016,7 @@ class TimeSeriesBaseDict(OrderedDict):
     @classmethod
     def fetch(cls, channels, start, end, host=None, port=None,
               verify=False, verbose=False, connection=None,
-              pad=None, scaled=True, allow_tape=None, type=None,
+              pad=None, scaled=False, allow_tape=None, type=None,
               dtype=None):
         """Fetch data from NDS for a number of channels.
 
@@ -1149,7 +1149,7 @@ class TimeSeriesBaseDict(OrderedDict):
 
     @classmethod
     def find(cls, channels, start, end, frametype=None,
-             frametype_match=None, pad=None, scaled=True, dtype=None, nproc=1,
+             frametype_match=None, pad=None, scaled=False, dtype=None, nproc=1,
              verbose=False, allow_tape=True, observatory=None, **readargs):
         """Find and read data from frames for a number of channels.
 
@@ -1257,7 +1257,7 @@ class TimeSeriesBaseDict(OrderedDict):
         return out
 
     @classmethod
-    def get(cls, channels, start, end, pad=None, scaled=True,
+    def get(cls, channels, start, end, pad=None, scaled=False,
             dtype=None, verbose=False, allow_tape=None, **kwargs):
         """Retrieve data for multiple channels from frames or NDS
 
@@ -1365,7 +1365,7 @@ class TimeSeriesBaseDict(OrderedDict):
                     for c in channels)
 
     @classmethod
-    def from_nds2_buffers(cls, buffers, scaled=True, copy=True, **metadata):
+    def from_nds2_buffers(cls, buffers, scaled=False, copy=True, **metadata):
         """Construct a new dict from a list of `nds2.buffer` objects
 
         **Requires:** |nds2|_

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -291,7 +291,7 @@ class TimeSeriesBase(Series):
     @classmethod
     def fetch(cls, channel, start, end, host=None, port=None, verbose=False,
               connection=None, verify=False, pad=None, allow_tape=None,
-              scaled=False, type=None, dtype=None):
+              scaled=True, type=None, dtype=None):
         """Fetch data from NDS
 
         Parameters
@@ -461,7 +461,7 @@ class TimeSeriesBase(Series):
 
     @classmethod
     def find(cls, channel, start, end, frametype=None, pad=None,
-             scaled=False, dtype=None, nproc=1, verbose=False, **readargs):
+             scaled=True, dtype=None, nproc=1, verbose=False, **readargs):
         """Find and read data from frames for a channel
 
         Parameters
@@ -520,7 +520,7 @@ class TimeSeriesBase(Series):
         )[str(channel)]
 
     @classmethod
-    def get(cls, channel, start, end, pad=None, scaled=False,
+    def get(cls, channel, start, end, pad=None, scaled=True,
             dtype=None, verbose=False, allow_tape=None, **kwargs):
         """Get data for this channel from frames or NDS
 
@@ -610,7 +610,7 @@ class TimeSeriesBase(Series):
         return super(TimeSeriesBase, self).plot(method=method, **kwargs)
 
     @classmethod
-    def from_nds2_buffer(cls, buffer_, scaled=False, copy=True, **metadata):
+    def from_nds2_buffer(cls, buffer_, scaled=True, copy=True, **metadata):
         """Construct a new series from an `nds2.buffer` object
 
         **Requires:** |nds2|_
@@ -1016,7 +1016,7 @@ class TimeSeriesBaseDict(OrderedDict):
     @classmethod
     def fetch(cls, channels, start, end, host=None, port=None,
               verify=False, verbose=False, connection=None,
-              pad=None, scaled=False, allow_tape=None, type=None,
+              pad=None, scaled=True, allow_tape=None, type=None,
               dtype=None):
         """Fetch data from NDS for a number of channels.
 
@@ -1149,7 +1149,7 @@ class TimeSeriesBaseDict(OrderedDict):
 
     @classmethod
     def find(cls, channels, start, end, frametype=None,
-             frametype_match=None, pad=None, scaled=False, dtype=None, nproc=1,
+             frametype_match=None, pad=None, scaled=True, dtype=None, nproc=1,
              verbose=False, allow_tape=True, observatory=None, **readargs):
         """Find and read data from frames for a number of channels.
 
@@ -1257,7 +1257,7 @@ class TimeSeriesBaseDict(OrderedDict):
         return out
 
     @classmethod
-    def get(cls, channels, start, end, pad=None, scaled=False,
+    def get(cls, channels, start, end, pad=None, scaled=True,
             dtype=None, verbose=False, allow_tape=None, **kwargs):
         """Retrieve data for multiple channels from frames or NDS
 
@@ -1365,7 +1365,7 @@ class TimeSeriesBaseDict(OrderedDict):
                     for c in channels)
 
     @classmethod
-    def from_nds2_buffers(cls, buffers, scaled=False, copy=True, **metadata):
+    def from_nds2_buffers(cls, buffers, scaled=True, copy=True, **metadata):
         """Construct a new dict from a list of `nds2.buffer` objects
 
         **Requires:** |nds2|_

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -79,7 +79,7 @@ class _Skip(ValueError):
 
 # -- read ---------------------------------------------------------------------
 
-def read(source, channels, start=None, end=None, scaled=True, type=None,
+def read(source, channels, start=None, end=None, scaled=False, type=None,
          series_class=TimeSeries):
     # pylint: disable=redefined-builtin
     """Read a dict of series from one or more GWF files
@@ -138,7 +138,7 @@ def read(source, channels, start=None, end=None, scaled=True, type=None,
     return out
 
 
-def read_gwf(filename, channels, start=None, end=None, scaled=True,
+def read_gwf(filename, channels, start=None, end=None, scaled=False,
              ctype=None, series_class=TimeSeries):
     """Read a dict of series data from a single GWF file
 
@@ -239,7 +239,7 @@ def read_gwf(filename, channels, start=None, end=None, scaled=True,
 
 
 def _read_channel(stream, num, name, ctype, epoch, start, end,
-                  scaled=True, series_class=TimeSeries):
+                  scaled=False, series_class=TimeSeries):
     """Read a channel from a specific frame in a stream
     """
     data = _get_frdata(stream, num, name, ctype=ctype)
@@ -277,7 +277,7 @@ def _need_frame(frame, start, end):
     return True
 
 
-def read_frdata(frdata, epoch, start, end, scaled=True,
+def read_frdata(frdata, epoch, start, end, scaled=False,
                 series_class=TimeSeries):
     """Read a series from an `FrData` structure
 

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -79,7 +79,7 @@ class _Skip(ValueError):
 
 # -- read ---------------------------------------------------------------------
 
-def read(source, channels, start=None, end=None, scaled=False, type=None,
+def read(source, channels, start=None, end=None, scaled=True, type=None,
          series_class=TimeSeries):
     # pylint: disable=redefined-builtin
     """Read a dict of series from one or more GWF files
@@ -138,7 +138,7 @@ def read(source, channels, start=None, end=None, scaled=False, type=None,
     return out
 
 
-def read_gwf(filename, channels, start=None, end=None, scaled=False,
+def read_gwf(filename, channels, start=None, end=None, scaled=True,
              ctype=None, series_class=TimeSeries):
     """Read a dict of series data from a single GWF file
 
@@ -239,7 +239,7 @@ def read_gwf(filename, channels, start=None, end=None, scaled=False,
 
 
 def _read_channel(stream, num, name, ctype, epoch, start, end,
-                  scaled=False, series_class=TimeSeries):
+                  scaled=True, series_class=TimeSeries):
     """Read a channel from a specific frame in a stream
     """
     data = _get_frdata(stream, num, name, ctype=ctype)
@@ -277,7 +277,7 @@ def _need_frame(frame, start, end):
     return True
 
 
-def read_frdata(frdata, epoch, start, end, scaled=False,
+def read_frdata(frdata, epoch, start, end, scaled=True,
                 series_class=TimeSeries):
     """Read a series from an `FrData` structure
 

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -34,6 +34,7 @@ from ....io.utils import file_list
 from ....segments import Segment
 from ....time import LIGOTimeGPS
 from ... import TimeSeries
+from ...core import _dynamic_scaled
 
 from . import channel_dict_kwarg
 
@@ -79,7 +80,7 @@ class _Skip(ValueError):
 
 # -- read ---------------------------------------------------------------------
 
-def read(source, channels, start=None, end=None, scaled=True, type=None,
+def read(source, channels, start=None, end=None, scaled=None, type=None,
          series_class=TimeSeries):
     # pylint: disable=redefined-builtin
     """Read a dict of series from one or more GWF files
@@ -138,7 +139,7 @@ def read(source, channels, start=None, end=None, scaled=True, type=None,
     return out
 
 
-def read_gwf(filename, channels, start=None, end=None, scaled=True,
+def read_gwf(filename, channels, start=None, end=None, scaled=None,
              ctype=None, series_class=TimeSeries):
     """Read a dict of series data from a single GWF file
 
@@ -210,10 +211,11 @@ def read_gwf(filename, channels, start=None, end=None, scaled=True,
 
         # and read all the channels
         for channel in channels:
+            _scaled = _dynamic_scaled(scaled, channel)
             try:
                 new = _read_channel(stream, this, str(channel),
                                     ctype.get(channel, None),
-                                    epoch, start, end, scaled=scaled,
+                                    epoch, start, end, scaled=_scaled,
                                     series_class=series_class)
             except _Skip:  # don't need this frame for this channel
                 continue

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -89,7 +89,7 @@ def set_parameter(connection, parameter, value, verbose=False):
 
 @io_nds2.open_connection
 def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
-          connection=None, host=None, port=None, pad=None, scaled=True,
+          connection=None, host=None, port=None, pad=None, scaled=False,
           verbose=False, series_class=TimeSeries):
     # host and port keywords are used by the decorator only
     # pylint: disable=unused-argument

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -89,7 +89,7 @@ def set_parameter(connection, parameter, value, verbose=False):
 
 @io_nds2.open_connection
 def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
-          connection=None, host=None, port=None, pad=None, scaled=False,
+          connection=None, host=None, port=None, pad=None, scaled=True,
           verbose=False, series_class=TimeSeries):
     # host and port keywords are used by the decorator only
     # pylint: disable=unused-argument

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -174,34 +174,6 @@ class TestTimeSeriesBase(_TestSeries):
         assert b.dt == 1/128. * units.s
         assert shares_memory(nds_buffer.data, b.value)
 
-    @utils.skip_missing_dependency('nds2')
-    def test_from_nds2_buffer_dynamic_scaled(self):
-        # build fake buffer for LIGO channel
-        nds_buffer = mocks.nds2_buffer(
-            'H1:TEST',
-            self.data,
-            1000000000,
-            self.data.shape[0],
-            'm',
-            name='test',
-            slope=2,
-            offset=1,
-        )
-
-        # check scaling defaults to off
-        utils.assert_array_equal(
-            self.TEST_CLASS.from_nds2_buffer(nds_buffer).value,
-            nds_buffer.data,
-        )
-        utils.assert_array_equal(
-            self.TEST_CLASS.from_nds2_buffer(nds_buffer, scaled=False).value,
-            nds_buffer.data,
-        )
-        utils.assert_array_equal(
-            self.TEST_CLASS.from_nds2_buffer(nds_buffer, scaled=True).value,
-            nds_buffer.data * 2 + 1,
-        )
-
     @utils.skip_missing_dependency('lal')
     def test_to_from_lal(self, array):
         import lal

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -174,6 +174,7 @@ class TestTimeSeriesBase(_TestSeries):
         assert b.dt == 1/128. * units.s
         assert shares_memory(nds_buffer.data, b.value)
 
+    @utils.skip_missing_dependency('nds2')
     def test_from_nds2_buffer_dynamic_scaled(self):
         # build fake buffer for LIGO channel
         nds_buffer = mocks.nds2_buffer(

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -283,6 +283,34 @@ class TestTimeSeries(_TestTimeSeriesBase):
             assert_equal=utils.assert_quantity_sub_equal,
             assert_kw={'exclude': ['unit', 'name', 'channel', 'x0']})
 
+    @utils.skip_missing_dependency('nds2')
+    def test_from_nds2_buffer_dynamic_scaled(self):
+        # build fake buffer for LIGO channel
+        nds_buffer = mocks.nds2_buffer(
+            'H1:TEST',
+            self.data,
+            1000000000,
+            self.data.shape[0],
+            'm',
+            name='test',
+            slope=2,
+            offset=1,
+        )
+
+        # check scaling defaults to off
+        utils.assert_array_equal(
+            self.TEST_CLASS.from_nds2_buffer(nds_buffer).value,
+            nds_buffer.data,
+        )
+        utils.assert_array_equal(
+            self.TEST_CLASS.from_nds2_buffer(nds_buffer, scaled=False).value,
+            nds_buffer.data,
+        )
+        utils.assert_array_equal(
+            self.TEST_CLASS.from_nds2_buffer(nds_buffer, scaled=True).value,
+            nds_buffer.data * 2 + 1,
+        )
+
     # -- test remote data access ----------------
 
     @utils.skip_minimum_version("gwosc", "0.4.0")


### PR DESCRIPTION
This PR swaps the defaults for applying ADC bias and slope calibration to a dynamic choice based on the channel name. For H1 and L1 channels, bias and slope are ignored, else they are applied.

cc @duncanmmacleod 