### PR TITLE
Add exception for catching in IO

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -279,7 +279,13 @@ def is_cache(cache):
     if isinstance(cache, string_types + FILE_LIKE):
         try:
             return bool(len(read_cache(cache)))
-        except (TypeError, ValueError, UnicodeDecodeError, ImportError):
+        except (
+            TypeError,
+            ValueError,
+            UnicodeDecodeError,
+            ImportError,
+            RuntimeError,
+        ):
             # failed to parse cache
             return False
     if HAS_CACHE and isinstance(cache, Cache):


### PR DESCRIPTION
I'm attempting to use `TimeSeriesBase` class as the basis for a data object in my new [CWInPy](https://github.com/cwinpy/cwinpy) code. I've written a new IO reader registry for the data format. However, an allowed data format for reading is an acsii txt file that has four columns. In these cases when the `io.is_cache` function checks these sort of files it causes a `RuntimeError` exception. However, this is not an exception that is caught, so this `is_cache` function doesn't just exit as `False`, but instead fails with an exception. This PR just adds `RuntimeError` as an exception that means that `is_cache` does return `False` in this case.