### PR TITLE
Fix bug in x0 handling in Series.pad

### DIFF
--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -977,7 +977,7 @@ class Series(Array):
         new.__metadata_finalize__(self)
         new._unit = self.unit
         # finally move the starting index based on the amount of left-padding
-        new.x0 -= self.dx * pad_width[0]
+        new.x0 = new.x0 - self.dx * pad_width[0]
         return new
 
     def inject(self, other):

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -951,9 +951,10 @@ class Series(Array):
         Parameters
         ----------
         pad_width : `int`, pair of `ints`
-            number of samples by which to pad each end of the array.
-            Single int to pad both ends by the same amount, or
-            (before, after) `tuple` to give uneven padding
+            number of samples by which to pad each end of the array;
+            given a single `int` to pad both ends by the same amount,
+            or a (before, after) `tuple` for assymetric padding
+
         **kwargs
             see :meth:`numpy.pad` for kwarg documentation
 

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -204,5 +204,14 @@ class TestArray2D(_TestSeries):
         with pytest.raises(IndexError):
             array.value_at(1.6, 4.8)
 
+    @pytest.mark.skip("not implemented for >1D arrays")
     def test_pad(self):
+        return NotImplemented
+
+    @pytest.mark.skip("not implemented for >1D arrays")
+    def test_pad_index(self):
+        return NotImplemented
+
+    @pytest.mark.skip("not implemented for >1D arrays")
+    def test_pad_asymmetric(self):
         return NotImplemented

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -29,7 +29,7 @@ from astropy import units
 
 from ...segments import Segment
 from ...testing import utils
-from .. import (Series, Array2D)
+from .. import (Series, Array2D, Index)
 from .test_array import TestArray as _TestArray
 
 
@@ -321,13 +321,16 @@ class TestSeries(_TestArray):
         ts2 = ts1.pad(10)
         utils.assert_array_equal(
             ts2.xindex,
-            numpy.linspace(*ts2.xspan, num=ts2.size, endpoint=False),
+            Index(
+                numpy.linspace(*ts2.xspan, num=ts2.shape[0], endpoint=False),
+                unit=ts1.xindex.unit,
+            ),
         )
 
     def test_pad_asymmetric(self):
         ts1 = self.create()
         ts2 = ts1.pad((20, 10))
-        assert ts2.size == ts1.size + 30
+        assert ts2.shape[0] == ts1.shape[0] + 30
         utils.assert_array_equal(
             ts2.value,
             numpy.concatenate((numpy.zeros(20), ts1.value, numpy.zeros(10))))

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -312,16 +312,26 @@ class TestSeries(_TestArray):
             ts2.value,
             numpy.concatenate((numpy.zeros(10), ts1.value, numpy.zeros(10))))
         assert ts2.x0 == ts1.x0 - 10*ts1.x0.unit
-        # test pre-pad
-        ts3 = ts1.pad((20, 10))
-        assert ts3.size == ts1.size + 30
+
+    def test_pad_index(self):
+        """Check that `Series.pad` correctly returns a padded index array
+        """
+        ts1 = self.create()
+        ts1.xindex  # <- create the index for ts1
+        ts2 = ts1.pad(10)
         utils.assert_array_equal(
-            ts3.value,
+            ts2.xindex,
+            numpy.linspace(*ts2.xspan, num=ts2.size, endpoint=False),
+        )
+
+    def test_pad_asymmetric(self):
+        ts1 = self.create()
+        ts2 = ts1.pad((20, 10))
+        assert ts2.size == ts1.size + 30
+        utils.assert_array_equal(
+            ts2.value,
             numpy.concatenate((numpy.zeros(20), ts1.value, numpy.zeros(10))))
-        assert ts3.x0 == ts1.x0 - 20*ts1.x0.unit
-        # test bogus input
-        with pytest.raises(ValueError):
-            ts1.pad(-1)
+        assert ts2.x0 == ts1.x0 - 20*ts1.x0.unit
 
     def test_diff(self, array):
         """Test the `Series.diff` method


### PR DESCRIPTION
This PR fixes #1182, and improves the tests for `Series.pad` to minimise risk of regression.