### PR TITLE
Apply index dimension Start property when reading LIGO_LW Arrays

### DIFF
--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -50,7 +50,7 @@ LIGO_LW_ARRAY = r"""<?xml version='1.0' encoding='utf-8'?>
     <Time Type="GPS" Name="epoch">1000000000</Time>
     <Param Type="lstring" Name="channel:param">X1:TEST-CHANNEL_1</Param>
     <Array Type="real_8" Name="PSD1:array" Unit="Hz^-1">
-      <Dim Start="0" Scale="1" Name="Frequency" Unit="Hz">5</Dim>
+      <Dim Start="10" Scale="1" Name="Frequency" Unit="Hz">5</Dim>
       <Dim Name="Frequency,Real">2</Dim>
       <Stream Delimiter=" " Type="Local">
         0 1
@@ -253,13 +253,13 @@ class TestFrequencySeries(_TestSeries):
     @utils.skip_missing_dependency('ligo.lw')
     def test_read_ligolw(self, ligolw):
         array = FrequencySeries.read(ligolw, 'PSD1')
-        utils.assert_array_equal(
+        utils.assert_quantity_equal(
             array,
             [1, 2, 3, 4, 5] / units.Hz,
         )
-        utils.assert_array_equal(
+        utils.assert_quantity_equal(
             array.frequencies,
-            [0, 1, 2, 3, 4] * units.Hz,
+            [10, 11, 12, 13, 14] * units.Hz,
         )
         assert numpy.isclose(array.epoch.gps, 1000000000)  # precision gah!
         assert array.unit == units.Hz ** -1

--- a/gwpy/types/io/ligolw.py
+++ b/gwpy/types/io/ligolw.py
@@ -200,10 +200,9 @@ def read_series(source, name=None, epoch=None, contenthandler=None, **params):
         array_kw["unit"] = array_kw["unit"].split(" ", 1)[1] + " Hz^-1"
 
     # build Series
-    try:
-        xindex, value = array.array
-    except ValueError:  # not two dimensions stored
-        return Series(array.array[0], x0=x0, dx=dx, **array_kw)
-    else:
-        xindex += x0
-        return Series(value, xindex=xindex, **array_kw)
+    # note: in order to match the functionality of lal.series,
+    #       we discard the actual frequency array, I (DMM) am
+    #       not convinced this is the right thing to do, but
+    #       it at least provides consistency across multiple
+    #       implementations
+    return Series(array.array[-1], x0=x0, dx=dx, **array_kw)


### PR DESCRIPTION
This PR fixes #1189, by applying the index `<Dim>` `Start` property properly.