### PR TITLE
Ensure percentile spectra have the same units as the parent Spectrogram

### DIFF
--- a/gwpy/spectrogram/spectrogram.py
+++ b/gwpy/spectrogram/spectrogram.py
@@ -418,10 +418,10 @@ class Spectrogram(Array2D):
             name = '{}: {} percentile'.format(self.name, _ordinal(percentile))
         else:
             name = None
-        return FrequencySeries(out, epoch=self.epoch, channel=self.channel,
-                               name=name, f0=self.f0, df=self.df,
-                               frequencies=(hasattr(self, '_frequencies') and
-                                            self.frequencies or None))
+        return FrequencySeries(
+            out, epoch=self.epoch, channel=self.channel, name=name,
+            f0=self.f0, df=self.df, unit=self.unit, frequencies=(
+                hasattr(self, '_frequencies') and self.frequencies or None))
 
     def zpk(self, zeros, poles, gain, analog=True):
         """Filter this `Spectrogram` by applying a zero-pole-gain filter

--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -186,8 +186,9 @@ class TestSpectrogram(_TestArray2D):
         utils.test_read_write(array, 'hdf5', write_kw={'overwrite': True})
 
     def test_percentile(self):
-        array = self.create(name='Test')
+        array = self.create(name='Test', unit='m')
         a2 = array.percentile(50)
         utils.assert_quantity_sub_equal(array.median(axis=0), a2,
                                         exclude=('name',))
         assert a2.name == 'Test: 50th percentile'
+        assert a2.unit == array.unit


### PR DESCRIPTION
This PR fixes a minor bug in which `Spectrogram.percentile` returns a `FrequencySeries` with no units. The fix is to ensure that the `FrequencySeries` has the same units as the parent `Spectrogram`.

cc @duncanmmacleod 