### PR TITLE
Updated custom legend formatting

### DIFF
--- a/docs/plot/index.rst
+++ b/docs/plot/index.rst
@@ -104,6 +104,7 @@ Plot customisation
 
    gps
    colorbars
+   legend
 
 =================
 Plot applications

--- a/docs/plot/index.rst
+++ b/docs/plot/index.rst
@@ -84,7 +84,7 @@ However, `separate=True` can be given to show each dataset on a separate
 
 .. plot::
    :include-source:
-   :context:
+   :context: close-figs
 
    >>> plot = Plot(hdata, ldata, figsize=(12, 6), separate=True, sharex=True)
    >>> plot.show()

--- a/docs/plot/legend.rst
+++ b/docs/plot/legend.rst
@@ -1,0 +1,62 @@
+.. currentmodule:: gwpy.plot
+
+.. _gwpy-plot-legend:
+
+######################
+Custom legends in GWpy
+######################
+
+GWpy overrides the default :class:`~matplotlib.axes.Axes` class with one that
+uses a different default legend handler for line plots.
+This means that, by default, a lines in a legend will be thicker than on a
+standard matplotlib figure:
+
+.. plot::
+   :include-source:
+   :context: reset
+
+   >>> import gwpy  # <- import anything from gwpy
+   >>> from matplotlib import pyplot
+   >>> fig = pyplot.figure()
+   >>> ax = fig.gca()
+   >>> ax.plot(range(10), label='My data')
+   >>> ax.legend()
+   >>> fig.show()
+
+This can be disabled by passing an empty ``handler_map`` to the
+:meth:`~matplotlib.axes.Axes.legend` method:
+
+.. plot::
+   :include-source:
+   :context: close-figs
+
+   >>> fig = pyplot.figure()
+   >>> ax = fig.gca()
+   >>> ax.plot(range(10), label='My data')
+   >>> ax.legend(handler_map=None)
+   >>> fig.show()
+
+Similarly, you can implement your own custom legend handler and overwrite
+things yourself, below is a simple example, but for more details see
+:ref:`matplotlib:sphx_glr_tutorials_intermediate_legend_guide.py`:
+
+.. plot::
+   :include-source:
+   :context: close-figs
+
+   >>> from matplotlib.legend_handler import HandlerLine2D
+   >>> from matplotlib.lines import Line2D
+   >>> class MyHandler(HandlerLine2D):
+   ...     def create_artists(self, *args, **kwargs):
+   ...         line, marker = super(MyHandler, self).create_artists(
+   ...             *args,
+   ...             **kwargs,
+   ...         )
+   ...         line.set_linewidth(4.)
+   ...         line.set_linestyle('--')
+   ...         return line, marker
+   >>> fig = pyplot.figure()
+   >>> ax = fig.gca()
+   >>> ax.plot(range(10), label='My data')
+   >>> ax.legend(handler_map={Line2D: MyHandler()}, handlelength=10)
+   >>> fig.show()

--- a/docs/plot/legend.rst
+++ b/docs/plot/legend.rst
@@ -37,7 +37,8 @@ This can be disabled by passing an empty ``handler_map`` to the
    >>> fig.show()
 
 Similarly, you can implement your own custom legend handler and overwrite
-things yourself, below is a simple example, but for more details see
+things yourself.
+Below is a simple example, but for more details see
 :ref:`matplotlib:sphx_glr_tutorials_intermediate_legend_guide.py`:
 
 .. plot::

--- a/docs/plot/legend.rst
+++ b/docs/plot/legend.rst
@@ -8,7 +8,7 @@ Custom legends in GWpy
 
 GWpy overrides the default :class:`~matplotlib.axes.Axes` class with one that
 uses a different default legend handler for line plots.
-This means that, by default, a lines in a legend will be thicker than on a
+This means that, by default, lines in a legend will be thicker than on a
 standard matplotlib figure:
 
 .. plot::

--- a/docs/timeseries/datafind.rst
+++ b/docs/timeseries/datafind.rst
@@ -31,9 +31,9 @@ at ``datafind.ligo.org:443`` to query for files archived under
 
 .. _gwpy-timeseries-datafind-discovery:
 
-==================================================
+===================================================
 Auto-discovery of data using :meth:`TimeSeries.get`
-==================================================
+===================================================
 
 **Additional dependencies:** |LDAStools.frameCPP|_
 

--- a/gwpy/plot/legend.py
+++ b/gwpy/plot/legend.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Extensions of `~matplotlib.legend` for gwpy
+"""
+
+from matplotlib import legend_handler
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+class HandlerLine2D(legend_handler.HandlerLine2D):
+    """Custom Line2D legend handler that draws lines with linewidth 8
+
+    Parameters
+    ----------
+    linewidth : `float`, optional
+        the linewidth to use when drawing lines on the legend
+
+    **kw
+        all keywords are passed to `matplotlib.legend_handler.HandlerLine2D`
+
+    See also
+    --------
+    matplotlib.legend_handler.HanderLine2D
+        for all information
+    """
+    def __init__(self, linewidth=6., **kw):
+        super(HandlerLine2D, self).__init__(**kw)
+        self._linewidth = linewidth
+
+    def create_artists(self, *args, **kwargs):
+        line, marker = super(HandlerLine2D, self).create_artists(
+            *args,
+            **kwargs
+        )
+        line.set_linewidth(self._linewidth)
+        return line, marker

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -206,12 +206,30 @@ class TestAxes(AxesTestBase):
 
     def test_legend(self, ax):
         ax.plot(numpy.arange(5), label='test')
-        leg = ax.legend(alpha=.5, linewidth=10.)
+        leg = ax.legend()
         lframe = leg.get_frame()
-        assert lframe.get_alpha() == .5
-        assert lframe.get_linewidth() == rcParams['axes.linewidth']
+        assert lframe.get_linewidth() == rcParams['patch.linewidth']
         for line in leg.get_lines():
-            assert line.get_linewidth() == 10.
+            assert line.get_linewidth() == 6.
+
+    def test_legend_no_handler_map(self, ax):
+        ax.plot(numpy.arange(5), label='test')
+        leg = ax.legend(handler_map=None)
+        for line in leg.get_lines():
+            assert line.get_linewidth() == rcParams["lines.linewidth"]
+
+    def test_legend_deprecated_linewidth(self, ax):
+        ax.plot(numpy.arange(5), label='test')
+        with pytest.deprecated_call():
+            leg = ax.legend(linewidth=4)
+        assert leg.get_lines()[0].get_linewidth() == 4.
+
+    def test_legend_deprecated_alpha(self, ax):
+        ax.plot(numpy.arange(5), label='test')
+        with pytest.deprecated_call():
+            leg = ax.legend(alpha=.1)
+        if mpl_version >= "1.3.0":
+            assert leg.get_frame().get_alpha() == .1
 
     def test_plot_mmm(self, ax):
         mean_ = Series(numpy.random.random(10))


### PR DESCRIPTION
This PR changes the way legends are customised by default, to make things easier to modify for the user.

The old way was to use some extra keyword arguments, namely `linewidth`, to specify a new default linewidth in the legend. However, those keywords aren't recognised by default matplotlib figures, so calling `ax.legend(linewidth=4)` isn't cross-compatible between gwpy and non-gwpy plots. There's also no way to disable the custom linewidth and use the linewidth of the original handle.

The new way is to define a custom legend handler, which operates on `Line2D` objects, and sets the default linewidth. The interface is now that gwpy's `Axes.legend` method inserts the new handler into the existing `handler_map` keyword of matplotlib's `Axes.legend` method, which is entirely cross-compatible with non-gwpy plots. This gwpy handler can be disabled simply be passing `handler_map=None` to `ax.legend().

This PR also includes a docs page that describes the legend customisation, how to disable it, or how to modify it with your own custom legend handler.