### PR TITLE
Improve RPM spec template

### DIFF
--- a/etc/spec.template
+++ b/etc/spec.template
@@ -14,15 +14,55 @@ URL:            {{ url }}
 Source0:        %pypi_source
 
 BuildArch:      noarch
-BuildRequires:  rpm-build
+
+# SRPM dependencies
 BuildRequires:  python-rpm-macros
 BuildRequires:  python-srpm-macros
-BuildRequires:  python2-rpm-macros
-BuildRequires:  python3-rpm-macros
-BuildRequires:  epel-rpm-macros
 
+# python2-gwpy
+BuildRequires:  python
+BuildRequires:  python2-rpm-macros
 BuildRequires:  python2-setuptools
+
+# check requirements for python2-gwpy
+BuildRequires:  h5py >= 1.3
+BuildRequires:  numpy >= 1.7.1
+BuildRequires:  python-pathlib
+BuildRequires:  python-six >= 1.5
+BuildRequires:  python2-astropy >= 1.1.1
+BuildRequires:  python2-dateutil
+BuildRequires:  python2-dqsegdb2
+BuildRequires:  python2-enum34
+BuildRequires:  python2-gwdatafind
+BuildRequires:  python2-gwosc
+BuildRequires:  python2-lal >= 6.14.0
+BuildRequires:  python2-ldas-tools-framecpp >= 2.6.0
+BuildRequires:  python2-ligo-segments >= 1.0.0
+BuildRequires:  python2-matplotlib >= 1.2.0
+BuildRequires:  python2-tqdm >= 4.10.0
+BuildRequires:  scipy >= 0.12.1
+
+# python3-gwpy
+BuildRequires:  epel-rpm-macros
+BuildRequires:  python3-rpm-macros
+BuildRequires:  python%{python3_pkgversion}
 BuildRequires:  python%{python3_pkgversion}-setuptools
+
+# check requirements for python3-gwpy
+BuildRequires:  python%{python3_pkgversion}-astropy >= 1.1.1
+BuildRequires:  python%{python3_pkgversion}-dateutil
+BuildRequires:  python%{python3_pkgversion}-dqsegdb2
+BuildRequires:  python%{python3_pkgversion}-gwdatafind
+BuildRequires:  python%{python3_pkgversion}-gwosc
+BuildRequires:  python%{python3_pkgversion}-h5py >= 1.3
+BuildRequires:  python%{python3_pkgversion}-lal >= 6.14.0
+BuildRequires:  python%{python3_pkgversion}-ldas-tools-framecpp >= 2.6.0
+BuildRequires:  python%{python3_pkgversion}-ligo-segments >= 1.0.0
+BuildRequires:  python%{python3_pkgversion}-matplotlib >= 1.2.0
+BuildRequires:  python%{python3_pkgversion}-numpy >= 1.7.1
+BuildRequires:  python%{python3_pkgversion}-scipy >= 0.12.1
+BuildRequires:  python%{python3_pkgversion}-six >= 1.5
+BuildRequires:  python%{python3_pkgversion}-tqdm >= 4.10.0
 
 %description
 {{ long_description }}
@@ -32,22 +72,23 @@ BuildRequires:  python%{python3_pkgversion}-setuptools
 
 %package -n python2-%{srcname}
 Summary:        %{summary}
-Requires:       python-six >= 1.5
-Requires:       python-dateutil
-Requires:       python-enum34
-Requires:       numpy >= 1.7.1
-Requires:       scipy >= 0.12.1
-Requires:       python-matplotlib >= 1.2.0
-Requires:       python-astropy >= 1.3.0
 Requires:       h5py >= 1.3
-Requires:       python2-ldas-tools-framecpp >= 2.6.0
-Requires:       python2-lal >= 6.14.0
-Requires:       python2-ligo-segments >= 1.0.0
+Requires:       numpy >= 1.7.1
+Requires:       python
 Requires:       python-pathlib
-Requires:       python2-tqdm >= 4.10.0
-Requires:       python2-gwosc
+Requires:       python-six >= 1.5
+Requires:       python2-astropy >= 1.1.1
+Requires:       python2-dateutil
 Requires:       python2-dqsegdb2
+Requires:       python2-enum34
 Requires:       python2-gwdatafind
+Requires:       python2-gwosc
+Requires:       python2-lal >= 6.14.0
+Requires:       python2-ldas-tools-framecpp >= 2.6.0
+Requires:       python2-ligo-segments >= 1.0.0
+Requires:       python2-matplotlib >= 1.2.0
+Requires:       python2-tqdm >= 4.10.0
+Requires:       scipy >= 0.12.1
 %{?python_provide:%python_provide python2-%{srcname}}
 
 %description -n python2-%{srcname}
@@ -57,6 +98,7 @@ Requires:       python2-gwdatafind
 
 %package -n python%{python3_pkgversion}-%{srcname}
 Summary:        %{summary}
+Requires:       python%{python3_pkgversion}
 Requires:       python%{python3_pkgversion}-astropy >= 1.1.1
 Requires:       python%{python3_pkgversion}-dateutil
 Requires:       python%{python3_pkgversion}-dqsegdb2
@@ -88,6 +130,18 @@ Requires:       python%{python3_pkgversion}-tqdm >= 4.10.0
 %install
 %py3_install
 %py2_install
+
+%check
+# sanity check python2
+export PYTHONPATH="${RPM_BUILD_ROOT}%{python2_sitelib}"
+%{__python2} -c "import gwpy; print(gwpy.__version__)"
+%{__python2} -m gwpy.time --help
+${RPM_BUILD_ROOT}%{_bindir}/gwpy-plot --help
+
+# sanity check python3
+export PYTHONPATH="${RPM_BUILD_ROOT}%{python3_sitelib}"
+%{__python3} -c "import gwpy; print(gwpy.__version__)"
+%{__python3} -m gwpy.time --help
 
 # -- files --------------------------------------------------------------------
 


### PR DESCRIPTION
This PR makes some generic improvements to the RPM spec file template, mainly in adding some sanity check tests in the `%check` section, which requires having all of the runtime dependencies declared as `BuildRequires` as well.