### PR TITLE
Fix to handle type changes when applying ADC scaling

### DIFF
--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -40,6 +40,10 @@ pushd build
 
 yum -y -q update
 
+# correct issue with missing tzdata files
+# https://listserv.fnal.gov/scripts/wa.exe?A2=ind1910&L=SCIENTIFIC-LINUX-USERS&P=21164
+yum -y -q reinstall tzdata
+
 # install basic build dependencies
 yum -y -q install \
     rpm-build \

--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -122,11 +122,25 @@ def assert_quantity_sub_equal(a, b, *attrs, **kwargs):
         assert_array = assert_allclose
     else:
         assert_array = assert_array_equal
+
     # parse attributes to be tested
     if not attrs:
         attrs = a._metadata_slots
     exclude = kwargs.pop('exclude', [])
     attrs = [attr for attr in attrs if attr not in exclude]
+
+    # don't assert indexes that don't exist for both
+    def _check_index(dim):
+        index = "{}index".format(dim)
+        _index = "_" + index
+        if index in attrs and (
+                getattr(a, _index, "-") == "-" and
+                getattr(b, _index, "-") == "-"
+        ):
+            attrs.remove(index)
+    _check_index("x")
+    _check_index("y")
+
     # test data
     assert_attributes(a, b, *attrs)
     assert_array(a.value, b.value)

--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -33,6 +33,8 @@ import pytest
 import numpy
 from numpy.testing import (assert_array_equal, assert_allclose)
 
+from astropy.time import Time
+
 # -- useful constants ---------------------------------------------------------
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -141,6 +143,8 @@ def assert_attributes(a, b, *attrs):
         y = getattr(b, attr, None)
         if isinstance(x, numpy.ndarray) and isinstance(b, numpy.ndarray):
             assert_array_equal(x, y)
+        elif isinstance(x, Time) and isinstance(y, Time):
+            assert x.gps == y.gps
         else:
             assert x == y
 

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -309,8 +309,15 @@ def register_gwf_api(library):
 
     # -- write ----------------------------------
 
-    def write_timeseriesdict(data, outfile, start=None, end=None,
-                             name='gwpy', run=0):
+    def write_timeseriesdict(
+            data,
+            outfile,
+            start=None,
+            end=None,
+            type=None,
+            name='gwpy',
+            run=0,
+    ):
         """Write a `TimeSeriesDict` to disk in GWF format
 
         Parameters
@@ -329,6 +336,10 @@ def register_gwf_api(library):
             GPS end time of required data,
             any input parseable by `~gwpy.time.to_gps` is fine
 
+        type : `str`, optional
+            the type of the channel, one of 'adc', 'proc', 'sim', default
+            is 'proc' unless stored in the channel structure
+
         name : `str`, optional
             name of the project that created this GWF
 
@@ -339,8 +350,15 @@ def register_gwf_api(library):
         import_gwf_library(library)
 
         # then write using the relevant API
-        return libwrite_(data, outfile, start=start, end=end,
-                         name=name, run=run)
+        return libwrite_(
+            data,
+            outfile,
+            start=start,
+            end=end,
+            type=type,
+            name=name,
+            run=run,
+        )
 
     def write_timeseries(series, *args, **kwargs):
         """Write a `TimeSeries` to disk in GWF format

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -443,7 +443,10 @@ def read_frvect(vect, epoch, start, end, name=None, series_class=TimeSeries):
 
 # -- write --------------------------------------------------------------------
 
-def write(tsdict, outfile, start=None, end=None, name='gwpy', run=0,
+def write(tsdict, outfile,
+          start=None, end=None,
+          type=None,
+          name='gwpy', run=0,
           compression='GZIP', compression_level=None):
     """Write data to a GWF file using the frameCPP API
 
@@ -460,6 +463,10 @@ def write(tsdict, outfile, start=None, end=None, name='gwpy', run=0,
 
     end : `float`, optional
         the GPS end time of the file
+
+    type : `str`, optional
+        the type of the channel, one of 'adc', 'proc', 'sim', default
+        is 'proc' unless stored in the channel structure
 
     name : `str`, optional
         the name of each frame
@@ -504,11 +511,11 @@ def write(tsdict, outfile, start=None, end=None, name='gwpy', run=0,
 
     # append channels
     for i, key in enumerate(tsdict):
-        try:
-            # pylint: disable=protected-access
-            ctype = tsdict[key].channel._ctype.lower() or 'proc'
-        except AttributeError:
-            ctype = 'proc'
+        ctype = (
+            type or
+            getattr(tsdict[key].channel, "_ctype", "proc").lower() or
+            "proc"
+        )
         if ctype == 'adc':
             kw = {"channelid": i}
         else:

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -175,8 +175,12 @@ def _read_channel(stream, channel, start, duration):
 
 # -- write --------------------------------------------------------------------
 
-def write(tsdict, outfile, start=None, end=None,
-          name='gwpy', run=0):
+def write(
+        tsdict, outfile,
+        start=None, end=None,
+        type=None,
+        name='gwpy', run=0,
+):
     """Write data to a GWF file using the LALFrame API
     """
     if not start:
@@ -201,12 +205,23 @@ def write(tsdict, outfile, start=None, end=None,
     frame = lalframe.FrameNew(start, duration, name, run, 0, detectors)
 
     for series in tsdict.values():
+        # get type
+        ctype = (
+                type or
+                getattr(series.channel, "_ctype", "proc") or
+                "proc"
+        ).title()
+
         # convert to LAL
         lalseries = series.to_lal()
 
         # find adder
         add_ = lalutils.find_typed_function(
-            series.dtype, 'FrameAdd', 'TimeSeriesProcData', module=lalframe)
+            series.dtype,
+            'FrameAdd',
+            'TimeSeries{}Data'.format(ctype),
+            module=lalframe,
+        )
 
         # add time series to frame
         add_(frame, lalseries)

--- a/gwpy/timeseries/tests/test_io_gwf_framecpp.py
+++ b/gwpy/timeseries/tests/test_io_gwf_framecpp.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwpy.timeseries.io.gwf.framecpp`
+"""
+
+import pytest
+
+import numpy
+
+from ...detector import Channel
+from ...testing.utils import (
+    assert_quantity_sub_equal,
+    TemporaryFilename,
+)
+from ...timeseries import TimeSeries
+
+frameCPP = pytest.importorskip("LDAStools.frameCPP")  # noqa: F401
+
+
+@pytest.fixture
+def int32ts():
+    ts = TimeSeries(
+        numpy.arange(10, dtype="int32"),
+        name="test",
+        unit="m",
+        channel=Channel(
+            "test",
+            sample_rate=1,
+            dtype="int32",
+            unit="m",
+        )
+    )
+    return ts
+
+
+def test_read_scaled_false(int32ts):
+    with TemporaryFilename() as tmpf:
+        int32ts.write(tmpf, format="gwf.framecpp", type="adc")
+        new = type(int32ts).read(tmpf, "test", type="adc", scaled=False)
+    assert new.dtype == int32ts.dtype
+    assert new.unit == "ct"
+
+
+def test_read_scaled_type_change(int32ts):
+    with TemporaryFilename() as tmpf:
+        int32ts.write(tmpf, format="gwf.framecpp", type="adc")
+        new = type(int32ts).read(tmpf, "test", type="adc")
+    assert new.dtype == numpy.dtype("float64")
+    assert_quantity_sub_equal(int32ts, new)

--- a/gwpy/timeseries/tests/test_io_gwf_lalframe.py
+++ b/gwpy/timeseries/tests/test_io_gwf_lalframe.py
@@ -163,8 +163,6 @@ def test_write():
         data2 = gwpy_lalframe.read(tmp, CHANNELS)
         assert_dict_equal(data, data2, assert_quantity_sub_equal)
 
-        #
-
 
 def test_write_no_ifo():
     # create timeseries with no IFO

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -269,7 +269,15 @@ class TestTimeSeries(_TestTimeSeriesBase):
         with utils.TemporaryFilename(suffix=".gwf") as tmp:
             losc.write(tmp, type=ctype, format=gwfformat)
             assert get_channel_type(losc.name, tmp) == expected_ctype
-            new = type(losc).read(tmp, losc.name, format=gwfformat)
+            try:
+                new = type(losc).read(tmp, losc.name, format=gwfformat)
+            except OverflowError:
+                if format.lower() == "framecpp" and ctype.lower() == "sim":
+                    pytest.xfail(
+                        "reading Sim data with "
+                        "python-ldas-tools-framecpp < 2.6.9 is broken"
+                    )
+                raise
         # epoch seems to mismatch at O(1e-12), which is unfortunate
         utils.assert_quantity_sub_equal(
             losc,


### PR DESCRIPTION
This PR fixes a bug in the application of ADC scale factors that prevented type casting between int arrays and floats.

cc @pmeyers279, @basswinkels