### PR TITLE
Improved support for pad in TimeSeries.read and TimeSeries.find

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1283,7 +1283,13 @@ class TimeSeriesBaseDict(OrderedDict):
                     exc.args = "Cannot parse list of IFOs from channel names",
                     raise
             # find frames
-            cache = io_datafind.find_urls(observatory, frametype, start, end)
+            cache = io_datafind.find_urls(
+                observatory,
+                frametype,
+                start,
+                end,
+                on_gaps="error" if pad is None else "warn",
+            )
             if not cache:
                 raise RuntimeError("No %s-%s frame files found for [%d, %d)"
                                    % (observatory, frametype, start, end))

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -523,17 +523,13 @@ class TimeSeriesBase(Series):
             name of frametype in which this channel is stored, will search
             for containing frame types if necessary
 
-        pad : `float`, optional
-            value with which to fill gaps in the source data,
-            by default gaps will result in a `ValueError`.
-
-        scaled : `bool`, optional
-            apply slope and bias calibration to ADC data, for non-ADC data
-            this option has no effect.
-
         nproc : `int`, optional, default: `1`
             number of parallel processes to use, serial process by
             default.
+
+        pad : `float`, optional
+            value with which to fill gaps in the source data,
+            by default gaps will result in a `ValueError`.
 
         dtype : `numpy.dtype`, `str`, `type`, or `dict`
             numeric data type for returned data, e.g. `numpy.float`, or
@@ -1217,8 +1213,8 @@ class TimeSeriesBaseDict(OrderedDict):
             regular expression to use for frametype matching
 
         pad : `float`, optional
-            value with which to fill gaps in the source data, defaults to
-            'don't fill gaps'
+            value with which to fill gaps in the source data,
+            by default gaps will result in a `ValueError`.
 
         scaled : `bool`, optional
             apply slope and bias calibration to ADC data, for non-ADC data
@@ -1327,8 +1323,8 @@ class TimeSeriesBaseDict(OrderedDict):
             will search for all required frame types
 
         pad : `float`, optional
-            value with which to fill gaps in the source data, only used if
-            gap is not given, or `gap='pad'` is given
+            value with which to fill gaps in the source data,
+            by default gaps will result in a `ValueError`.
 
         scaled : `bool`, optional
             apply slope and bias calibration to ADC data, for non-ADC data
@@ -1593,8 +1589,9 @@ class TimeSeriesBaseList(list):
 
         Parameters
         ----------
-        pad : `float`, optional, default: `0.0`
-            value with which to pad gaps
+        pad : `float`, optional
+            value with which to fill gaps in the source data,
+            by default gaps will result in a `ValueError`.
 
         gap : `str`, optional, default: `'raise'`
             what to do if there are gaps in the data, one of

--- a/gwpy/timeseries/io/core.py
+++ b/gwpy/timeseries/io/core.py
@@ -90,13 +90,11 @@ def _pad_series(ts, pad, start=None, end=None):
     """
     span = ts.span
     if start is None:
-        pada = 0
-    else:
-        pada = max(int((span[0] - start) * ts.sample_rate.value), 0)
+        start = span[0]
     if end is None:
-        padb = 0
-    else:
-        padb = max(int((end - span[1]) * ts.sample_rate.value), 0)
+        end = span[1]
+    pada = max(int((span[0] - start) * ts.sample_rate.value), 0)
+    padb = max(int((end - span[1]) * ts.sample_rate.value), 0)
     if pada or padb:
         return ts.pad((pada, padb), mode='constant', constant_values=(pad,))
     return ts

--- a/gwpy/timeseries/io/core.py
+++ b/gwpy/timeseries/io/core.py
@@ -49,6 +49,7 @@ def read(cls, source, *args, **kwargs):
     # read
     return io_read_multi(joiner, cls, source, *args, **kwargs)
 
+
 def _join_factory(cls, gap, pad, start, end):
     """Build a joiner for the given cls, and the given padding options
     """

--- a/gwpy/timeseries/io/core.py
+++ b/gwpy/timeseries/io/core.py
@@ -39,13 +39,17 @@ def read(cls, source, *args, **kwargs):
     # get join arguments
     pad = kwargs.pop('pad', None)
     gap = kwargs.pop('gap', 'raise' if pad is None else 'pad')
-    joiner = _join_factory(cls, gap, pad)
-
+    joiner = _join_factory(
+        cls,
+        gap,
+        pad,
+        kwargs.get("start", None),
+        kwargs.get("end", None),
+    )
     # read
     return io_read_multi(joiner, cls, source, *args, **kwargs)
 
-
-def _join_factory(cls, gap, pad):
+def _join_factory(cls, gap, pad, start, end):
     """Build a joiner for the given cls, and the given padding options
     """
     if issubclass(cls, dict):
@@ -56,11 +60,42 @@ def _join_factory(cls, gap, pad):
                 tsd = data.pop(0)
                 out.append(tsd, gap=gap, pad=pad)
                 del tsd
+            for key in out:
+                out[key] = _pad_series(
+                    out[key],
+                    pad,
+                    start,
+                    end,
+                )
             return out
     else:
         from .. import TimeSeriesBaseList
 
         def _join(arrays):
             list_ = TimeSeriesBaseList(*arrays)
-            return list_.join(pad=pad, gap=gap)
+            return _pad_series(
+                list_.join(pad=pad, gap=gap),
+                pad,
+                start,
+                end,
+            )
     return _join
+
+
+def _pad_series(ts, pad, start=None, end=None):
+    """Pad a timeseries to match the specified [start, end) limits
+
+    To cover a gap in data returned from a data source
+    """
+    span = ts.span
+    if start is None:
+        pada = 0
+    else:
+        pada = max(int((span[0] - start) * ts.sample_rate.value), 0)
+    if end is None:
+        padb = 0
+    else:
+        padb = max(int((end - span[1]) * ts.sample_rate.value), 0)
+    if pada or padb:
+        return ts.pad((pada, padb), mode='constant', constant_values=(pad,))
+    return ts

--- a/gwpy/timeseries/io/hdf5.py
+++ b/gwpy/timeseries/io/hdf5.py
@@ -41,11 +41,11 @@ def read_hdf5_timeseries(h5f, path=None, start=None, end=None, **kwargs):
     kwargs.setdefault('array_type', TimeSeries)
     series = read_hdf5_array(h5f, path=path, **kwargs)
     # crop if needed
+    if start is not None:
+        start = max(start, series.span[0])
+    if end is not None:
+        end = min(end, series.span[1])
     if start is not None or end is not None:
-        if start is not None:
-            start = max(start, series.span[0])
-        if end is not None:
-            end = min(end, series.span[1])
         return series.crop(start, end)
     return series
 

--- a/gwpy/timeseries/io/hdf5.py
+++ b/gwpy/timeseries/io/hdf5.py
@@ -42,6 +42,10 @@ def read_hdf5_timeseries(h5f, path=None, start=None, end=None, **kwargs):
     series = read_hdf5_array(h5f, path=path, **kwargs)
     # crop if needed
     if start is not None or end is not None:
+        if start is not None:
+            start = max(start, series.span[0])
+        if end is not None:
+            end = min(end, series.span[1])
         return series.crop(start, end)
     return series
 

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -34,6 +34,7 @@ from ...segments import (Segment, SegmentList)
 from ...utils import gprint
 from ...utils.progress import progress_bar
 from .. import (TimeSeries)
+from .core import _pad_series
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -186,19 +187,6 @@ def fetch(channels, start, end, type=None, dtype=None, allow_tape=None,
                 out[chan] = _pad_series(ts, pad, start, end)
 
     return out
-
-
-def _pad_series(ts, pad, start, end):
-    """Pad a timeseries to match the specified [start, end) limits
-
-    To cover a gap in data returned from NDS
-    """
-    span = ts.span
-    pada = max(int((span[0] - start) * ts.sample_rate.value), 0)
-    padb = max(int((end - span[1]) * ts.sample_rate.value), 0)
-    if pada or padb:
-        return ts.pad((pada, padb), mode='constant', constant_values=(pad,))
-    return ts
 
 
 def _create_series(ndschan, value, start, end, series_class=TimeSeries):

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -300,6 +300,27 @@ class TestTimeSeries(_TestTimeSeriesBase):
             assert_equal=utils.assert_quantity_sub_equal,
             assert_kw={'exclude': ['unit', 'name', 'channel', 'x0']})
 
+    def test_read_pad(self):
+        a = self.TEST_CLASS.read(
+            utils.TEST_HDF5_FILE,
+            "H1:LDAS-STRAIN",
+        )
+        b = self.TEST_CLASS.read(
+            utils.TEST_HDF5_FILE,
+            "H1:LDAS-STRAIN",
+            pad=0.,
+            start=a.span[0]-1,
+            end=a.span[1]+1,
+        )
+        utils.assert_quantity_sub_equal(
+            a.pad(
+                (int(a.sample_rate.value), int(a.sample_rate.value)),
+                mode="constant",
+                constant_values=(0,),
+            ),
+            b,
+        )
+
     @utils.skip_missing_dependency('nds2')
     def test_from_nds2_buffer_dynamic_scaled(self):
         # build fake buffer for LIGO channel


### PR DESCRIPTION
This PR improves the support for padding gaps in data read using `.find()` or `.read()`. The main changes are:

- borrowed logic from the nds2 reader to ensure that all series are returned with the requested boundaries, padding the start or end as required
- allow gaps in datafind queries if `pad` is given

This should allow users to read, for example, months of trend data directly from GWF even if gaps are present.