### PR TITLE
Fix CIS API support

### DIFF
--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -400,7 +400,7 @@ class Channel(object):
     # -- classmethods ---------------------------
 
     @classmethod
-    def query(cls, name, use_kerberos=None, debug=False):
+    def query(cls, name, kerberos=None):
         """Query the LIGO Channel Information System for the `Channel`
         matching the given name
 
@@ -409,14 +409,10 @@ class Channel(object):
         name : `str`
             name of channel
 
-        use_kerberos : `bool`, optional
+        kerberos : `bool`, optional
             use an existing Kerberos ticket as the authentication credential,
             default behaviour will check for credentials and request username
             and password if none are found (`None`)
-
-        debug : `bool`, optional
-            print verbose HTTP connection status for debugging,
-            default: `False`
 
         Returns
         -------
@@ -424,8 +420,7 @@ class Channel(object):
              a new `Channel` containing all of the attributes set from
              its entry in the CIS
         """
-        channellist = ChannelList.query(name, use_kerberos=use_kerberos,
-                                        debug=debug)
+        channellist = ChannelList.query(name, kerberos=kerberos)
         if not channellist:
             raise ValueError("No channels found matching '%s'" % name)
         if len(channellist) > 1:
@@ -766,7 +761,7 @@ class ChannelList(list):
         return self.__class__(matched)
 
     @classmethod
-    def query(cls, name, use_kerberos=None, debug=False):
+    def query(cls, name, kerberos=None):
         """Query the LIGO Channel Information System a `ChannelList`.
 
         Parameters
@@ -774,14 +769,10 @@ class ChannelList(list):
         name : `str`
             name of channel, or part of it.
 
-        use_kerberos : `bool`, optional
+        kerberos : `bool`, optional
             use an existing Kerberos ticket as the authentication credential,
             default behaviour will check for credentials and request username
             and password if none are found (`None`)
-
-        debug : `bool`, optional
-            print verbose HTTP connection status for debugging,
-            default: `False`
 
         Returns
         -------
@@ -789,7 +780,7 @@ class ChannelList(list):
             a new list containing all `Channels <Channel>` found.
         """
         from .io import cis
-        return cis.query(name, use_kerberos=use_kerberos, debug=debug)
+        return cis.query(name, kerberos=kerberos)
 
     @classmethod
     def query_nds2(cls, names, host=None, port=None, connection=None,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,8 +8,8 @@
 -r requirements-doc.txt
 
 # extras
+ciecplib
 lalsuite ; sys_platform != 'win32'
-git+https://github.com/duncanmmacleod/ligo.org.git
 lscsoft-glue ; sys_platform != 'win32'
 maya
 pandas

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,4 +4,5 @@ freezegun >= 0.2.3
 pytest >= 3.3.0
 pytest-cov >= 2.4.0
 pytest-xdist
+requests-mock
 sqlparse >= 0.2.0


### PR DESCRIPTION
This PR updates the `Channel{List}.query` interface to the CIS API to use `ciecplib`, rather than the discontinued `ligo.org` python package.