### PR TITLE
Fixed GPS epoch handling in mpl-3.1.0

### DIFF
--- a/gwpy/plot/tests/test_gps.py
+++ b/gwpy/plot/tests/test_gps.py
@@ -25,7 +25,7 @@ import pytest
 
 import numpy
 
-from matplotlib import (__version__ as mpl_version, pyplot)
+from matplotlib import pyplot
 
 from astropy.units import Unit
 
@@ -162,7 +162,7 @@ def test_gps_scale(scale):
 
 @pytest.mark.parametrize('scale, unit', [
     (1e-5, 'ms'),
-    (1e-4, 's' if mpl_version < '2.0' else 'ms'),
+    (1e-4, 'ms'),
     (1e-3, 's'),
     (1e-2, 's'),
     (1e-1, 's'),


### PR DESCRIPTION
This PR fixes/attempts to fix errors in getting the correct default GPS epoch for plots when using matplotlib-3.1.0.