### PR TITLE
Fixed some bugs in gwpy.plot.Axes overrides of upstream methods

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ install:
   - activate gwpy
   - python ci\\parse-conda-requirements.py requirements-dev.txt -o conda-reqs.txt
   - conda install --yes --file conda-reqs.txt
+  - conda install openssl=1.0.2
   # print everything we have
   - conda list
 build_script:

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -200,7 +200,7 @@ class Axes(_Axes):
     )
 
     @log_norm
-    def imshow(self, array, **kwargs):
+    def imshow(self, array, *args, **kwargs):
         """Display an image, i.e. data on a 2D regular raster.
 
         If ``array`` is a :class:`~gwpy.types.Array2D` (e.g. a
@@ -220,8 +220,8 @@ class Axes(_Axes):
         array : array-like or PIL image
             The image data.
 
-        **kwargs
-            All keywords are passed to the inherited
+        *args, **kwargs
+            All arguments and keywords are passed to the inherited
             :meth:`~matplotlib.axes.Axes.imshow` method.
 
         See Also
@@ -230,9 +230,9 @@ class Axes(_Axes):
             for details of the image rendering
         """
         if isinstance(array, Array2D):
-            return self._imshow_array2d(array, **kwargs)
+            return self._imshow_array2d(array, *args, **kwargs)
 
-        image = super(Axes, self).imshow(array, **kwargs)
+        image = super(Axes, self).imshow(array, *args, **kwargs)
         self.autoscale(enable=None, axis='both', tight=None)
         return image
 
@@ -279,13 +279,13 @@ class Axes(_Axes):
             return self._pcolormesh_array2d(*args, **kwargs)
         return super(Axes, self).pcolormesh(*args, **kwargs)
 
-    def _pcolormesh_array2d(self, array, **kwargs):
+    def _pcolormesh_array2d(self, array, *args, **kwargs):
         """Render an `~gwpy.types.Array2D` using `Axes.pcolormesh`
         """
         x = numpy.concatenate((array.xindex.value, array.xspan[-1:]))
         y = numpy.concatenate((array.yindex.value, array.yspan[-1:]))
         xcoord, ycoord = numpy.meshgrid(x, y, copy=False, sparse=True)
-        return self.pcolormesh(xcoord, ycoord, array.value.T, **kwargs)
+        return self.pcolormesh(xcoord, ycoord, array.value.T, *args, **kwargs)
 
     def hist(self, x, *args, **kwargs):
         x = numpy.asarray(x)

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -41,13 +41,40 @@ class TestAxes(AxesTestBase):
 
     def test_plot(self, ax):
         series = Series(range(10), dx=.1)
-        line, = ax.plot(series, 'r--')
+        lines = ax.plot(
+            series,
+            series * 2, 'k--',
+            series.xindex, series, 'b-',
+            [1, 2, 3], [4, 5, 6],
+        )
 
+        # check line 1 maps the series with default params
+        line = lines[0]
         linex, liney = line.get_data()
         utils.assert_array_equal(linex, series.xindex.value)
         utils.assert_array_equal(liney, series.value)
-        assert line.get_color() == 'r'
+
+        # check line 2 maps 2*series with specific params
+        line = lines[1]
+        linex, liney = line.get_data()
+        utils.assert_array_equal(linex, series.xindex.value)
+        utils.assert_array_equal(liney, series.value * 2)
+        assert line.get_color() == 'k'
         assert line.get_linestyle() == '--'
+
+        # check line 3
+        line = lines[2]
+        linex, liney = line.get_data()
+        utils.assert_array_equal(linex, series.xindex.value)
+        utils.assert_array_equal(liney, series.value)
+        assert line.get_color() == 'b'
+        assert line.get_linestyle() == '-'
+
+        # check line 4
+        line = lines[3]
+        linex, liney = line.get_data()
+        utils.assert_array_equal(linex, [1, 2, 3])
+        utils.assert_array_equal(liney, [4, 5, 6])
 
     @pytest.mark.parametrize('c_sort', (False, True))
     def test_scatter(self, ax, c_sort):


### PR DESCRIPTION
This PR fixes two issues with using `gwpy.plot.Axes` for 'normal' matplotlib usage, include via `pylab`

- fixed handling of positional arguments in `Axes.plot`
- fixed handling of positional arguments in `Axes.imshow`