### PR TITLE
Don't include test skips in coverage

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -90,12 +90,14 @@ def test_example(script):
         code = compile(raw, str(script), "exec")
         try:
             exec(code, globals())
-        except NDSWarning as exc:  # if we can't authenticate, dont worry
+        except NDSWarning as exc:  # pragma: no-cover
+            # if we can't authenticate, dont worry
             for msg in NDS2_AUTH_FAILURES:
                 if msg.match(str(exc)):
                     pytest.skip(str(exc))
             raise
-        except ImportError as exc:  # needs an optional dependency
+        except ImportError as exc:  # pragma: no-cover
+            # needs an optional dependency
             if "gwpy" in str(exc):
                 raise
             pytest.skip(str(exc))

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -72,7 +72,7 @@ def psd():
     try:
         data = TimeSeries.read(utils.TEST_HDF5_FILE, 'L1:LDAS-STRAIN',
                                format='hdf5')
-    except ImportError as e:
+    except ImportError as e:  # pragma: no-cover
         pytest.skip(str(e))
     return data.psd(.4, overlap=.2, window=('kaiser', 24))
 
@@ -82,7 +82,7 @@ def hoft():
     try:
         data = TimeSeries.read(utils.TEST_HDF5_FILE, 'L1:LDAS-STRAIN',
                                format='hdf5')
-    except ImportError as e:
+    except ImportError as e:  # pragma: no-cover
         pytest.skip(str(e))
     return data
 

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -162,7 +162,7 @@ def query_segdb(query_func, *args, **kwargs):
              mock.patch('glue.segmentdb.segmentdb_utils.query_segments',
                         mocks.segdb_query_segments(QUERY_RESULT)):
             return query_func(*args, **kwargs)
-    except ImportError as e:
+    except ImportError as e:  # pragma: no-cover
         pytest.skip(str(e))
 
 
@@ -633,7 +633,7 @@ class TestDataQualityFlag(object):
         try:
             segs = self.TEST_CLASS.fetch_open_data(
                 'H1_DATA', 946339215, 946368015)
-        except (URLError, SSLError) as exc:
+        except (URLError, SSLError) as exc:  # pragma: no-cover
             pytest.skip(str(exc))
         assert segs.ifo == 'H1'
         assert segs.name == 'H1:DATA'

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -63,7 +63,7 @@ class TestGravitySpyTable(_TestEventTable):
                 howmany=1,
                 remote_timeout=60,
             )
-        except (URLError, SSLError, timeout) as e:
+        except (URLError, SSLError, timeout) as e:  # pragma: no-cover
             pytest.skip(str(e))
 
         utils.assert_table_equal(table, self.TABLE(JSON_RESPONSE))

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -351,8 +351,8 @@ class TestTable(object):
             # check write
             try:
                 table.write(tmp, 'test_read_write_gwf')
-            except TypeError as exc:  # frameCPP broken (2.6.7)
-                if 'ParamList' in str(exc):
+            except TypeError as exc:  # pragma: no-cover
+                if 'ParamList' in str(exc):  # frameCPP broken (2.6.7)
                     pytest.skip(
                         "bug in python-ldas-tools-framecpp: {!s}".format(exc),
                     )
@@ -760,7 +760,7 @@ class TestEventTable(TestTable):
         )
         try:
             connect.start()
-        except ImportError as exc:
+        except ImportError as exc:  # pragma: no-cover
             pytest.skip(str(exc))
         yield table
         connect.stop()
@@ -786,7 +786,7 @@ class TestEventTable(TestTable):
     def test_fetch_open_data(self):
         try:
             table = self.TABLE.fetch_open_data("GWTC-1-confident")
-        except (URLError, SSLError) as exc:
+        except (URLError, SSLError) as exc:  # pragma: no-cover
             pytest.skip(str(exc))
         assert len(table)
         assert {"L_peak", "distance", "mass1"}.intersection(table.colnames)
@@ -802,7 +802,7 @@ class TestEventTable(TestTable):
                 "GWTC-1-confident",
                 selection="mass1 < 5",
                 columns=["name", "mass1", "mass2", "distance"])
-        except (URLError, SSLError) as exc:
+        except (URLError, SSLError) as exc:  # pragma: no-cover
             pytest.skip(str(exc))
         assert len(table) == 1
         assert table[0]["name"] == "GW170817"

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -320,7 +320,7 @@ class TestStateVector(_TestTimeSeriesBase):
         try:
             sv = self.TEST_CLASS.fetch_open_data(
                 LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, version=1)
-        except LOSC_FETCH_ERROR as e:
+        except LOSC_FETCH_ERROR as e:  # pragma: no-cover
             pytest.skip(str(e))
         ref = StateVector(
             [127, 127, 127, 127],

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -102,7 +102,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         try:
             return self.TEST_CLASS.fetch_open_data(
                 LOSC_IFO, *LOSC_GW150914_SEGMENT)
-        except LOSC_FETCH_ERROR as e:
+        except LOSC_FETCH_ERROR as e:  # pragma: no-cover
             pytest.skip(str(e))
 
     @pytest.fixture(scope='class')
@@ -110,7 +110,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         try:
             return self.TEST_CLASS.fetch_open_data(
                 LOSC_IFO, *LOSC_GW150914_SEGMENT, sample_rate=16384)
-        except LOSC_FETCH_ERROR as e:
+        except LOSC_FETCH_ERROR as e:  # pragma: no-cover
             pytest.skip(str(e))
 
     # -- test class functionality ---------------
@@ -161,7 +161,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
                 array, fmt, extension='gwf', read_args=[array.name],
                 assert_equal=utils.assert_quantity_sub_equal,
                 assert_kw={'exclude': ['channel']})
-        except ImportError as e:
+        except ImportError as e:  # pragma: no-cover
             pytest.skip(str(e))
 
         # test read keyword arguments
@@ -406,7 +406,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         try:
             ts = self.TEST_CLASS.fetch_open_data(
                 LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, verbose=True)
-        except LOSC_FETCH_ERROR as e:
+        except LOSC_FETCH_ERROR as e:  # pragma: no-cover
             pytest.skip(str(e))
         utils.assert_quantity_sub_equal(ts, losc,
                                         exclude=['name', 'unit', 'channel'])
@@ -507,7 +507,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         try:
             ft = datafind.find_best_frametype(
                 channel, 1143504017, 1143504017+100)
-        except ValueError as exc:  # ignore
+        except ValueError as exc:  # pragma: no-cover
             if str(exc).lower().startswith('cannot locate'):
                 pytest.skip(str(exc))
             raise
@@ -527,7 +527,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         try:
             ts = self.TEST_CLASS.get(FIND_CHANNEL, *LOSC_GW150914_SEGMENT,
                                      frametype_match=r'C01\Z')
-        except (ImportError, RuntimeError) as e:
+        except (ImportError, RuntimeError) as e:  # pragma: no-cover
             pytest.skip(str(e))
         utils.assert_quantity_sub_equal(ts, losc_16384,
                                         exclude=['name', 'channel', 'unit'])
@@ -1186,7 +1186,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         try:
             tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
             tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-        except LOSC_FETCH_ERROR as exc:
+        except LOSC_FETCH_ERROR as exc:  # pragma: no-cover
             pytest.skip(str(exc))
         coh = tsh.coherence(tsl, fftlength=1.0)
         assert coh.df == 1 * units.Hz
@@ -1196,7 +1196,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         try:
             tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
             tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-        except LOSC_FETCH_ERROR as exc:
+        except LOSC_FETCH_ERROR as exc:  # pragma: no-cover
             pytest.skip(str(exc))
         cohsg = tsh.coherence_spectrogram(tsl, 4, fftlength=1.0)
         assert cohsg.t0 == tsh.t0

--- a/gwpy/utils/tests/test_lal.py
+++ b/gwpy/utils/tests/test_lal.py
@@ -70,7 +70,7 @@ def test_to_lal_unit():
 def test_from_lal_unit():
     try:
         lalms = lal.MeterUnit / lal.SecondUnit
-    except TypeError as exc:
+    except TypeError as exc:  # pragma: no-cover
         # see https://git.ligo.org/lscsoft/lalsuite/issues/65
         pytest.skip(str(exc))
     assert utils_lal.from_lal_unit(lalms) == units.Unit('m/s')


### PR DESCRIPTION
This PR adds a bunch of `# pragma: no-cover` comments around `pytest.skip()` calls, to exclude the skips in the coverage reports. This should mean that if tests start passing (when they used to fail) the coverage doesn't drop, and that the coverage doesn't fluctuate around flaky tests.