### PR TITLE
Myriad build/CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,14 +212,14 @@ jobs:
   debian:stretch:2.7:
     <<: *debian-build
     docker:
-      - image: ligo/base:stretch
+      - image: containers.ligo.org/docker/base:stretch
     environment:
       PIP_FLAGS: " "
 
   debian:stretch:3.5:
     <<: *debian-build
     docker:
-      - image: ligo/base:stretch
+      - image: containers.ligo.org/docker/base:stretch
     environment:
       PIP_FLAGS: " "
 
@@ -228,7 +228,7 @@ jobs:
   el7:2.7:
     <<: *centos-build
     docker:
-      - image: ligo/base:el7
+      - image: containers.ligo.org/docker/base:el7
     environment:
       PIP_FLAGS: " "
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -284,7 +284,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             # check that we can't then write the same data again
             with pytest.raises(IOError):
                 array.write(tmp)
-            with pytest.raises(RuntimeError):
+            with pytest.raises((RuntimeError, OSError)):
                 array.write(tmp, append=True)
 
             # check reading with start/end works

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,7 @@
 # requirements for GWpy tests
 # pytest needs more-itertools, we need it to work on python2.7
 more-itertools < 6.0a0 ; python_version < '3'
-pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2 ; python_version >= '3.5'
-pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0 ; python_version < '3.5'
+pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0
 pytest-cov >= 2.4.0
 pytest-xdist < 1.28.0
 mock ; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if not PEP_508 and (
 
 # test dependencies
 tests_require = [
-    'pytest>=3.3.0',
+    'pytest>=3.3.0,<5.0.0',
     'freezegun>=0.2.3',
     'sqlparse>=0.2.0',
     'beautifulsoup4',


### PR DESCRIPTION
~This PR updates a test of the `TimeSeries` object to handle more exception types from `h5py`. Apparently the exception types cannot be relied upon because the upstream HDF5 library doesn't consider error codes part of the public API, see http://docs.h5py.org/en/2.9.0/faq.html#exceptions for information.~

UPDATE: This PR fixes a few unrelated build failures:

- updates a test of the `TimeSeries` object to handle more exception types from `h5py`; apparently the exception types cannot be relied upon because the upstream HDF5 library doesn't consider error codes part of the public API, see http://docs.h5py.org/en/2.9.0/faq.html#exceptions for information
- pin to pytest<5.0.0 to avoid annoying internal errors
- updated images for ligo reference OS builds