### PR TITLE
Add heterodyne method to TimeSeries class

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -861,7 +861,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             data.heterodyne(phases[0:len(phases) // 2])
 
         # test with exp=True
-        het = data.heterodyne(phases, stride=stride, exp=True)
+        het = data.heterodyne(phases, stride=stride)
         assert het.unit == data.unit
         assert het.size == duration // stride
         utils.assert_allclose(numpy.abs(het.value), 0.5*amp, rtol=1e-4)
@@ -869,25 +869,22 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
         # test with singlesided=True
         het = data.heterodyne(
-            phases, stride=stride, exp=True, singlesided=True
+            phases, stride=stride, singlesided=True
         )
         assert het.unit == data.unit
         assert het.size == duration // stride
         utils.assert_allclose(numpy.abs(het.value), amp, rtol=1e-4)
         utils.assert_allclose(numpy.angle(het.value), phase, rtol=2e-4)
 
-        # test with exp=False, deg=True
-        mag, ph = data.heterodyne(phases, stride=stride)
-        assert mag.unit == data.unit
-        assert mag.size == ph.size
-        assert ph.unit == 'deg'
-        utils.assert_allclose(mag.value, 0.5*amp, rtol=1e-4)
-        utils.assert_allclose(ph.value, numpy.rad2deg(phase), rtol=2e-4)
-
-        # test with exp=False, deg=False
-        mag, ph = data.heterodyne(phases, stride=stride, deg=False)
-        assert ph.unit == 'rad'
-        utils.assert_allclose(ph.value, phase, rtol=2e-4)
+        # test against demodulate for a fixed frequency
+        phasesfixed = 2*numpy.pi*(f*t)
+        data = TimeSeries(amp * numpy.cos(phasesfixed + phase),
+                          unit='', times=t)
+        het = data.heterodyne(
+            phases, stride=stride, singlesided=True
+        )
+        demod = data.demodulate(f, stride=stride, exp=True)
+        utils.assert_array_equal(het, demod)
 
     def test_taper(self):
         # create a flat timeseries, then taper it

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -868,7 +868,9 @@ class TestTimeSeries(_TestTimeSeriesBase):
         utils.assert_allclose(numpy.angle(het.value), phase, rtol=2e-4)
 
         # test with singlesided=True
-        het = data.heterodyne(phases, stride=stride, exp=True, singlesided=True)
+        het = data.heterodyne(
+            phases, stride=stride, exp=True, singlesided=True
+        )
         assert het.unit == data.unit
         assert het.size == duration // stride
         utils.assert_allclose(numpy.abs(het.value), amp, rtol=1e-4)

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -876,15 +876,15 @@ class TestTimeSeries(_TestTimeSeriesBase):
         utils.assert_allclose(numpy.abs(het.value), amp, rtol=1e-4)
         utils.assert_allclose(numpy.angle(het.value), phase, rtol=2e-4)
 
-        # test against demodulate for a fixed frequency
+        # test against demodulation for a fixed frequency
         phasesfixed = 2*numpy.pi*(f*t)
         data = TimeSeries(amp * numpy.cos(phasesfixed + phase),
                           unit='', times=t)
         het = data.heterodyne(
-            phases, stride=stride, singlesided=True
+            phasesfixed, stride=stride, singlesided=True
         )
         demod = data.demodulate(f, stride=stride, exp=True)
-        utils.assert_array_equal(het, demod)
+        utils.assert_allclose(het.value, demod.value, rtol=1e-9)
 
     def test_taper(self):
         # create a flat timeseries, then taper it

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -860,7 +860,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         with pytest.raises(ValueError):
             data.heterodyne(phases[0:len(phases) // 2])
 
-        # test with exp=True
+        # test with default settings
         het = data.heterodyne(phases, stride=stride)
         assert het.unit == data.unit
         assert het.size == duration // stride

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -842,6 +842,51 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert ph.unit == 'rad'
         utils.assert_allclose(ph.value, phase, rtol=1e-5)
 
+    def test_heterodyne(self):
+        # create a timeseries that is simply one loud sinusoidal oscillation,
+        # with a frequency and frequency derivative, then heterodyne using the
+        # phase evolution to recover the amplitude and phase
+        amp, phase, f, fdot = 1., numpy.pi/4, 30, 1e-4
+        duration, sample_rate, stride = 600, 4096, 60
+        t = numpy.linspace(0, duration, duration*sample_rate)
+        phases = 2*numpy.pi*(f*t + 0.5*fdot*t**2)
+        data = TimeSeries(amp * numpy.cos(phases + phase),
+                          unit='', times=t)
+
+        # test exceptions
+        with pytest.raises(TypeError):
+            data.heterodyne(1.0)
+
+        with pytest.raises(ValueError):
+            data.heterodyne(phases[0:len(phases) // 2])
+
+        # test with exp=True
+        het = data.heterodyne(phases, stride=stride, exp=True)
+        assert het.unit == data.unit
+        assert het.size == duration // stride
+        utils.assert_allclose(numpy.abs(het.value), 0.5*amp, rtol=1e-4)
+        utils.assert_allclose(numpy.angle(het.value), phase, rtol=2e-4)
+
+        # test with singlesided=True
+        het = data.heterodyne(phases, stride=stride, exp=True, singlesided=True)
+        assert het.unit == data.unit
+        assert het.size == duration // stride
+        utils.assert_allclose(numpy.abs(het.value), amp, rtol=1e-4)
+        utils.assert_allclose(numpy.angle(het.value), phase, rtol=2e-4)
+
+        # test with exp=False, deg=True
+        mag, ph = data.heterodyne(phases, stride=stride)
+        assert mag.unit == data.unit
+        assert mag.size == ph.size
+        assert ph.unit == 'deg'
+        utils.assert_allclose(mag.value, 0.5*amp, rtol=1e-4)
+        utils.assert_allclose(ph.value, numpy.rad2deg(phase), rtol=2e-4)
+
+        # test with exp=False, deg=False
+        mag, ph = data.heterodyne(phases, stride=stride, deg=False)
+        assert ph.unit == 'rad'
+        utils.assert_allclose(ph.value, phase, rtol=2e-4)
+
     def test_taper(self):
         # create a flat timeseries, then taper it
         t = numpy.linspace(0, 1, 2048)

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -876,16 +876,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
         utils.assert_allclose(numpy.abs(het.value), amp, rtol=1e-4)
         utils.assert_allclose(numpy.angle(het.value), phase, rtol=2e-4)
 
-        # test against demodulation for a fixed frequency
-        phasesfixed = 2*numpy.pi*(f*t)
-        data = TimeSeries(amp * numpy.cos(phasesfixed + phase),
-                          unit='', times=t)
-        het = data.heterodyne(
-            phasesfixed, stride=stride, singlesided=True
-        )
-        demod = data.demodulate(f, stride=stride, exp=True)
-        utils.assert_allclose(het.value, demod.value, rtol=1e-9)
-
     def test_taper(self):
         # create a flat timeseries, then taper it
         t = numpy.linspace(0, 1, 2048)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1396,7 +1396,7 @@ class TimeSeries(TimeSeriesBase):
         """
         # stride through the TimeSeries and heterodyne at a single frequency
         phase = (2 * numpy.pi * f *
-                 self.dt.astype('float32').decompose().value *
+                 self.dt.decompose().value *
                  numpy.arange(0, self.size))
         out = self.heterodyne(phase, stride=stride, singlesided=True)
         if exp:

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1464,7 +1464,7 @@ class TimeSeries(TimeSeriesBase):
         phase evolution, and create the signal:
 
         >>> f0 = 123.456789  # signal frequency (Hz)
-        >>> fdot = -9.87654321e-7  # signal frequency derivative (Hz/s) 
+        >>> fdot = -9.87654321e-7  # signal frequency derivative (Hz/s)
         >>> fpeoch = 1131350417  # phase epoch
         >>> amp = 1.5e-22  # signal amplitude
         >>> phase0 = 0.4  # signal phase at the phase epoch

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1338,7 +1338,7 @@ class TimeSeries(TimeSeriesBase):
 
     def demodulate(self, f, stride=1, exp=False, deg=True):
         """Compute the average magnitude and phase of this `TimeSeries`
-        once per stride at a given frequency.
+        once per stride at a given frequency
 
         Parameters
         ----------
@@ -1388,21 +1388,17 @@ class TimeSeries(TimeSeriesBase):
         >>> ax = plot.gca()
         >>> ax.set_ylabel('Strain Amplitude at 331.3 Hz')
         >>> plot.show()
+
+        See also
+        --------
+        TimeSeries.heterodyne
+            for the underlying heterodyne detection method
         """
-        stridesamp = int(stride * self.sample_rate.value)
-        nsteps = int(self.size // stridesamp)
-        # stride through the TimeSeries and mix with a local oscillator,
-        # taking the average over each stride
-        out = type(self)(numpy.zeros(nsteps, dtype=complex))
-        out.__array_finalize__(self)
-        out.sample_rate = 1 / float(stride)
-        w = 2 * numpy.pi * f * self.dt.decompose().value
-        for step in range(nsteps):
-            istart = int(stridesamp * step)
-            iend = istart + stridesamp
-            idx = numpy.arange(istart, iend)
-            mixed = 2 * numpy.exp(-1j * w * idx) * self.value[idx]
-            out.value[step] = mixed.mean()
+        # stride through the TimeSeries and heterodyne at a single frequency
+        phase = (2 * numpy.pi * f *
+                 self.dt.decompose().value *
+                 numpy.arange(0, self.size))
+        out = self.heterodyne(phase, stride=stride, singlesided=True)
         if exp:
             return out
         mag = out.abs()

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1425,9 +1425,9 @@ class TimeSeries(TimeSeriesBase):
             stride (seconds) between calculations, defaults to 1 second
 
         singlesided : `bool`, optional
-            Boolean switch to return single-sided output (i.e., to multiply by 2
-            so that the signal is distributed across positive frequencies only),
-            default: False
+            Boolean switch to return single-sided output (i.e., to multiply by
+            2 so that the signal is distributed across positive frequencies
+            only), default: False
 
         Returns
         -------
@@ -1438,8 +1438,8 @@ class TimeSeries(TimeSeriesBase):
         Notes
         -----
         This is similar to the :meth:`~gwpy.timeseries.TimeSeries.demodulate`
-        method, but is more general in that it accepts a varying phase evolution,
-        rather than a fixed frequency.
+        method, but is more general in that it accepts a varying phase
+        evolution, rather than a fixed frequency.
 
         Unlike :meth:`~gwpy.timeseries.TimeSeries.demodulate`, the complex
         output is double-sided by default, so is not multiplied by 2.

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1396,7 +1396,7 @@ class TimeSeries(TimeSeriesBase):
         """
         # stride through the TimeSeries and heterodyne at a single frequency
         phase = (2 * numpy.pi * f *
-                 self.dt.decompose().value *
+                 self.dt.astype('float32').decompose().value *
                  numpy.arange(0, self.size))
         out = self.heterodyne(phase, stride=stride, singlesided=True)
         if exp:

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1411,47 +1411,43 @@ class TimeSeries(TimeSeriesBase):
         phase.override_unit('deg' if deg else 'rad')
         return (mag, phase)
 
-    def heterodyne(self, phase, stride=1, exp=False, deg=True,
-                   singlesided=False):
+    def heterodyne(self, phase, stride=1, singlesided=False):
         """Compute the average magnitude and phase of this `TimeSeries`
-        once per stride after heterodyning using a given phase series.
-        This is similar to the :meth:`~gwpy.timeseries.TimeSeries.demodulate`
-        method, but can use a varying phase evolution, rather than that from
-        a fixed frequency. Unlike with
-        :meth:`~gwpy.timeseries.TimeSeries.demodulate`, the complex output
-        is by default double-sided, so is not multiplied by 2.
+        once per stride after heterodyning with a given phase series
 
         Parameters
         ----------
         phase : `array_like`
-            a phase array (rads) with which to heterodyne the signal
+            an array of phase measurements (radians) with which to heterodyne
+            the signal
 
         stride : `float`, optional
             stride (seconds) between calculations, defaults to 1 second
 
-        exp : `bool`, optional
-            return the magnitude and phase trends as one `TimeSeries` object
-            representing a complex exponential, default: False
-
-        deg : `bool`, optional
-            if `exp=False`, calculates the phase in degrees
-
         singlesided : `bool`, optional
-            if `singlesided=True` it is equivalent to a single-sided output
-            (i.e., as if the power has not been split between the complex
-            components), which is what is done with
-            :meth:`~gwpy.timeseries.TimeSeries.demodulate`. default: False
+            Boolean switch to return single-sided output (i.e., to multiply by 2
+            so that the signal is distributed across positive frequencies only),
+            default: False
 
         Returns
         -------
-        mag, phase : `TimeSeries`
-            if `exp=False`, returns a pair of `TimeSeries` objects representing
-            magnitude and phase trends with `dt=stride`
-
         out : `TimeSeries`
-            if `exp=True`, returns a single `TimeSeries` with magnitude and
-            phase trends represented as `mag * exp(1j*phase)` with `dt=stride`
+            magnitude and phase trends, represented as
+            `mag * exp(1j*phase)` with `dt=stride`
 
+        Notes
+        -----
+        This is similar to the :meth:`~gwpy.timeseries.TimeSeries.demodulate`
+        method, but is more general in that it accepts a varying phase evolution,
+        rather than a fixed frequency.
+
+        Unlike :meth:`~gwpy.timeseries.TimeSeries.demodulate`, the complex
+        output is double-sided by default, so is not multiplied by 2.
+
+        See also
+        --------
+        TimeSeries.demodulate
+            for a method to heterodyne at a fixed frequency
         """
         try:
             phaselen = len(phase)
@@ -1463,8 +1459,7 @@ class TimeSeries(TimeSeriesBase):
             )
         stridesamp = int(stride * self.sample_rate.value)
         nsteps = int(self.size // stridesamp)
-        # stride through the TimeSeries and mix with a local oscillator,
-        # taking the average over each stride
+        # stride through the TimeSeries and heterodyne
         out = type(self)(numpy.zeros(nsteps, dtype=complex))
         out.__array_finalize__(self)
         out.sample_rate = 1 / float(stride)
@@ -1475,13 +1470,7 @@ class TimeSeries(TimeSeriesBase):
             idx = numpy.arange(istart, iend)
             mixed = numpy.exp(-1j * phasearray[idx]) * self.value[idx]
             out.value[step] = 2 * mixed.mean() if singlesided else mixed.mean()
-        if exp:
-            return out
-        mag = out.abs()
-        phase = type(mag)(numpy.angle(out, deg=deg))
-        phase.__array_finalize__(out)
-        phase.override_unit('deg' if deg else 'rad')
-        return (mag, phase)
+        return out
 
     def taper(self, side='leftright'):
         """Taper the ends of this `TimeSeries` smoothly to zero.

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1443,16 +1443,18 @@ class TimeSeries(TimeSeriesBase):
         Examples
         --------
         Heterodyning can be useful in examining quasi-monochromatic signals
-        with a known phase evolution. An example of such signals are the
+        with a known phase evolution. Examples of such signals are the
         `continuous-wave hardware injections
-        <https://www.gw-openscience.org/s6hwcw/>`_ in many of the observing
-        runs, which are designed to mimic the expected signals from rapidly
-        rotationing neutron stars. In these cases the signals frequency
-        slowly decreases, while the signal is also Doppler modulated due to
-        the Earth's rotational and orbital motion. For instance, we can
-        download some data from GWOSC from the sixth science run of the
+        <https://www.gw-openscience.org/s6hwcw/>`_ in many of the LIGO
+        observing runs, which are designed to mimic the expected signals
+        from rapidly rotating neutron stars. For these sources the signal's
+        frequency slowly decreases and is also Doppler modulated due to
+        the Earth's rotational and orbital motion.
+
+        We can download some data from GWOSC from the sixth science run of the
         initial LIGO detectors, and heterodyne it using the phase
-        evolution for the hardware injection pulsar number 3 (see the table
+        evolution for the hardware injection pulsar signal "number 3" (see the
+        table
         `here <https://www.gw-openscience.org/static/injections/cw/S6_injections/pulsar_injections.html>`_).  # noqa
 
         >>> from gwpy.timeseries import TimeSeries
@@ -1513,9 +1515,9 @@ class TimeSeries(TimeSeriesBase):
         >>>     lalpulsar.TIMECORRECTION_TDB
         >>> )
 
-        Now bandpass the data around the signal frequency, and then heterodyne
-        the `TimeSeries` using this phase evolution with a stride of one
-        minute:
+        We now bandpass the data around the signal frequency, and then
+        heterodyne the `TimeSeries` using this phase evolution with a stride of
+        one minute:
 
         >>> import numpy
         >>> filtdata = data.bandpass(par["F0"] - 0.5, par["F0"] + 0.5)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1440,6 +1440,103 @@ class TimeSeries(TimeSeriesBase):
         Unlike :meth:`~gwpy.timeseries.TimeSeries.demodulate`, the complex
         output is double-sided by default, so is not multiplied by 2.
 
+        Examples
+        --------
+        Heterodyning can be useful in examining quasi-monochromatic signals
+        with a known phase evolution. An example of such signals are the
+        `continuous-wave hardware injections
+        <https://www.gw-openscience.org/s6hwcw/>`_ in many of the observing
+        runs, which are designed to mimic the expected signals from rapidly
+        rotationing neutron stars. In these cases the signals frequency
+        slowly decreases, while the signal is also Doppler modulated due to
+        the Earth's rotational and orbital motion. For instance, we can
+        download some data from GWOSC from the sixth science run of the
+        initial LIGO detectors, and heterodyne it using the phase
+        evolution for the hardware injection pulsar number 3 (see the table
+        `here <https://www.gw-openscience.org/static/injections/cw/S6_injections/pulsar_injections.html>`_).  # noqa
+
+        >>> from gwpy.timeseries import TimeSeries
+        >>> data = TimeSeries.fetch_open_data("H1", 943213436, 943213436+3600)
+
+        We now need to generate the expected phase evolution:
+
+        >>> import lal
+        >>> import lalpulsar
+        >>> from lalpulsar.PulsarParametersWrapper import PulsarParametersPy
+        >>> # set the hardware injection parameters
+        >>> par = PulsarParametersPy()
+        >>> par["RAJ"] = 3.113188712  # source right ascension (rads)
+        >>> par["DECJ"] = -0.583578803  # source declination (rads)
+        >>> # source frequency (Hz) and frequency derivative (Hz/s)
+        >>> par["F"] = [108.8571594, -1.46e-17]
+        >>> par["PEPOCH"] = 751680013.0  # frequency epoch (GPS seconds)
+        >>> # get the LAL-style detector
+        >>> det = lalpulsar.GetSiteInfo("H1")
+        >>> # convert data times to GPS times vector
+        >>> gpstimes = lalpulsar.CreateTimestampVector(len(data))
+        >>> for i, time in enumerate(data.times.value):
+        >>>     gpstimes.data[i] = lal.LIGOTimeGPS(time)
+        >>> # get the solar system ephemeris files
+        >>> from astropy.utils.data import download_file
+        >>> DOWNLOAD_URL = ("https://git.ligo.org/lscsoft/lalsuite/raw/master/"
+        >>>                 "lalpulsar/src/{}")
+        >>> earthfile = "earth00-40-DE200.dat.gz"
+        >>> sunfile = "sun00-40-DE200.dat.gz"
+        >>> efile = download_file(DOWNLOAD_URL.format(earthfile), cache=True)
+        >>> sfile = download_file(DOWNLOAD_URL.format(sunfile), cache=True)
+        >>> edat = lalpulsar.InitBarycenter(efile, sfile)
+        >>> timefile = "tdb_2000-2040.dat.gz"
+        >>> tfile = download_file(DOWNLOAD_URL.format(timefile), cache=True)
+        >>> tdat = lalpulsar.InitTimeCorrections(tfile)
+        >>> # get the time delay between signal arrival at the detector and
+        >>> # solar system barycentre
+        >>> ssbdelay = lalpulsar.HeterodynedPulsarGetSSBDelay(
+        >>>     par.PulsarParameters()
+        >>>     gpstimes,
+        >>>     det,
+        >>>     edat,
+        >>>     tdat,
+        >>>     lalpulsar.TIMECORRECTION_TDB
+        >>> )
+        >>> # get the phase evolution of the signal (in cycles)
+        >>> phase = lalpulsar.HeterodynedPulsarPhaseDifference(
+        >>>     par.PulsarParameters(),
+        >>>     gpstimes,
+        >>>     1.0,  # multiplicative factor for the frequencies
+        >>>     ssbdelay,
+        >>>     0,  # do not update the solar system barycentre delays
+        >>>     None,  # source not in binary system
+        >>>     0,  # do not update binary system barycentre delays
+        >>>     det,
+        >>>     edat,
+        >>>     tdat,
+        >>>     lalpulsar.TIMECORRECTION_TDB
+        >>> )
+
+        Now bandpass the data around the signal frequency, and then heterodyne
+        the `TimeSeries` using this phase evolution with a stride of one
+        minute:
+
+        >>> import numpy
+        >>> filtdata = data.bandpass(par["F0"] - 0.5, par["F0"] + 0.5)
+        >>> het = filtdata.heterodyne(2.0 * numpy.pi * phase.data, stride=60)
+
+        We can then plot the real and imaginary parts of the heterodyned data
+        to visualise the amplitude variations of the injected signal buried in
+        the noise (we cut off the first two points to discard the filter
+        response):
+
+        >>> from gwpy.plot import Plot
+        >>> plot = Plot(het[2:].real)
+        >>> ax = plot.gca()
+        >>> ax.plot(het[2:].imag, 'r')
+        >>> ax.set_ylabel("Complex Strain Amplitude at 108.9 Hz")
+        >>> plot.show()
+
+        If repeating this over data for a day or so, the amplitude modulation
+        of the simulated signal due to the detector's antenna pattern should
+        become visible.
+
         See also
         --------
         TimeSeries.demodulate

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1474,9 +1474,7 @@ class TimeSeries(TimeSeriesBase):
             iend = istart + stridesamp
             idx = numpy.arange(istart, iend)
             mixed = numpy.exp(-1j * phasearray[idx]) * self.value[idx]
-            if singlesided:
-                mixed *= 2
-            out.value[step] = mixed.mean()
+            out.value[step] = 2 * mixed.mean() if singlesided else mixed.mean()
         if exp:
             return out
         mag = out.abs()

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1442,60 +1442,49 @@ class TimeSeries(TimeSeriesBase):
 
         Examples
         --------
-        Heterodyning can be useful in examining quasi-monochromatic signals
-        with a known phase evolution. Examples of such signals are the
-        `continuous-wave hardware injections
-        <https://www.gw-openscience.org/s6hwcw/>`_ in many of the LIGO
-        observing runs, which are designed to mimic the expected signals
-        from rapidly rotating neutron stars. For these sources the signal's
-        frequency slowly decreases and is also Doppler modulated due to
-        the Earth's rotational and orbital motion.
+        Heterodyning can be useful in analysing quasi-monochromatic signals
+        with a known phase evolution, such as continuous-wave signals
+        from rapidly rotating neutron stars. These sources radiate at a
+        frequency that slowly decreases over time, and is Doppler modulated
+        due to the Earth's rotational and orbital motion.
 
-        We can show an example of demodulation by creating a simulated signal
-        with a phase evolution described by a second order Taylor expansion in
-        phase, i.e., it is defined by a frequency and first frequency
-        derivative. We can download some LIGO Livingston data from GWOSC and
-        inject such a signal and attempt to recover the amplitude.
+        To see an example of heterodyning in action, we can simulate a signal
+        whose phase evolution is described by the frequency and its first
+        derivative with respect to time. We can download some O1 era
+        LIGO-Livingston data from GWOSC, inject the simulated signal, and
+        recover its amplitude.
 
-        >>> from gwpy.timeseries import TimeSeries, TimeSeriesDict
-        >>> data = TimeSeries.fetch_open_data('L1', 1131350417, 1131357617)
+        >>> from gwpy.timeseries import TimeSeries
+        >>> data = TimeSeries.fetch_open_data('L1', 1131350417, 1131354017)
 
         We now need to set the signal parameters, generate the expected
         phase evolution, and create the signal:
 
+        >>> import numpy
         >>> f0 = 123.456789  # signal frequency (Hz)
         >>> fdot = -9.87654321e-7  # signal frequency derivative (Hz/s)
         >>> fpeoch = 1131350417  # phase epoch
         >>> amp = 1.5e-22  # signal amplitude
         >>> phase0 = 0.4  # signal phase at the phase epoch
-        >>> import numpy
         >>> times = data.times.value - fepoch
         >>> phase = 2 * numpy.pi * (f0 * times + 0.5 * fdot * times**2)
         >>> signal = TimeSeries(amp * numpy.cos(phase + phase0),
         >>>                     sample_rate=data.sample_rate, t0=data.t0)
         >>> data = data.inject(signal)
 
-        We now bandpass the data around the signal frequency, and then
-        heterodyne the `TimeSeries` using this phase evolution with a stride of
-        one minute:
+        To recover the signal, we can bandpass the injected data around the
+        signal frequency, then heterodyne using our phase model with a stride
+        of 60 seconds:
 
         >>> filtdata = data.bandpass(f0 - 0.5, f0 + 0.5)
         >>> het = filtdata.heterodyne(phase, stride=60, singlesided=True)
 
-        Let's also demodulate the signal at a fixed freqeuncy for comparison
-
-        >>> demod = filtdata.demodulate(f0, stride=60, exp=True)
-
         We can then plot signal amplitude over time (cropping the first two
         minutes to remove the filter response):
 
-        >>> combined = TimeSeriesDict()
-        >>> combined['Heterodyned'] = het.crop(het.x0.value + 180).abs()
-        >>> combined['Demodulated'] = demod.crop(demod.x0.value + 180).abs()
-        >>> plot = combined.plot()
+        >>> plot = het.crop(het.x0.value + 180).abs().plot()
         >>> ax = plot.gca()
-        >>> ax.legend()
-        >>> ax.set_ylabel("Signal Strain Amplitude")
+        >>> ax.set_ylabel("Strain amplitude")
         >>> plot.show()
 
         See also


### PR DESCRIPTION
This adds a method similar to the TimeSeries demodulate method, however, this takes in the phase evolution within which to demodulate/heterodyne the array. By default this returns a double-sided complex output, rather than the single-sided value.

This PR also adds testing of the method.

Closes #1146 

cc @duncanmmacleod 