### PR TITLE
Improve reading of empty tables from LIGO_LW XML

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -37,7 +37,7 @@ PYTHON=$(which "python${PYTHON_VERSION}")
 PIP="${PYTHON} -m pip"
 
 # upgrade setuptools in order to understand environment markers
-${PIP} install ${PIP_FLAGS} "pip>=8.0.0" "setuptools>=20.2.2"
+${PIP} install ${PIP_FLAGS} "pip>=8.0.0" "setuptools>=20.2.2" wheel
 
 # install test dependencies
 ${PIP} install ${PIP_FLAGS} -r requirements-test.txt

--- a/gwpy/table/tests/test_io_ligolw.py
+++ b/gwpy/table/tests/test_io_ligolw.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2020)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwpy.table.io.ligolw`
+"""
+
+import pytest
+
+import numpy
+from numpy.testing import assert_array_equal
+
+from .. import EventTable
+from ...testing.utils import skip_missing_dependency
+
+
+# -- fixtures -----------------------------------------------------------------
+
+@pytest.fixture()
+def llwtable():
+    from ligo.lw.lsctables import (New, SnglBurstTable)
+    llwtab = New(SnglBurstTable, columns=["peak_frequency", "snr"])
+    for i in range(10):
+        row = llwtab.RowType()
+        row.peak_frequency = float(i)
+        row.snr = float(i)
+        llwtab.append(row)
+    return llwtab
+
+
+# -- test to_astropy_table() via EventTable conversions -----------------------
+
+@skip_missing_dependency('ligo.lw.lsctables')
+def test_to_astropy_table(llwtable):
+    tab = EventTable(llwtable)
+    assert set(tab.colnames) == {"peak_frequency", "snr"}
+    assert_array_equal(tab["snr"], llwtable.getColumnByName("snr"))
+
+
+@skip_missing_dependency('ligo.lw.lsctables')
+def test_to_astropy_table_rename(llwtable):
+    tab = EventTable(llwtable, rename={"peak_frequency": "frequency"})
+    assert set(tab.colnames) == {"frequency", "snr"}
+    assert_array_equal(
+        tab["frequency"],
+        llwtable.getColumnByName("peak_frequency"),
+    )
+
+
+@skip_missing_dependency('ligo.lw.lsctables')
+def test_to_astropy_table_empty():
+    from ligo.lw.lsctables import (New, SnglBurstTable)
+    llwtable = New(
+        SnglBurstTable,
+        columns=["peak_time", "peak_time_ns", "ifo"],
+    )
+    tab = EventTable(llwtable, columns=["peak", "ifo"])
+    assert set(tab.colnames) == {"peak", "ifo"}
+    assert tab['peak'].dtype.type is numpy.object_
+    assert tab['ifo'].dtype.type is numpy.unicode_

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -33,7 +33,6 @@ import pytest
 import sqlparse
 
 from numpy import (random, isclose, dtype, asarray, all)
-from numpy.testing import assert_array_equal
 from numpy.ma.core import MaskedConstant
 
 import h5py
@@ -126,34 +125,7 @@ class TestTable(object):
                                [0.0, 1.9, 1.95, 2.0, 2.05, 2.1, 4.0]],
                          names=['amplitude', 'time'])
 
-    @staticmethod
-    @pytest.fixture()
-    def llwtable():
-        from ligo.lw.lsctables import (New, SnglBurstTable)
-        llwtab = New(SnglBurstTable, columns=["peak_frequency", "snr"])
-        for i in range(10):
-            row = llwtab.RowType()
-            row.peak_frequency = float(i)
-            row.snr = float(i)
-            llwtab.append(row)
-        return llwtab
-
     # -- test I/O -------------------------------
-
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
-    def test_ligolw(self, llwtable):
-        tab = self.TABLE(llwtable)
-        assert set(tab.colnames) == {"peak_frequency", "snr"}
-        assert_array_equal(tab["snr"], llwtable.getColumnByName("snr"))
-
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
-    def test_ligolw_rename(self, llwtable):
-        tab = self.TABLE(llwtable, rename={"peak_frequency": "frequency"})
-        assert set(tab.colnames) == {"frequency", "snr"}
-        assert_array_equal(
-            tab["frequency"],
-            llwtable.getColumnByName("peak_frequency"),
-        )
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
     @pytest.mark.parametrize('ext', ['xml', 'xml.gz'])


### PR DESCRIPTION
This PR improves the reading of empty tables from `LIGO_LW`-format XML. The tricky part is determining the correct `dtype` for dynamic columns (i.e. ones that aren't natively part of the XML structure, but are supported by the `ligo.lw` python API).