### PR TITLE
Add basic clustering method to EventTable

### DIFF
--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -755,12 +755,12 @@ class EventTable(Table):
         # and divide the resulting array into clusters of adjacent points
         clusterpoints = numpy.where(numpy.diff(times) <= window)[0]
         sublists = numpy.split(clusterpoints,
-                            numpy.where(numpy.diff(clusterpoints) > 1)[0]+1)
+                               numpy.where(numpy.diff(clusterpoints) > 1)[0]+1)
 
         # Add end-points to each cluster and find the index of the maximum
         # point in each list
         padded_sublists = [numpy.append(s, numpy.array([s[-1]+1]))
-                          for s in sublists]
+                           for s in sublists]
         maxidx = [s[numpy.argmax(param[s])] for s in padded_sublists]
 
         # Construct a mask that removes all points within clusters and

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -707,26 +707,26 @@ class EventTable(Table):
         """
         return filter_table(self, *column_filters)
 
-    def cluster(self, timecolumn=None, clusterparam=None, window=None):
-        """Cluster this `EventTable` in time, maximizing over a specified
-        column in the table.
+    def cluster(self, column=None, clusterparam=None, window=None):
+        """Cluster this `EventTable` over a given column, maximizing over a
+        specified column in the table.
 
         The clustering algorithm uses a pooling method to identify groups
-        of points that are all separated in time by less than `window`.
+        of points that are all separated in `column` by less than `window`.
 
         Each cluster of nearby points is replaced by the point in that cluster
         with the maximum value of `clusterparam`.
 
         Parameters
         ----------
-        timecolumn : `str`
-            name of the column to use as the time axis when clustering
+        column : `str`
+            name of the column which is used to search for clusters
 
         clusterparam : `str`
-            name of the column to maximize over in each time window
+            name of the column to maximize over in each cluster
 
         window : `float`
-            time window to use when clustering data points, will raise
+            window to use when clustering data points, will raise
             ValueError if `window > 0` is not satisfied
 
         Returns
@@ -737,23 +737,23 @@ class EventTable(Table):
 
         Examples
         --------
-        To cluster an `EventTable` (``table``) whose `timecolumn` is
+        To cluster an `EventTable` (``table``) whose `column` is
         `end_time`, `window` is `0.1`, and maximize over `snr`:
 
-        >>> table.cluster(timecolumn='end_time', clusterparam='snr',
+        >>> table.cluster(column='end_time', clusterparam='snr',
                           window=0.1)
         """
         if window <= 0.0:
             raise ValueError('Window must be a positive value')
 
-        # Generate time and clusterparam vectors that are time-ordered
-        timeidx = numpy.argsort(self[timecolumn])
-        times = self[timecolumn][timeidx]
-        param = self[clusterparam][timeidx]
+        # Generate column and clusterparam vectors that are ordered
+        orderidx = numpy.argsort(self[column])
+        col = self[column][orderidx]
+        param = self[clusterparam][orderidx]
 
-        # Find all points where the time vector changes by less than window
+        # Find all points where the column vector changes by less than window
         # and divide the resulting array into clusters of adjacent points
-        clusterpoints = numpy.where(numpy.diff(times) <= window)[0]
+        clusterpoints = numpy.where(numpy.diff(col) <= window)[0]
         sublists = numpy.split(clusterpoints,
                                numpy.where(numpy.diff(clusterpoints) > 1)[0]+1)
 
@@ -765,8 +765,8 @@ class EventTable(Table):
 
         # Construct a mask that removes all points within clusters and
         # replaces them with the maximum point from each cluster
-        mask = numpy.ones_like(times, dtype=bool)
+        mask = numpy.ones_like(col, dtype=bool)
         mask[numpy.concatenate(padded_sublists)] = False
         mask[maxidx] = True
 
-        return self[timeidx[mask]]
+        return self[orderidx[mask]]

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -726,7 +726,8 @@ class EventTable(Table):
             name of the column to maximize over in each time window
 
         window : `float`
-            time window to use when clustering data points
+            time window to use when clustering data points, will raise
+            ValueError if `window > 0` is not satisfied
 
         Returns
         -------
@@ -741,8 +742,10 @@ class EventTable(Table):
 
         >>> table.cluster(timecolumn='end_time', clusterparam='snr',
                           window=0.1)
-
         """
+        if window <= 0.0:
+            raise ValueError('Window must be a positive value')
+
         # Generate time and clusterparam vectors that are time-ordered
         timeidx = numpy.argsort(self.get_column(timecolumn))
         times = self.get_column(timecolumn)[timeidx]

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -707,22 +707,22 @@ class EventTable(Table):
         """
         return filter_table(self, *column_filters)
 
-    def cluster(self, column=None, clusterparam=None, window=None):
-        """Cluster this `EventTable` over a given column, maximizing over a
-        specified column in the table.
+    def cluster(self, index, rank, window):
+        """Cluster this `EventTable` over a given column, `index`, maximizing
+        over a specified column in the table, `rank`.
 
         The clustering algorithm uses a pooling method to identify groups
-        of points that are all separated in `column` by less than `window`.
+        of points that are all separated in `index` by less than `window`.
 
         Each cluster of nearby points is replaced by the point in that cluster
-        with the maximum value of `clusterparam`.
+        with the maximum value of `rank`.
 
         Parameters
         ----------
-        column : `str`
+        index : `str`
             name of the column which is used to search for clusters
 
-        clusterparam : `str`
+        rank : `str`
             name of the column to maximize over in each cluster
 
         window : `float`
@@ -737,21 +737,20 @@ class EventTable(Table):
 
         Examples
         --------
-        To cluster an `EventTable` (``table``) whose `column` is
+        To cluster an `EventTable` (``table``) whose `index` is
         `end_time`, `window` is `0.1`, and maximize over `snr`:
 
-        >>> table.cluster(column='end_time', clusterparam='snr',
-                          window=0.1)
+        >>> table.cluster('end_time', 'snr', 0.1)
         """
         if window <= 0.0:
             raise ValueError('Window must be a positive value')
 
-        # Generate column and clusterparam vectors that are ordered
-        orderidx = numpy.argsort(self[column])
-        col = self[column][orderidx]
-        param = self[clusterparam][orderidx]
+        # Generate index and rank vectors that are ordered
+        orderidx = numpy.argsort(self[index])
+        col = self[index][orderidx]
+        param = self[rank][orderidx]
 
-        # Find all points where the column vector changes by less than window
+        # Find all points where the index vector changes by less than window
         # and divide the resulting array into clusters of adjacent points
         clusterpoints = numpy.where(numpy.diff(col) <= window)[0]
         sublists = numpy.split(clusterpoints,

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -747,9 +747,9 @@ class EventTable(Table):
             raise ValueError('Window must be a positive value')
 
         # Generate time and clusterparam vectors that are time-ordered
-        timeidx = numpy.argsort(self.get_column(timecolumn))
-        times = self.get_column(timecolumn)[timeidx]
-        param = self.get_column(clusterparam)[timeidx]
+        timeidx = numpy.argsort(self[timecolumn])
+        times = self[timecolumn][timeidx]
+        param = self[clusterparam][timeidx]
 
         # Find all points where the time vector changes by less than window
         # and divide the resulting array into clusters of adjacent points

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -516,8 +516,7 @@ class TestEventTable(TestTable):
         # check that the central data points are all clustered away,
         # the original table is unchanged, and all points return their
         # intended values
-        t = clustertable.cluster(column='time', clusterparam='amplitude',
-                                 window=0.6)
+        t = clustertable.cluster('time', 'amplitude', 0.6)
         assert len(t) == 3
         assert len(clustertable) == 7
         assert all(t['amplitude'] == [11, 10, 9])
@@ -525,8 +524,7 @@ class TestEventTable(TestTable):
 
     def test_single_point_cluster(self, clustertable):
         # check that a large cluster window returns at least one data point
-        t = clustertable.cluster(column='time', clusterparam='amplitude',
-                                 window=10)
+        t = clustertable.cluster('time', 'amplitude', 10)
         assert len(t) == 1
         assert all(t['amplitude'] == [11])
         assert all(t['time'] == [0.0])
@@ -534,8 +532,7 @@ class TestEventTable(TestTable):
     def test_cluster_window(self, clustertable):
         # check that a non-positive window throws an appropriate ValueError
         with pytest.raises(ValueError) as exc:
-            clustertable.cluster(column='time', clusterparam='amplitude',
-                                 window=0)
+            clustertable.cluster('time', 'amplitude', 0)
         assert str(exc.value) == 'Window must be a positive value'
 
     # -- test I/O -------------------------------

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -509,9 +509,9 @@ class TestEventTable(TestTable):
         # check that the central data points are all clustered away,
         # the original table is unchanged, and all points return their
         # intended values
-        t = self.TABLE(data=[[11,1,1,10,1,1,9],
-                            [0.0,1.9,1.95,2.0,2.05,2.1,4.0]],
-                       names=['amplitude','time'])
+        t = self.TABLE(data=[[11, 1, 1, 10, 1, 1, 9],
+                       [0.0, 1.9, 1.95, 2.0, 2.05, 2.1, 4.0]],
+                       names=['amplitude', 'time'])
         t2 = t.cluster(timecolumn='time', clusterparam='amplitude', window=0.6)
         assert len(t2) == 3
         assert len(t) == 7

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -123,7 +123,7 @@ class TestTable(object):
     @pytest.fixture()
     def clustertable(cls):
         return cls.TABLE(data=[[11, 1, 1, 10, 1, 1, 9],
-                         [0.0, 1.9, 1.95, 2.0, 2.05, 2.1, 4.0]],
+                               [0.0, 1.9, 1.95, 2.0, 2.05, 2.1, 4.0]],
                          names=['amplitude', 'time'])
 
     @staticmethod

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -32,7 +32,7 @@ import pytest
 
 import sqlparse
 
-from numpy import (random, isclose, dtype, asarray)
+from numpy import (random, isclose, dtype, asarray, all)
 from numpy.testing import assert_array_equal
 from numpy.ma.core import MaskedConstant
 
@@ -515,8 +515,19 @@ class TestEventTable(TestTable):
         t2 = t.cluster(timecolumn='time', clusterparam='amplitude', window=0.6)
         assert len(t2) == 3
         assert len(t) == 7
-        assert numpy.all(t2.get_column('amplitude') == [11, 10, 9])
-        assert numpy.all(t2.get_column('time') == [0.0, 2.0, 4.0])
+        assert all(t2.get_column('amplitude') == [11, 10, 9])
+        assert all(t2.get_column('time') == [0.0, 2.0, 4.0])
+
+        # check that a large cluster window returns at least one data point
+        t3 = t.cluster(timecolumn='time', clusterparam='amplitude', window=10)
+        assert len(t3) == 1
+        assert all(t3.get_column('amplitude') == [11])
+        assert all(t3.get_column('time') == [0.0])
+
+        # check that a non-positive window throws an appropriate ValueError
+        with pytest.raises(ValueError) as exc:
+            t.cluster(timecolumn='time', clusterparam='amplitude', window=0)
+        assert str(exc.value) == 'Window must be a positive value'
 
     # -- test I/O -------------------------------
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -516,7 +516,7 @@ class TestEventTable(TestTable):
         # check that the central data points are all clustered away,
         # the original table is unchanged, and all points return their
         # intended values
-        t = clustertable.cluster(timecolumn='time', clusterparam='amplitude',
+        t = clustertable.cluster(column='time', clusterparam='amplitude',
                                  window=0.6)
         assert len(t) == 3
         assert len(clustertable) == 7
@@ -525,7 +525,7 @@ class TestEventTable(TestTable):
 
     def test_single_point_cluster(self, clustertable):
         # check that a large cluster window returns at least one data point
-        t = clustertable.cluster(timecolumn='time', clusterparam='amplitude',
+        t = clustertable.cluster(column='time', clusterparam='amplitude',
                                  window=10)
         assert len(t) == 1
         assert all(t['amplitude'] == [11])
@@ -534,7 +534,7 @@ class TestEventTable(TestTable):
     def test_cluster_window(self, clustertable):
         # check that a non-positive window throws an appropriate ValueError
         with pytest.raises(ValueError) as exc:
-            clustertable.cluster(timecolumn='time', clusterparam='amplitude',
+            clustertable.cluster(column='time', clusterparam='amplitude',
                                  window=0)
         assert str(exc.value) == 'Window must be a positive value'
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -505,6 +505,19 @@ class TestEventTable(TestTable):
     def test_get_column(self, table):
         utils.assert_array_equal(table.get_column('snr'), table['snr'])
 
+    def test_cluster(self):
+        # check that the central data points are all clustered away,
+        # the original table is unchanged, and all points return their
+        # intended values
+        t = self.TABLE(data=[[11,1,1,10,1,1,9],
+                            [0.0,1.9,1.95,2.0,2.05,2.1,4.0]],
+                       names=['amplitude','time'])
+        t2 = t.cluster(timecolumn='time', clusterparam='amplitude', window=0.6)
+        assert len(t2) == 3
+        assert len(t) == 7
+        assert numpy.all(t2.get_column('amplitude') == [11, 10, 9])
+        assert numpy.all(t2.get_column('time') == [0.0, 2.0, 4.0])
+
     # -- test I/O -------------------------------
 
     def test_read_write_hdf5(self, table):

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -517,7 +517,7 @@ class TestEventTable(TestTable):
         # the original table is unchanged, and all points return their
         # intended values
         t = clustertable.cluster(timecolumn='time', clusterparam='amplitude',
-                                  window=0.6)
+                                 window=0.6)
         assert len(t) == 3
         assert len(clustertable) == 7
         assert all(t['amplitude'] == [11, 10, 9])


### PR DESCRIPTION
This adds a basic clustering method to `EventTable` objects. The clustering algorithm uses a pooling method to identify points that are all separated in time by less than `window`. The maximum value point of each cluster is calculated and replaces the cluster. 

An example (behind LIGO credentials) of clustering PyCBC Live triggers clustered with a 0.1 second window and maximizing over SNR.
Before: https://ldas-jobs.ligo.caltech.edu/~thomas.massinger/plots/test_clustering_unclustered_SNR.pdf
After: https://ldas-jobs.ligo.caltech.edu/~thomas.massinger/plots/test_clustering_clustered_SNR.pdf

Unit tests all pass when run from the command line.