### PR TITLE
Fixed bugs in gwpy.plot.utils for new matplotlib

### DIFF
--- a/gwpy/plot/tests/test_utils.py
+++ b/gwpy/plot/tests/test_utils.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2018-2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `gwpy.plot.text`
+"""
+
+import itertools
+
+from matplotlib import (
+    __version__ as mpl_version,
+    colors as mpl_colors,
+)
+
+from .. import utils as plot_utils
+
+
+def test_color_cycle():
+    cyc = plot_utils.color_cycle()
+    assert isinstance(cyc, itertools.cycle)
+    if mpl_version < '1.5':
+        assert next(cyc) == 'b'
+    else:
+        assert next(cyc) == mpl_colors.to_hex("C0")
+
+
+def test_color_cycle_arg():
+    cyc = plot_utils.color_cycle(['1', '2', '3'])
+    assert isinstance(cyc, itertools.cycle)
+    assert next(cyc) == '1'
+    assert next(cyc) == '2'
+    assert next(cyc) == '3'
+    assert next(cyc) == '1'
+
+
+def test_marker_cycle():
+    cyc = plot_utils.marker_cycle()
+    assert isinstance(cyc, itertools.cycle)
+    assert next(cyc) == 'o'
+
+
+def test_marker_cycle_arg():
+    cyc = plot_utils.marker_cycle(['1', '2', '3'])
+    assert isinstance(cyc, itertools.cycle)
+    assert next(cyc) == '1'
+    assert next(cyc) == '2'
+    assert next(cyc) == '3'
+    assert next(cyc) == '1'

--- a/gwpy/plot/utils.py
+++ b/gwpy/plot/utils.py
@@ -42,7 +42,10 @@ def color_cycle(colors=None):
     """
     if colors:
         return itertools.cycle(colors)
-    return itertools.cycle(rcParams['axes.color_cycle'])
+    try:
+        return itertools.cycle(p["color"] for p in rcParams["axes.prop_cycle"])
+    except KeyError:  # matplotlib < 1.5
+        return itertools.cycle(rcParams["axes.color_cycle"])
 
 
 def marker_cycle(markers=None):


### PR DESCRIPTION
This PR updates the `color_cycle` function in `gwpy.plot.utils` to work with `matplotlib >= 2.2`. This also adds unit tests for that module.