### PR TITLE
add optional segment ribbons to gwpy-plot when x-axis is time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,14 +212,14 @@ jobs:
   debian:stretch:2.7:
     <<: *debian-build
     docker:
-      - image: ligo/base:stretch
+      - image: containers.ligo.org/docker/base:stretch
     environment:
       PIP_FLAGS: " "
 
   debian:stretch:3.5:
     <<: *debian-build
     docker:
-      - image: ligo/base:stretch
+      - image: containers.ligo.org/docker/base:stretch
     environment:
       PIP_FLAGS: " "
 
@@ -228,7 +228,7 @@ jobs:
   el7:2.7:
     <<: *centos-build
     docker:
-      - image: ligo/base:el7
+      - image: containers.ligo.org/docker/base:el7
     environment:
       PIP_FLAGS: " "
 

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -732,7 +732,8 @@ class CliProduct(object):
             self.plot_num += 1
 
     def add_segs(self, args):
-        """ If requested add DQ segments"""
+        """ If requested add DQ segments
+        """
         std_segments = [
                 '{ifo}:DMT-GRD_ISC_LOCK_NOMINAL:1',
                 '{ifo}:DMT-DC_READOUT_LOCKED:1',
@@ -764,14 +765,9 @@ class CliProduct(object):
 
             for segment in segments:
                 seg_name = segment.replace('{ifo}', ifo)
-                try:
-                    seg_data = DataQualityFlag. \
-                        query_dqsegdb(seg_name, start, end,
-                                      url='https://segments.ligo.org')
-                except:             # noqa: E722
-                    seg_data = DataQualityFlag. \
-                        query_dqsegdb(seg_name, start, end,
-                                      url='https://segments-backup.ligo.org/')
+                seg_data = DataQualityFlag.query_dqsegdb(
+                        seg_name, start, end)
+
                 self.plot.add_segments_bar(seg_data, label=seg_name)
 
 

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -48,6 +48,7 @@ from ..plot.gps import (GPS_SCALES, GPSTransform)
 from ..plot.tex import label_to_latex
 from ..segments import DataQualityFlag
 
+
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 
 BAD_UNITS = {'*', 'Counts.', }
@@ -752,6 +753,7 @@ class CliProduct(object):
             ifo = m.group(1) if m else '?:'
 
             start = None
+            end = 0
             for ts in self.timeseries:
                 if start:
                     start = min(ts.t0, start)
@@ -946,7 +948,7 @@ class TimeDomainProduct(CliProduct):
             args.xmin = min(starts)
         if args.epoch is None:
             args.epoch = args.xmin
-        elif (args.epoch < 1e8):
+        elif args.epoch < 1e8:
             args.epoch += min(starts)
 
         if args.xmax is None:

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -46,7 +46,7 @@ from ..time import to_gps
 from ..timeseries import TimeSeriesDict
 from ..plot.gps import (GPS_SCALES, GPSTransform)
 from ..plot.tex import label_to_latex
-from ..segments import DataQualityFlag   # noqa: E402
+from ..segments import DataQualityFlag
 
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 
@@ -732,8 +732,7 @@ class CliProduct(object):
 
     def add_segs(self, args):
         """ If requested add DQ segments"""
-        std_segments = \
-            [
+        std_segments = [
                 '{ifo}:DMT-GRD_ISC_LOCK_NOMINAL:1',
                 '{ifo}:DMT-DC_READOUT_LOCKED:1',
                 '{ifo}:DMT-CALIBRATED:1',
@@ -750,9 +749,8 @@ class CliProduct(object):
 
             chan = args.chan[0][0]
             m = re.match('^([A-Za-z][0-9]):', chan)
-            ifo = '?:'
-            if m:
-                ifo = m.group(1)
+            ifo = m.group(1) if m else '?:'
+
             start = None
             for ts in self.timeseries:
                 if start:

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -185,6 +185,10 @@ class CliProduct(object):
         #: channels to load
         self.chan_list = unique(c for clist in args.chan for c in clist)
 
+        # use reduced as an alias for rds in channel name
+        for idx in range(len(self.chan_list)):
+            self.chan_list[idx] = self.chan_list[idx].replace('reduced', 'rds')
+
         # total number of datasets that _should_ be acquired
         self.n_datasets = len(self.chan_list) * len(self.start_list)
 
@@ -417,6 +421,7 @@ class CliProduct(object):
 
         if args.out is None:
             args.out = "gwpy.png"
+
 
     def _validate_arguments(self):
         """Sanity check arguments and raise errors if required
@@ -740,7 +745,9 @@ class CliProduct(object):
             if args.std_seg:
                 segments = std_segments
             if args.seg:
-                segments += args.seg
+                for seg in args.seg:
+                    # NB: args.seg may be list of lists
+                    segments += seg
 
             chan = args.chan[0][0]
             m = re.match('^([A-Za-z][0-9]):', chan)

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -422,7 +422,6 @@ class CliProduct(object):
         if args.out is None:
             args.out = "gwpy.png"
 
-
     def _validate_arguments(self):
         """Sanity check arguments and raise errors if required
         """
@@ -734,12 +733,12 @@ class CliProduct(object):
     def add_segs(self, args):
         """ If requested add DQ segments"""
         std_segments = \
-        [
-            '{ifo}:DMT-GRD_ISC_LOCK_NOMINAL:1',
-            '{ifo}:DMT-DC_READOUT_LOCKED:1',
-            '{ifo}:DMT-CALIBRATED:1',
-            '{ifo}:DMT-ANALYSIS_READY:1'
-        ]
+            [
+                '{ifo}:DMT-GRD_ISC_LOCK_NOMINAL:1',
+                '{ifo}:DMT-DC_READOUT_LOCKED:1',
+                '{ifo}:DMT-CALIBRATED:1',
+                '{ifo}:DMT-ANALYSIS_READY:1'
+            ]
         segments = list()
         if hasattr(args, 'std_seg'):
             if args.std_seg:
@@ -769,7 +768,7 @@ class CliProduct(object):
                     seg_data = DataQualityFlag. \
                         query_dqsegdb(seg_name, start, end,
                                       url='https://segments.ligo.org')
-                except:
+                except:             # noqa: E722
                     seg_data = DataQualityFlag. \
                         query_dqsegdb(seg_name, start, end,
                                       url='https://segments-backup.ligo.org/')

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -735,11 +735,11 @@ class CliProduct(object):
         """ If requested add DQ segments
         """
         std_segments = [
-                '{ifo}:DMT-GRD_ISC_LOCK_NOMINAL:1',
-                '{ifo}:DMT-DC_READOUT_LOCKED:1',
-                '{ifo}:DMT-CALIBRATED:1',
-                '{ifo}:DMT-ANALYSIS_READY:1'
-            ]
+            '{ifo}:DMT-GRD_ISC_LOCK_NOMINAL:1',
+            '{ifo}:DMT-DC_READOUT_LOCKED:1',
+            '{ifo}:DMT-CALIBRATED:1',
+            '{ifo}:DMT-ANALYSIS_READY:1'
+        ]
         segments = list()
         if hasattr(args, 'std_seg'):
             if args.std_seg:

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -494,7 +494,7 @@ class DataQualityFlag(object):
         for start, end in qsegs:
             # handle infinities
             if float(end) == +inf:
-                end = to_gps('now').seconds
+                end = int(to_gps('now'))
 
             # query
             try:
@@ -1152,7 +1152,7 @@ class DataQualityDict(OrderedDict):
                 vers = dqflag.version
             for gpsstart, gpsend in qsegs:
                 if float(gpsend) == +inf:
-                    gpsend = to_gps('now').seconds
+                    gpsend = int(to_gps('now'))
                 gpsstart = float(gpsstart)
                 if not gpsstart.is_integer():
                     raise ValueError("Segment database queries can only"

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -189,6 +189,8 @@ class QTiling(QObject):
         QPlane.transform
             compute the Q-transform over a single time-frequency plane
         """
+        if not numpy.isfinite(fseries).all():
+            raise ValueError('Input signal contains non-numerical values')
         weight = 1 + numpy.log10(self.qrange[1]/self.qrange[0]) / numpy.sqrt(2)
         nind, nplanes, peak, result = (0, 0, 0, None)
         # identify the plane with the loudest tile

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1086,6 +1086,12 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert qspecgram.q == 5.65685424949238
         nptest.assert_almost_equal(qspecgram.value.max(), 155.93774, decimal=5)
 
+    def test_q_transform_nan(self):
+        data = TimeSeries(numpy.empty(256*10) * numpy.nan, sample_rate=256)
+        with pytest.raises(ValueError) as exc:
+            data.q_transform()
+        assert str(exc.value) == 'Input signal contains non-numerical values'
+
     def test_boolean_statetimeseries(self, array):
         comp = array >= 2 * array.unit
         assert isinstance(comp, StateTimeSeries)

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -284,7 +284,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             # check that we can't then write the same data again
             with pytest.raises(IOError):
                 array.write(tmp)
-            with pytest.raises(RuntimeError):
+            with pytest.raises((RuntimeError, OSError)):
                 array.write(tmp, append=True)
 
             # check reading with start/end works

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,7 @@
 # requirements for GWpy tests
 # pytest needs more-itertools, we need it to work on python2.7
 more-itertools < 6.0a0 ; python_version < '3'
-pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2 ; python_version >= '3.5'
-pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0 ; python_version < '3.5'
+pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0
 pytest-cov >= 2.4.0
 pytest-xdist < 1.28.0
 mock ; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ if not PEP_508 and (
 
 # test dependencies
 tests_require = [
-    'pytest>=3.3.0',
+    'pytest>=3.3.0,<5.0.0',
     'freezegun>=0.2.3',
     'sqlparse>=0.2.0',
     'beautifulsoup4',


### PR DESCRIPTION
There are two new command line options 
 * `--std-seg` which adds a predefined list of DQ segment ribbons see: https://ldvw.ligo.caltech.edu/ldvw/view?act=getImg&imgId=254114
* `--seg <segment name:version> [...]` add one or more segments by full name. See: https://ldvw.ligo.caltech.edu/ldvw/view?act=getImg&imgId=254112

Next version of ldvw implements the `--std-seg` option.  A subsequent version will have the ability to select which segments are displayed.