### PR TITLE
Improved reading tables from GWOSC

### DIFF
--- a/docs/table/gwosc.rst
+++ b/docs/table/gwosc.rst
@@ -7,6 +7,13 @@
 Querying for catalogue events
 #############################
 
+
+.. _gwpy-table-gwosc-query:
+
+==============
+Simple queries
+==============
+
 The :class:`EventTable` class comes with a :meth:`~EventTable.fetch_open_data`
 method that queries the Gravitational-Wave Open Science Center (GWOSC) database
 for events and their parameters associated with one of the catalogue event
@@ -64,6 +71,12 @@ The full list of available columns can be queried as follows::
            tc float64
       utctime   str10
 
+.. _gwpy-table-gwosc-filter:
+
+================
+Filtered queries
+================
+
 The columns returned can be selected using the ``column`` keyword,
 and mathematical selection filters can be applied on-the-fly
 using the ``selection`` keyword::
@@ -83,3 +96,23 @@ For more information on filtering, see :ref:`gwpy-table-filter`.
 
 For some examples of visualising the catalogues, see
 :ref:`gwpy-example-table-scatter` and :ref:`gwpy-example-table-histogram`.
+
+.. _gwpy-table-gwosc-index:
+
+======================
+Indexing by event name
+======================
+
+The `EventTable` returned by :meth:`~EventTable.fetch_open_data` includes an
+index based on the ``'name'`` column, so you can directly access rows in the
+table based on their name::
+
+   >>> t = EventTable.fetch_open_data(
+   ...     "GWTC-1-confident",
+   ...     columns=["name", "utctime", "mass1", "mass2", "distance"],
+   ... )
+   >>> print(t.loc["GW170817"])
+     name    utctime    mass1   mass2  distance
+                       solMass solMass   Mpc
+   -------- ---------- ------- ------- --------
+   GW170817 12:41:04.4    1.46    1.27     40.0

--- a/docs/table/gwosc.rst
+++ b/docs/table/gwosc.rst
@@ -1,0 +1,85 @@
+.. sectionauthor:: Duncan Macleod <duncan.macleod@ligo.org>
+.. currentmodule:: gwpy.table
+
+.. _gwpy-table-gwosc:
+
+#############################
+Querying for catalogue events
+#############################
+
+The :class:`EventTable` class comes with a :meth:`~EventTable.fetch_open_data`
+method that queries the Gravitational-Wave Open Science Center (GWOSC) database
+for events and their parameters associated with one of the catalogue event
+releases.
+
+.. note::
+
+   For more details on the GWOSC catalogues, see https://www.gw-openscience.org/catalog/.
+
+The simplest query just requires the catalogue name, and will return all parameters
+for all events in the catalogue::
+
+   >>> from gwpy.table import EventTable
+   >>> t = EventTable.fetch_open_data("GWTC-1-confident")
+   >>> print(t)
+     name              E_rad                L_peak    ...      tc       utctime
+            8.98755e+16 m2 solMass / s2 1e+56 erg / s ...
+   -------- --------------------------- ------------- ... ------------ ----------
+   GW150914                         3.1           3.6 ... 1126259462.4 09:50:45.4
+   GW151012                         1.5           3.2 ... 1128678900.4 09:54:43.4
+   GW151226                         1.0           3.4 ... 1135136350.6 03:38:53.6
+   GW170104                         2.2           3.3 ... 1167559936.6 10:11:58.6
+   GW170608                         0.9           3.5 ... 1180922494.5 02:01:16.5
+   GW170729                         4.8           4.2 ... 1185389807.3 18:56:29.3
+   GW170809                         2.7           3.5 ... 1186302519.8 08:28:21.8
+   GW170814                         2.7           3.7 ... 1186741861.5 10:30:43.5
+   GW170817                        0.04           0.1 ... 1187008882.4 12:41:04.4
+   GW170818                         2.7           3.4 ... 1187058327.1 02:25:09.1
+   GW170823                         3.3           3.6 ... 1187529256.5 13:13:58.5
+
+The full list of available columns can be queried as follows::
+
+   >>> print(t.info)
+   <EventTable length=11>
+      name     dtype              unit
+   ---------- ------- ---------------------------
+         name    str8
+        E_rad float64 8.98755e+16 m2 solMass / s2
+       L_peak float64               1e+56 erg / s
+      a_final float64
+      chi_eff float64
+     distance float64                         Mpc
+      far_cwb   str32                      1 / yr
+   far_gstlal float64                      1 / yr
+    far_pycbc   str32                      1 / yr
+        mass1 float64                     solMass
+        mass2 float64                     solMass
+       mchirp float64                     solMass
+       mfinal float64                     solMass
+     redshift float64
+     sky_size float64                        deg2
+      snr_cwb   str32
+   snr_gstlal float64
+    snr_pycbc   str32
+           tc float64
+      utctime   str10
+
+The columns returned can be selected using the ``column`` keyword,
+and mathematical selection filters can be applied on-the-fly
+using the ``selection`` keyword::
+
+   >>> t = EventTable.fetch_open_data(
+   ...     "GWTC-1-confident",
+   ...     selection="mass1 < 4",
+   ...     columns=["name", "mass1", "mass2", "distance"],
+   ... )
+   >>> print(t)
+     name    mass1   mass2  distance
+            solMass solMass   Mpc
+   -------- ------- ------- --------
+   GW170817    1.46    1.27     40.0
+
+For more information on filtering, see :ref:`gwpy-table-filter`.
+
+For some examples of visualising the catalogues, see
+:ref:`gwpy-example-table-scatter` and :ref:`gwpy-example-table-histogram`.

--- a/gwpy/table/gravityspy.py
+++ b/gwpy/table/gravityspy.py
@@ -37,18 +37,10 @@ class GravitySpyTable(EventTable):
     - WDNN
     - Karoo GP
 
-    This differs from the basic `~astropy.table.Table` in two ways
-
-    - GW-specific file formats are registered to use with
-      `GravitySpyTable.fetch`
-    - columns of this table are of the `EventColumn` type, which provides
-      methods for filtering based on a `~gwpy.segments.SegmentList` (not
-      specifically time segments)
-
     See also
     --------
     astropy.table.Table
-        for details on parameters for creating an `GravitySpyTable`
+        for details on parameters for creating a `GravitySpyTable`
     """
 
     # -- i/o ------------------------------------

--- a/gwpy/table/io/losc.py
+++ b/gwpy/table/io/losc.py
@@ -127,4 +127,7 @@ def fetch_catalog(catalog, host=DEFAULT_GWOSC_URL):
         unit = _parse_unit(parameter)
         tab[name].unit = unit
 
+    # add an index on the event name
+    tab.add_index('name')
+
     return tab

--- a/gwpy/table/io/losc.py
+++ b/gwpy/table/io/losc.py
@@ -107,7 +107,7 @@ def fetch_catalog(catalog, host=DEFAULT_GWOSC_URL):
         # values replaced by a 'sensible' default for that dtype
         cols[name] = [
             _mask_replace(x, dtype) if mask[name][i] else x for
-             i, x in enumerate(col)
+            i, x in enumerate(col)
         ]
 
     # convert to columns

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -109,6 +109,11 @@ def _rates_preprocess(func):
 class EventColumn(Column):
     """Custom `Column` that allows filtering with segments
     """
+    def __new__(cls, *args, **kwargs):
+        warnings.warn("the EventColumn is deprecated, and will be removed in "
+                      "a future gwpy release", DeprecationWarning)
+        super(EventColumn, cls).__new__(*args, **kwargs)
+
     def in_segmentlist(self, segmentlist):
         """Return the index of values lying inside the given segmentlist
 
@@ -133,23 +138,17 @@ class EventColumn(Column):
 
 @inherit_io_registrations
 class EventTable(Table):
-    """A container for a table of events
+    """A container for a table of events.
 
-    This differs from the basic `~astropy.table.Table` in two ways
-
-    - GW-specific file formats are registered to use with
-      `EventTable.read` and `EventTable.write`
-    - columns of this table are of the `EventColumn` type, which provides
-      methods for filtering based on a `~gwpy.segments.SegmentList` (not
-      specifically time segments)
+    This object expands the default :class:`~astropy.table.Table`
+    with extra read/write formats, and methods to perform filtering,
+    rate calculations, and visualisation.
 
     See also
     --------
     astropy.table.Table
         for details on parameters for creating an `EventTable`
     """
-    Column = EventColumn
-
     # -- utilities ------------------------------
 
     def _get_time_column(self):

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -34,6 +34,7 @@ import sqlparse
 
 from numpy import (random, isclose, dtype, asarray)
 from numpy.testing import assert_array_equal
+from numpy.ma.core import MaskedConstant
 
 import h5py
 
@@ -710,7 +711,10 @@ class TestEventTable(TestTable):
             pytest.skip(str(exc))
         assert len(table)
         assert {"L_peak", "distance", "mass1"}.intersection(table.colnames)
+        # check unit parsing worked
         assert table["distance"].unit == "Mpc"
+        # check that masking worked
+        assert isinstance(table["snr_pycbc"][9], MaskedConstant)
 
     def test_fetch_open_data_kwargs(self):
         try:

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -713,8 +713,9 @@ class TestEventTable(TestTable):
         assert {"L_peak", "distance", "mass1"}.intersection(table.colnames)
         # check unit parsing worked
         assert table["distance"].unit == "Mpc"
-        # check that masking worked
-        assert isinstance(table["snr_pycbc"][9], MaskedConstant)
+        # check that masking worked (needs table to be sorted)
+        gw170818 = table.loc["GW170818"]
+        assert isinstance(gw170818["snr_pycbc"], MaskedConstant)
 
     def test_fetch_open_data_kwargs(self):
         try:


### PR DESCRIPTION
This PR improves the parsing of open-data catalog event tables from GWOSC, mainly by detecting and replacing the `'NA'` that GWOSC uses to mark missing data. The logic here is a bit more complicated, because we have to determine the underlying data type of the column without the missing values, in order to replace the `'NA'` with the appropriate null value (`0` for `int`, `nan` for float).