### PR TITLE
Run lintian after building debian packages

### DIFF
--- a/ci/install-debian.sh
+++ b/ci/install-debian.sh
@@ -36,7 +36,7 @@ pushd build
 apt-get -yqq update
 
 # install basic build dependencies
-apt-get -yqq install dpkg-dev devscripts
+apt-get -yqq install dpkg-dev devscripts lintian
 
 # unwrap tarball into build path
 tar -xf ../*.tar.* --strip-components=1
@@ -48,6 +48,9 @@ mk-build-deps --tool "apt-get -y" --install --remove
 dpkg-buildpackage -us -uc -b
 
 popd
+
+# lint the result
+lintian gwpy_*.changes
 
 # -- install ------------------------------------
 

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -182,15 +182,14 @@ class changelog(Command):
             build = 1
         else:
             repo = git.Repo()
-            config = repo.config_reader()
+            commit = repo.head.commit
+            date = commit.authored_datetime
+            tz = commit.author_tz_offset
             version = str(tag)
-            build = 1000
-            author = config.get_value("user", "name", default="user")
-            email = config.get_value("user", "email",
-                                     default="<user@email.com>")
+            author = commit.author.name
+            email = commit.author.email
             message = 'Test build'
-            date = datetime.datetime.now()
-            tz = 0
+            build = 1000
         name = self.distribution.get_name()
         if self.format == 'rpm':
             formatter = self._format_entry_rpm


### PR DESCRIPTION
This PR adds a call to `lintian` to validate the debian packages, after building them.