### PR TITLE
Improved error reporting when tconverting leap seconds

### DIFF
--- a/gwpy/time/tests/test_time.py
+++ b/gwpy/time/tests/test_time.py
@@ -113,6 +113,7 @@ def test_to_gps(in_, out):
     pytest.param(GlueGPS(GW150914.gpsSeconds, GW150914.gpsNanoSeconds),
                  GW150914_DT, marks=skip_missing_dependency('glue')),
     ('test', ValueError),
+    (1167264017, ValueError),  # gwpy/gwpy#1021
 ])
 def test_from_gps(in_, out):
     """Test :func:`gwpy.time.from_gps`


### PR DESCRIPTION
Python's `datetime.datetime` can't handle an exact leap second, so `gwpy.time.tconvert` will fail when trying to convert one:

```pytb
$ python -m gwpy.time 1167264017
Traceback (most recent call last):
  File "/Users/duncan/opt/miniconda3/envs/py37/lib/python3.7/site-packages/astropy/time/formats.py", line 680, in to_value
    .format((iy, im, id, ihr, imin, isec, ifracsec)))
ValueError: Time (array(2016, dtype=int32), array(12, dtype=int32), array(31, dtype=int32), array(23, dtype=int32), array(59, dtype=int32), array(60, dtype=int32), array(0, dtype=int32)) is within a leap second but datetime does not support leap seconds
```

This PR just improves the error reporting of that:

```pytb
$ python -m gwpy.time 1167264017
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/astropy/time/formats.py", line 609, in to_value
    .format((iy, im, id, ihr, imin, isec, ifracsec)))
ValueError: cannot represent leap second using datetime.datetime, consider using astropy.time.Time(1167264017, format="gps", scale="utc") directly
```

Closes #1021.