### PR TITLE
Pin mock for testing on python2

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@ pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0 ; python_version >= '3'
 pytest >= 3.3.0, < 4.0.0a0 ; python_version < '3'
 pytest-cov >= 2.4.0
 pytest-xdist < 1.28.0
-mock ; python_version < '3'
+mock < 4.0.0a0 ; python_version < '3'
 freezegun >= 0.2.3
 sqlparse >= 0.2.0
 beautifulsoup4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,5 @@ mock < 4.0.0a0 ; python_version < '3'
 freezegun >= 0.2.3
 sqlparse >= 0.2.0
 beautifulsoup4
+# modern freezegun needs a modern dateutil
+python-dateutil >= 2.7.0

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ tests_require = [
     'beautifulsoup4',
 ]
 if sys.version < '3':
-    tests_require.append('mock')
+    tests_require.append('mock<4.0.0a0')
 
 # -- run setup ----------------------------------------------------------------
 


### PR DESCRIPTION
This PR pins `mock` to `<4.0.0a0` on python 2, since 4.0.0 is python3-only, but `pip` has no idea how to respect that. This should fix the build failures seen in #1209, etc.