### PR TITLE
Improved read_cache and write_cache functions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,6 +31,7 @@ Depends: ${misc:Depends},
          python-ligo-segments (>= 1.0.0),
          python-matplotlib (>= 1.2.0),
          python-numpy (>= 1.7.1),
+         python-pathlib,
          python-scipy (>= 0.12.1),
          python-six (>= 1.5),
          python-tqdm (>= 4.10.0)

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -38,6 +38,7 @@ Requires:       h5py >= 1.3
 Requires:       python2-ldas-tools-framecpp >= 2.6.0
 Requires:       python2-lal >= 6.14.0
 Requires:       python2-ligo-segments >= 1.0.0
+Requires:       python-pathlib
 Requires:       python2-tqdm >= 4.10.0
 Requires:       python2-gwosc
 Requires:       python2-dqsegdb2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ ligo-segments >= 1.0.0
 ligotimegps >= 1.2.1
 matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
 numpy >= 1.7.1
+pathlib ; python_version < '3'
 python-dateutil
 scipy >= 0.12.1
 six >= 1.5

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ install_requires = [
     'ligotimegps >= 1.2.1',
     'matplotlib >= 1.2.0, != 2.1.0, != 2.1.1',
     'numpy >= 1.7.1',
+    'pathlib ; python_version < \'3\'',
     'python-dateutil',
     'scipy >= 0.12.1',
     'six >= 1.5',


### PR DESCRIPTION
This PR improves the `read_cache` and `write_cache` functions from `gwpy.io.cache` to support the following:

- read a plaintxt file of paths (in LIGO-T050017 format)
- a new `format` keyword argument to `write_cache` to specify the format

To support this, a new `filename_metadata` function was added. This is essentially the same as that in `gwdatafind.utils`, but handles floats in the filename.