### PR TITLE
Remove use of local functions with multiprocessing

### DIFF
--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -81,25 +81,16 @@ def read_multi(flatten, cls, source, *args, **kwargs):
     # calculate maximum number of processes
     nproc = min(kwargs.pop('nproc', 1), len(files))
 
-    # define multiprocessing method
-    def _read_single_file(fobj):
-        try:
-            return fobj, io_read(cls, fobj, *args, **kwargs)
-        # pylint: disable=broad-except,redefine-in-handler
-        except Exception as exc:
-            if nproc == 1:
-                raise
-            if isinstance(exc, SAXException):  # SAXExceptions don't pickle
-                return fobj, exc.getException()  # pylint: disable=no-member
-            return fobj, exc
-
     # format verbosity
     if verbose is True:
         verbose = 'Reading ({})'.format(kwargs['format'])
 
+    # bundle inputs
+    inputs = [(f, cls, nproc, args, kwargs) for f in files]
+
     # read files
     output = mp_utils.multiprocess_with_queues(
-        nproc, _read_single_file, files, verbose=verbose, unit='files')
+        nproc, _read_single_file, inputs, verbose=verbose, unit='files')
 
     # raise exceptions (from multiprocessing, single process raises inline)
     for fobj, exc in output:
@@ -110,3 +101,28 @@ def read_multi(flatten, cls, source, *args, **kwargs):
     # return combined object
     _, out = zip(*output)
     return flatten(out)
+
+
+def _read_single_file(bundle):
+    """Reads a single file and returns the output
+
+    This is designed only to be passed to
+    :func:`gwpy.utils.mp.multiprocess_with_queues`
+
+    Returns
+    -------
+    f, output :
+        the input file (object) that was (attempted to be) read, and
+        the result of the read operation, which may be an exception
+        object.
+    """
+    fobj, cls, nproc, args, kwargs = bundle
+    try:
+        return fobj, io_read(cls, fobj, *args, **kwargs)
+    # pylint: disable=broad-except,redefine-in-handler
+    except Exception as exc:
+        if nproc == 1:
+            raise
+        if isinstance(exc, SAXException):  # SAXExceptions don't pickle
+            return fobj, exc.getException()  # pylint: disable=no-member
+        return fobj, exc

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -493,9 +493,13 @@ class TimeSeries(TimeSeriesBase):
         # set kwargs for periodogram()
         kwargs.setdefault('fs', self.sample_rate.to('Hz').value)
         # run
-        return spectral.spectrogram(self, signal.periodogram,
-                                    fftlength=fftlength, overlap=overlap,
-                                    window=window, **kwargs)
+        return spectral.spectrogram(
+            self,
+            fftlength=fftlength,
+            overlap=overlap,
+            window=window,
+            **kwargs
+        )
 
     def fftgram(self, fftlength, overlap=None, window='hann', **kwargs):
         """Calculate the Fourier-gram of this `TimeSeries`.

--- a/gwpy/utils/mp.py
+++ b/gwpy/utils/mp.py
@@ -19,7 +19,6 @@
 """Utilities for multi-processing
 """
 
-import os
 import warnings
 from multiprocessing import (Queue, Process)
 from operator import itemgetter
@@ -94,13 +93,6 @@ def multiprocess_with_queues(nproc, func, inputs, verbose=False,
         the `list` of results from calling ``func(x)`` for each element
         of ``inputs``
     """
-    if nproc != 1 and os.name == 'nt':
-        warnings.warn(
-            "multiprocessing is currently not supported on Windows, see "
-            "https://github.com/gwpy/gwpy/issues/880, will continue with "
-            "serial procesing (nproc=1)")
-        nproc = 1
-
     if progress_kw.pop('raise_exceptions', None) is not None:
         warnings.warn("the `raise_exceptions` keyword to "
                       "multiprocess_with_queues is deprecated, and will be "

--- a/gwpy/utils/tests/test_mp.py
+++ b/gwpy/utils/tests/test_mp.py
@@ -19,33 +19,25 @@
 """Unit test for utils module
 """
 
-import os
 from math import sqrt
 
 import pytest
 
 from .. import mp as utils_mp
-from ..misc import null_context
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-
-pytestmark = pytest.mark.filterwarnings(
-    'always:multiprocessing is currently not supported on Windws')
 
 
 @pytest.mark.parametrize('verbose', [False, True, 'Test'])
 @pytest.mark.parametrize('nproc', [1, 2])
 def test_multiprocess_with_queues(capsys, nproc, verbose):
     inputs = [1, 4, 9, 16, 25]
-    if os.name == 'nt' and nproc > 1:
-        ctx = pytest.warns(UserWarning)
-    else:
-        ctx = null_context()
-
-    with ctx:  # on windows, mp prints warning and falls back to nproc=1
-        out = utils_mp.multiprocess_with_queues(
-            nproc, sqrt, inputs, verbose=verbose,
-        )
+    out = utils_mp.multiprocess_with_queues(
+        nproc,
+        sqrt,
+        inputs,
+        verbose=verbose,
+    )
     assert out == [1, 2, 3, 4, 5]
 
     # assert progress bar prints correctly

--- a/gwpy/utils/tests/test_mp.py
+++ b/gwpy/utils/tests/test_mp.py
@@ -57,12 +57,25 @@ def test_multiprocess_with_queues(capsys, nproc, verbose):
     else:
         assert cap.out.startswith('\r{}: '.format(verbose))
 
-    with pytest.raises(ValueError):
-        utils_mp.multiprocess_with_queues(nproc, sqrt, [-1],
-                                          verbose=verbose)
+
+@pytest.mark.parametrize('nproc', [1, 2])
+def test_multiprocess_with_queues_errors(nproc):
+    """Check that errors from child processes propagate to the parent
+    """
+    with pytest.raises(ValueError) as exc:
+        utils_mp.multiprocess_with_queues(
+            nproc,
+            sqrt,
+            [-1, -1, -1, -1],
+        )
+    assert str(exc.value) == "math domain error"
 
 
 def test_multiprocess_with_queues_raise():
     with pytest.deprecated_call():
-        utils_mp.multiprocess_with_queues(1, sqrt, [1],
-                                          raise_exceptions=True)
+        utils_mp.multiprocess_with_queues(
+            1,
+            sqrt,
+            [1],
+            raise_exceptions=True,
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,6 @@ parentdir_prefix = gwpy-
 [tool:pytest]
 ; print skip reasons
 addopts = -r s
-filterwarnings =
-	ignore:multiprocessing is not currently supported on Windows
 
 [coverage:run]
 source = gwpy


### PR DESCRIPTION
This PR fixes use of multiprocessing with 'spawn' start methods (default on Windows, and on macOS for python-3.8) by removing the use of local functions with `multiprocess_with_queues`.