### PR TITLE
Fixed case error in setting nds connection epoch

### DIFF
--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -445,7 +445,7 @@ def find_channels(channels, connection=None, host=None, port=None,
     """
     # set epoch
     if not isinstance(epoch, tuple):
-        epoch = (epoch or 'All',)
+        epoch = (epoch or 'ALL',)
     connection.set_epoch(*epoch)
 
     # format sample_rate as tuple for find_channels call


### PR DESCRIPTION
This PR fixes #1103 by fixing the casing of the default epoch name (`'All' -> 'ALL'`).