### PR TITLE
Pin requirements to compatible pytest-xdist

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@
 more-itertools < 6.0a0 ; python_version < '3'
 pytest >= 3.3.0
 pytest-cov >= 2.4.0
-pytest-xdist
+pytest-xdist < 1.28.0
 mock ; python_version < '3'
 freezegun >= 0.2.3
 sqlparse >= 0.2.0


### PR DESCRIPTION
This PR fixes [this sort of issue](https://circleci.com/gh/gwpy/gwpy/5443) with testing on older python versions where astropy still pins pytest.