### PR TITLE
Improved index handling in Series and Array2D

### DIFF
--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -289,7 +289,7 @@ class FrequencySeries(Series):
         """
         f0 = self.f0.decompose().value
         N = (self.size - 1) * (self.df.decompose().value / df) + 1
-        fsamples = numpy.arange(0, numpy.rint(N)) * df + f0
+        fsamples = numpy.arange(0, numpy.rint(N), dtype=self.dtype) * df + f0
         out = type(self)(numpy.interp(fsamples, self.frequencies.value,
                                       self.value))
         out.__array_finalize__(self)

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -258,7 +258,8 @@ class TimeSeriesBase(Series):
 
         :type: `~astropy.units.Quantity` scalar
         """
-        return units.Quantity(self.span[1] - self.span[0], self.xunit)
+        return units.Quantity(self.span[1] - self.span[0], self.xunit,
+                              dtype=float)
 
     # -- TimeSeries accessors -------------------
 
@@ -711,7 +712,7 @@ class TimeSeriesBase(Series):
             unit = None
         channel = Channel(lalts.name, sample_rate=1/lalts.deltaT, unit=unit,
                           dtype=lalts.data.data.dtype)
-        out = cls(lalts.data.data, channel=channel, t0=float(lalts.epoch),
+        out = cls(lalts.data.data, channel=channel, t0=lalts.epoch,
                   dt=lalts.deltaT, unit=unit, name=lalts.name, copy=False)
         if copy:
             return out.copy()

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -218,9 +218,9 @@ def register_gwf_api(library):
         # -- from here read data
 
         if start:
-            start = float(to_gps(start))
+            start = to_gps(start)
         if end:
-            end = float(to_gps(end))
+            end = to_gps(end)
 
         # parse output format kwargs -- DEPRECATED
         if resample is not None:

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -149,7 +149,7 @@ def read(source, channels, start=None, end=None, series_class=TimeSeries,
         offset = float(start - epoch)
         duration = streamdur - offset
     else:
-        end = min(epoch + streamdur, end)
+        end = min(epoch + streamdur, lalutils.to_lal_ligotimegps(end))
         duration = float(end - start)
 
     # read data

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -21,8 +21,6 @@
 
 from warnings import warn
 
-import numpy
-
 from matplotlib import __version__ as mpl_version
 
 from astropy.units import (Unit, Quantity)

--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -27,6 +27,43 @@ from astropy.units import Quantity
 class Index(Quantity):
     """1-D `~astropy.units.Quantity` array for indexing a `Series`
     """
+    @classmethod
+    def define(cls, start, step, num, dtype=None):
+        """Define a new `Index`.
+
+        The output is basically::
+
+            start + numpy.arange(num) * step
+
+        Parameters
+        ----------
+        start : `Number`
+            The starting value of the index.
+
+        step : `Number`
+            The step size of the index.
+
+        num : `int`
+            The size of the index (number of samples).
+
+        dtype : `numpy.dtype`, `None`, optional
+            The desired dtype of the index, if not given, defaults
+            to the higher-precision dtype from ``start`` and ``step``.
+
+        Returns
+        -------
+        index : `Index`
+            A new `Index` created from the given parameters.
+        """
+        if dtype is None:
+            dtype = max(
+                numpy.array(start, subok=True, copy=False).dtype,
+                numpy.array(step, subok=True, copy=False).dtype,
+            )
+        start = start.astype(dtype, copy=False)
+        step = step.astype(dtype, copy=False)
+        return cls(start + numpy.arange(num, dtype=dtype) * step, copy=False)
+
     @property
     def regular(self):
         """`True` if this index is linearly increasing

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -896,39 +896,49 @@ class Series(Array):
         `Series` span, warnings will be printed and the limits will
         be restricted to the :attr:`~Series.xspan`
         """
+        x0, x1 = self.xspan
+        xtype = type(x0)
+        if isinstance(start, Quantity):
+            start = start.to(self.xunit).value
+        if isinstance(end, Quantity):
+            end = end.to(self.xunit).value
+
         # pin early starts to time-series start
-        if start == self.xspan[0]:
+        if start == x0:
             start = None
-        elif start is not None and start < self.xspan[0]:
+        elif start is not None and xtype(start) < x0:
             warn('%s.crop given start smaller than current start, '
                  'crop will begin when the Series actually starts.'
                  % type(self).__name__)
             start = None
+
         # pin late ends to time-series end
-        if end == self.xspan[1]:
+        if end == x1:
             end = None
-        if end is not None and end > self.xspan[1]:
+        if end is not None and xtype(end) > x1:
             warn('%s.crop given end larger than current end, '
                  'crop will end when the Series actually ends.'
                  % type(self).__name__)
             end = None
+
         # find start index
         if start is None:
             idx0 = None
         else:
-            idx0 = int(float(start - self.xspan[0]) // self.dx.value)
+            idx0 = int((xtype(start) - x0) // self.dx.value)
+
         # find end index
         if end is None:
             idx1 = None
         else:
-            idx1 = int(float(end - self.xspan[0]) // self.dx.value)
+            idx1 = int((xtype(end) - x0) // self.dx.value)
             if idx1 >= self.size:
                 idx1 = None
+
         # crop
         if copy:
             return self[idx0:idx1].copy()
-        else:
-            return self[idx0:idx1]
+        return self[idx0:idx1]
 
     def pad(self, pad_width, **kwargs):
         """Pad this series to a new size

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -111,6 +111,12 @@ class TestSeries(_TestArray):
         assert series.x0 == units.Quantity(1, 'Mpc')
         assert series.xspan == (x[0], x[-1] + x[-1] - x[-2])
 
+    def test_xindex_dtype(self):
+        x0 = numpy.longdouble(100)
+        dx = numpy.float32(1e-4)
+        series = self.create(x0=x0, dx=dx)
+        assert series.xindex.dtype is x0.dtype
+
     def test_xunit(self, unit=None):
         if unit is None:
             unit = self.TEST_CLASS._default_xunit


### PR DESCRIPTION
This PR simplifies the way that index properties are handled between the `Series` and `Array2D` classes, mainly to remove the large amount of code duplication between the two.

Additionally I put in some small changes to preserve `dtype` wherever possible, mainly in `numpy` calls, and also to remove some unnecessary casts of `LIGOTimeGPS` to `float`, which can cause precision loss.