### PR TITLE
Handle scaled keyword argument when reading GWF with lalframe

### DIFF
--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -24,6 +24,7 @@ The frame format is defined in LIGO-T970130 available from dcc.ligo.org.
 from __future__ import (absolute_import, division)
 
 import os.path
+import warnings
 
 from six import string_types
 
@@ -122,9 +123,18 @@ def get_stream_duration(stream):
 
 # -- read ---------------------------------------------------------------------
 
-def read(source, channels, start=None, end=None, series_class=TimeSeries):
+def read(source, channels, start=None, end=None, series_class=TimeSeries,
+         scaled=None):
     """Read data from one or more GWF files using the LALFrame API
     """
+    # scaled must be provided to provide a consistent API with frameCPP
+    if scaled is not None:
+        warnings.warn(
+            "the `scaled` keyword argument is not supported by lalframe, "
+            "if you require ADC scaling, please install "
+            "python-ldas-tools-framecpp",
+        )
+
     stream = open_data_source(source)
 
     # parse times and restrict to available data

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -238,6 +238,24 @@ class TestTimeSeries(_TestTimeSeriesBase):
                 "Failed to read {0!r} from {1!r}".format(losc.name, tmp)
             )
 
+    @utils.skip_missing_dependency('lalframe')
+    def test_read_gwf_scaled_lalframe(self):
+        with pytest.warns(None) as record:
+            data = self.TEST_CLASS.read(
+                utils.TEST_GWF_FILE,
+                "L1:LDAS-STRAIN",
+                format="gwf.lalframe",
+            )
+        assert not record.list  # no warning
+        with pytest.warns(UserWarning):
+            data2 = self.TEST_CLASS.read(
+                utils.TEST_GWF_FILE,
+                "L1:LDAS-STRAIN",
+                format="gwf.lalframe",
+                scaled=True,
+            )
+        utils.assert_quantity_sub_equal(data, data2)
+
     @pytest.mark.parametrize('ext', ('hdf5', 'h5'))
     @pytest.mark.parametrize('channel', [
         None,


### PR DESCRIPTION
This PR fixes a bug in GWF reading whereby the `scaled` keyword argument is always passed, but the `lalframe` API doesn't expect it. The mod is to handle it and just present a warning when the user has actually used it, since the `lalframe` API doesn't support it.