### PR TITLE
Run all tests from a separate directory

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,9 +31,7 @@ build_script:
 test_script:
   # run scripts from a separate directory, so that we test the installed code
   - mkdir "tests"
-  - pushd "tests"
-  - python -m pytest --pyargs gwpy --cov gwpy --cov-report xml --junitxml junit.xml --numprocesses 2
-  - popd
+  - pushd "tests" && python -m pytest --pyargs gwpy --cov gwpy --cov-report xml:coverage.xml --junitxml junit.xml --numprocesses 2
 after_test:
   - "set _PYV=%PYTHON_VERSION:.=%"
   - python -m pip install codecov

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,7 @@ build_script:
 test_script:
   # run scripts from a separate directory, so that we test the installed code
   - mkdir "tests"
-  - pushd "tests" && python -m pytest --pyargs gwpy --cov gwpy --cov-report xml:coverage.xml --junitxml junit.xml --numprocesses 2
+  - pushd "tests" && python -m pytest --pyargs gwpy --cov gwpy --cov-report xml:coverage.xml --junitxml junit.xml --numprocesses 2 && popd
 after_test:
   - "set _PYV=%PYTHON_VERSION:.=%"
   - python -m pip install codecov

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,10 +29,14 @@ install:
 build_script:
   - python -m pip install .
 test_script:
-  - python -m pytest --pyargs gwpy --cov gwpy --junitxml=junit.xml --numprocesses=2
+  # run scripts from a separate directory, so that we test the installed code
+  - mkdir "tests"
+  - pushd "tests"
+  - python -m pytest --pyargs gwpy --cov gwpy --cov-report xml --junitxml junit.xml --numprocesses 2
+  - popd
 after_test:
   - "set _PYV=%PYTHON_VERSION:.=%"
   - python -m pip install codecov
-  - python -m codecov --flags Windows python%_PYV% conda
+  - python -m codecov --file .\tests\coverage.xml --flags Windows python%_PYV% conda
 on_finish:
-  - ps: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\junit.xml))
+  - ps: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests\junit.xml))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,11 @@ aliases:
 
   - &store_test_results
       store_test_results:
-        path: test-reports
+        path: tests
 
   - &store_test_artifacts
       store_artifacts:
-        path: test-reports
+        path: tests
 
   - &python-build
       docker:
@@ -50,9 +50,9 @@ aliases:
         - run: *run-tests
         - run: *codecov
         - store_test_results:
-            path: test-reports
+            path: tests
         - store_artifacts:
-            path: test-reports
+            path: tests
 
   - &pip-build
       docker:
@@ -156,15 +156,15 @@ jobs:
           command: |
             set -ex
             python -m pip install ${PIP_FLAGS} "flake8>=3.7.0"
-            mkdir -p test-reports
-            python -m flake8 --output-file test-reports/flake8.txt
+            mkdir -p tests
+            python -m flake8 --output-file tests/flake8.txt
       - run:
           name: Create flake8 report
           when: always
           command: |
             set -ex
             python -m pip install ${PIP_FLAGS} flake8-junit-report
-            python -m junit_conversor test-reports/flake8.txt test-reports/junit.xml
+            python -m junit_conversor tests/flake8.txt tests/junit.xml
       - *store_test_results
       - *store_test_artifacts
 

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -39,4 +39,4 @@ ${PYTHON} -m pip install ${PIP_FLAGS} coverage codecov
 _JOBNAME=${CIRCLE_JOB:-${TRAVIS_JOB_NAME}}
 
 # submit coverage results
-${PYTHON} -m codecov --flags $(uname) python${PYTHON_VERSION/./} ${_JOBNAME%%:*}
+${PYTHON} -m codecov --file tests/coverage.xml --flags $(uname) python${PYTHON_VERSION/./} ${_JOBNAME%%:*}

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -52,5 +52,14 @@ else
     conda list --name gwpyci
 fi
 
-# run tests with coverage
-${PYTHON} -m pytest --pyargs gwpy --cov=gwpy --junitxml=test-reports/junit.xml --numprocesses=2
+# run tests with coverage - we use a separate directory here
+# to guarantee that we run the tests from the installed code
+mkdir -p tests
+pushd tests
+${PYTHON} -m pytest \
+    --pyargs gwpy \
+    --cov gwpy \
+    --cov-report xml \
+    --junitxml junit.xml \
+    --numprocesses 2
+popd

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -18,6 +18,9 @@
 
 set -ex
 trap 'set +ex' RETURN
+unset -f cd
+unset -f pushd
+unset -f popd
 
 #
 # Run the test suite for GWpy on the current system

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -59,7 +59,7 @@ pushd tests
 ${PYTHON} -m pytest \
     --pyargs gwpy \
     --cov gwpy \
-    --cov-report xml \
+    --cov-report xml:coverage.xml \
     --junitxml junit.xml \
     --numprocesses 2
 popd


### PR DESCRIPTION
This PR modifies the CI configurations to run `pytest` from a separate directory, to guarantee that we are testing the installed version of the code.