### PR TITLE
Update readme, contributing guide, and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -1,0 +1,2 @@
+All GWpy contributors are expected to abide by the
+`Astropy Project Code of Conduct <http://www.astropy.org/code_of_conduct.html>`_.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ the errors and assumptions that seasoned contributors have glossed over.
 
 Note: This disclaimer was originally written by
 [Adrienne Lowe](https://github.com/adriennefriend) for a
-[PyCon talk](https://www.youtube.com/watch?v=6Uj746j9Heo), and was adapted by
+[PyCon talk](https://www.youtube.com/watch?v=6Uj746j9Heo), and was adapted for
 GWpy based on its use in the [Astropy](https://github.com/astropy/astropy/)
 contributing guide.
 
@@ -40,7 +40,7 @@ Contributions to GWpy are made via pull requests from GitHub users' forks of the
 The basic idea is to use the `master` branch of your fork as a way of updating your fork with other people's changes that have been merged into the main repo, and then  working on a dedicated _feature branch_ for each piece of work:
 
 - create the fork (if needed) by clicking _Fork_ in the upper-right corner of <https://github.com/gwpy/gwpy/> - this only needs to be done once, ever
-- clone the fork (replace `<username>`) with your GitHub username):
+- clone the fork (replace `<username>` with your GitHub username):
 
   ```bash
   git clone https://github.com/<username>/gwpy.git gwpy-fork
@@ -100,8 +100,9 @@ python -m flake8
 ### Testing
 
 GWpy has a fairly complete test suite, covering over 90% of the codebase.
-All tests should be written to be executed with
-[`pytest`](https://docs.pytest.org/en/latest/), and should cover all lines of
+All code contributions should be accompanied by (unit) tests to be executed with
+[`pytest`](https://docs.pytest.org/en/latest/), and should cover
+all new or modified lines.
 
 You can run the test suite locally from the root of the repository via:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,50 @@
 # Contributing to GWpy
 
-This is [@duncanmmacleod](//github.com/duncanmmacleod/)'s workflow, which might work well for others, it is just a verbose version of the [GitHub flow](https://guides.github.com/introduction/flow/).
+## Reporting Issues
+
+When opening an issue to report a problem, please try to provide a minimal code
+example that reproduces the issue along with details of the operating
+system and the Python, NumPy, Astropy, and GWpy versions you are using.
+
+## Contributing Code
+
+**Imposter syndrome disclaimer**: We want your help. No, really.
+
+There may be a little voice inside your head that is telling you that you're not
+ready to be an open source contributor; that your skills aren't nearly good
+enough to contribute. What could you possibly offer a project like this one?
+
+We assure you - the little voice in your head is wrong. If you can write code at
+all, you can contribute code to open source. Contributing to open source
+projects is a fantastic way to advance one's coding skills. Writing perfect code
+isn't the measure of a good developer (that would disqualify all of us!); it's
+trying to create something, making mistakes, and learning from those
+mistakes. That's how we all improve, and we are happy to help others learn.
+
+Being an open source contributor doesn't just mean writing code, either. You can
+help out by writing documentation, tests, or even giving feedback about the
+project (and yes - that includes giving feedback about the contribution
+process). Some of these contributions may be the most valuable to the project as
+a whole, because you're coming to the project with fresh eyes, so you can see
+the errors and assumptions that seasoned contributors have glossed over.
+
+Note: This disclaimer was originally written by
+[Adrienne Lowe](https://github.com/adriennefriend) for a
+[PyCon talk](https://www.youtube.com/watch?v=6Uj746j9Heo), and was adapted by
+GWpy based on its use in the [Astropy](https://github.com/astropy/astropy/)
+contributing guide.
+
+## Development model
+
+Contributions to GWpy are made via pull requests from GitHub users' forks of the main [gwpy repositories](https://github.com/gwpy/gwpy), following the [GitHub flow](https://guides.github.com/introduction/flow/) workflow.
 The basic idea is to use the `master` branch of your fork as a way of updating your fork with other people's changes that have been merged into the main repo, and then  working on a dedicated _feature branch_ for each piece of work:
 
-- create the fork (if needed) by clicking _Fork_ in the upper-right corner of https://github.com/gwpy/gwpy/ - this only needs to be done once, ever
-- clone the fork into a new folder dedicated for this piece of work (replace `<username>` with yout GitHub username):
+- create the fork (if needed) by clicking _Fork_ in the upper-right corner of <https://github.com/gwpy/gwpy/> - this only needs to be done once, ever
+- clone the fork (replace `<username>`) with your GitHub username):
 
   ```bash
-  git clone https://github.com/<username>/gwpy.git gwpy-my-work  # change gwpy-my-work as appropriate
-  cd gwpy-my-work
+  git clone https://github.com/<username>/gwpy.git gwpy-fork
+  cd gwpy-fork
   ```
   
 - link the fork to the upstream 'main' repo:
@@ -38,9 +74,37 @@ The basic idea is to use the `master` branch of your fork as a way of updating y
   ```
 
 - open a merge request on github.com
-- when the request is merged, you should 'delete the source branch' (there's a button), then just delete the clone of your fork and forget about it
+- when the request is merged, you should 'delete the source branch' (there's a button), to keep your fork clean
 
- ```bash
-  cd ../
-  rm -rf ./gwpy-my-work
-  ```
+And that's it.
+
+## Coding guidelines
+
+### Python compatibility
+
+**GWpy code must be compatible with Python 2.7 and all versions >=3.4.**
+
+### Style
+
+This package follows [PEP 8](https://www.python.org/dev/peps/pep-0008/),
+and all code should adhere to that as far as is reasonable.
+
+The first stage in the automated testing of pull requests is a job that runs
+the [`flake8`](http://flake8.pycqa.org) linter, which checks the style of code
+in the repo. You can run this locally before committing changes via:
+
+```bash
+python -m flake8
+```
+
+### Testing
+
+GWpy has a fairly complete test suite, covering over 90% of the codebase.
+All tests should be written to be executed with
+[`pytest`](https://docs.pytest.org/en/latest/), and should cover all lines of
+
+You can run the test suite locally from the root of the repository via:
+
+```bash
+python -m pytest gwpy/
+```

--- a/README.md
+++ b/README.md
@@ -18,18 +18,12 @@ step.
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/gwpy.svg)](https://travis-ci.org/gwpy/gwpy)
 [![Research software impact](http://depsy.org/api/package/pypi/gwpy/badge.svg)](http://depsy.org/package/python/gwpy)
 
+# Development status
+
 [![Linux](https://img.shields.io/circleci/project/github/gwpy/gwpy/master.svg?label=Linux)](https://circleci.com/gh/gwpy/gwpy)
 [![OSX](https://img.shields.io/travis/gwpy/gwpy/master.svg?label=macOS)](https://travis-ci.org/gwpy/gwpy)
 [![Windows](https://img.shields.io/appveyor/ci/gwpy/gwpy/master.svg?label=Windows)](https://ci.appveyor.com/project/gwpy/gwpy/branch/master)
 [![codecov](https://codecov.io/gh/gwpy/gwpy/branch/master/graph/badge.svg)](https://codecov.io/gh/gwpy/gwpy)
-
-# Development status
-
-
-[![Linux dev](https://img.shields.io/circleci/project/github/gwpy/gwpy/develop.svg?label=Linux)](https://circleci.com/gh/gwpy/gwpy)
-[![OSX dev](https://img.shields.io/travis/gwpy/gwpy/develop.svg?label=macOS)](https://travis-ci.org/gwpy/gwpy)
-[![Windows dev](https://img.shields.io/appveyor/ci/gwpy/gwpy/develop.svg?label=Windows)](https://ci.appveyor.com/project/gwpy/gwpy/branch/develop)
-[![codecov dev](https://codecov.io/gh/gwpy/gwpy/branch/develop/graph/badge.svg)](https://codecov.io/gh/gwpy/gwpy)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2cf14445b3e070133745/maintainability)](https://codeclimate.com/github/gwpy/gwpy/maintainability)
 
 # Installation


### PR DESCRIPTION
This PR updates the readme and contributing guide to reflect the return to a stable mainline development model where everything lands on `master`. I have also added a code of conduct file that just links to the Astropy CoC.