### PR TITLE
Strip whitespace when testing shell.call

### DIFF
--- a/gwpy/utils/tests/test_shell.py
+++ b/gwpy/utils/tests/test_shell.py
@@ -31,8 +31,8 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 def test_shell_call():
     out, err = shell.call(["echo", "This works"])
-    assert out == 'This works\n'
-    assert err == ''
+    assert out.rstrip() == 'This works'
+    assert err.rstrip() == ''
 
     shell.call("echo 'This works'")
 


### PR DESCRIPTION
This PR attempts to fix failures under windows on azure CI [[ref](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=21287)] by stripping whitespace when comparing the output of `gwpy.utils.shell.call`.