### PR TITLE
corrected LIGOTimeGPS attribute call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,14 +212,14 @@ jobs:
   debian:stretch:2.7:
     <<: *debian-build
     docker:
-      - image: ligo/base:stretch
+      - image: containers.ligo.org/docker/base:stretch
     environment:
       PIP_FLAGS: " "
 
   debian:stretch:3.5:
     <<: *debian-build
     docker:
-      - image: ligo/base:stretch
+      - image: containers.ligo.org/docker/base:stretch
     environment:
       PIP_FLAGS: " "
 
@@ -228,7 +228,7 @@ jobs:
   el7:2.7:
     <<: *centos-build
     docker:
-      - image: ligo/base:el7
+      - image: containers.ligo.org/docker/base:el7
     environment:
       PIP_FLAGS: " "
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -494,7 +494,11 @@ class DataQualityFlag(object):
         for start, end in qsegs:
             # handle infinities
             if float(end) == +inf:
+<<<<<<< HEAD
                 end = to_gps('now').gpsSeconds
+=======
+                end = int(to_gps('now'))
+>>>>>>> 4987e35509a2121b3dca6886ccbfe63bb58cf41a
 
             # query
             try:
@@ -1152,7 +1156,11 @@ class DataQualityDict(OrderedDict):
                 vers = dqflag.version
             for gpsstart, gpsend in qsegs:
                 if float(gpsend) == +inf:
+<<<<<<< HEAD
                     gpsend = to_gps('now').gpsSeconds
+=======
+                    gpsend = int(to_gps('now'))
+>>>>>>> 4987e35509a2121b3dca6886ccbfe63bb58cf41a
                 gpsstart = float(gpsstart)
                 if not gpsstart.is_integer():
                     raise ValueError("Segment database queries can only"

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -494,7 +494,7 @@ class DataQualityFlag(object):
         for start, end in qsegs:
             # handle infinities
             if float(end) == +inf:
-                end = to_gps('now').seconds
+                end = to_gps('now').gpsSeconds
 
             # query
             try:
@@ -1152,7 +1152,7 @@ class DataQualityDict(OrderedDict):
                 vers = dqflag.version
             for gpsstart, gpsend in qsegs:
                 if float(gpsend) == +inf:
-                    gpsend = to_gps('now').seconds
+                    gpsend = to_gps('now').gpsSeconds
                 gpsstart = float(gpsstart)
                 if not gpsstart.is_integer():
                     raise ValueError("Segment database queries can only"

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -494,11 +494,7 @@ class DataQualityFlag(object):
         for start, end in qsegs:
             # handle infinities
             if float(end) == +inf:
-<<<<<<< HEAD
-                end = to_gps('now').gpsSeconds
-=======
                 end = int(to_gps('now'))
->>>>>>> 4987e35509a2121b3dca6886ccbfe63bb58cf41a
 
             # query
             try:
@@ -1156,11 +1152,7 @@ class DataQualityDict(OrderedDict):
                 vers = dqflag.version
             for gpsstart, gpsend in qsegs:
                 if float(gpsend) == +inf:
-<<<<<<< HEAD
-                    gpsend = to_gps('now').gpsSeconds
-=======
                     gpsend = int(to_gps('now'))
->>>>>>> 4987e35509a2121b3dca6886ccbfe63bb58cf41a
                 gpsstart = float(gpsstart)
                 if not gpsstart.is_integer():
                     raise ValueError("Segment database queries can only"

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -284,7 +284,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             # check that we can't then write the same data again
             with pytest.raises(IOError):
                 array.write(tmp)
-            with pytest.raises(RuntimeError):
+            with pytest.raises((RuntimeError, OSError)):
                 array.write(tmp, append=True)
 
             # check reading with start/end works

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,7 @@
 # requirements for GWpy tests
 # pytest needs more-itertools, we need it to work on python2.7
 more-itertools < 6.0a0 ; python_version < '3'
-pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2 ; python_version >= '3.5'
-pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0 ; python_version < '3.5'
+pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0
 pytest-cov >= 2.4.0
 pytest-xdist < 1.28.0
 mock ; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if not PEP_508 and (
 
 # test dependencies
 tests_require = [
-    'pytest>=3.3.0',
+    'pytest>=3.3.0,<5.0.0',
     'freezegun>=0.2.3',
     'sqlparse>=0.2.0',
     'beautifulsoup4',


### PR DESCRIPTION
In `segments/flag.py`,  there are cases of `LIGOTimeGPS` objects attempting to access the `LIGOTimeGPS.seconds` attribute, which doesn't exist, the correct attribute should be `.gpsSeconds`. These are invoked in cases where the end time of a flag is set to `+inf`, such as when populating a `DataQualityDict` from a veto definer. I was able to successfully populate a `DataQualityDict` with `+inf` end times locally after this fix.