### PR TITLE
A few fixes to support astropy 4.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,6 +23,8 @@ install:
   # fill it with our dependencies
   - python ci\\parse-conda-requirements.py requirements-dev.txt -o conda-reqs.txt
   - conda install --yes --file conda-reqs.txt
+  - conda deactivate
+  - conda activate gwpy
   # print everything we have
   - conda list
 build_script:

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -186,8 +186,8 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
             imin = specgram.value.min()
             imax = specgram.value.max()
         else:
-            imin = percentile(specgram, 1)
-            imax = percentile(specgram, 100)
+            imin = percentile(specgram.value, 1)
+            imax = percentile(specgram.value, 100)
         imin = args.imin if args.imin is not None else imin
         imax = args.imax if args.imax is not None else imax
 

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -299,7 +299,7 @@ class SpectralVariance(Array2D):
             else:
                 bins = numpy.linspace(low, high, num=nbins+1)
         nbins = bins.size-1
-        bins = bins * spectrogram.unit
+        qbins = bins * spectrogram.unit
 
         # loop over frequencies
         out = numpy.zeros((data.shape[1], nbins))
@@ -311,7 +311,7 @@ class SpectralVariance(Array2D):
 
         # return SpectralVariance
         name = '%s variance' % spectrogram.name
-        new = cls(out, bins, epoch=spectrogram.epoch, name=name,
+        new = cls(out, qbins, epoch=spectrogram.epoch, name=name,
                   channel=spectrogram.channel, f0=spectrogram.f0,
                   df=spectrogram.df)
         return new

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -352,7 +352,7 @@ class SpectralVariance(Array2D):
         if method == 'imshow':
             raise TypeError("plotting a {0} with {1}() is not "
                             "supported".format(type(self).__name__, method))
-        bins = self.bins
+        bins = self.bins.value
         if (numpy.all(bins > 0) and
                 numpy.allclose(numpy.diff(numpy.log10(bins), n=2), 0)):
             kwargs.setdefault('yscale', 'log')

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -19,6 +19,7 @@
 """Unit tests for `gwpy.table`
 """
 
+from socket import timeout
 from ssl import SSLError
 
 from six.moves.urllib.error import URLError
@@ -57,8 +58,12 @@ class TestGravitySpyTable(_TestEventTable):
 
     def test_search(self):
         try:
-            table = self.TABLE.search(gravityspy_id="8FHTgA8MEu", howmany=1)
-        except (URLError, SSLError) as e:
+            table = self.TABLE.search(
+                gravityspy_id="8FHTgA8MEu",
+                howmany=1,
+                remote_timeout=60,
+            )
+        except (URLError, SSLError, timeout) as e:
             pytest.skip(str(e))
 
         utils.assert_table_equal(table, self.TABLE(JSON_RESPONSE))

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -973,7 +973,7 @@ class Series(Array):
         if isinstance(pad_width, int):
             pad_width = (pad_width,)
         # form pad and view to this type
-        new = numpy.pad(self, pad_width, **kwargs).view(type(self))
+        new = numpy.pad(self.value, pad_width, **kwargs).view(type(self))
         # numpy.pad has stripped all metadata, so copy it over
         new.__metadata_finalize__(self)
         new._unit = self.unit


### PR DESCRIPTION
This PR fixes a few errors when running with `astropy` 4.0, mainly to do with comparing units, all fixed by using regular numpy arrays in that particular operation.