### PR TITLE
Fixed interactive usage of kinit() in ipython kernels (jupyter)

### DIFF
--- a/gwpy/io/kerberos.py
+++ b/gwpy/io/kerberos.py
@@ -39,6 +39,11 @@ __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 __all__ = ['kinit']
 
+try:
+    _IPYTHON = __IPYTHON__
+except NameError:
+    _IPYTHON = False
+
 
 class KerberosError(RuntimeError):
     """Kerberos (krb5) operation failed
@@ -127,7 +132,9 @@ def kinit(username=None, password=None, realm=None, exe=None, keytab=None,
                 keytab = None
 
     # refuse to prompt if we can't get an answer
-    if not sys.stdout.isatty() and (
+    # note: jupyter streams are not recognised as interactive
+    #       (isatty() returns False) so we have a special case here
+    if not sys.stdout.isatty() and not _IPYTHON and (
             username is None or
             (not keytab and password is None)
     ):

--- a/gwpy/io/kerberos.py
+++ b/gwpy/io/kerberos.py
@@ -87,23 +87,23 @@ def kinit(username=None, password=None, realm=None, exe=None, keytab=None,
 
     Notes
     -----
-    If a keytab is given, or is read from the KRB5_KTNAME environment
+    If a keytab is given, or is read from the ``KRB5_KTNAME`` environment
     variable, this will be used to guess the username and realm, if it
-    contains only a single credential
+    contains only a single credential.
 
     Examples
     --------
     Example 1: standard user input, with password prompt::
 
-        >>> kinit('albert.einstein')
-        Password for albert.einstein@LIGO.ORG:
-        Kerberos ticket generated for albert.einstein@LIGO.ORG
+    >>> kinit('albert.einstein')
+    Password for albert.einstein@LIGO.ORG:
+    Kerberos ticket generated for albert.einstein@LIGO.ORG
 
     Example 2: extract username and realm from keytab, and use that
     in authentication::
 
-        >>> kinit(keytab='~/.kerberos/ligo.org.keytab')
-        Kerberos ticket generated for albert.einstein@LIGO.ORG
+    >>> kinit(keytab='~/.kerberos/ligo.org.keytab', verbose=True)
+    Kerberos ticket generated for albert.einstein@LIGO.ORG
     """
     # get kinit path
     if exe is None:
@@ -146,12 +146,13 @@ def kinit(username=None, password=None, realm=None, exe=None, keytab=None,
     if realm is None:
         realm = 'LIGO.ORG'
     if username is None:
+        verbose = True
         username = input("Please provide username for the {} kerberos "
                          "realm: ".format(realm))
     identity = '{}@{}'.format(username, realm)
     if not keytab and password is None:
-        password = getpass.getpass(prompt="Password for {}: ".format(identity),
-                                   stream=sys.stdout)
+        verbose = True
+        password = getpass.getpass(prompt="Password for {}: ".format(identity))
 
     # format kinit command
     if keytab:

--- a/gwpy/io/tests/test_kerberos.py
+++ b/gwpy/io/tests/test_kerberos.py
@@ -21,7 +21,6 @@
 
 import os
 import subprocess
-import sys
 
 import pytest
 
@@ -99,7 +98,6 @@ def test_kinit_up(popen, getpass, input_, which, _, capsys):
     )
     getpass.assert_called_with(
         prompt="Password for rainer.weiss@LIGO.ORG: ",
-        stream=sys.stdout,
     )
     popen.assert_called_with(
         ['/bin/kinit', 'rainer.weiss@LIGO.ORG'],


### PR DESCRIPTION
This PR fixes an a problem using `gwpy.io.kerberos.kinit` in jupyter notebooks (ipython kernels in general) when the `sys.stdout.isatty()` returns `False`, to the function would refuse to attempt an interactive prompt.

The solution here is to manually look up existence of the `__IPYTHON__` special variable, and use that to override the result of `isatty()`. 