### PR TITLE
Manually request numpy when creating environment

### DIFF
--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -53,7 +53,7 @@ conda info --all
 
 # create environment for tests (if needed)
 if [ ! -f ${CONDA_PATH}/envs/gwpyci/conda-meta/history ]; then
-    conda create --name gwpyci python=${PYTHON_VERSION} gwpy
+    conda create --name gwpyci python=${PYTHON_VERSION} numpy gwpy
 fi
 conda activate gwpyci || source activate gwpyci
 PYTHON=$(which python)


### PR DESCRIPTION
This PR patches the travis conda installer script to manually request `numpy` when creating the environment, this forces `numpy` to come from `conda-forge`, rather than `defaults`, meaning when we install `lal` and friends, we end up not having to switch.