### PR TITLE
Handle noop in TimeSeries.resample with warning

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -782,6 +782,12 @@ class TestTimeSeries(_TestTimeSeriesBase):
         # FIXME: this test needs to be more robust
         assert l2.sample_rate == 1024 * units.Hz
 
+    def test_resample_noop(self):
+        data = self.TEST_CLASS([1, 2, 3, 4, 5])
+        with pytest.warns(UserWarning):
+            new = data.resample(data.sample_rate)
+            assert data is new
+
     def test_rms(self, losc):
         rms = losc.rms(1.)
         assert rms.sample_rate == 1 * units.Hz

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -21,6 +21,8 @@
 
 from __future__ import (division, print_function)
 
+import warnings
+
 from six.moves import range
 
 import numpy
@@ -937,6 +939,15 @@ class TimeSeries(TimeSeriesBase):
         if isinstance(rate, units.Quantity):
             rate = rate.value
         factor = (self.sample_rate.value / rate)
+        # NOTE: use math.isclose when python >= 3.5
+        if numpy.isclose(factor, 1., rtol=1e-09, atol=0.):
+            warnings.warn(
+                "resample() rate matches current sample_rate ({}), returning "
+                "input data unmodified; please double-check your "
+                "parameters".format(self.sample_rate),
+                UserWarning,
+            )
+            return self
         # if integer down-sampling, use decimate
         if factor.is_integer():
             if ftype == 'iir':


### PR DESCRIPTION
This PR patches `TimeSeries.resample` to detect when the requested rate matches the input rate, and just returns `self`.