### PR TITLE
Try and reconnect to datafind if connection fails with HTTPError

### DIFF
--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -425,7 +425,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     else:
         gpssegment = None
     if gpstime is not None:
-        gpstime = to_gps(gpstime).gpsSeconds
+        gpstime = int(to_gps(gpstime))
 
     # if use gaps post-S5 GPStime, forcibly skip _GRBYYMMDD frametypes at CIT
     if frametype_match is None and gpstime is not None and gpstime > 875232014:

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -311,6 +311,25 @@ def test_find_best_frametype(reconnect, num_channels, iter_channels,
         'L1:LDAS-STRAIN', 968654552, 968654553) == 'HW100916'
 
 
+def test_find_types(connection):
+    types = ["a", "b", "c"]
+    connection.find_types.return_value = types
+    assert io_datafind.find_types(
+        "X",
+        connection=connection,
+    ) == types
+
+
+def test_find_types_priority(connection):
+    types = ["L1_R", "L1_T", "L1_M"]
+    connection.find_types.return_value = types
+    assert io_datafind.find_types(
+        "X",
+        trend="m-trend",
+        connection=connection,
+    ) == ["L1_M", "L1_R", "L1_T"]
+
+
 def test_on_tape():
     assert io_datafind.on_tape(TEST_GWF_FILE) is False
 

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -223,6 +223,8 @@ class TestFflConnection(object):
 @mock.patch("gwpy.io.datafind.connect", return_value="connection")
 def test_with_connection(connect):
     func = mock.MagicMock()
+    # https://stackoverflow.com/questions/22204660/python-mock-wrapsf-problems
+    func.__name__ = "func"
     wrapped_func = io_datafind.with_connection(func)
 
     wrapped_func(1, host="host")
@@ -234,6 +236,8 @@ def test_with_connection(connect):
 @mock.patch("gwpy.io.datafind.reconnect", lambda x: x)
 def test_with_connection_reconnect(connect):
     func = mock.MagicMock()
+    # https://stackoverflow.com/questions/22204660/python-mock-wrapsf-problems
+    func.__name__ = "func"
     func.side_effect = [HTTPException, "return"]
     wrapped_func = io_datafind.with_connection(func)
 


### PR DESCRIPTION
Sometimes `gwdatafind` fails with an `HTTPError` (`BadStatusLine`?), so the simple thing to do is just try to reconnect and try again.