### PR TITLE
gwpy.io: return unique creds from parse_keytab

### DIFF
--- a/gwpy/io/tests/test_kerberos.py
+++ b/gwpy/io/tests/test_kerberos.py
@@ -35,6 +35,7 @@ KLIST = b"""Keytab name: FILE:/test.keytab
 KVNO Principal
 ---- -------------------------------
    1 albert.einstein@LIGO.ORG
+   2 ronald.drever@LIGO.ORG
    2 ronald.drever@LIGO.ORG"""
 
 # mock os.environ
@@ -63,8 +64,8 @@ def test_parse_keytab(check_output):
     """
     # assert principals get extracted correctly
     principals = io_kerberos.parse_keytab('test.keytab')
-    assert principals == [['albert.einstein', 'LIGO.ORG'],
-                          ['ronald.drever', 'LIGO.ORG']]
+    assert principals == [('albert.einstein', 'LIGO.ORG', 1),
+                          ('ronald.drever', 'LIGO.ORG', 2)]
 
     # assert klist fail gets raise appropriately
     check_output.side_effect = [


### PR DESCRIPTION
This PR fixes an issue in `gwpy.io.kerberos` whereby keytab files with multiple copies of the same kvno/principal would be returned, causing `kinit()` to fall over. `parse_keytab()` has been modified to return an ordered, unique list of credentials, and also to return a `list` of `tuple`, rather than a `list` of `list`.

cc @scottcoughlin2014 