### PR TITLE
Change spectrogram axis set from crop for y-axis to ax.set_ylim() try#2

### DIFF
--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -172,8 +172,12 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
             args.ymax = self.result.yspan[1]
 
         specgram = self.result.crop(
-            args.xmin, min(args.xmax, self.result.xspan[1]),
-        ).crop_frequencies(args.ymin, args.ymax)
+            args.xmin, min(args.xmax, self.result.xspan[1])
+        )
+
+        # y axis cannot be cropped if non-linear
+        ax = self.plot.gca()
+        ax.set_ylim(args.ymin, args.ymax)
 
         # auto scale colours
         if args.norm:


### PR DESCRIPTION
The current way to set axis limits for spectrogram and q-transform is to crop the transformed data.

         specgram = self.result.crop(
            args.xmin, min(args.xmax, self.result.xspan[1]),
        ).crop_frequencies(args.ymin, args.ymax)```

The change to log spacing for y-axis causes the following error:

```Traceback (most recent call last):
  File "/Users/areeda/miniconda2/envs/ligo-py27/bin/gwpy-plot", line 105, in <module>
    prod.run()
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/cli/cliproduct.py", line 712, in run
    self.set_plot_properties()
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/cli/cliproduct.py", line 547, in set_plot_properties
    self.set_axes_properties()
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/cli/cliproduct.py", line 778, in set_axes_properties
    super(ImageProduct, self).set_axes_properties()
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/cli/cliproduct.py", line 556, in set_axes_properties
    self.scale_axes_from_data()
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/cli/qtransform.py", line 234, in scale_axes_from_data
    return super(Qtransform, self).scale_axes_from_data()
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/cli/spectrogram.py", line 176, in scale_axes_from_data
    ).crop_frequencies(args.ymin, args.ymax)
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/spectrogram/spectrogram.py", line 582, in crop_frequencies
    idx0 = int(float(low.value - self.f0.value) // self.df.value)
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/types/array.py", line 195, in __getattr__
    return super(Array, self).__getattribute__(attr)
  File "/Users/areeda/miniconda2/envs/ligo-py27/lib/python2.7/site-packages/gwpy/types/array2d.py", line 246, in dy
    "This series has an irregular y-axis "
AttributeError: This series has an irregular y-axis index, so 'dy' is not well defined```

This change crops in x-direction and ax.set_ylim(...) in y-direction.

Try number 2