### PR TITLE
Move unique utility into gwpy.utils.misc

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -26,7 +26,6 @@ import re
 import time
 import warnings
 import sys
-from collections import OrderedDict
 from functools import wraps
 
 from six import add_metaclass
@@ -40,6 +39,7 @@ except ImportError:
 from astropy.time import Time
 from astropy.units import Quantity
 
+from ..utils import unique
 from ..signal import filter_design
 from ..signal.window import recommended_overlap
 from ..time import to_gps
@@ -89,17 +89,6 @@ def to_float(unit):
 
 to_hz = to_float('Hz')  # pylint: disable=invalid-name
 to_s = to_float('s')  # pylint: disable=invalid-name
-
-
-def unique(list_):
-    """Returns a unique version of the input list preserving order
-
-    Examples
-    --------
-    >>> unique(['b', 'c', 'a', 'a', 'd', 'e', 'd', 'a'])
-    ['b', 'c', 'a', 'd', 'e']
-    """
-    return list(OrderedDict.fromkeys(list_).keys())
 
 
 # -- base product class -------------------------------------------------------

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -20,7 +20,9 @@
 """
 
 from numpy import percentile
-from .cliproduct import (FFTMixin, TimeDomainProduct, ImageProduct, unique)
+
+from .cliproduct import (FFTMixin, TimeDomainProduct, ImageProduct)
+from ..utils import unique
 
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -22,7 +22,8 @@
 from astropy.time import Time
 import warnings
 
-from .cliproduct import (FrequencyDomainProduct, FFTMixin, unique)
+from .cliproduct import (FrequencyDomainProduct, FFTMixin)
+from ..utils import unique
 from ..plot import Plot
 from ..plot.tex import label_to_latex
 

--- a/gwpy/cli/tests/base.py
+++ b/gwpy/cli/tests/base.py
@@ -74,11 +74,6 @@ def test_to_float():
     assert to_s('4ms') == 0.004
 
 
-def test_unique():
-    a = [1, 2, 4, 3, 5, 4, 5, 3]
-    assert cliproduct.unique(a) == [1, 2, 4, 3, 5]
-
-
 # -- class tests --------------------------------------------------------------
 
 class _TestCliProduct(object):

--- a/gwpy/utils/__init__.py
+++ b/gwpy/utils/__init__.py
@@ -27,6 +27,7 @@ from .misc import (
     gprint,
     if_not_none,
     null_context,
+    unique,
 )
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -22,7 +22,9 @@
 from __future__ import print_function
 
 import sys
+from collections import OrderedDict
 from contextlib import contextmanager
+
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -58,3 +60,15 @@ def if_not_none(func, value):
     if value is None:
         return
     return func(value)
+
+
+def unique(list_):
+    """Return a version of the input list with unique elements,
+    preserving order
+
+    Examples
+    --------
+    >>> unique(['b', 'c', 'a', 'a', 'd', 'e', 'd', 'a'])
+    ['b', 'c', 'a', 'd', 'e']
+    """
+    return list(OrderedDict.fromkeys(list_).keys())

--- a/gwpy/utils/tests/test_misc.py
+++ b/gwpy/utils/tests/test_misc.py
@@ -47,6 +47,13 @@ def test_null_context():
         print('this should work')
 
 
+def test_unique():
+    """Test for :func:`gwpy.utils.misc.unique`
+    """
+    a = [1, 2, 4, 3, 5, 4, 5, 3]
+    assert utils_misc.unique(a) == [1, 2, 4, 3, 5]
+
+
 @pytest.mark.parametrize('func, value, out', [
     (str, None, None),
     (str, 1, '1'),


### PR DESCRIPTION
This PR simply moves the `gwpy.cli.cliproduct.unique` utility into `gwpy.utils.misc`, which emerged as an useful thing to do in the discussion of #1156.

cc @duncanmmacleod 