### PR TITLE
Introduce a round_to_power utility

### DIFF
--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -289,7 +289,8 @@ class QPlane(QBase):
     def whitening_duration(self):
         """The recommended data duration required for whitening
         """
-        return round_to_power(self.q / (2 * self.frange[0]))
+        return round_to_power(self.q / (2 * self.frange[0]),
+                              base=2, which=None)
 
     def transform(self, fseries, norm=True, epoch=None, search=None):
         """Calculate the energy `TimeSeries` for the given `fseries`
@@ -355,7 +356,8 @@ class QTile(QBase):
         :type: `int`
         """
         tcum_mismatch = self.duration * 2 * pi * self.frequency / self.q
-        return round_to_power(tcum_mismatch / self.deltam, which='upper')
+        return round_to_power(tcum_mismatch / self.deltam,
+                              base=2, which='upper')
 
     @property
     def windowsize(self):

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -34,6 +34,7 @@ from six.moves import xrange
 import numpy
 from numpy import fft as npfft
 
+from ..utils import round_to_power
 from ..segments import Segment
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -288,7 +289,7 @@ class QPlane(QBase):
     def whitening_duration(self):
         """The recommended data duration required for whitening
         """
-        return 2 ** (round(log(self.q / (2 * self.frange[0]), 2)))
+        return round_to_power(log(self.q / (2 * self.frange[0]), 2))
 
     def transform(self, fseries, norm=True, epoch=None, search=None):
         """Calculate the energy `TimeSeries` for the given `fseries`
@@ -354,7 +355,7 @@ class QTile(QBase):
         :type: `int`
         """
         tcum_mismatch = self.duration * 2 * pi * self.frequency / self.q
-        return next_power_of_two(tcum_mismatch / self.deltam)
+        return round_to_power(tcum_mismatch / self.deltam, which='upper')
 
     @property
     def windowsize(self):
@@ -632,12 +633,6 @@ class QGram(object):
 
 
 # -- utilities ----------------------------------------------------------------
-
-def next_power_of_two(x):
-    """Return the smallest power of two greater than or equal to `x`
-    """
-    return 2**(ceil(log(x, 2)))
-
 
 def q_scan(data, mismatch=DEFAULT_MISMATCH, qrange=DEFAULT_QRANGE,
            frange=DEFAULT_FRANGE, duration=None, sampling=None,

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -289,7 +289,7 @@ class QPlane(QBase):
     def whitening_duration(self):
         """The recommended data duration required for whitening
         """
-        return round_to_power(log(self.q / (2 * self.frange[0]), 2))
+        return round_to_power(self.q / (2 * self.frange[0]))
 
     def transform(self, fseries, norm=True, epoch=None, search=None):
         """Calculate the energy `TimeSeries` for the given `fseries`

--- a/gwpy/utils/__init__.py
+++ b/gwpy/utils/__init__.py
@@ -27,6 +27,7 @@ from .misc import (
     gprint,
     if_not_none,
     null_context,
+    round_to_power,
     unique,
 )
 

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -22,6 +22,7 @@
 from __future__ import print_function
 
 import sys
+import math
 from collections import OrderedDict
 from contextlib import contextmanager
 
@@ -51,7 +52,7 @@ def if_not_none(func, value):
 
     Examples
     --------
-    >>> from gwpy.utils.misc import if_not_none
+    >>> from gwpy.utils import if_not_none
     >>> if_not_none(int, '1')
     1
     >>> if_not_none(int, None)
@@ -62,12 +63,59 @@ def if_not_none(func, value):
     return func(value)
 
 
+def round_to_power(x, base=2, which=None):
+    """Round a positive `float` to the nearest integer power of `base`
+
+    Parameters
+    ----------
+    x : scalar
+        value to round, must be strictly positive
+
+    base : scalar, optional
+        base to whose power `x` will be rounded, default: 2
+
+    which : `str` or `NoneType`, optional
+        which value to round to, must be one of `'lower'`, `'upper'`, or
+        `None` to round to whichever is nearest, default: `None`
+
+    Returns
+    -------
+    rounded : scalar
+        the rounded value
+
+    Notes
+    -----
+    The object returned will be of the same type as `base`.
+
+    Examples
+    --------
+    >>> from gwpy.utils import round_to_power
+    >>> round_to_power(2)
+    2
+    >>> round_to_power(9, base=10)
+    10
+    >>> round_to_power(5, which='lower')
+    4
+    """
+    if which == 'lower':
+        selector = math.floor
+    elif which == 'upper':
+        selector = math.ceil
+    elif which is not None:
+        raise ValueError("'which' argument must be one of 'lower', "
+                         "'upper', or None")
+    else:
+        selector = round
+    return type(base)(base ** selector(math.log(x, base)))
+
+
 def unique(list_):
     """Return a version of the input list with unique elements,
     preserving order
 
     Examples
     --------
+    >>> from gwpy.utils import unique
     >>> unique(['b', 'c', 'a', 'a', 'd', 'e', 'd', 'a'])
     ['b', 'c', 'a', 'd', 'e']
     """

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -64,7 +64,7 @@ def if_not_none(func, value):
 
 
 def round_to_power(x, base=2, which=None):
-    """Round a positive `float` to the nearest integer power of `base`
+    """Round a positive value to the nearest integer power of `base`
 
     Parameters
     ----------

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -52,7 +52,7 @@ def if_not_none(func, value):
 
     Examples
     --------
-    >>> from gwpy.utils import if_not_none
+    >>> from gwpy.utils.misc import if_not_none
     >>> if_not_none(int, '1')
     1
     >>> if_not_none(int, None)
@@ -89,7 +89,7 @@ def round_to_power(x, base=2, which=None):
 
     Examples
     --------
-    >>> from gwpy.utils import round_to_power
+    >>> from gwpy.utils.misc import round_to_power
     >>> round_to_power(2)
     2
     >>> round_to_power(9, base=10)
@@ -115,7 +115,7 @@ def unique(list_):
 
     Examples
     --------
-    >>> from gwpy.utils import unique
+    >>> from gwpy.utils.misc import unique
     >>> unique(['b', 'c', 'a', 'a', 'd', 'e', 'd', 'a'])
     ['b', 'c', 'a', 'd', 'e']
     """

--- a/gwpy/utils/tests/test_misc.py
+++ b/gwpy/utils/tests/test_misc.py
@@ -60,6 +60,11 @@ def test_round_to_power():
     rounded = utils_misc.round_to_power(9, base=base)
     assert base == rounded
     assert type(base) == type(rounded)
+
+
+def test_round_to_power_error():
+    """Test for an errored use case of :func:`gwpy.utils.misc.round_to_power`
+    """
     with pytest.raises(ValueError) as exc:
         utils_misc.round_to_power(7, which='')
     assert str(exc.value) == (

--- a/gwpy/utils/tests/test_misc.py
+++ b/gwpy/utils/tests/test_misc.py
@@ -47,6 +47,25 @@ def test_null_context():
         print('this should work')
 
 
+def test_round_to_power():
+    """Test for :func:`gwpy.utils.misc.round_to_power`
+    """
+    # test basic features
+    assert utils_misc.round_to_power(2) == 2
+    assert utils_misc.round_to_power(9, base=10) == 10
+    assert utils_misc.round_to_power(5, which='lower') == 4
+    assert utils_misc.round_to_power(5, which='upper') == 8
+    # test output
+    base = 10.
+    rounded = utils_misc.round_to_power(9, base=10.)
+    assert base == rounded
+    assert type(base) == type(rounded)
+    with pytest.raises(ValueError) as exc:
+        utils_misc.round_to_power(7, which='')
+    assert str(exc.value) == (
+        "'which' argument must be one of 'lower', 'upper', or None")
+
+
 def test_unique():
     """Test for :func:`gwpy.utils.misc.unique`
     """

--- a/gwpy/utils/tests/test_misc.py
+++ b/gwpy/utils/tests/test_misc.py
@@ -57,7 +57,7 @@ def test_round_to_power():
     assert utils_misc.round_to_power(5, which='upper') == 8
     # test output
     base = 10.
-    rounded = utils_misc.round_to_power(9, base=10.)
+    rounded = utils_misc.round_to_power(9, base=base)
     assert base == rounded
     assert type(base) == type(rounded)
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
This PR introduces a new utility, `gwpy.utils.misc.round_to_power`, which accepts any positive scalar (`float`, `int`, `~astropy.units.Quantity`, etc.) and rounds (in log space) to the nearest integer power of a given base. The output has the same type as the base, and users can force the function to round up or down if they desire.

The new utility replaces and generalizes an existing one in `gwpy.signal.qtransform`.

cc @duncanmmacleod 