### PR TITLE
Miscellaneous python2/3 cross-compatibility changes

### DIFF
--- a/gwpy/plot/tex.py
+++ b/gwpy/plot/tex.py
@@ -57,7 +57,7 @@ HAS_TEX = has_tex()
 
 # -- tex formatting -----------------------------------------------------------
 
-LATEX_CONTROL_CHARS = ["%", "\\", "_", "~", "&"]
+LATEX_CONTROL_CHARS = ["%", "\\", "_", "~", "&", "#"]
 re_latex_control = re.compile(r'(?<!\\)[%s](?!.*{)'
                               % ''.join(LATEX_CONTROL_CHARS))
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -936,6 +936,8 @@ class DataQualityFlag(object):
             If the input ``name`` cannot be parsed into
             {ifo}:{tag}:{version} format.
         """
+        if isinstance(name, bytes):
+            name = name.decode('utf-8')
         if name is None:
             self.ifo = None
             self.tag = None


### PR DESCRIPTION
This PR fixes a bug discovered in the production LIGO summary pages. The issue comes when attempting to use python > 3 to read an HDF5 file that was written with python < 3, largely because of UTF encoding compatibility issues.

For the same reason, this PR also adds `#` to the list of `LATEX_CONTROL_CHARACTERS`.

cc @duncanmmacleod 