### PR TITLE
Bump minimum astropy requirement to 1.3.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Package: python-gwpy
 Architecture: all
 Depends: ${misc:Depends},
          ${python:Depends},
-         python-astropy (>= 1.3.0),
+         python-astropy (>= 1.3),
          python-dateutil,
          python-dqsegdb2,
          python-enum34,
@@ -52,7 +52,7 @@ Package: python3-gwpy
 Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
-         python3-astropy (>= 1.3.0),
+         python3-astropy (>= 1.3),
          python3-dateutil,
          python3-dqsegdb2,
          python3-gwosc (>= 0.3.1),

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Package: python-gwpy
 Architecture: all
 Depends: ${misc:Depends},
          ${python:Depends},
-         python-astropy (>= 1.1.1),
+         python-astropy (>= 1.3.0),
          python-dateutil,
          python-dqsegdb2,
          python-enum34,
@@ -52,7 +52,7 @@ Package: python3-gwpy
 Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
-         python3-astropy (>= 1.1.1),
+         python3-astropy (>= 1.3.0),
          python3-dateutil,
          python3-dqsegdb2,
          python3-gwosc (>= 0.3.1),

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -78,7 +78,7 @@ GWpy has the following strict requirements:
    ==================  ===========================
    Name                Constraints
    ==================  ===========================
-   |astropy|_          ``>=1.1.1``
+   |astropy|_          ``>=1.3.0``
    |dqsegdb2|_
    |gwdatafind|_
    |gwosc-mod|_        ``>=0.4.0``

--- a/etc/spec.template
+++ b/etc/spec.template
@@ -33,7 +33,7 @@ Requires:       python-enum34
 Requires:       numpy >= 1.7.1
 Requires:       scipy >= 0.12.1
 Requires:       python-matplotlib >= 1.2.0
-Requires:       python-astropy >= 1.1.1
+Requires:       python-astropy >= 1.3.0
 Requires:       h5py >= 1.3
 Requires:       python2-ldas-tools-framecpp >= 2.6.0
 Requires:       python2-lal >= 6.14.0

--- a/gwpy/table/io/fetch.py
+++ b/gwpy/table/io/fetch.py
@@ -24,10 +24,6 @@ import re
 from six import string_types
 
 from astropy.io import registry as io_registry
-try:
-    from astropy.io.registry import IORegistryError
-except ImportError:  # astropy < 1.2.1
-    IORegistryError = Exception
 from astropy.table import Table
 
 _FETCHERS = {}
@@ -58,9 +54,10 @@ def register_fetcher(data_format, data_class, function, force=False,
     if key not in _FETCHERS or force:
         _FETCHERS[key] = (function, usage)
     else:
-        raise IORegistryError("Fetcher for format '{0}' and class '{1}' "
-                              "has already been " "defined".format(
-                                  data_format, data_class))
+        raise io_registry.IORegistryError(
+            "Fetcher for format '{0}' and class '{1}' has already "
+            "been defined".format(data_format, data_class),
+        )
     _update__doc__(data_class)
 
 
@@ -89,10 +86,11 @@ def get_fetcher(data_format, data_class):
         formats = [fmt for fmt, cls in _FETCHERS if
                    io_registry._is_best_match(fmt, cls, fetchers)]
         formatstr = '\n'.join(sorted(formats))
-        raise IORegistryError(
+        raise io_registry.IORegistryError(
             "No fetcher definer for format '{0}' and class '{1}'.\n"
             "The available formats are:\n{2}".format(
-                data_format, data_class.__name__, formatstr))
+                data_format, data_class.__name__, formatstr),
+        )
 
 
 def _update__doc__(data_class):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # GWpy core requirements
 #           [use requirements-dev.txt for a full development environment
 #            including docs and testing dependencies]
-astropy >= 1.1.1, < 3.0.0 ; python_version < '3.5'
-astropy >= 1.1.1 ; python_version >= '3.5'
+astropy >= 1.3.0, < 3.0.0 ; python_version < '3.5'
+astropy >= 1.3.0 ; python_version >= '3.5'
 dqsegdb2
 enum34 ; python_version < '3.4'
 gwdatafind

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ setup_requires = get_setup_requires()
 
 # runtime dependencies
 install_requires = [
-    'astropy >= 1.1.1, < 3.0.0 ; python_version < \'3.5\'',
-    'astropy >= 1.1.1 ; python_version >= \'3.5\'',
+    'astropy >= 1.3.0, < 3.0.0 ; python_version < \'3.5\'',
+    'astropy >= 1.3.0 ; python_version >= \'3.5\'',
     'dqsegdb2',
     'enum34 ; python_version < \'3.4\'',
     'gwdatafind',


### PR DESCRIPTION
This PR bumps the minimum astropy requirement to 1.3.0 now that the LSCSoft yum repositories have gotten that far. This allows the removal of one hack in `gwpy.table`.