### PR TITLE
Introduce a SegmentList.to_table method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ aliases:
         - checkout
         - *attach_workspace
         - restore_cache:
-            key: v4-gwpy-{{ .Environment.CIRCLE_JOB }}
+            key: v5-gwpy-{{ .Environment.CIRCLE_JOB }}
         - run: *set_python_environment
         - run:
             name: Install
@@ -90,7 +90,7 @@ aliases:
         - run: *run-tests
         - run: *codecov
         - save_cache:
-            key: v4-gwpy-{{ .Environment.CIRCLE_JOB }}
+            key: v5-gwpy-{{ .Environment.CIRCLE_JOB }}
             paths:
               - "/opt/conda/envs/gwpyci"
         - *store_test_results

--- a/gwpy/segments/segments.py
+++ b/gwpy/segments/segments.py
@@ -144,6 +144,25 @@ class SegmentList(segmentlist):
         return self
     coalesce.__doc__ = segmentlist.coalesce.__doc__
 
+    def to_table(self):
+        """Convert this `SegmentList` to a `~gwpy.table.Table`
+
+        The resulting `Table` has four columns: `index`, `start`, `end`, and
+        `duration`, corresponding to the zero-counted list index, GPS start
+        and end times, and total duration in seconds, respectively.
+
+        This method exists mainly to provide a way to write `SegmentList`
+        objects in comma-separated value (CSV) format, via the
+        :meth:`~gwpy.table.Table.write` method.
+        """
+        from ..table import Table
+        return Table([
+            list(range(len(self))),
+            [seg[0] for seg in self],
+            [seg[1] for seg in self],
+            [abs(seg) for seg in self],
+        ], names=('index', 'start', 'end', 'duration'))
+
     # -- i/o ------------------------------------
 
     @classmethod

--- a/gwpy/segments/segments.py
+++ b/gwpy/segments/segments.py
@@ -23,6 +23,7 @@ configuration.
 """
 
 from astropy.io import registry as io_registry
+from astropy.table import Table
 
 from ligo.segments import (segment, segmentlist, segmentlistdict)
 
@@ -145,7 +146,7 @@ class SegmentList(segmentlist):
     coalesce.__doc__ = segmentlist.coalesce.__doc__
 
     def to_table(self):
-        """Convert this `SegmentList` to a `~gwpy.table.Table`
+        """Convert this `SegmentList` to a `~astropy.table.Table`
 
         The resulting `Table` has four columns: `index`, `start`, `end`, and
         `duration`, corresponding to the zero-counted list index, GPS start
@@ -153,9 +154,8 @@ class SegmentList(segmentlist):
 
         This method exists mainly to provide a way to write `SegmentList`
         objects in comma-separated value (CSV) format, via the
-        :meth:`~gwpy.table.Table.write` method.
+        :meth:`~astropy.table.Table.write` method.
         """
-        from ..table import Table
         return Table([
             list(range(len(self))),
             [seg[0] for seg in self],

--- a/gwpy/segments/segments.py
+++ b/gwpy/segments/segments.py
@@ -156,12 +156,10 @@ class SegmentList(segmentlist):
         objects in comma-separated value (CSV) format, via the
         :meth:`~astropy.table.Table.write` method.
         """
-        return Table([
-            list(range(len(self))),
-            [seg[0] for seg in self],
-            [seg[1] for seg in self],
-            [abs(seg) for seg in self],
-        ], names=('index', 'start', 'end', 'duration'))
+        return Table(
+            rows=[(i, s[0], s[1], abs(s)) for i, s in enumerate(self)],
+            names=('index', 'start', 'end', 'duration'),
+        )
 
     # -- i/o ------------------------------------
 

--- a/gwpy/segments/tests/test_segments.py
+++ b/gwpy/segments/tests/test_segments.py
@@ -25,9 +25,10 @@ import pytest
 
 import h5py
 
-from ...testing.utils import (assert_array_equal, assert_segmentlist_equal,
-                              TemporaryFilename)
-from ...table import Table
+from astropy.table import Table
+
+from ...testing.utils import (
+    assert_segmentlist_equal, assert_table_equal, TemporaryFilename)
 from ...time import LIGOTimeGPS
 from .. import (Segment, SegmentList)
 
@@ -86,12 +87,18 @@ class TestSegmentList(object):
 
     def test_to_table(self, segmentlist):
         segtable = segmentlist.to_table()
-        assert isinstance(segtable, Table)
-        assert_array_equal(segtable['index'], list(range(len(segmentlist))))
-        assert_array_equal(segtable['start'], [seg[0] for seg in segmentlist])
-        assert_array_equal(segtable['end'], [seg[1] for seg in segmentlist])
-        assert_array_equal(
-            segtable['duration'], [abs(seg) for seg in segmentlist])
+        assert_table_equal(
+            segtable,
+            Table(
+                rows=[
+                    (0, 1, 2, 1),
+                    (1, 3, 4, 1),
+                    (2, 4, 6, 2),
+                    (3, 8, 10, 2),
+                ],
+                names=('index', 'start', 'end', 'duration'),
+            ),
+        )
 
     # -- test I/O -------------------------------
 

--- a/gwpy/segments/tests/test_segments.py
+++ b/gwpy/segments/tests/test_segments.py
@@ -25,7 +25,9 @@ import pytest
 
 import h5py
 
-from ...testing.utils import (assert_segmentlist_equal, TemporaryFilename)
+from ...testing.utils import (assert_array_equal, assert_segmentlist_equal,
+                              TemporaryFilename)
+from ...table import Table
 from ...time import LIGOTimeGPS
 from .. import (Segment, SegmentList)
 
@@ -81,6 +83,15 @@ class TestSegmentList(object):
         assert c is segmentlist
         assert_segmentlist_equal(c, [(1, 2), (3, 5)])
         assert isinstance(c[0], self.ENTRY_CLASS)
+
+    def test_to_table(self, segmentlist):
+        segtable = segmentlist.to_table()
+        assert isinstance(segtable, Table)
+        assert_array_equal(segtable['index'], list(range(len(segmentlist))))
+        assert_array_equal(segtable['start'], [seg[0] for seg in segmentlist])
+        assert_array_equal(segtable['end'], [seg[1] for seg in segmentlist])
+        assert_array_equal(
+            segtable['duration'], [abs(seg) for seg in segmentlist])
 
     # -- test I/O -------------------------------
 


### PR DESCRIPTION
This PR introduces a new method, `SegmentList.to_table`, to cast `SegmentList` objects as type `~gwpy.table.Table`. This is provided mainly to have a way to write `SegmentList` objects to standard CSV tables, which has proven useful in delivering data products to LIGO management; see [**this tool**](https://git.ligo.org/detchar/ligo-summary-pages/blob/master/scripts/gw_epoch_time_accounting) for the LIGO summary pages (requires `LIGO.ORG` credentials).

cc @duncanmmacleod 