### PR TITLE
Fix bug in interpolating complex frequency series

### DIFF
--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -292,7 +292,8 @@ class FrequencySeries(Series):
         """
         f0 = self.f0.decompose().value
         N = (self.size - 1) * (self.df.decompose().value / df) + 1
-        fsamples = numpy.arange(0, numpy.rint(N), dtype=self.dtype) * df + f0
+        fsamples = numpy.arange(0, numpy.rint(N),
+                                dtype=self.real.dtype) * df + f0
         out = type(self)(numpy.interp(fsamples, self.frequencies.value,
                                       self.value))
         out.__array_finalize__(self)


### PR DESCRIPTION
Fix the following error that occurred when interpolating a
complex-valued frequency series:

    >>> FrequencySeries(np.arange(10) * 1j).interpolate(1)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/lib/python/site-packages/gwpy/frequencyseries/frequencyseries.py", line 297, in interpolate
        self.value))
      File "<__array_function__ internals>", line 6, in interp
      File "/usr/lib/python3.7/site-packages/numpy/lib/function_base.py", line 1412, in interp
        return interp_func(x, xp, fp, left, right)
    TypeError: Cannot cast array data from dtype('complex128') to dtype('float64') according to the rule 'safe'

The abscissa for interpolation must be a real data type, even if
the frequency series is complex.