### PR TITLE
Refactor of GWF I/O utility code

### DIFF
--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -27,8 +27,6 @@ from math import ceil
 
 from six.moves.urllib.parse import urlparse
 
-import numpy
-
 from astropy import units
 from astropy.io import registry as io_registry
 
@@ -269,8 +267,6 @@ class Channel(object):
     def type(self, type_):
         if type_ is None:
             self._type = None
-        elif isinstance(type_, int):
-            self._type = io_nds2.Nds2ChannelType(type_).name
         else:
             self._type = io_nds2.Nds2ChannelType.find(type_).name
 
@@ -300,7 +296,7 @@ class Channel(object):
         if type_ is None:
             self._dtype = None
         else:
-            self._dtype = numpy.dtype(type_)
+            self._dtype = io_nds2.Nds2DataType.find(type_).dtype
 
     @property
     def url(self):
@@ -482,24 +478,13 @@ class Channel(object):
     def from_nds2(cls, nds2channel):
         """Generate a new channel using an existing nds2.channel object
         """
-        # extract metadata
-        name = nds2channel.name
-        sample_rate = nds2channel.sample_rate
-        unit = nds2channel.signal_units
-        if not unit:
-            unit = None
-        ctype = nds2channel.channel_type_to_string(nds2channel.channel_type)
-        # get dtype
-        dtype = {  # pylint: disable: no-member
-            nds2channel.DATA_TYPE_INT16: numpy.int16,
-            nds2channel.DATA_TYPE_INT32: numpy.int32,
-            nds2channel.DATA_TYPE_INT64: numpy.int64,
-            nds2channel.DATA_TYPE_FLOAT32: numpy.float32,
-            nds2channel.DATA_TYPE_FLOAT64: numpy.float64,
-            nds2channel.DATA_TYPE_COMPLEX32: numpy.complex64,
-        }.get(nds2channel.data_type)
-        return cls(name, sample_rate=sample_rate, unit=unit, dtype=dtype,
-                   type=ctype)
+        return cls(
+            nds2channel.name,
+            sample_rate=nds2channel.sample_rate,
+            unit=nds2channel.signal_units or None,
+            dtype=nds2channel.data_type,
+            type=nds2channel.channel_type,
+        )
 
     # -- methods --------------------------------
 

--- a/gwpy/detector/tests/test_channel.py
+++ b/gwpy/detector/tests/test_channel.py
@@ -20,6 +20,7 @@
 """
 
 import json
+import sys
 
 import pytest
 
@@ -168,6 +169,8 @@ class TestChannel(object):
         new = self.TEST_CLASS('test', model=arg)
         assert new.model == model
 
+    @pytest.mark.xfail(sys.version_info < (3, 4),
+                       reason="enum34 error messages don't match python34")
     @pytest.mark.parametrize('arg, type_, ndstype', [
         (None, None, None),
         ('m-trend', 'm-trend', 16),

--- a/gwpy/detector/tests/test_channel.py
+++ b/gwpy/detector/tests/test_channel.py
@@ -178,7 +178,7 @@ class TestChannel(object):
         if type_ == 'RAISE':  # check invalid raises correct exception
             with pytest.raises(ValueError) as exc:
                 c = self.TEST_CLASS('', type=arg)
-            assert str(exc.value) == '%s is not a valid Nds2ChannelType' % arg
+            assert str(exc.value) == '%r is not a valid Nds2ChannelType' % arg
         else:
             c = self.TEST_CLASS('', type=arg)
             assert getattr(c, 'type') == type_

--- a/gwpy/detector/tests/test_channel.py
+++ b/gwpy/detector/tests/test_channel.py
@@ -189,8 +189,10 @@ class TestChannel(object):
 
     @pytest.mark.parametrize('arg, dtype', [
         (None, None),
+        (16, numpy.dtype('float64')),
         (float, numpy.dtype('float64')),
         ('float', numpy.dtype('float64')),
+        ('float64', numpy.dtype('float64')),
         ('u4', numpy.dtype('uint32')),
     ])
     def test_dtype(self, arg, dtype):

--- a/gwpy/io/_framecpp.py
+++ b/gwpy/io/_framecpp.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""GWF I/O utilities for frameCPP
+
+This module is where all constants and variables that require
+frameCPP should go, as opposed to functions which can import
+the necessary objects at runtime.
+"""
+
+from enum import IntEnum
+
+from LDAStools import frameCPP
+
+from ..utils.enum import NumpyTypeEnum
+
+# -- detectors ----------------------------------------------------------------
+
+DetectorLocation = IntEnum(
+    "DetectorLocation",
+    {key[18:]: val for key, val in vars(frameCPP).items() if
+     key.startswith("DETECTOR_LOCATION_")},
+)
+
+
+# -- type mapping -------------------------------------------------------------
+
+class FrVectType(IntEnum, NumpyTypeEnum):
+    INT8 = frameCPP.FrVect.FR_VECT_C
+    INT16 = frameCPP.FrVect.FR_VECT_2S
+    INT32 = frameCPP.FrVect.FR_VECT_4S
+    INT64 = frameCPP.FrVect.FR_VECT_8S
+    FLOAT32 = frameCPP.FrVect.FR_VECT_4R
+    FLOAT64 = frameCPP.FrVect.FR_VECT_8R
+    COMPLEX64 = frameCPP.FrVect.FR_VECT_8C
+    COMPLEX128 = frameCPP.FrVect.FR_VECT_16C
+    BYTES = frameCPP.FrVect.FR_VECT_STRING
+    UINT8 = frameCPP.FrVect.FR_VECT_1U
+    UINT16 = frameCPP.FrVect.FR_VECT_2U
+    UINT32 = frameCPP.FrVect.FR_VECT_4U
+    UINT64 = frameCPP.FrVect.FR_VECT_8U
+
+
+# -- compression types --------------------------------------------------------
+
+class Compression(IntEnum):
+    RAW = frameCPP.FrVect.RAW
+    GZIP = frameCPP.FrVect.GZIP
+    DIFF_GZIP = frameCPP.FrVect.DIFF_GZIP
+    ZERO_SUPPRESS_WORD_2 = frameCPP.FrVect.ZERO_SUPPRESS_WORD_2
+    ZERO_SUPPRESS_WORD_4 = frameCPP.FrVect.ZERO_SUPPRESS_WORD_4
+    ZERO_SUPPRESS_WORD_8 = frameCPP.FrVect.ZERO_SUPPRESS_WORD_8
+    ZERO_SUPPRESS_OTHERWISE_GZIP = frameCPP.FrVect.ZERO_SUPPRESS_OTHERWISE_GZIP
+
+
+class DefaultCompressionLevel(IntEnum):
+    RAW = 0
+    GZIP = 6
+    DIFF_GZIP = 6
+    ZERO_SUPPRESS_WORD_2 = 0
+    ZERO_SUPPRESS_WORD_4 = 0
+    ZERO_SUPPRESS_WORD_8 = 0
+    ZERO_SUPPRESS_OTHERWISE_GZIP = 6
+
+
+# -- Proc data types ----------------------------------------------------------
+
+class FrProcDataType(IntEnum):
+    UNKNOWN = frameCPP.FrProcData.UNKNOWN_TYPE
+    TIME_SERIES = frameCPP.FrProcData.TIME_SERIES
+    FREQUENCY_SERIES = frameCPP.FrProcData.FREQUENCY_SERIES
+    OTHER_1D_SERIES_DATA = frameCPP.FrProcData.OTHER_1D_SERIES_DATA
+    TIME_FREQUENCY = frameCPP.FrProcData.TIME_FREQUENCY
+    WAVELETS = frameCPP.FrProcData.WAVELETS
+    MULTI_DIMENSIONAL = frameCPP.FrProcData.MULTI_DIMENSIONAL
+
+
+class FrProcDataSubType(IntEnum):
+    UNKNOWN = frameCPP.FrProcData.UNKNOWN_SUB_TYPE
+    DFT = frameCPP.FrProcData.DFT
+    AMPLITUDE_SPECTRAL_DENSITY = frameCPP.FrProcData.AMPLITUDE_SPECTRAL_DENSITY
+    POWER_SPECTRAL_DENSITY = frameCPP.FrProcData.POWER_SPECTRAL_DENSITY
+    CROSS_SPECTRAL_DENSITY = frameCPP.FrProcData.CROSS_SPECTRAL_DENSITY
+    COHERENCE = frameCPP.FrProcData.COHERENCE
+    TRANSFER_FUNCTION = frameCPP.FrProcData.TRANSFER_FUNCTION

--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -632,12 +632,22 @@ def _gwf_channel_segments(path, channel, warn=True):
 
 
 def _get_type(type_, enum):
+    """Handle a type string, or just return an `int`
+
+    Only to be called in relation to FrProcDataType and FrProcDataSubType
+    """
     if isinstance(type_, int):
         return type_
     return enum[str(type_).upper()]
 
 
 def _get_frprocdata_type(series, type_):
+    """Determine the appropriate `FrProcDataType` for this series
+
+    Notes
+    -----
+    See Table 17 (§4.3.2.11) of LIGO-T970130 for more details
+    """
     from ._framecpp import FrProcDataType
 
     if type_ is not None:  # format user value
@@ -664,6 +674,12 @@ def _get_frprocdata_type(series, type_):
 
 
 def _get_frprocdata_subtype(series, subtype):
+    """Determine the appropriate `FrProcDataSubType` for this series
+
+    Notes
+    -----
+    See Table 17 (§4.3.2.11) of LIGO-T970130 for more details
+    """
     from ._framecpp import FrProcDataSubType
 
     if subtype is not None:  # format user value

--- a/gwpy/io/tests/test_gwf.py
+++ b/gwpy/io/tests/test_gwf.py
@@ -57,6 +57,19 @@ def test_open_gwf():
         io_gwf.open_gwf('test', mode='a')
 
 
+@skip_missing_dependency("LDAStools.frameCPP")
+def test_create_frvect(noisy_sinusoid):
+    vect = io_gwf.create_frvect(noisy_sinusoid)
+    assert vect.nData == noisy_sinusoid.size
+    assert vect.nBytes == noisy_sinusoid.nbytes
+    assert vect.name == noisy_sinusoid.name
+    assert vect.unitY == noisy_sinusoid.unit
+    xdim = vect.GetDim(0)
+    assert xdim.unitX == noisy_sinusoid.xunit
+    assert xdim.dx == noisy_sinusoid.dx.value
+    assert xdim.startX == noisy_sinusoid.x0.value
+
+
 @skip_missing_dependency('LDAStools.frameCPP')
 def test_iter_channel_names():
     # maybe need something better?

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -20,6 +20,7 @@
 """
 
 import os
+import sys
 
 import pytest
 
@@ -40,6 +41,8 @@ class _TestNds2Enum(object):
     def test_any(self):
         assert self.TEST_CLASS.any() == 2 ** (len(self.TEST_CLASS) - 1) - 1
 
+    @pytest.mark.xfail(sys.version_info < (3, 4),
+                       reason="enum34 error messages don't match python34")
     def test_find_errors(self):
         """Test error raising for :meth:`gwpy.io.nds2.Nds2ChannelType.find`
         """

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -23,13 +23,12 @@ import os
 
 import pytest
 
-import numpy
-
 from ...detector import Channel
 from ...segments import (Segment, SegmentList)
 from ...testing import mocks
 from ...testing.compat import mock
 from ...testing.utils import skip_missing_dependency
+from ...utils.tests.test_enum import TestNumpyTypeEnum as _TestNumpyTypeEnum
 from .. import nds2 as io_nds2
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -40,6 +39,15 @@ class _TestNds2Enum(object):
 
     def test_any(self):
         assert self.TEST_CLASS.any() == 2 ** (len(self.TEST_CLASS) - 1) - 1
+
+    def test_find_errors(self):
+        """Test error raising for :meth:`gwpy.io.nds2.Nds2ChannelType.find`
+        """
+        with pytest.raises(ValueError) as exc:
+            self.TEST_CLASS.find('blah')
+        assert str(exc.value) == "'blah' is not a valid {}".format(
+            self.TEST_CLASS.__name__,
+        )
 
 
 class TestNds2ChannelType(_TestNds2Enum):
@@ -60,32 +68,11 @@ class TestNds2ChannelType(_TestNds2Enum):
         """
         assert self.TEST_CLASS.find(input_) == self.TEST_CLASS.MTREND
 
-    def test_find_errors(self):
-        """Test error raising for :meth:`gwpy.io.nds2.Nds2ChannelType.find`
-        """
-        with pytest.raises(ValueError) as exc:
-            self.TEST_CLASS.find('blah')
-        assert str(exc.value).startswith('blah is not a valid')
 
-
-class TestNds2DataType(_TestNds2Enum):
+class TestNds2DataType(_TestNds2Enum, _TestNumpyTypeEnum):
     """Tests of :class:`gwpy.io.nds2.Nds2DataType`
     """
     TEST_CLASS = io_nds2.Nds2DataType
-
-    @pytest.mark.parametrize('input_', [float, 'float64', 16, numpy.float64])
-    def test_find(self, input_):
-        """Test :meth:`gwpy.io.nds2.Nds2DataType.find`
-        """
-        assert self.TEST_CLASS.find(input_) == self.TEST_CLASS.FLOAT64
-
-    @pytest.mark.parametrize('input_', ['blah', numpy.float16])
-    def test_find_errors(self, input_):
-        """Test error raising for :meth:`gwpy.io.nds2.Nds2ChannelType.find`
-        """
-        with pytest.raises(ValueError) as exc:
-            self.TEST_CLASS.find(input_)
-        assert str(exc.value).startswith('{0} is not a valid'.format(input_))
 
 
 @pytest.mark.parametrize('key, value, hosts', [

--- a/gwpy/testing/fixtures.py
+++ b/gwpy/testing/fixtures.py
@@ -90,7 +90,7 @@ def noisy_sinusoid():
     time = numpy.arange(size) / rate
     x = amp * numpy.sin(2 * numpy.pi * freq * time)
     x += numpy.random.normal(scale=numpy.sqrt(noise_power), size=time.shape)
-    return TimeSeries(x, xindex=time, unit='V')
+    return TimeSeries(x, xindex=time, unit='V', name="noisy sinusoid")
 
 
 @pytest.fixture
@@ -102,4 +102,5 @@ def corrupt_noisy_sinusoid(noisy_sinusoid):
     # add corruption in part of the signal
     size = noisy_sinusoid.size
     noisy_sinusoid.value[int(size//2):int(size//2)+10] *= 50.
+    noisy_sinusoid.name = "corrupt noisy sinusoid"
     return noisy_sinusoid

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -27,7 +27,7 @@ from math import ceil
 
 import numpy
 
-from LDAStools import frameCPP
+from LDAStools import frameCPP  # noqa: F401
 
 from ....io import gwf as io_gwf
 from ....io import _framecpp as io_framecpp
@@ -474,8 +474,6 @@ def write(tsdict, outfile, start=None, end=None, name='gwpy', run=0,
         compression level for given method, default is ``6`` for GZIP-based
         methods, otherwise ``0``
     """
-    from ....io._framecpp import DetectorLocation
-
     # set frame header metadata
     if not start or not end:
         starts, ends = zip(*(ts.span for ts in tsdict.values()))
@@ -484,7 +482,7 @@ def write(tsdict, outfile, start=None, end=None, name='gwpy', run=0,
     duration = end - start
     ifos = {ts.channel.ifo for ts in tsdict.values() if
             ts.channel and ts.channel.ifo and
-            ts.channel.ifo in DetectorLocation}
+            ts.channel.ifo in io_framecpp.DetectorLocation}
 
     # create frame
     frame = io_gwf.create_frame(

--- a/gwpy/utils/enum.py
+++ b/gwpy/utils/enum.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Utilties for enumerations
+"""
+
+from __future__ import absolute_import
+
+from enum import Enum
+
+import numpy
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+
+class NumpyTypeEnum(Enum):
+    """`~enum.Enum` of numpy types
+    """
+    @property
+    def dtype(self):
+        return numpy.dtype(self.name.lower())
+
+    @property
+    def type(self):
+        return self.dtype.type
+
+    @classmethod
+    def find(cls, type_):
+        """Returns the enumerated type corresponding to the given python type
+        """
+        try:
+            return cls(type_)
+        except ValueError as exc:
+            if isinstance(type_, str):
+                type_ = type_.lower()
+            try:
+                return cls[numpy.dtype(type_).name.upper()]
+            except (KeyError, TypeError):
+                raise exc

--- a/gwpy/utils/tests/test_enum.py
+++ b/gwpy/utils/tests/test_enum.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwpy.utils.enum`
+"""
+
+import pytest
+
+import numpy
+
+from .. import enum as gwpy_enum
+
+
+class _MyEnum(gwpy_enum.NumpyTypeEnum):
+    INT16 = 100
+    FLOAT32 = 200
+
+
+class TestNumpyTypeEnum(object):
+    TEST_CLASS = _MyEnum
+
+    def test_dtype(self):
+        """Test `NumpyTypeEnum.dtype` property
+        """
+        assert self.TEST_CLASS.INT16.dtype is numpy.dtype("int16")
+
+    def test_type(self):
+        """Test `NumpyTypeEnum.type` property
+        """
+        assert self.TEST_CLASS.INT16.type is numpy.int16
+
+    @pytest.mark.parametrize("arg", [
+        "INT16",
+        "int16",
+        numpy.int16,
+        numpy.dtype("int16"),
+    ])
+    def test_find(self, arg):
+        """Test :meth:`NumpyTypeEnum.find` method
+        """
+        assert self.TEST_CLASS.find(arg) is self.TEST_CLASS.INT16
+
+    def test_find_value(self):
+        """Test :meth:`NumpyTypeEnum.find` method with value
+
+        This is a round-about way of testing that .find() can take in an
+        the enum value (integer) for TEST_CLASS, and return just the enum
+        """
+        assert self.TEST_CLASS.find(
+            self.TEST_CLASS.INT16.value
+        ) is self.TEST_CLASS.INT16
+
+    def test_find_errors(self):
+        """Test :meth:`NumpyTypeEnum.find` method error handling
+        """
+        with pytest.raises(ValueError) as exc:
+            self.TEST_CLASS.find('blah')
+        assert str(exc.value) == "'blah' is not a valid {}".format(
+            self.TEST_CLASS.__name__,
+        )

--- a/gwpy/utils/tests/test_enum.py
+++ b/gwpy/utils/tests/test_enum.py
@@ -19,6 +19,8 @@
 """Tests for :mod:`gwpy.utils.enum`
 """
 
+import sys
+
 import pytest
 
 import numpy
@@ -65,6 +67,8 @@ class TestNumpyTypeEnum(object):
             self.TEST_CLASS.INT16.value
         ) is self.TEST_CLASS.INT16
 
+    @pytest.mark.xfail(sys.version_info < (3, 4),
+                       reason="enum34 error messages don't match python34")
     def test_find_errors(self):
         """Test :meth:`NumpyTypeEnum.find` method error handling
         """


### PR DESCRIPTION
This PR introduces a re-factoring of a bunch of code, mainly moving functions from `gwpy.timeseries.io.gwf.framecpp` into `gwpy.io.framecpp` and the new `gwpy.io._framecpp` module.

In order to reduce duplication, there is a new `gwpy.utils.enum` module that provides a common parent class for enums that reference numpy types, and is now used by `gwpy.io.nds2.Nds2DataType` and `gwpy.io._framecpp.FrVectType`.

This change should present exactly zero functional changes to the code for 99.9% of cases, technically the API to `TimeSeries{Dict}.write` has changed when `format='gwf'` is given, but I suspect that nobody has ever attempted to use the (undocumented) keywords that have changed.