### PR TITLE
Don't exclude examples from flake8 in CI

### DIFF
--- a/examples/frequencyseries/coherence.py
+++ b/examples/frequencyseries/coherence.py
@@ -39,9 +39,11 @@ from gwpy.timeseries import TimeSeriesDict
 # and then :meth:`~TimeSeriesDict.get` the data for the strain output
 # (``H1:GDS-CALIB_STRAIN``) and the PSL periscope accelerometer
 # (``H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ``):
-data = TimeSeriesDict.get(['H1:GDS-CALIB_STRAIN',
-                           'H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ'],
-                           1126260017, 1126260617)
+data = TimeSeriesDict.get(
+    ['H1:GDS-CALIB_STRAIN', 'H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ'],
+    1126260017,
+    1126260617,
+)
 hoft = data['H1:GDS-CALIB_STRAIN']
 acc = data['H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ']
 
@@ -50,7 +52,8 @@ acc = data['H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ']
 # transform length, with a 1-second (50%) overlap:
 coh = hoft.coherence(acc, fftlength=2, overlap=1)
 
-# Finally, we can :meth:`~gwpy.frequencyseries.FrequencySeries.plot` the resulting data:
+# Finally, we can :meth:`~gwpy.frequencyseries.FrequencySeries.plot` the
+# resulting data:
 plot = coh.plot(
     xlabel='Frequency [Hz]', xscale='log',
     ylabel='Coherence', yscale='linear', ylim=(0, 1),

--- a/examples/frequencyseries/variance.py
+++ b/examples/frequencyseries/variance.py
@@ -59,6 +59,6 @@ ax.set_ylabel(r'[strain/$\sqrt{\mathrm{Hz}}$]')
 ax.set_title('LIGO-Livingston sensitivity variance')
 plot.show()
 
-# From this we see that in general the sensitivity varies a few parts in 
+# From this we see that in general the sensitivity varies a few parts in
 # 10 :sup:`-23`, while many of the lines (narrow-band peaks in the spectrum)
 # are much more stationary.

--- a/examples/miscellaneous/range-spectrogram.py
+++ b/examples/miscellaneous/range-spectrogram.py
@@ -52,7 +52,7 @@ ax.set_title('LIGO-Livingston sensitivity to BNS around GW170817')
 ax.set_epoch(1187008882)  # <- set 0 on plot to GW170817
 ax.colorbar(cmap='cividis', clim=(0, 16),
             label='BNS range amplitude spectral density '
-                  '[Mpc/$\sqrt{\mathrm{Hz}}$]')
+                  r'[Mpc/$\sqrt{\mathrm{Hz}}$]')
 plot.show()
 
 # Note, the extreme dip in sensitivity near GW170817 is caused by a

--- a/examples/signal/gw150914.py
+++ b/examples/signal/gw150914.py
@@ -90,7 +90,7 @@ ax1.set_title('LIGO-Hanford strain data around GW150914')
 ax1.text(1.0, 1.01, 'Unfiltered data', transform=ax1.transAxes, ha='right')
 ax1.set_ylabel('Amplitude [strain]', y=-0.2)
 ax2.set_ylabel('')
-ax2.text(1.0, 1.01, '50-250\,Hz bandpass, notches at 60, 120, 180 Hz',
+ax2.text(1.0, 1.01, r'50-250\,Hz bandpass, notches at 60, 120, 180 Hz',
          transform=ax2.transAxes, ha='right')
 plot.show()
 plot.close()  # hide

--- a/examples/spectrogram/coherence.py
+++ b/examples/spectrogram/coherence.py
@@ -39,9 +39,11 @@ from gwpy.timeseries import TimeSeriesDict
 # and then :meth:`~TimeSeriesDict.get` the data for the strain output
 # (``H1:GDS-CALIB_STRAIN``) and the PSL periscope accelerometer
 # (``H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ``):
-data = TimeSeriesDict.get(['H1:GDS-CALIB_STRAIN',
-                           'H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ'],
-                           1126260017, 1126260617)
+data = TimeSeriesDict.get(
+    ['H1:GDS-CALIB_STRAIN', 'H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ'],
+    1126260017,
+    1126260617,
+)
 hoft = data['H1:GDS-CALIB_STRAIN']
 acc = data['H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ']
 
@@ -57,7 +59,9 @@ ax = plot.gca()
 ax.set_ylabel('Frequency [Hz]')
 ax.set_yscale('log')
 ax.set_ylim(10, 8000)
-ax.set_title('Coherence between PSL periscope motion and LIGO-Hanford strain data')
+ax.set_title(
+    'Coherence between PSL periscope motion and LIGO-Hanford strain data',
+)
 ax.grid(True, 'both', 'both')
 ax.colorbar(label='Coherence', clim=[0, 1], cmap='plasma')
 plot.show()

--- a/examples/spectrogram/spectrogram2.py
+++ b/examples/spectrogram/spectrogram2.py
@@ -68,6 +68,6 @@ plot.show()
 
 # Here we can see the trace of a high-mass binary black hole system,
 # referred to as GW150914.
-# For more details on this signal, please see 
+# For more details on this signal, please see
 # `Abbott et al. (2016) <https://doi.org/10.1103/PhysRevLett.116.061102>`_
 # (the joint LSC-Virgo publication announcing this detection).

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test suite for all examples
+"""
+
+import os
+import re
+import sys
+import warnings
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from matplotlib import use
+
+from gwpy.io.nds2 import NDSWarning
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+if sys.version_info < (3, 6):  # python < 3.6
+    pytest.skip('example tests will only run on python >= 3.6',
+                allow_module_level=True)
+pytest.importorskip("matplotlib", minversion="2.2.0")
+pytest.importorskip("astropy", minversion="2.0.0")
+
+use('agg')  # force non-interactive backend
+
+# acceptable authentication failures
+NDS2_AUTH_FAILURES = {
+    re.compile("failed to establish a connection", re.I),
+    re.compile("error authenticating against", re.I),
+}
+
+# find all examples
+EXAMPLE_BASE = Path(__file__).parent
+EXAMPLE_DIRS = [exdir for exdir in EXAMPLE_BASE.iterdir() if exdir.is_dir()]
+EXAMPLES = sorted([
+    pytest.param(expy, id=str(expy.relative_to(EXAMPLE_BASE))) for
+    exdir in EXAMPLE_DIRS for expy in exdir.glob('*.py')],
+)
+
+
+@contextmanager
+def cwd(path):
+    oldpwd = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(oldpwd)
+
+
+@pytest.fixture(autouse=True)
+def example_context():
+    from matplotlib import pyplot
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', category=NDSWarning)
+            warnings.filterwarnings('ignore', message=".*non-GUI backend.*")
+            yield
+    finally:
+        # close all open figures regardless of test status
+        pyplot.close('all')
+
+
+@pytest.mark.parametrize('script', EXAMPLES)
+def test_example(script):
+    with cwd(script.parent):
+        with script.open('r') as example:
+            raw = example.read()
+        if not isinstance(raw, bytes):  # python < 3
+            raw = raw.encode('utf-8')
+        code = compile(raw, str(script), "exec")
+        try:
+            exec(code, globals())
+        except NDSWarning as exc:  # if we can't authenticate, dont worry
+            for msg in NDS2_AUTH_FAILURES:
+                if msg.match(str(exc)):
+                    pytest.skip(str(exc))
+            raise
+        except ImportError as exc:  # needs an optional dependency
+            if "gwpy" in str(exc):
+                raise
+            pytest.skip(str(exc))

--- a/examples/timeseries/blrms.py
+++ b/examples/timeseries/blrms.py
@@ -56,7 +56,7 @@ for ifo, ax in zip(('Hanford', 'Livingston'), (ax1, ax2)):
     ax.legend(['X', 'Y', 'Z'])
     ax.text(1.01, 0.5, ifo, ha='left', va='center', transform=ax.transAxes,
             fontsize=18)
-ax1.set_ylabel('$1-3$\,Hz motion [nm/s]', y=-0.1)
+ax1.set_ylabel(r'$1-3$\,Hz motion [nm/s]', y=-0.1)
 ax2.set_ylabel('')
 ax1.set_title('Magnitude 7.1 earthquake impact on LIGO')
 plot.show()

--- a/examples/timeseries/correlate.py
+++ b/examples/timeseries/correlate.py
@@ -53,7 +53,7 @@ aux = TimeSeries.get('L1:PSL-ISS_PDA_REL_OUT_DQ', 1172489751, 1172489815)
 whoft = hoft.whiten(8, 4)
 waux = aux.whiten(8, 4)
 
- # We can now cross-correlate these channels:
+# We can now cross-correlate these channels:
 mfilter = waux.crop(1172489782.57, 1172489783.57)
 snr = whoft.correlate(mfilter).abs()
 

--- a/examples/timeseries/filter.py
+++ b/examples/timeseries/filter.py
@@ -62,7 +62,8 @@ plot = Plot(whiteasd, dispasd, separate=True, sharex=True,
 # together.
 #
 # Finally, we prettify our plot with some limits, and some labels:
-plot.text(0.95, 0.05, 'Preliminary', fontsize=40, color='gray', ha='right', rotation=45, va='bottom', alpha=0.5)  # hide
+plot.text(0.95, 0.05, 'Preliminary', fontsize=40, color='gray',  # hide
+          ha='right', rotation=45, va='bottom', alpha=0.5)  # hide
 plot.axes[0].set_ylabel('ASD [whitened]')
 plot.axes[1].set_ylabel(r'ASD [m/$\sqrt{\mathrm{Hz}}$]')
 plot.axes[1].set_xlabel('Frequency [Hz]')

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,9 +38,9 @@ exclude =
 	build/,
 	ci/,
 	docs/,
-	examples/,
 	gwpy/_version.py,
 	venv/,
 	versioneer.py,
 per-file-ignores =
-	__init__.py:F401
+	__init__.py:F401,
+	examples/**.py:E402


### PR DESCRIPTION
This PR un-excludes `examples/` from the `flake8` configuration in `setup.cfg`.