### PR TITLE
Compatibility fixes for matplotlib-3.1+

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -137,12 +137,12 @@ class Axes(_Axes):
     def _fmt_xdata(self, x):
         if self.get_xscale() in GPS_SCALES:
             return str(LIGOTimeGPS(x))
-        raise TypeError  # fall back to default
+        return self.xaxis.get_major_formatter().format_data_short(x)
 
     def _fmt_ydata(self, y):
         if self.get_yscale() in GPS_SCALES:
             return str(LIGOTimeGPS(y))
-        raise TypeError  # fall back to default
+        return self.yaxis.get_major_formatter().format_data_short(y)
 
     set_xlim = xlim_as_gps(_Axes.set_xlim)
 

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -567,9 +567,10 @@ register_projection(Axes)
 class PlotArgsProcessor(_process_plot_var_args):
     """This class controls how ax.plot() works
     """
-    def _grab_next_args(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """Find `Series` data in `plot()` args and unwrap
         """
+        newargs = []
         while args:
             # strip first argument
             this, args = args[:1], args[1:]
@@ -584,6 +585,6 @@ class PlotArgsProcessor(_process_plot_var_args):
             if args and isinstance(args[0], str):
                 this += args[0],
                 args = args[1:]
-            # use yield from with python3
-            for item in self._plot_args(this, kwargs):
-                yield item
+            newargs.extend(this)
+
+        return super(PlotArgsProcessor, self).__call__(*newargs, **kwargs)

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -30,7 +30,6 @@ from astropy.time import Time
 from matplotlib import (__version__ as mpl_version, rcParams)
 from matplotlib.artist import allow_rasterization
 from matplotlib.axes import Axes as _Axes
-from matplotlib.cbook import iterable
 from matplotlib.collections import PolyCollection
 from matplotlib.projections import register_projection
 try:
@@ -65,7 +64,7 @@ def xlim_as_gps(func):
     """
     @wraps(func)
     def wrapped_func(self, left=None, right=None, **kw):
-        if right is None and iterable(left):
+        if right is None and numpy.iterable(left):
             left, right = left
         kw['left'] = left
         kw['right'] = right
@@ -297,7 +296,7 @@ class Axes(_Axes):
 
         # calculate log-spaced bins on-the-fly
         if (kwargs.pop('logbins', False) and
-                not iterable(kwargs.get('bins', None))):
+                not numpy.iterable(kwargs.get('bins', None))):
             nbins = kwargs.get('bins', None) or rcParams.get('hist.bins', 30)
             # get range
             hrange = kwargs.pop('range', None)

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -21,19 +21,19 @@
 
 from __future__ import division
 
-import textwrap
-
 from decimal import Decimal
 from math import isinf
 from numbers import Number
-from inspect import getdoc
 
 import numpy
 
 from matplotlib import (ticker, docstring)
+from matplotlib.scale import (register_scale, LinearScale, get_scale_names)
 from matplotlib.transforms import Transform
-from matplotlib.scale import (_scale_mapping, register_scale,
-                              LinearScale, get_scale_names)
+try:
+    from matplotlib.scale import _get_scale_docs as get_scale_docs
+except ImportError:  # matplotlib < 3.1
+    from matplotlib.scale import get_scale_docs
 
 from astropy import units
 
@@ -488,18 +488,8 @@ for _unit in TIME_UNITS:
         break
     register_gps_scale(_gps_scale_factory(_unit))
 
-# collect all scale docstrings
-docs = []
-for name in get_scale_names():
-    scale_class = _scale_mapping[name]
-    docs.extend([
-        f"    {name!r}",
-        "",
-        textwrap.indent(getdoc(scale_class.__init__), " " * 8),
-        ""
-    ])
-
 # update the docstring for matplotlib scale methods
 docstring.interpd.update(
     scale=' | '.join([repr(x) for x in get_scale_names()]),
-    scale_docs="\n".join(docs).rstrip())
+    scale_docs=get_scale_docs().rstrip(),
+)

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -21,6 +21,8 @@
 
 from __future__ import division
 
+import textwrap
+
 from decimal import Decimal
 from math import isinf
 from numbers import Number
@@ -29,8 +31,9 @@ from inspect import getdoc
 import numpy
 
 from matplotlib import (ticker, docstring)
-from matplotlib.scale import (register_scale, LinearScale, get_scale_names)
 from matplotlib.transforms import Transform
+from matplotlib.scale import (_scale_mapping, register_scale,
+                              LinearScale, get_scale_names)
 
 from astropy import units
 
@@ -474,6 +477,8 @@ def _gps_scale_factory(unit):
                                  unit.names[0]))
 
         def __init__(self, axis, epoch=None):
+            """
+            """
             super(FixedGPSScale, self).__init__(axis, epoch=epoch, unit=unit)
     return FixedGPSScale
 
@@ -483,7 +488,18 @@ for _unit in TIME_UNITS:
         break
     register_gps_scale(_gps_scale_factory(_unit))
 
+# collect all scale docstrings
+docs = []
+for name in get_scale_names():
+    scale_class = _scale_mapping[name]
+    docs.extend([
+        f"    {name!r}",
+        "",
+        textwrap.indent(getdoc(scale_class.__init__), " " * 8),
+        ""
+    ])
+
 # update the docstring for matplotlib scale methods
 docstring.interpd.update(
     scale=' | '.join([repr(x) for x in get_scale_names()]),
-    scale_docs=getdoc(LinearScale.__init__))
+    scale_docs="\n".join(docs).rstrip())

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -24,12 +24,12 @@ from __future__ import division
 from decimal import Decimal
 from math import isinf
 from numbers import Number
+from inspect import getdoc
 
 import numpy
 
 from matplotlib import (ticker, docstring)
-from matplotlib.scale import (register_scale, LinearScale,
-                              get_scale_docs, get_scale_names)
+from matplotlib.scale import (register_scale, LinearScale, get_scale_names)
 from matplotlib.transforms import Transform
 
 from astropy import units
@@ -486,4 +486,4 @@ for _unit in TIME_UNITS:
 # update the docstring for matplotlib scale methods
 docstring.interpd.update(
     scale=' | '.join([repr(x) for x in get_scale_names()]),
-    scale_docs=get_scale_docs().rstrip())
+    scale_docs=getdoc(LinearScale.__init__))

--- a/gwpy/plot/rc.py
+++ b/gwpy/plot/rc.py
@@ -29,6 +29,12 @@ from ..utils.env import bool_env
 # record matplotlib's original rcParams
 MPL_RCPARAMS = rc_params()
 
+# record the LaTeX preamble
+try:
+    PREAMBLE = rcParams.get('text.latex.preamble', []) + tex.MACROS
+except TypeError:
+    PREAMBLE = rcParams.get('text.latex.preamble', '') + '\n'.join(tex.MACROS)
+
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 # -- custom rc ----------------------------------------------------------------
@@ -75,8 +81,7 @@ except KeyError:  # matplotlib < 1.5
 GWPY_TEX_RCPARAMS = RcParams(**{
     # use latex styling
     'text.usetex': True,
-    'text.latex.preamble': (
-        rcParams.get('text.latex.preamble', []) + tex.MACROS),
+    'text.latex.preamble': PREAMBLE,
     # use bigger font for labels (since the font is good)
     'font.family': ['serif'],
     'font.size': 16,

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -202,7 +202,7 @@ class TestAxes(AxesTestBase):
         else:
             cbar = ax.colorbar(vmin=2, vmax=4, **cb_kw)
         assert cbar.mappable is mesh
-        assert cbar.get_clim() == (2., 4.)
+        assert cbar.mappable.get_clim() == (2., 4.)
 
     def test_legend(self, ax):
         ax.plot(numpy.arange(5), label='test')

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -109,7 +109,7 @@ class TestPlot(FigureTestBase):
         image = ax.imshow(array)
         cbar = fig.colorbar(vmin=2, vmax=4, fraction=0.)
         assert cbar.mappable is image
-        assert cbar.get_clim() == (2., 4.)
+        assert cbar.mappable.get_clim() == (2., 4.)
 
     def test_add_colorbar(self, fig):
         ax = fig.gca()


### PR DESCRIPTION
This PR fixes some compatibility issues with matplotlib-3.1+:

* Since LaTeX preamble definitions will now have expected type `str` (not `list`), try to concatenate TeX macros to a list first, then fall back to a string if that fails (see [**TeX API changes**](https://matplotlib.org/devdocs/api/api_changes.html#latex-code-in-matplotlibrc-file))
* Since the public utility `matplotlib.scale.get_scale_docs` is deprecated, switch to using `inspect.getdocs` directly while preserving the order of scales (see [**attribute deprecations**](https://matplotlib.org/devdocs/api/api_changes.html#class-method-attribute-deprecations))
* `matplotlib.cbook.iterable` is deprecated, use `numpy.iterable`
* `cbar.get_clim` is deprecated, use `cbar.mappable.get_clim`

This fixes #1099, and supersedes #1100.

cc @duncanmmacleod 