### PR TITLE
Timeout conda install of root_numpy in CI

### DIFF
--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -58,6 +58,11 @@ fi
 conda activate gwpyci || { source activate gwpyci; set -ex; }
 PYTHON=$(which python)
 
+# install basic dependencies (please document each entry)
+conda install --name gwpyci --yes \
+    coreutils `# needed for timeout` \
+;
+
 # install conda dependencies (based on pip requirements file)
 ${PYTHON} ./ci/parse-conda-requirements.py requirements-dev.txt -o conda-reqs.txt
 conda install --name gwpyci --yes --file conda-reqs.txt

--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -71,7 +71,7 @@ conda install --name gwpyci --yes \
     python-ldas-tools-framecpp \
     python-nds2-client
 # try and install root_numpy, but don't try too hard, incompatibility is easy
-conda install --name gwpyci --yes root_numpy || true
+timeout 2m conda install --name gwpyci --yes root_numpy || true
 
 # install gwpy into this environment
 ${PYTHON} -m pip install ${PIP_FLAGS} . --ignore-installed --no-deps


### PR DESCRIPTION
This PR modifies the conda CI jobs to timeout the `conda install root_numpy` command after 2 minutes, so as to not timeout the whole build (e.g. [here](https://travis-ci.com/gwpy/gwpy/jobs/259811528)). `root_numpy` is an optional dependency, and this only times out on `python2.7`, so we don't really care if we don't have it in every test environment.