### PR TITLE
Introduce a range_spectrogram method as a figure-of-merit

### DIFF
--- a/examples/miscellaneous/index.rst
+++ b/examples/miscellaneous/index.rst
@@ -9,4 +9,5 @@ Miscellaneous examples
    :numbered:
 
    range-timeseries
+   range-spectrogram
    open-data-spectrogram

--- a/examples/miscellaneous/range-spectrogram.py
+++ b/examples/miscellaneous/range-spectrogram.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Estimating the spectral contribution to inspiral range
+
+We have seen how the binary neutron star (BNS) inspiral range of a
+gravitational-wave detector can be measured directly from the strain
+readout. In this example, we will estimate the average spectral
+contribution to BNS range from the strain record surrounding GW170817
+using :meth:`gwpy.timeseries.TimeSeries.range_spectrogram`.
+"""
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+# First, we need to load some data. As before we can `fetch` the
+# `public data <https://www.gw-openscience.org/catalog/>`__
+# around the GW170817 BNS merger:
+
+from gwpy.timeseries import TimeSeries
+l1 = TimeSeries.fetch_open_data('L1', 1187006834, 1187010930, tag='C02')
+
+# Then, we can calculate a `Spectrogram` of the inspiral range
+# amplitude spectrum:
+
+from gwpy.astro import range_spectrogram
+l1spec = range_spectrogram(l1, 30, fftlength=4, fmin=15, fmax=500) ** (1./2)
+
+# We can plot this `Spectrogram` to visualise spectral variation in
+# LIGO-Livingston's sensitivity in the hour or so surrounding GW170817:
+
+plot = l1spec.plot(figsize=(12, 5))
+ax = plot.gca()
+ax.set_yscale('log')
+ax.set_ylim(15, 500)
+ax.set_title('LIGO-Livingston sensitivity to BNS around GW170817')
+ax.set_epoch(1187008882)  # <- set 0 on plot to GW170817
+ax.colorbar(cmap='cividis', clim=(0, 16),
+            label='BNS range amplitude spectral density '
+                  '[Mpc/$\sqrt{\mathrm{Hz}}$]')
+plot.show()
+
+# Note, the extreme dip in sensitivity near GW170817 is caused by a
+# loud, transient noise event, see `Phys. Rev. Lett. vol. 119, p.
+# 161101 <http://doi.org/10.1103/PhysRevLett.119.161101>`_ for more
+# information.

--- a/examples/miscellaneous/range-spectrogram.py
+++ b/examples/miscellaneous/range-spectrogram.py
@@ -23,7 +23,7 @@ We have seen how the binary neutron star (BNS) inspiral range of a
 gravitational-wave detector can be measured directly from the strain
 readout. In this example, we will estimate the average spectral
 contribution to BNS range from the strain record surrounding GW170817
-using :meth:`gwpy.timeseries.TimeSeries.range_spectrogram`.
+using :func:`gwpy.astro.range_spectrogram`.
 """
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'

--- a/examples/miscellaneous/range-timeseries.py
+++ b/examples/miscellaneous/range-timeseries.py
@@ -17,55 +17,47 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Generating an inspiral range timeseries
+"""Measuring the inspiral range of gravitational-wave detectors
 
-The standard metric of the sensitivity of a gravitational-wave detector
-is the distance to which a canonical binary neutron star (BNS) inspiral
-(with two 1.4 solar mass components) would be detected with a
-signal-to-noise ratio (SNR) of 8.
-
-We can estimate using :func:`gwpy.astro.inspiral_range` after calculating
-the power-spectral density (PSD) of the strain readout for a detector, and
-can plot the variation over time by looping over a power spectral density
-:class:`~gwpy.spectrogram.Spectrogram`.
+One standard figure-of-merit for the sensitivity of a gravitational-wave
+detector is the distance to which a binary neutron star (BNS) inspiral
+with two 1.4 solar mass components would be detected with a signal-to-noise
+ratio (SNR) of 8. We can estimate this using
+:meth:`gwpy.timeseries.TimeSeries.range_timeseries` directly from the strain
+readout for a detector.
 """
 
-# First, we need to load some data, for this we can use the
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+# First, we need to load some data. We can `fetch` the
 # `public data <https://www.gw-openscience.org/catalog/>`__
-# around the GW150914 event:
+# around the GW170817 BNS merger:
 
 from gwpy.timeseries import TimeSeries
-h1 = TimeSeries.fetch_open_data('H1', 1126257414, 1126261510)
-l1 = TimeSeries.fetch_open_data('L1', 1126257414, 1126261510)
+h1 = TimeSeries.fetch_open_data('H1', 1187006834, 1187010930, tag='C02')
+l1 = TimeSeries.fetch_open_data('L1', 1187006834, 1187010930, tag='C02')
 
-# and then calculating the PSD spectrogram:
+# Then, we can measure the inspiral range directly:
 
-h1spec = h1.spectrogram(30, fftlength=4)
-l1spec = l1.spectrogram(30, fftlength=4)
+from gwpy.astro import range_timeseries
+h1range = range_timeseries(h1, 30, fftlength=4, fmin=10)
+l1range = range_timeseries(l1, 30, fftlength=4, fmin=10)
 
-# To calculate the inspiral range variation, we need to create a
-# :class:`~gwpy.timeseries.TimeSeries` in which to store the values, then
-# loop over each PSD bin in the spectrogram, calculating the
-# :func:`gwpy.astro.inspiral_range` for each one:
+# We can now plot these trends to see the variation in LIGO
+# sensitivity over an hour or so surrounding GW170817:
 
-import numpy
-from gwpy.astro import inspiral_range
-h1range = TimeSeries(numpy.zeros(len(h1spec)),
-                     dt=h1spec.dt, t0=h1spec.t0, unit='Mpc')
-l1range = h1range.copy()
-for i in range(h1range.size):
-    h1range[i] = inspiral_range(h1spec[i], fmin=10)
-    l1range[i] = inspiral_range(l1spec[i], fmin=10)
-
-# We can now easily plot the timeseries to see the variation in LIGO
-# sensitivity over the hour or so including GW150914:
-
-plot = h1range.plot(label='LIGO-Hanford', color='gwpy:ligo-hanford',
-                    figsize=(12, 5))
+plot = h1range.plot(
+    label='LIGO-Hanford', color='gwpy:ligo-hanford', figsize=(12, 5))
 ax = plot.gca()
 ax.plot(l1range, label='LIGO-Livingston', color='gwpy:ligo-livingston')
 ax.set_ylabel('Angle-averaged sensitive distance [Mpc]')
-ax.set_title('LIGO sensitivity to BNS around GW150914')
-ax.set_epoch(1126259462)  # <- set 0 on plot to GW150914
+ax.set_title('LIGO sensitivity to BNS around GW170817')
+ax.set_epoch(1187008882)  # <- set 0 on plot to GW170817
 ax.legend()
 plot.show()
+
+# Note, the extreme dip in LIGO-Livingston's sensitivity near GW170817
+# is caused by a loud, transient noise event, see `Phys. Rev. Lett.
+# vol. 119, p. 161101 <http://doi.org/10.1103/PhysRevLett.119.161101>`_
+# for more information.

--- a/examples/miscellaneous/range-timeseries.py
+++ b/examples/miscellaneous/range-timeseries.py
@@ -23,8 +23,8 @@ One standard figure-of-merit for the sensitivity of a gravitational-wave
 detector is the distance to which a binary neutron star (BNS) inspiral
 with two 1.4 solar mass components would be detected with a signal-to-noise
 ratio (SNR) of 8. We can estimate this using
-:meth:`gwpy.timeseries.TimeSeries.range_timeseries` directly from the strain
-readout for a detector.
+:func:`gwpy.astro.range_timeseries` directly from the strain readout for
+a detector.
 """
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/examples/miscellaneous/range-timeseries.py
+++ b/examples/miscellaneous/range-timeseries.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Measuring the inspiral range of gravitational-wave detectors
+"""Generating an inspiral range timeseries
 
 One standard figure-of-merit for the sensitivity of a gravitational-wave
 detector is the distance to which a binary neutron star (BNS) inspiral

--- a/gwpy/astro/__init__.py
+++ b/gwpy/astro/__init__.py
@@ -35,6 +35,8 @@ distance range of a detector
    ~gwpy.astro.inspiral_range_spectrum
    ~gwpy.astro.burst_range
    ~gwpy.astro.burst_range_spectrum
+   ~gwpy.astro.range_timeseries
+   ~gwpy.astro.range_spectrogram
 
 Each of the above methods has been given default parameters corresponding to
 the standard usage by the LIGO project.
@@ -45,6 +47,8 @@ from .range import (
     burst_range_spectrum,
     inspiral_range,
     inspiral_range_psd,
+    range_timeseries,
+    range_spectrogram,
 )
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -361,8 +361,8 @@ def range_timeseries(hoft, stride=None, fftlength=None, overlap=None,
     # compute average spectrogram
     if not isinstance(hoft, Spectrogram):
         hoft = hoft.spectrogram(
-            stride, fftlength=fftlength, overlap=overlap, window=window,
-            method=method, nproc=nproc)
+            stride, fftlength=fftlength, overlap=overlap,
+            window=window, method=method, nproc=nproc)
     # loop over time bins
     for psd in hoft:
         out.append(range_func(psd, **rangekwargs).value)
@@ -454,8 +454,8 @@ def range_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
     # compute average spectrogram
     if not isinstance(hoft, Spectrogram):
         hoft = hoft.spectrogram(
-            stride, fftlength=fftlength, overlap=overlap, window=window,
-            method=method, nproc=nproc)
+            stride, fftlength=fftlength, overlap=overlap,
+            window=window, method=method, nproc=nproc)
     # set frequency limits
     f = hoft.frequencies.to('Hz')
     fmin = units.Quantity(

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -37,6 +37,57 @@ __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 DEFAULT_FFT_METHOD = "welch"
 
 
+def _get_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
+                     window='hann', method=DEFAULT_FFT_METHOD, nproc=1):
+    """Check that the input is a spectrogram, or compute one if compatible
+
+    Parameters
+    ----------
+    hoft : `~gwpy.timeseries.TimeSeries` or `~gwpy.spectrogram.Spectrogram`
+        record of gravitational-wave strain output from a detector
+
+    stride : `float`, optional
+        desired step size (seconds) of range timeseries, required if
+        `hoft` is an instance of `TimeSeries`
+
+    fftlength : `float`, optional
+        number of seconds in a single FFT
+
+    overlap : `float`, optional
+        number of seconds of overlap between FFTs, defaults to the
+        recommended overlap for the given window (if given), or 0
+
+    window : `str`, `numpy.ndarray`, optional
+        window function to apply to timeseries prior to FFT, see
+        :func:`scipy.signal.get_window` for details on acceptable
+        formats
+
+    method : `str`, optional
+        FFT-averaging method, see
+        :meth:`~gwpy.timeseries.TimeSeries.spectrogram` for
+        more details
+
+    nproc : `int`, optional
+        number of CPUs to use in parallel processing of FFTs, default: 1
+
+    Returns
+    -------
+    hoft : `~gwpy.spectrogram.Spectrogram`
+        a time-frequency `Spectrogram` of the input
+    """
+    if not isinstance(hoft, Spectrogram):
+        try:
+            hoft = hoft.spectrogram(
+                stride, fftlength=fftlength, overlap=overlap,
+                window=window, method=method, nproc=nproc)
+        except (AttributeError, TypeError):
+            msg = ('Could not produce a spectrogram from the input, please '
+                   'pass an instance of gwpy.timeseries.TimeSeries or '
+                   'gwpy.spectrogram.Spectrogram')
+            raise TypeError(msg)
+    return hoft
+
+
 def _preformat_psd(func):
     @wraps(func)
     def decorated_func(psd, *args, **kwargs):
@@ -358,11 +409,8 @@ def range_timeseries(hoft, stride=None, fftlength=None, overlap=None,
     rangekwargs = rangekwargs or {'mass1': 1.4, 'mass2': 1.4}
     range_func = (burst_range if 'energy' in rangekwargs
                   else inspiral_range)
-    # compute average spectrogram
-    if not isinstance(hoft, Spectrogram):
-        hoft = hoft.spectrogram(
-            stride, fftlength=fftlength, overlap=overlap,
-            window=window, method=method, nproc=nproc)
+    hoft = _get_spectrogram(stride, fftlength=fftlength, overlap=overlap,
+                            window=window, method=method, nproc=nproc)
     # loop over time bins
     for psd in hoft:
         out.append(range_func(psd, **rangekwargs).value)
@@ -451,11 +499,8 @@ def range_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
     rangekwargs = rangekwargs or {'mass1': 1.4, 'mass2': 1.4}
     range_func = (burst_range_spectrum if 'energy' in rangekwargs
                   else inspiral_range_psd)
-    # compute average spectrogram
-    if not isinstance(hoft, Spectrogram):
-        hoft = hoft.spectrogram(
-            stride, fftlength=fftlength, overlap=overlap,
-            window=window, method=method, nproc=nproc)
+    hoft = _get_spectrogram(stride, fftlength=fftlength, overlap=overlap,
+                            window=window, method=method, nproc=nproc)
     # set frequency limits
     f = hoft.frequencies.to('Hz')
     fmin = units.Quantity(

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -37,8 +37,7 @@ __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 DEFAULT_FFT_METHOD = "welch"
 
 
-def _get_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
-                     window='hann', method=DEFAULT_FFT_METHOD, nproc=1):
+def _get_spectrogram(hoft, **kwargs):
     """Check that the input is a spectrogram, or compute one if compatible
 
     Parameters
@@ -46,29 +45,9 @@ def _get_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
     hoft : `~gwpy.timeseries.TimeSeries` or `~gwpy.spectrogram.Spectrogram`
         record of gravitational-wave strain output from a detector
 
-    stride : `float`, optional
-        desired step size (seconds) of range timeseries, required if
-        `hoft` is an instance of `TimeSeries`
-
-    fftlength : `float`, optional
-        number of seconds in a single FFT
-
-    overlap : `float`, optional
-        number of seconds of overlap between FFTs, defaults to the
-        recommended overlap for the given window (if given), or 0
-
-    window : `str`, `numpy.ndarray`, optional
-        window function to apply to timeseries prior to FFT, see
-        :func:`scipy.signal.get_window` for details on acceptable
-        formats
-
-    method : `str`, optional
-        FFT-averaging method, see
-        :meth:`~gwpy.timeseries.TimeSeries.spectrogram` for
-        more details
-
-    nproc : `int`, optional
-        number of CPUs to use in parallel processing of FFTs, default: 1
+    **kwargs : `dict`, optional
+        additional keyword arguments to
+        `~gwpy.timeseries.TimeSeries.spectrogram`
 
     Returns
     -------
@@ -77,9 +56,7 @@ def _get_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
     """
     if not isinstance(hoft, Spectrogram):
         try:
-            hoft = hoft.spectrogram(
-                stride, fftlength=fftlength, overlap=overlap,
-                window=window, method=method, nproc=nproc)
+            hoft = hoft.spectrogram(**kwargs)
         except (AttributeError, TypeError):
             msg = ('Could not produce a spectrogram from the input, please '
                    'pass an instance of gwpy.timeseries.TimeSeries or '
@@ -409,8 +386,9 @@ def range_timeseries(hoft, stride=None, fftlength=None, overlap=None,
     rangekwargs = rangekwargs or {'mass1': 1.4, 'mass2': 1.4}
     range_func = (burst_range if 'energy' in rangekwargs
                   else inspiral_range)
-    hoft = _get_spectrogram(hoft, stride, fftlength=fftlength, overlap=overlap,
-                            window=window, method=method, nproc=nproc)
+    hoft = _get_spectrogram(
+        hoft, stride=stride, fftlength=fftlength, overlap=overlap,
+        window=window, method=method, nproc=nproc)
     # loop over time bins
     for psd in hoft:
         out.append(range_func(psd, **rangekwargs).value)
@@ -499,8 +477,9 @@ def range_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
     rangekwargs = rangekwargs or {'mass1': 1.4, 'mass2': 1.4}
     range_func = (burst_range_spectrum if 'energy' in rangekwargs
                   else inspiral_range_psd)
-    hoft = _get_spectrogram(hoft, stride, fftlength=fftlength, overlap=overlap,
-                            window=window, method=method, nproc=nproc)
+    hoft = _get_spectrogram(
+        hoft, stride=stride, fftlength=fftlength, overlap=overlap,
+        window=window, method=method, nproc=nproc)
     # set frequency limits
     f = hoft.frequencies.to('Hz')
     fmin = units.Quantity(

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -409,7 +409,7 @@ def range_timeseries(hoft, stride=None, fftlength=None, overlap=None,
     rangekwargs = rangekwargs or {'mass1': 1.4, 'mass2': 1.4}
     range_func = (burst_range if 'energy' in rangekwargs
                   else inspiral_range)
-    hoft = _get_spectrogram(stride, fftlength=fftlength, overlap=overlap,
+    hoft = _get_spectrogram(hoft, stride, fftlength=fftlength, overlap=overlap,
                             window=window, method=method, nproc=nproc)
     # loop over time bins
     for psd in hoft:
@@ -499,7 +499,7 @@ def range_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
     rangekwargs = rangekwargs or {'mass1': 1.4, 'mass2': 1.4}
     range_func = (burst_range_spectrum if 'energy' in rangekwargs
                   else inspiral_range_psd)
-    hoft = _get_spectrogram(stride, fftlength=fftlength, overlap=overlap,
+    hoft = _get_spectrogram(hoft, stride, fftlength=fftlength, overlap=overlap,
                             window=window, method=method, nproc=nproc)
     # set frequency limits
     f = hoft.frequencies.to('Hz')

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -516,7 +516,7 @@ def range_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
     for psd in hoft:
         out.append(range_func(psd[frange], **rangekwargs).value)
     # finalise output
-    out = type(hoft)(out)
+    out = Spectrogram(out)
     out.__array_finalize__(hoft)
     out.f0 = fmin
     out.override_unit('Mpc' if 'energy' in rangekwargs

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -154,6 +154,6 @@ def test_range_spectrogram(hoft, rangekwargs, outunit):
 ])
 def test_range_incompatible_input(range_func):
     with pytest.raises(TypeError) as exc:
-        spec = range_func(2, 0.5)
+        range_func(2, 0.5)
     assert str(exc.value).startswith(
         'Could not produce a spectrogram from the input')

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -32,6 +32,7 @@ from ...frequencyseries import FrequencySeries
 from ...spectrogram import Spectrogram
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 # -- test results -------------------------------------------------------------
 
@@ -120,8 +121,8 @@ def test_burst_range_spectrum(psd):
 
 
 @pytest.mark.parametrize('rangekwargs', [
-    ({'mass1': 1.4, 'mass2': 1.4}),
-    ({'energy': 1e-2}),
+    {'mass1': 1.4, 'mass2': 1.4},
+    {'energy': 1e-2},
 ])
 def test_range_timeseries(hoft, rangekwargs):
     trends = astro.range_timeseries(
@@ -145,3 +146,14 @@ def test_range_spectrogram(hoft, rangekwargs, outunit):
     assert spec.f0 == spec.df
     assert spec.dt == 0.5 * units.second
     assert spec.df == 4 * units.Hertz
+
+
+@pytest.mark.parametrize('range_func', [
+    astro.range_timeseries,
+    astro.range_spectrogram,
+])
+def test_range_incompatible_input(range_func):
+    with pytest.raises(TypeError) as exc:
+        spec = range_func(2, 0.5)
+    assert str(exc.value).startswith(
+        'Could not produce a spectrogram from the input')


### PR DESCRIPTION
This PR introduces two new functions in `gwpy.astro`:

* `range_timeseries`
* `range_spectrogram`

Unit tests and documentation examples for these new functions are also included.

The `range_spectrogram` utility works by first calculating a standard PSD spectrogram (or accepting one as an input), then stepping through its time bins, passing each PSD measurement to either the `astro.burst_range_spectrum` or `astro.inspiral_range_psd` function depending on the use case. The `range_timeseries` utility follows a similar procedure, but returns a `TimeSeries` record of the output of `astro.burst_range` or `astro.inspiral_range`.

**Notes:**
* This PR is mainly to address requests from Advanced LIGO commissioners, who want to analyze spectral contributions to the binary neutron star inspiral range on the LIGO summary pages
* Both methods default to a 1.4-1.4 binary neutron star (BNS) inspiral range, but support either inspiral (of arbitrary masses) or burst (of arbitrary energy) range calculations

cc @duncanmmacleod 