### PR TITLE
Raise ValueError in TimeSeries.read if file(s) return a proper subset of request

### DIFF
--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -177,8 +177,8 @@ def fetch_losc_data(detector, start, end, cls=TimeSeries, **kwargs):
     kwargs['cls'] = cls
     for url in cache:
         keep = file_segment(url) & span
-        new = _fetch_losc_data_file(url, *args, **kwargs).crop(
-            *keep, copy=False)
+        kwargs["start"], kwargs["end"] = keep
+        new = _fetch_losc_data_file(url, *args, **kwargs)
         if is_gwf and (not args or args[0] is None):
             args = (new.name,)
         if out is None:

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -442,6 +442,24 @@ class TestTimeSeries(_TestTimeSeriesBase):
             b,
         )
 
+    def test_read_pad_raise(self):
+        """Check that `TimeSeries.read` with `gap='raise'` actually
+        raises appropriately.
+
+        [regression: https://github.com/gwpy/gwpy/issues/1211]
+        """
+        from gwpy.io.cache import file_segment
+        span = file_segment(utils.TEST_HDF5_FILE)
+        with pytest.raises(ValueError):
+            self.TEST_CLASS.read(
+                utils.TEST_HDF5_FILE,
+                "H1:LDAS-STRAIN",
+                pad=0.,
+                start=span[0],
+                end=span[1]+1.,
+                gap="raise",
+            )
+
     @utils.skip_missing_dependency('nds2')
     def test_from_nds2_buffer_dynamic_scaled(self):
         # build fake buffer for LIGO channel

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -21,7 +21,6 @@
 
 import os.path
 from itertools import (chain, product)
-from math import isnan
 from ssl import SSLError
 from unittest import mock
 from urllib.error import URLError

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -353,19 +353,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
             exclude=("channel", "x0"),
         )
 
-    @SKIP_FRAMECPP
-    def test_read_gwf_sample_error(self):
-        """Regression against bug where final sample would be missed
-        when reading too close to the end of the vector
-        """
-        ts = self.TEST_CLASS.read(
-            utils.TEST_GWF_FILE,
-            "H1:LDAS-STRAIN",
-            start=968654552,
-            end=968654553.0001,
-        )
-        assert not isnan(ts[-1].value)
-
     @pytest.mark.parametrize('ext', ('hdf5', 'h5'))
     @pytest.mark.parametrize('channel', [
         None,


### PR DESCRIPTION
This PR fixes #1211 by fixing the timeseries reader to actually raise a `ValueError` if the underlying reader returns a proper subset of the requested `[start, end)` segment _and_ `gap='raise'` was given.