### PR TITLE
Raise IndexError early when reading an empty list of files

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,5 +30,5 @@ after_test:
   - "set _PYV=%PYTHON_VERSION:.=%"
   - python -m pip install codecov
   - python -m codecov --flags Windows python%_PYV% conda
-on_success:
+on_finish:
   - ps: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\junit.xml))

--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -158,6 +158,11 @@ class FrequencySeries(Series):
         **kwargs
             Other keywords are (in general) specific to the given ``format``.
 
+        Raises
+        ------
+        IndexError
+            if ``source`` is an empty list
+
         Notes
         -----"""
         return io_registry.read(cls, source, *args, **kwargs)

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -180,6 +180,11 @@ class SpectralVariance(Array2D):
         **kwargs
             Other keywords are (in general) specific to the given ``format``.
 
+        Raises
+        ------
+        IndexError
+            if ``source`` is an empty list
+
         Notes
         -----"""
         return io_registry.read(cls, source, *args, **kwargs)

--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -68,6 +68,12 @@ def read_multi(flatten, cls, source, *args, **kwargs):
     else:
         path = files[0] if files else None
 
+    # raise IndexError early when reading from empty cache
+    if not files:
+        raise IndexError(
+            "cannot read {} from empty source list".format(cls.__name__),
+        )
+
     # determine input format (so we don't have to do it multiple times)
     if kwargs.get('format', None) is None:
         kwargs['format'] = get_read_format(cls, path, (source,) + args, kwargs)

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -53,7 +53,7 @@ def tmp2():
 def test_read_multi_single(tmp1):
     """Check that serial processing works with `mp.read_multi`
     """
-    tab = io_mp.read_multi(vstack, Table, tmp1, verbose=True)
+    tab = io_mp.read_multi(vstack, Table, tmp1.name, verbose=True)
     assert tab.colnames == ["a", "b", "c"]
     assert list(tab[0]) == [1, 2, 3]
 
@@ -62,15 +62,15 @@ def test_read_multi_list_of_one(tmp1):
     """Check that a list of one is the same as just passing the element
     """
     assert_table_equal(
-        io_mp.read_multi(vstack, Table, tmp1),
-        io_mp.read_multi(vstack, Table, [tmp1]),
+        io_mp.read_multi(vstack, Table, tmp1.name),
+        io_mp.read_multi(vstack, Table, [tmp1.name]),
     )
 
 
 def test_read_multi_nproc(tmp1, tmp2):
     """Check that simple multiprocessing works with `mp.read_multi`
     """
-    tab = io_mp.read_multi(vstack, Table, [tmp1, tmp2], nproc=2)
+    tab = io_mp.read_multi(vstack, Table, [tmp1.name, tmp2.name], nproc=2)
     assert tab.colnames == ["a", "b", "c"]
     assert list(tab["a"]) == [1, 4, 7, 10]
 
@@ -78,7 +78,7 @@ def test_read_multi_nproc(tmp1, tmp2):
 def test_read_multi_order_preservation(tmp1, tmp2):
     """Check that input order is preserved in `mp.read_multi`
     """
-    tab = io_mp.read_multi(vstack, Table, [tmp2, tmp1], nproc=2)
+    tab = io_mp.read_multi(vstack, Table, [tmp2.name, tmp1.name], nproc=2)
     assert tab.colnames == ["a", "b", "c"]
     assert list(tab["a"]) == [7, 10, 1, 4]
 
@@ -104,13 +104,13 @@ def test_read_multi_error_propagation_serial():
     """Check that errors get raised in-place during serial reads
     """
     with NamedTemporaryFile() as tmp, pytest.raises(ValueError):
-        io_mp.read_multi(vstack, Table, [tmp, tmp], format="ascii.csv",
-                         nproc=1)
+        io_mp.read_multi(vstack, Table, [tmp.name, tmp.name],
+                         format="ascii.csv", nproc=1)
 
 
 def test_read_multi_error_propagation_multi():
     """Check that errors get propagated back up the stack during multi reads
     """
     with NamedTemporaryFile() as tmp, pytest.raises(ValueError):
-        io_mp.read_multi(vstack, Table, [tmp, tmp], format="ascii.csv",
-                         nproc=2)
+        io_mp.read_multi(vstack, Table, [tmp.name, tmp.name],
+                         format="ascii.csv", nproc=2)

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -104,13 +104,13 @@ def test_read_multi_not_a_file():
     pytest.param(1, id="serial"),
     pytest.param(2, id="multi"),
 ))
-def test_read_multi_error_propagation(nproc):
+def test_read_multi_error_propagation(tmp1, tmp2, nproc):
     """Check that errors get raised in-place during reads
     """
-    with NamedTemporaryFile() as tmp, pytest.raises(ValueError):
-        # write nonsense into the file
-        tmp.write(b"blahblahblah\n1,2,3,4blah")
-        tmp.seek(0)
-        # try and read it
-        io_mp.read_multi(vstack, Table, [tmp.name, tmp.name],
+    # write nonsense into the file
+    tmp1.write(b"blahblahblah\n1,2,3,4blah")
+    tmp1.seek(0)
+    # try and read it
+    with pytest.raises(ValueError):
+        io_mp.read_multi(vstack, Table, [tmp1.name, tmp2.name],
                          format="ascii.csv", nproc=nproc)

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -19,7 +19,6 @@
 """Unit tests for :mod:`gwpy.io.mp`
 """
 
-from io import BytesIO
 from tempfile import NamedTemporaryFile
 
 import pytest

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -19,14 +19,12 @@
 """Unit tests for :mod:`gwpy.io.mp`
 """
 
-from tempfile import NamedTemporaryFile
-
 import pytest
 
 from astropy import __version__ as astropy_version
 from astropy.table import (Table, vstack)
 
-from ...testing.utils import assert_table_equal
+from ...testing.utils import (assert_table_equal, TemporaryFilename)
 from .. import (
     mp as io_mp,
 )
@@ -36,24 +34,24 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 @pytest.fixture
 def tmp1():
-    with NamedTemporaryFile(suffix='.csv') as tmp:
-        tmp.write(b"a,b,c\n1,2,3\n4,5,6")
-        tmp.seek(0)
+    with TemporaryFilename(suffix='.csv') as tmp:
+        with open(tmp, "w") as tmpf:
+            tmpf.write("a,b,c\n1,2,3\n4,5,6")
         yield tmp
 
 
 @pytest.fixture
 def tmp2():
-    with NamedTemporaryFile(suffix='.csv') as tmp:
-        tmp.write(b"a,b,c\n7,8,9\n10,11,12")
-        tmp.seek(0)
+    with TemporaryFilename(suffix='.csv') as tmp:
+        with open(tmp, "w") as tmpf:
+            tmpf.write("a,b,c\n7,8,9\n10,11,12")
         yield tmp
 
 
 def test_read_multi_single(tmp1):
     """Check that serial processing works with `mp.read_multi`
     """
-    tab = io_mp.read_multi(vstack, Table, tmp1.name, verbose=True)
+    tab = io_mp.read_multi(vstack, Table, tmp1, verbose=True)
     assert tab.colnames == ["a", "b", "c"]
     assert list(tab[0]) == [1, 2, 3]
 
@@ -62,15 +60,15 @@ def test_read_multi_list_of_one(tmp1):
     """Check that a list of one is the same as just passing the element
     """
     assert_table_equal(
-        io_mp.read_multi(vstack, Table, tmp1.name),
-        io_mp.read_multi(vstack, Table, [tmp1.name]),
+        io_mp.read_multi(vstack, Table, tmp1),
+        io_mp.read_multi(vstack, Table, [tmp1]),
     )
 
 
 def test_read_multi_nproc(tmp1, tmp2):
     """Check that simple multiprocessing works with `mp.read_multi`
     """
-    tab = io_mp.read_multi(vstack, Table, [tmp1.name, tmp2.name], nproc=2)
+    tab = io_mp.read_multi(vstack, Table, [tmp1, tmp2], nproc=2)
     assert tab.colnames == ["a", "b", "c"]
     assert list(tab["a"]) == [1, 4, 7, 10]
 
@@ -78,7 +76,7 @@ def test_read_multi_nproc(tmp1, tmp2):
 def test_read_multi_order_preservation(tmp1, tmp2):
     """Check that input order is preserved in `mp.read_multi`
     """
-    tab = io_mp.read_multi(vstack, Table, [tmp2.name, tmp1.name], nproc=2)
+    tab = io_mp.read_multi(vstack, Table, [tmp2, tmp1], nproc=2)
     assert tab.colnames == ["a", "b", "c"]
     assert list(tab["a"]) == [7, 10, 1, 4]
 
@@ -108,9 +106,9 @@ def test_read_multi_error_propagation(tmp1, tmp2, nproc):
     """Check that errors get raised in-place during reads
     """
     # write nonsense into the file
-    tmp1.write(b"blahblahblah\n1,2,3,4blah")
-    tmp1.seek(0)
+    with open(tmp1, "a") as tmp:
+        tmp.write("blahblahblah\n1,2,3,4blah")
     # try and read it
     with pytest.raises(ValueError):
-        io_mp.read_multi(vstack, Table, [tmp1.name, tmp2.name],
+        io_mp.read_multi(vstack, Table, [tmp1, tmp2],
                          format="ascii.csv", nproc=nproc)

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -24,6 +24,7 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
+from astropy import __version__ as astropy_version
 from astropy.table import (Table, vstack)
 
 from ...testing.utils import assert_table_equal
@@ -95,7 +96,8 @@ def test_read_multi_not_a_file():
     """Check that a strange input gets passed along properly
     so that errors can be raise by the reader.
     """
-    with pytest.raises(TypeError):
+    # astropy < 3 has a different error message
+    with pytest.raises(ValueError if astropy_version < '3.0' else TypeError):
         io_mp.read_multi(vstack, Table, None, format="ascii.csv", nproc=1)
 
 

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for :mod:`gwpy.io.mp`
+"""
+
+from io import BytesIO
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from astropy.table import (Table, vstack)
+
+from ...testing.utils import assert_table_equal
+from .. import (
+    mp as io_mp,
+)
+
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+@pytest.fixture
+def tmp1():
+    with NamedTemporaryFile(suffix='.csv') as tmp:
+        tmp.write(b"a,b,c\n1,2,3\n4,5,6")
+        tmp.seek(0)
+        yield tmp
+
+
+@pytest.fixture
+def tmp2():
+    with NamedTemporaryFile(suffix='.csv') as tmp:
+        tmp.write(b"a,b,c\n7,8,9\n10,11,12")
+        tmp.seek(0)
+        yield tmp
+
+
+def test_read_multi_single(tmp1):
+    """Check that serial processing works with `mp.read_multi`
+    """
+    tab = io_mp.read_multi(vstack, Table, tmp1, verbose=True)
+    assert tab.colnames == ["a", "b", "c"]
+    assert list(tab[0]) == [1, 2, 3]
+
+
+def test_read_multi_list_of_one(tmp1):
+    """Check that a list of one is the same as just passing the element
+    """
+    assert_table_equal(
+        io_mp.read_multi(vstack, Table, tmp1),
+        io_mp.read_multi(vstack, Table, [tmp1]),
+    )
+
+
+def test_read_multi_nproc(tmp1, tmp2):
+    """Check that simple multiprocessing works with `mp.read_multi`
+    """
+    tab = io_mp.read_multi(vstack, Table, [tmp1, tmp2], nproc=2)
+    assert tab.colnames == ["a", "b", "c"]
+    assert list(tab["a"]) == [1, 4, 7, 10]
+
+
+def test_read_multi_order_preservation(tmp1, tmp2):
+    """Check that input order is preserved in `mp.read_multi`
+    """
+    tab = io_mp.read_multi(vstack, Table, [tmp2, tmp1], nproc=2)
+    assert tab.colnames == ["a", "b", "c"]
+    assert list(tab["a"]) == [7, 10, 1, 4]
+
+
+def test_read_multi_error_empty():
+    """Check that an `IndexError` is raised when the input list is empty
+    """
+    with pytest.raises(IndexError) as exc:
+        io_mp.read_multi(1, int, [])
+    assert str(exc.value) == "cannot read int from empty source list"
+
+
+def test_read_multi_not_a_file():
+    """Check that a strange input gets passed along properly
+    so that errors can be raise by the reader.
+    """
+    with pytest.raises(TypeError):
+        io_mp.read_multi(vstack, Table, None, format="ascii.csv", nproc=1)
+
+
+def test_read_multi_error_propagation_serial():
+    """Check that errors get raised in-place during serial reads
+    """
+    with NamedTemporaryFile() as tmp, pytest.raises(ValueError):
+        io_mp.read_multi(vstack, Table, [tmp, tmp], format="ascii.csv",
+                         nproc=1)
+
+
+def test_read_multi_error_propagation_multi():
+    """Check that errors get propagated back up the stack during multi reads
+    """
+    with NamedTemporaryFile() as tmp, pytest.raises(ValueError):
+        io_mp.read_multi(vstack, Table, [tmp, tmp], format="ascii.csv",
+                         nproc=2)

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -100,17 +100,17 @@ def test_read_multi_not_a_file():
         io_mp.read_multi(vstack, Table, None, format="ascii.csv", nproc=1)
 
 
-def test_read_multi_error_propagation_serial():
-    """Check that errors get raised in-place during serial reads
+@pytest.mark.parametrize("nproc", (
+    pytest.param(1, id="serial"),
+    pytest.param(2, id="multi"),
+))
+def test_read_multi_error_propagation(nproc):
+    """Check that errors get raised in-place during reads
     """
     with NamedTemporaryFile() as tmp, pytest.raises(ValueError):
+        # write nonsense into the file
+        tmp.write(b"blahblahblah\n1,2,3,4blah")
+        tmp.seek(0)
+        # try and read it
         io_mp.read_multi(vstack, Table, [tmp.name, tmp.name],
-                         format="ascii.csv", nproc=1)
-
-
-def test_read_multi_error_propagation_multi():
-    """Check that errors get propagated back up the stack during multi reads
-    """
-    with NamedTemporaryFile() as tmp, pytest.raises(ValueError):
-        io_mp.read_multi(vstack, Table, [tmp.name, tmp.name],
-                         format="ascii.csv", nproc=2)
+                         format="ascii.csv", nproc=nproc)

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -613,6 +613,11 @@ class DataQualityFlag(object):
             formatted `DataQualityFlag` containing the active and known
             segments read from file.
 
+        Raises
+        ------
+        IndexError
+            if ``source`` is an empty list
+
         Notes
         -----"""
         if 'flag' in kwargs:  # pragma: no cover

--- a/gwpy/segments/segments.py
+++ b/gwpy/segments/segments.py
@@ -174,6 +174,11 @@ class SegmentList(segmentlist):
         segmentlist : `SegmentList`
             `SegmentList` active and known segments read from file.
 
+        Raises
+        ------
+        IndexError
+            if ``source`` is an empty list
+
         Notes
         -----"""
         def combiner(listofseglists):

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -235,6 +235,8 @@ class EventTable(Table):
         ------
         astropy.io.registry.IORegistryError
             if the `format` cannot be automatically identified
+        IndexError
+            if ``source`` is an empty list
 
         Notes
         -----"""

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -304,6 +304,11 @@ class TimeSeriesBase(Series):
             value with which to fill gaps in the source data,
             by default gaps will result in a `ValueError`.
 
+        Raises
+        ------
+        IndexError
+            if ``source`` is an empty list
+
         Notes
         -----"""
         from .io.core import read as timeseries_reader

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -659,6 +659,11 @@ class StateVector(TimeSeriesBase):
             value with which to fill gaps in the source data, only used if
             gap is not given, or `gap='pad'` is given
 
+        Raises
+        ------
+        IndexError
+            if ``source`` is an empty list
+
         Examples
         --------
         To read the S6 state vector, with names for all the bits::

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -392,6 +392,11 @@ class Series(Array):
         -------
         data : `Series`
 
+        Raises
+        ------
+        IndexError
+            if ``source`` is an empty list
+
         Notes
         -----"""
         return io_registry.read(cls, source, *args, **kwargs)


### PR DESCRIPTION
This PR modifies `gwpy.io.mp.read_multi` (the function that underpins `EventTable.read`, `TimeSeries.read`, etc) to raise an `IndexError` early if the input `source` argument is parsed as an empty list.

Currently the behaviour in this condition is unpredictable, and dependent on the other keyword arguments, which doesn't make a great UX.

I also added an independent test suite for that function. 