### PR TITLE
Implemented __array_ufunc__ for gwpy.types.Array

### DIFF
--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -34,7 +34,7 @@ from six.moves import range
 
 import numpy
 
-from astropy import (units, __version__ as astropy_version)
+from astropy import units
 
 from .core import (TimeSeriesBase, TimeSeriesBaseDict, TimeSeriesBaseList,
                    as_series_dict_class)
@@ -198,10 +198,12 @@ class StateTimeSeries(TimeSeriesBase):
 
     # -- math handling (always boolean) ---------
 
-    if astropy_version >= '2.0.0':  # remove _if_ when we pin astropy >= 2.0.0
-        def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-            return super(StateTimeSeries, self).__array_ufunc__(
-                ufunc, method, *inputs, **kwargs).view(bool)
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        out = super(StateTimeSeries, self).__array_ufunc__(
+            ufunc, method, *inputs, **kwargs)
+        if out.ndim:
+            return out.view(bool)
+        return out
 
     def __array_wrap__(self, obj, context=None):
         return super(StateTimeSeries, self).__array_wrap__(

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -394,6 +394,15 @@ class Array(Quantity):
 
     # -- array methods --------------------------
 
+    def __array_ufunc__(self, function, method, *inputs, **kwargs):
+        out = super(Array, self).__array_ufunc__(function, method,
+                                                 *inputs, **kwargs)
+        # if a ufunc returns a scalar, return a Quantity
+        if not out.ndim:
+            return Quantity(out, copy=False)
+        # otherwise return an array
+        return out
+
     def abs(self, axis=None, **kwargs):
         return self._wrap_function(numpy.abs, axis, **kwargs)
     abs.__doc__ = numpy.abs.__doc__


### PR DESCRIPTION
This PR implements a top-level `Array.__array_ufunc__` method that returns scalars as `Quantity` objects from ufuncs. This will be required to support astropy-3.2, but should be backwards compatible.