### PR TITLE
Remove all __future__ imports

### DIFF
--- a/ci/parse-conda-requirements.py
+++ b/ci/parse-conda-requirements.py
@@ -3,8 +3,6 @@
 """Parse a requirements.txt-format file for use with Conda
 """
 
-from __future__ import print_function
-
 import argparse
 import atexit
 import json

--- a/docs/plot/colors.rst
+++ b/docs/plot/colors.rst
@@ -11,7 +11,6 @@ In order to simplify visual identification of a specific gravitational-wave obse
 .. plot::
     :include-source: False
 
-    from __future__ import division
     import numpy
     from matplotlib import (pyplot, rcParams)
     from matplotlib.colors import to_hex

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -19,7 +19,6 @@
 """Base class for CLI (`gwpy-plot`) products.
 """
 
-from __future__ import print_function
 import abc
 import os.path
 import re

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -19,8 +19,6 @@
 """This module defines the `Channel` and `ChannelList` classes.
 """
 
-from __future__ import print_function
-
 import re
 from copy import copy
 from math import ceil

--- a/gwpy/detector/io/omega.py
+++ b/gwpy/detector/io/omega.py
@@ -19,8 +19,6 @@
 """I/O routines for parsing Omega pipeline scan channel lists
 """
 
-from __future__ import print_function
-
 import sys
 import os
 from collections import OrderedDict

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -23,8 +23,6 @@ and associated metadata for those files, designed to make identifying
 relevant data, and sieving large file lists, easier for the user.
 """
 
-from __future__ import (division, print_function)
-
 import os.path
 import warnings
 from collections import (namedtuple, OrderedDict)

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -20,8 +20,6 @@
 to LIGO data.
 """
 
-from __future__ import (absolute_import, print_function)
-
 import enum
 import operator
 import os

--- a/gwpy/io/tests/test_cache.py
+++ b/gwpy/io/tests/test_cache.py
@@ -19,8 +19,6 @@
 """Unit test for `io` module
 """
 
-from __future__ import print_function
-
 import os.path
 import tempfile
 from copy import deepcopy

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -19,8 +19,6 @@
 """Unit tests for :mod:`gwpy.io.datafind`
 """
 
-from __future__ import print_function
-
 import os
 from io import BytesIO
 from itertools import cycle

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -19,8 +19,6 @@
 """This module defines locators/formatters and a scale for GPS data.
 """
 
-from __future__ import division
-
 from decimal import Decimal
 from numbers import Number
 

--- a/gwpy/plot/log.py
+++ b/gwpy/plot/log.py
@@ -20,8 +20,6 @@
 helpful set of major and minor ticks.
 """
 
-from __future__ import division
-
 from math import (ceil, floor, modf)
 
 import numpy

--- a/gwpy/plot/tex.py
+++ b/gwpy/plot/tex.py
@@ -19,8 +19,6 @@
 """Handle TeX formatting for matplotlib output
 """
 
-from __future__ import division
-
 import re
 
 from ..utils.shell import which

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -26,8 +26,6 @@ The `DataQualityDict` is just a `dict` of flags, provided as a convenience
 for handling multiple flags over the same global time interval.
 """
 
-from __future__ import absolute_import
-
 import datetime
 import json
 import operator

--- a/gwpy/segments/io/json.py
+++ b/gwpy/segments/io/json.py
@@ -19,8 +19,6 @@
 """Read/write segments and flags from DQSEGDB-format JSON
 """
 
-from __future__ import absolute_import
-
 import json
 
 from six import string_types

--- a/gwpy/segments/io/segwizard.py
+++ b/gwpy/segments/io/segwizard.py
@@ -19,8 +19,6 @@
 """Read SegmentLists from seg-wizard format ASCII files
 """
 
-from __future__ import print_function
-
 import re
 
 from six import string_types

--- a/gwpy/segments/tests/test_segments.py
+++ b/gwpy/segments/tests/test_segments.py
@@ -19,8 +19,6 @@
 """Tests for :mod:`gwpy.segments.segments`
 """
 
-from __future__ import print_function
-
 import pytest
 
 import h5py

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -19,7 +19,6 @@
 """Custom filtering utilities for the `TimeSeries`
 """
 
-from __future__ import division
 import operator
 from math import (pi, log10)
 

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -23,8 +23,6 @@ pipeline, all credits for the original algorithm go to its
 authors.
 """
 
-from __future__ import division
-
 import warnings
 from math import (log, ceil, pi, isinf, exp)
 

--- a/gwpy/signal/spectral/_lal.py
+++ b/gwpy/signal/spectral/_lal.py
@@ -25,8 +25,6 @@ for more details
 This module is deprecated and will be removed in a future release.
 """
 
-from __future__ import absolute_import
-
 import re
 import warnings
 

--- a/gwpy/signal/spectral/_pycbc.py
+++ b/gwpy/signal/spectral/_pycbc.py
@@ -21,8 +21,6 @@
 This module is deprecated and will be removed in a future release.
 """
 
-from __future__ import absolute_import
-
 from ...frequencyseries import FrequencySeries
 from ...utils.misc import null_context
 from ._utils import scale_timeseries_unit

--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -19,8 +19,6 @@
 """GWpy API to the scipy.signal FFT routines
 """
 
-from __future__ import absolute_import
-
 import numpy
 
 from scipy import __version__ as scipy_version

--- a/gwpy/signal/spectral/_ui.py
+++ b/gwpy/signal/spectral/_ui.py
@@ -22,8 +22,6 @@ This module provides the methods that eventually get called by TimeSeries.xxx,
 so isn't really for direct user interaction.
 """
 
-from __future__ import absolute_import
-
 from functools import wraps
 
 from six import string_types

--- a/gwpy/spectrogram/coherence.py
+++ b/gwpy/spectrogram/coherence.py
@@ -20,8 +20,6 @@
 time-frequency coherence spectrogram from a pair of time-series.
 """
 
-from __future__ import division
-
 from multiprocessing import (Process, Queue as ProcessQueue)
 from math import ceil
 

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -37,8 +37,6 @@ This module defines the following classes
 user-facing objects.**
 """
 
-from __future__ import (division, print_function)
-
 import os
 import sys
 import warnings

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -20,8 +20,6 @@
 |LDAStools.frameCPP|__.
 """
 
-from __future__ import division
-
 import re
 from math import ceil
 

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -21,8 +21,6 @@
 The frame format is defined in LIGO-T970130 available from dcc.ligo.org.
 """
 
-from __future__ import (absolute_import, division)
-
 import os.path
 import warnings
 

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -21,8 +21,6 @@
 For more details, see https://losc.ligo.org
 """
 
-from __future__ import print_function
-
 import os.path
 import re
 from math import ceil

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -19,8 +19,6 @@
 """NDS2 data query routines for the TimeSeries
 """
 
-from __future__ import division
-
 import operator
 import warnings
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -19,8 +19,6 @@
 """Array with metadata
 """
 
-from __future__ import (division, print_function)
-
 import warnings
 
 from six.moves import range

--- a/gwpy/utils/__init__.py
+++ b/gwpy/utils/__init__.py
@@ -19,8 +19,6 @@
 """Miscellaneous utilties for GWpy
 """
 
-from __future__ import print_function
-
 from sys import stdout
 
 from .misc import (

--- a/gwpy/utils/enum.py
+++ b/gwpy/utils/enum.py
@@ -19,8 +19,6 @@
 """Utilties for enumerations
 """
 
-from __future__ import absolute_import
-
 from enum import Enum
 
 import numpy

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -21,8 +21,6 @@
 This module requires lal >= 6.14.0
 """
 
-from __future__ import absolute_import
-
 import operator
 from collections import OrderedDict
 

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -19,8 +19,6 @@
 """Miscellaneous utilties for GWpy
 """
 
-from __future__ import print_function
-
 import sys
 import math
 from collections import OrderedDict

--- a/gwpy/utils/sphinx/zenodo.py
+++ b/gwpy/utils/sphinx/zenodo.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import print_function
-
 import argparse
 import requests
 import sys

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@
 # ignore all invalid names (pylint isn't good at looking at executables)
 # pylint: disable=invalid-name
 
-from __future__ import print_function
-
 import os
 import sys
 from distutils.version import LooseVersion

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -19,8 +19,6 @@
 """Packaging utilities for the GWpy package
 """
 
-from __future__ import print_function
-
 import contextlib
 import datetime
 import glob


### PR DESCRIPTION
This PR removes all `from __future__` import statements, in anticipation of dropping python2 support. This probably needs to be rebased and CI rerun after #1172 is merged.