### PR TITLE
Add table format to read in SNAX features

### DIFF
--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -267,6 +267,31 @@ Writing
 
 Writing tables in PyCBC Live HDF5 format is not supported at this time.
 
+.. _gwpy-table-io-snax:
+
+===========
+SNAX (HDF5)
+===========
+
+The SNAX (Signal-based Noise Acquisition and eXtraction) analysis pipeline is a low-latency search for identifying glitches in h(t) and auxiliary channel data using glitch waveforms, operating in low-latency (online) and offline modes.
+This search writes files on the LIGO Data Grid (LIGO.ORG-authenticated users only) in HDF5 format containing regularly-sampled features; each channel in the table is recorded as a separate HDF5 Dataset.
+
+Reading
+-------
+
+To read an `EventTable` from a ``snax`` format HDF5 file, specify a ``channel`` and use the ``format='hdf5.snax'`` keyword::
+
+   >>> t = EventTable.read('H-GSTLAL_IDQ_FEATURES-1255853400-20.h5', 'H1:CAL-DELTAL_EXTERNAL_DQ', format='hdf5.snax')
+
+To restrict the returned columns, use the ``columns`` keyword argument::
+
+   >>> t = EventTable.read('H-GSTLAL_IDQ_FEATURES-1255853400-20.h5', 'H1:CAL-DELTAL_EXTERNAL_DQ', format='hdf5.snax', columns=['time', 'snr'])
+
+Writing
+-------
+
+Writing tables in SNAX HDF5 format is not supported at this time.
+
 .. _gwpy-table-io-gwf:
 
 ===

--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -36,6 +36,7 @@ from . import (
     hacr,  # Hierarchichal Algorithm for Curves and Ridges
     gwf,  # GWF FrEvents (e.g. MBTA)
     gravityspy,  # Gravity Spy Triggers
+    snax, # SNAX HDF5 features
 )
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -36,7 +36,7 @@ from . import (
     hacr,  # Hierarchichal Algorithm for Curves and Ridges
     gwf,  # GWF FrEvents (e.g. MBTA)
     gravityspy,  # Gravity Spy Triggers
-    snax, # SNAX HDF5 features
+    snax,  # SNAX HDF5 features
 )
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwpy/table/io/snax.py
+++ b/gwpy/table/io/snax.py
@@ -19,15 +19,12 @@
 """Read events from SNAX
 """
 
-import os
-
 from astropy.io.misc.hdf5 import read_table_hdf5
 from astropy.table import vstack
 
 from ...io.hdf5 import with_read_hdf5
 from ...io.registry import register_reader
 from .. import EventTable
-from ..filter import filter_table
 from .utils import (read_with_columns, read_with_selection)
 
 __author__ = 'Patrick Godwin <patrick.godwin@ligo.org>'

--- a/gwpy/table/io/snax.py
+++ b/gwpy/table/io/snax.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Patrick Godwin (2019)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read events from SNAX
+"""
+
+import re
+import os
+
+import numpy
+
+import h5py
+
+from astropy.io.misc.hdf5 import read_table_hdf5
+from astropy.table import vstack
+
+from ...io.hdf5 import with_read_hdf5
+from ...io.registry import register_reader
+from .. import EventTable
+from ..filter import filter_table
+
+__author__ = 'Patrick Godwin <patrick.godwin@ligo.org>'
+
+
+@with_read_hdf5
+def table_from_file(source, channel, columns=None, selection=None):
+    """Read an `EventTable` from a SNAX HDF5 file
+
+    Parameters
+    ----------
+    source : `h5py.File`
+        the file path of open `h5py` object from which to read the data
+
+    channel : `str`
+        the channel to read data from
+
+    columns : `list` of `str`, optional
+        the list of column names to read
+
+    selection : `str`, or `list` of `str`, optional
+        one or more column filters with which to downselect the
+        returned table rows as they as read, e.g. ``'snr > 5'``;
+        multiple selections should be connected by ' && ', or given as
+        a `list`, e.g. ``'snr > 5 && frequency < 1000'`` or
+        ``['snr > 5', 'frequency < 1000']``
+
+    Returns
+    -------
+    table : `~gwpy.table.EventTable`
+    """
+
+    # concatenate all datasets with a given channel
+    datasets = source[channel].keys()
+    tables = [read_table_hdf5(source, path=os.path.join(channel, dataset))
+              for dataset in datasets]
+    table = vstack(tables)
+
+    # apply selection and column filters
+    if selection:
+        table = filter_table(table, selection)
+    if columns:
+        table = table[columns]
+
+    return EventTable(data=table)
+
+
+# register for unified I/O
+register_reader('hdf5.snax', EventTable, table_from_file)

--- a/gwpy/table/io/snax.py
+++ b/gwpy/table/io/snax.py
@@ -19,12 +19,7 @@
 """Read events from SNAX
 """
 
-import re
 import os
-
-import numpy
-
-import h5py
 
 from astropy.io.misc.hdf5 import read_table_hdf5
 from astropy.table import vstack

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -686,19 +686,18 @@ class TestEventTable(TestTable):
         try:
             # write table in snax format (by hand)
             with h5py.File(fp, 'w') as h5f:
-                group = h5f.create_group('H1:FAKE/0.0_20.0')
-                for col in table.columns:
-                    group.create_dataset(data=table[col], name=col)
+                group = h5f.create_group('H1:FAKE')
+                group.create_dataset(data=table, name='0.0_20.0')
 
             # check that we can read
-            t2 = self.TABLE.read(fp, 'H1:FAKE', format="hdf5.snax")
+            t2 = self.TABLE.read(fp, 'H1:FAKE', format='hdf5.snax')
             utils.assert_table_equal(table, t2)
 
             # test with selection and columns
             t2 = self.TABLE.read(
                 fp,
-                format='hdf5.snax',
                 'H1:FAKE',
+                format='hdf5.snax',
                 selection='snr>.5',
                 columns=('time', 'snr'),
             )


### PR DESCRIPTION
This adds in a new EventTable format, `hdf5.snax`, to read in SNAX-based features (formally known as GstLAL feature extractor).

Example:
```
>>> from gwpy.table import EventTable
>>> data = EventTable.read('H-GSTLAL_IDQ_FEATURES-1255853400-20.h5', 'H1:SUS-PRM_M3_WIT_P_DQ', format='hdf5.snax')
>>> data
<EventTable length=319>
       time        frequency     q        snr       phase      duration 
     float64        float32   float32   float32    float32     float32  
------------------ --------- --------- --------- ------------ ----------
 1255853400.046875 29.116926  8.01923  3.179394 0.0115922745 0.59008665
...
```

`EventTable.read()` takes in an additional positional argument, `channel`, to specify the channel needed from the file since multiple channels are contained within.

I added a unit test, `test_read_snax` in `gwpy/table/tests/test_table.py` as well.