### PR TITLE
Use set to format readcols for pycbc

### DIFF
--- a/gwpy/table/io/pycbc.py
+++ b/gwpy/table/io/pycbc.py
@@ -79,12 +79,12 @@ def table_from_file(source, ifo=None, columns=None, selection=None,
     # parse default columns
     if columns is None:
         columns = list(_get_columns(source))
-    readcols = list(columns)
+    readcols = set(columns)
 
     # parse selections
     selection = parse_column_filters(selection or [])
     if selection:
-        readcols.extend(list(zip(*selection))[0])
+        readcols.update(list(zip(*selection))[0])
 
     # set up meta dict
     meta = {'ifo': ifo}

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -577,6 +577,20 @@ class TestEventTable(TestTable):
                 t2,
                 filter_table(table, 'snr>.5')[("a", "b", "mass1")],
             )
+
+            # regression test: gwpy/gwpy#1081
+            t2 = self.TABLE.read(
+                fp,
+                format='hdf5.pycbc_live',
+                ifo='X1',
+                selection='snr>.5',
+                columns=("a", "b", "snr"),
+            )
+            utils.assert_table_equal(
+                t2,
+                filter_table(table, 'snr>.5')[("a", "b", "snr")],
+            )
+
         finally:
             if os.path.isdir(os.path.dirname(fp)):
                 shutil.rmtree(os.path.dirname(fp))


### PR DESCRIPTION
This PR fixes #1081 by using `set` to parse the necessary read column names.