### PR TITLE
Added python36 RPM build on epel77

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,13 @@ jobs:
     environment:
       PIP_FLAGS: " "
 
+  el7:3.6:
+    <<: *centos-build
+    docker:
+      - image: igwn/base:el7
+    environment:
+      PIP_FLAGS: " "
+
   # -- deploy ---------------
 
   deploy:
@@ -309,6 +316,9 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - el7:3.6:
+          requires:
+            - sdist
 
       # deploy
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,14 +212,14 @@ jobs:
   debian:stretch:2.7:
     <<: *debian-build
     docker:
-      - image: containers.ligo.org/docker/base:stretch
+      - image: igwn/base:stretch
     environment:
       PIP_FLAGS: " "
 
   debian:stretch:3.5:
     <<: *debian-build
     docker:
-      - image: containers.ligo.org/docker/base:stretch
+      - image: igwn/base:stretch
     environment:
       PIP_FLAGS: " "
 
@@ -228,7 +228,7 @@ jobs:
   el7:2.7:
     <<: *centos-build
     docker:
-      - image: containers.ligo.org/docker/base:el7
+      - image: igwn/base:el7
     environment:
       PIP_FLAGS: " "
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,40 +239,19 @@ jobs:
     environment:
       PIP_FLAGS: " "
 
-  # -- deploy ---------------
-
-  deploy:
-    docker:
-      - image: python
-    steps:
-      - run:
-          name: Twine upload
-          command: |
-            # TWINE_USERNAME and TWINE_PASSWORD are set in repo settings
-            python -m pip install twine
-            python -m twine upload gwpy-*.tar.* gwpy-*-none-any.whl
-
 # -- workflow ---------------
 
 workflows:
   version: 2
   build-and-test:
     jobs:
-      # sdist includes filters because the deploy job requires it
-      # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
-      - sdist:
-          filters:
-            tags:
-              only: /^v.*/
+      - sdist
       - flake8
 
       # basic tests with minimal dependencies
       - python:2.7:
           requires:
             - sdist
-          filters:
-            tags:
-              only: /^v.*/
       - python:3.5:
           requires:
             - sdist
@@ -282,9 +261,6 @@ workflows:
       - python:3.7:
           requires:
             - sdist
-          filters:
-            tags:
-              only: /^v.*/
 
       # conda tests
       - conda:2.7:
@@ -301,36 +277,12 @@ workflows:
       - debian:stretch:2.7:
           requires:
             - sdist
-          filters:
-            tags:
-              only: /^v.*/
       - debian:stretch:3.5:
           requires:
             - sdist
-          filters:
-            tags:
-              only: /^v.*/
       - el7:2.7:
           requires:
             - sdist
-          filters:
-            tags:
-              only: /^v.*/
       - el7:3.6:
           requires:
             - sdist
-
-      # deploy
-      - deploy:
-          requires:
-            - sdist
-            - python:2.7
-            - python:3.7
-            - debian:stretch:2.7
-            - debian:stretch:3.5
-            - el7:2.7
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -34,12 +34,11 @@ yum -y -q install \
 # https://listserv.fnal.gov/scripts/wa.exe?A2=ind1910&L=SCIENTIFIC-LINUX-USERS&P=21164
 yum -y -q reinstall tzdata
 
-# determine python prefix, even though we only install for python2
-
-if [[ "${PYTHON_VERSION}" == "2.7" ]]; then
-    PY_PREFIX="python2"
-else
+# determine python package prefix
+if [ "${PYTHON_VERSION:0:1}" -eq 3 ]; then
     PY_PREFIX="python$(rpm --eval "%python3_pkgversion")"
+else
+    PY_PREFIX="python${PYTHON_VERSION:0:1}"
 fi
 
 # -- build --------------------------------------

--- a/ci/install-el.sh
+++ b/ci/install-el.sh
@@ -24,7 +24,8 @@
 
 # install basic build dependencies
 yum -y -q update
-
+yum -y -q install lscsoft-testing-config
+yum -y -q update
 yum -y -q install \
     rpm-build \
     yum-utils \

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -11,13 +11,18 @@ Summary:        {{ description }}
 
 License:        {{ license }}
 URL:            {{ url }}
-Source0:        https://files.pythonhosted.org/packages/source/g/%{srcname}/%{srcname}-%{version}.tar.gz
+Source0:        %pypi_source
 
 BuildArch:      noarch
 BuildRequires:  rpm-build
 BuildRequires:  python-rpm-macros
+BuildRequires:  python-srpm-macros
 BuildRequires:  python2-rpm-macros
+BuildRequires:  python3-rpm-macros
+BuildRequires:  epel-rpm-macros
+
 BuildRequires:  python2-setuptools
+BuildRequires:  python%{python3_pkgversion}-setuptools
 
 %description
 {{ long_description }}
@@ -43,10 +48,32 @@ Requires:       python2-tqdm >= 4.10.0
 Requires:       python2-gwosc
 Requires:       python2-dqsegdb2
 Requires:       python2-gwdatafind
-
 %{?python_provide:%python_provide python2-%{srcname}}
 
 %description -n python2-%{srcname}
+{{ long_description }}
+
+# -- python3-gwpy -------------------------------------------------------------
+
+%package -n python%{python3_pkgversion}-%{srcname}
+Summary:        %{summary}
+Requires:       python%{python3_pkgversion}-astropy >= 1.1.1
+Requires:       python%{python3_pkgversion}-dateutil
+Requires:       python%{python3_pkgversion}-dqsegdb2
+Requires:       python%{python3_pkgversion}-gwdatafind
+Requires:       python%{python3_pkgversion}-gwosc
+Requires:       python%{python3_pkgversion}-h5py >= 1.3
+Requires:       python%{python3_pkgversion}-lal >= 6.14.0
+Requires:       python%{python3_pkgversion}-ldas-tools-framecpp >= 2.6.0
+Requires:       python%{python3_pkgversion}-ligo-segments >= 1.0.0
+Requires:       python%{python3_pkgversion}-matplotlib >= 1.2.0
+Requires:       python%{python3_pkgversion}-numpy >= 1.7.1
+Requires:       python%{python3_pkgversion}-scipy >= 0.12.1
+Requires:       python%{python3_pkgversion}-six >= 1.5
+Requires:       python%{python3_pkgversion}-tqdm >= 4.10.0
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+%description -n python%{python3_pkgversion}-%{srcname}
 {{ long_description }}
 
 # -- build stages -------------------------------------------------------------
@@ -56,8 +83,10 @@ Requires:       python2-gwdatafind
 
 %build
 %py2_build
+%py3_build
 
 %install
+%py3_install
 %py2_install
 
 # -- files --------------------------------------------------------------------
@@ -67,6 +96,11 @@ Requires:       python2-gwdatafind
 %doc README.md
 %{python2_sitelib}/*
 %{_bindir}/gwpy-plot
+
+%files -n python%{python3_pkgversion}-%{srcname}
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/*
 
 # -- changelog ----------------------------------------------------------------
 

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -519,17 +519,8 @@ class TestDataQualityFlag(object):
             f2 = self.TEST_CLASS.read(fp)
             utils.assert_flag_equal(f2, flag)
 
-    @utils.skip_missing_dependency('glue.ligolw.lsctables')
-    @pytest.mark.parametrize("ilwdchar_compat", [
-        pytest.param(
-            False,
-            marks=utils.skip_missing_dependency("ligo.lw.lsctables"),
-        ),
-        pytest.param(
-            True,
-            marks=utils.skip_missing_dependency("glue.ligolw.lsctables"),
-        ),
-    ])
+    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.parametrize("ilwdchar_compat", [False, True])
     def test_read_write_ligolw(self, flag, ilwdchar_compat):
         utils.test_read_write(
             flag, "ligolw", extension="xml",
@@ -808,16 +799,8 @@ class TestDataQualityDict(object):
             _read_write(autoidentify=True)
         _read_write(autoidentify=True, write_kw={'overwrite': True})
 
-    @pytest.mark.parametrize("ilwdchar_compat", [
-        pytest.param(
-            False,
-            marks=utils.skip_missing_dependency("ligo.lw.lsctables"),
-        ),
-        pytest.param(
-            True,
-            marks=utils.skip_missing_dependency("glue.ligolw.lsctables"),
-        ),
-    ])
+    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.parametrize("ilwdchar_compat", [False, True])
     def test_read_write_ligolw(self, instance, ilwdchar_compat):
         def _assert(a, b):
             return utils.assert_dict_equal(a, b, utils.assert_flag_equal)
@@ -862,20 +845,8 @@ class TestDataQualityDict(object):
             with pytest.raises(ValueError) as exc:
                 _read(on_missing='blah')
 
-    @pytest.mark.parametrize("ilwdchar_compat", [
-        pytest.param(  # default `None` maps to `True` for now
-            None,
-            marks=utils.skip_missing_dependency("ligo.lw.lsctables"),
-        ),
-        pytest.param(
-            False,
-            marks=utils.skip_missing_dependency("ligo.lw.lsctables"),
-        ),
-        pytest.param(
-            True,
-            marks=utils.skip_missing_dependency("glue.ligolw.lsctables"),
-        ),
-    ])
+    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.parametrize("ilwdchar_compat", [None, False, True])
     def test_to_ligolw_tables(self, instance, ilwdchar_compat):
         if ilwdchar_compat is None:
             ctx = pytest.warns(PendingDeprecationWarning)


### PR DESCRIPTION
Now that the LSCSoft yum repositories are updated to EPEL7.7, we can build python3.6 rpms directly, so this PR updates the spec file and adds the necessary CI jobs to do that.

I also took the opportunity to rip out the custom git tag workflow on CircleCI which has never worked, and just complicates the CI configuration.