### PR TITLE
Pass mode to all h5py.File calls

### DIFF
--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -830,7 +830,12 @@ class TestDataQualityDict(object):
         )
 
     def test_read_on_missing(self, instance):
-        with h5py.File('test', driver='core', backing_store=False) as h5f:
+        with h5py.File(
+                'test',
+                mode='w-',
+                driver='core',
+                backing_store=False,
+        ) as h5f:
             instance.write(h5f)
             names = ['randomname']
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -657,7 +657,7 @@ class TestEventTable(TestTable):
 
             # add another IFO, then assert that reading the table without
             # specifying the IFO fails
-            with h5py.File(fp) as h5f:
+            with h5py.File(fp, "r+") as h5f:
                 h5f.create_group('Z1')
             with pytest.raises(ValueError) as exc:
                 self.TABLE.read(fp, format="hdf5.pycbc_live")

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -330,7 +330,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             # check that we can't then write the same data again
             with pytest.raises(IOError):
                 array.write(tmp)
-            with pytest.raises((RuntimeError, OSError)):
+            with pytest.raises((IOError, OSError, RuntimeError)):
                 array.write(tmp, append=True)
 
             # check reading with start/end works


### PR DESCRIPTION
This PR adds explicit `mode=<>` keyword arguments to all `h5py.File` calls. The default `mode` is changing in h5py-3.0.0 from `'a'` to `'r'`, so we need this to make sure nothing breaks - this should be backwards-compatible.