### PR TITLE
WIP: Attempt to fix the codecov path issues

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,3 +11,5 @@ coverage:
       default:
         target: 90
 
+fixes:
+  - "::gwpy/"


### PR DESCRIPTION
This PR attempts to fix issues with the codecov reports, whereby the paths in the codecov reports don't match those in the repo, so you can't read the reports properly ([example](https://codecov.io/gh/gwpy/gwpy/tree/068b09fd0aaa0cfee7bcf459d79a16a11616daa8)).