### PR TITLE
Write series to GWF using name attribute for all structure names

### DIFF
--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -236,7 +236,7 @@ def create_fradcdata(series, frame_epoch=0,
                         "written as FrAdcData")
 
     frdata = frameCPP.FrAdcData(
-        str(series.channel or series.name),
+        _series_name(series),
         channelgroup,
         channelid,
         nbits,
@@ -323,7 +323,7 @@ def create_frprocdata(series, frame_epoch=0, comment=None,
         frange = _get_series_frange(series)
 
     return frameCPP.FrProcData(
-        str(series.channel or series.name),
+        _series_name(series),
         str(comment or series.name),
         _get_frprocdata_type(series, type),
         _get_frprocdata_subtype(series, subtype),
@@ -375,7 +375,7 @@ def create_frsimdata(series, frame_epoch=0, comment=None, fshift=0, phase=0):
         raise TypeError("only timeseries data can be written as FrSimData")
 
     return frameCPP.FrSimData(
-        str(series.channel or series.name),
+        _series_name(series),
         str(comment or series.name),
         (1 / series.dx.to('s')).value,
         float(LIGOTimeGPS(series.x0.value) - LIGOTimeGPS(frame_epoch)),
@@ -414,7 +414,7 @@ def create_frvect(series):
 
     # create FrVect
     vect = frameCPP.FrVect(
-        series.name or '',  # name
+        _series_name(series),  # name
         int(FrVectType.find(series.dtype)),  # data type enum
         series.ndim,  # num dimensions
         dims,  # dimension object
@@ -688,3 +688,25 @@ def _get_frprocdata_subtype(series, subtype):
     if series.unit == 'coherence':
         return FrProcDataSubType.COHERENCE
     return FrProcDataSubType.UNKNOWN
+
+
+def _series_name(series):
+    """Returns the 'name' of a `Series` that should be written to GWF
+
+    This is basically `series.name or str(series.channel) or ""`
+
+    Parameters
+    ----------
+    series : `gwpy.types.Series`
+        the input series that will be written
+
+    Returns
+    -------
+    name : `str`
+        the name to use when storing this series
+    """
+    return (
+            series.name or
+            str(series.channel) or
+            ""
+    )

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -498,7 +498,7 @@ def write(tsdict, outfile,
     duration = end - start
     ifos = {ts.channel.ifo for ts in tsdict.values() if
             ts.channel and ts.channel.ifo and
-            ts.channel.ifo in io_framecpp.DetectorLocation}
+            ts.channel.ifo in io_framecpp.DetectorLocation.__members__}
 
     # create frame
     frame = io_gwf.create_frame(

--- a/gwpy/timeseries/tests/test_io_gwf_framecpp.py
+++ b/gwpy/timeseries/tests/test_io_gwf_framecpp.py
@@ -63,3 +63,17 @@ def test_read_scaled_type_change(int32ts):
         new = type(int32ts).read(tmpf, "test", type="adc")
     assert new.dtype == numpy.dtype("float64")
     assert_quantity_sub_equal(int32ts, new)
+
+
+def test_read_write_frvect_name():
+    """Test against regression of https://github.com/gwpy/gwpy/issues/1206
+    """
+    data = TimeSeries(
+        numpy.random.random(10),
+        channel="X1:TEST",
+        name="test",
+    )
+    with TemporaryFilename() as tmpf:
+        data.write(tmpf, format="gwf.framecpp", type="proc")
+        new = type(data).read(tmpf, "test")
+    assert_quantity_sub_equal(data, new, exclude=('channel',))


### PR DESCRIPTION
This PR fixes #1206 by patching `gwpy.io.gwf` to prefer the `Series.name` attribute when creating GWF structures, rather than the buggy mix that existed previously.

In principle this is backwards incompatible, since the `Series.channel` attribute was used before, but anyone who tried to write/read series where the `channel` and `name` were different would have hit #1206 anyway.