### PR TITLE
Import KeysView and ValuesView from collections.abc

### DIFF
--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -22,7 +22,10 @@
 import itertools
 import importlib
 import warnings
-from collections import (KeysView, ValuesView)
+try:
+    from collections.abc import (KeysView, ValuesView)
+except ImportError:  # python < 3.3
+    from collections import (KeysView, ValuesView)
 
 from six.moves import zip_longest
 


### PR DESCRIPTION
This PR fixes a `DeprecationWarning` in `gwpy.plot.plot` by importing `{Keys/Values}View` from `collections.abc` if we can.