### PR TITLE
Added fixed length args to TimeSeries.taper

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -856,6 +856,22 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert tapered.size == data.size
         utils.assert_allclose(data.value, numpy.cos(10*numpy.pi*t))
 
+        # run the same tests for a user-specified taper duration
+        dtapered = data.taper(duration=0.1)
+        assert dtapered[0].value == 0
+        assert dtapered[-1].value == 0
+        assert dtapered.unit == data.unit
+        assert dtapered.size == data.size
+        utils.assert_allclose(data.value, numpy.cos(10*numpy.pi*t))
+
+        # run the same tests for a user-specified number of samples to taper
+        stapered = data.taper(nsamples=10)
+        assert stapered[0].value == 0
+        assert stapered[-1].value == 0
+        assert stapered.unit == data.unit
+        assert stapered.size == data.size
+        utils.assert_allclose(data.value, numpy.cos(10*numpy.pi*t))
+
     def test_inject(self):
         # create a timeseries out of an array of zeros
         duration, sample_rate = 1, 4096

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1421,12 +1421,12 @@ class TimeSeries(TimeSeriesBase):
             `'right'`, or `'leftright'`
 
         duration : `float`, optional
-            the duration of time to taper, cannot be specified if `nsamples`
-            is provided as an argument
+            the duration of time to taper, will override `nsamples`
+            if both are provided as arguments
 
         nsamples : `int`, optional
-            the number of samples to taper, cannot be specified if `duration`
-            is provided as an argument
+            the number of samples to taper, will be overridden by `duration`
+            if both are provided as arguments
 
         Returns
         -------
@@ -1474,10 +1474,7 @@ class TimeSeries(TimeSeriesBase):
         if side not in ('left', 'right', 'leftright'):
             raise ValueError("side must be one of 'left', 'right', "
                              "or 'leftright'")
-        if duration and nsamples:
-            raise ValueError("only one of 'duration' or 'nsamples' may be "
-                             "provided as arguments")
-        elif duration:
+        if duration:
             nsamples = int(duration * self.sample_rate.to("Hz").value)
         out = self.copy()
         # if a duration or number of samples is not specified, automatically
@@ -1488,11 +1485,10 @@ class TimeSeries(TimeSeriesBase):
             mini, = signal.argrelmin(out.value)
             maxi, = signal.argrelmax(out.value)
         if 'left' in side:
-            nleft = nsamples if nsamples else max(mini[0], maxi[0])
+            nleft = nsamples or max(mini[0], maxi[0])
             nleft = min(nleft, int(self.size/2))
         if 'right' in side:
-            nright = (nsamples if nsamples else
-                      out.size - min(mini[-1], maxi[-1]))
+            nright = nsamples or out.size - min(mini[-1], maxi[-1])
             nright = min(nright, int(self.size/2))
         out *= planck(out.size, nleft=nleft, nright=nright)
         return out

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1438,9 +1438,6 @@ class TimeSeries(TimeSeriesBase):
         ValueError
             if `side` is not one of `('left', 'right', 'leftright')`
 
-        ValueError
-            if `duration` and `nsamples` are both provided as arguments
-
         Examples
         --------
         To see the effect of the Planck-taper window, we can taper a


### PR DESCRIPTION
Adds `duration` and `nsamples` options to `TimeSeries.taper()` that allow user to specify a time duration or number of samples to taper rather than using the automatic tapering window. If neither are provided, the method defaults to the automatic tapering. If both `duration` and `nsamples` are provided, a `ValueError` is thrown to avoid mismatched taper arguments.

I also added a couple of explicit type casts to `int` that were causing issues when the specified number of taper samples was more than half of the duration of the data.