### PR TITLE
Cast return of EventTable.fetch to subclasses

### DIFF
--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -335,7 +335,22 @@ class EventTable(Table):
         # standard registered fetch
         from .io.fetch import get_fetcher
         fetcher = get_fetcher(format_, cls)
-        return fetcher(*args, **kwargs)
+        out = fetcher(*args, **kwargs)
+        if not isinstance(out, cls):
+            if issubclass(cls, type(out)):
+                try:
+                    return cls(out)
+                except Exception as exc:
+                    exc.args = (
+                        "could not convert fetch() output to {0}: {1}".format(
+                            cls.__name__, str(exc),
+                        ),
+                    )
+                    raise
+            raise TypeError(
+                "fetch() should return a {0} instance".format(cls.__name__),
+            )
+        return out
 
     @classmethod
     def fetch_open_data(cls, catalog, columns=None, selection=None,

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -749,7 +749,6 @@ class TestEventTable(TestTable):
                 shutil.rmtree(os.path.dirname(fp))
 
     @pytest.fixture(scope="module")
-    @utils.skip_missing_dependency("pymysql")
     def hacr_table(self):
         """Create a table of HACR-like data, and patch
         `pymysql.connect` to return it
@@ -759,7 +758,10 @@ class TestEventTable(TestTable):
             "pymysql.connect",
             return_value=mock_hacr_connection(table, 123, 456),
         )
-        connect.start()
+        try:
+            connect.start()
+        except ImportError as exc:
+            return pytest.skip(str(exc))
         yield table
         connect.stop()
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -761,7 +761,7 @@ class TestEventTable(TestTable):
         try:
             connect.start()
         except ImportError as exc:
-            return pytest.skip(str(exc))
+            pytest.skip(str(exc))
         yield table
         connect.stop()
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,8 @@
 # requirements for GWpy tests
 # pytest needs more-itertools, we need it to work on python2.7
 more-itertools < 6.0a0 ; python_version < '3'
-pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0
+pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0 ; python_version >= '3'
+pytest >= 3.3.0, < 4.0.0a0 ; python_version < '3'
 pytest-cov >= 2.4.0
 pytest-xdist < 1.28.0
 mock ; python_version < '3'


### PR DESCRIPTION
This PR fixes #886 by patching `EventTable.fetch()` to cast the returned table to a subclass if appropriate.

@scottcoughlin2014, please check that this fixes the issue properly for you.