### PR TITLE
Remove python2 version pins

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,13 +1,7 @@
 # requirements for GWpy tests
-# pytest needs more-itertools, we need it to work on python2.7
-more-itertools < 6.0a0 ; python_version < '3'
-pytest >= 3.3.0, !=4.6.0, !=4.6.1, !=4.6.2, < 5.0.0 ; python_version >= '3'
-pytest >= 3.3.0, < 4.0.0a0 ; python_version < '3'
-pytest-cov >= 2.4.0
-pytest-xdist < 1.28.0
-mock < 4.0.0a0 ; python_version < '3'
-freezegun >= 0.2.3
-sqlparse >= 0.2.0
 beautifulsoup4
-# modern freezegun needs a modern dateutil
-python-dateutil >= 2.7.0
+freezegun >= 0.2.3
+pytest >= 3.3.0
+pytest-cov >= 2.4.0
+pytest-xdist
+sqlparse >= 0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # GWpy core requirements
 #           [use requirements-dev.txt for a full development environment
 #            including docs and testing dependencies]
-astropy >= 1.3.0, < 3.0.0 ; python_version < '3.5'
-astropy >= 1.3.0 ; python_version >= '3.5'
+astropy >= 1.3.0
 dqsegdb2
 gwdatafind
 gwosc >= 0.4.0

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,7 @@ setup_requires = get_setup_requires()
 
 # runtime dependencies
 install_requires = [
-    'astropy >= 1.3.0, < 3.0.0 ; python_version < \'3.5\'',
-    'astropy >= 1.3.0 ; python_version >= \'3.5\'',
+    'astropy >= 1.3.0',
     'dqsegdb2',
     'gwdatafind',
     'gwosc >= 0.4.0',


### PR DESCRIPTION
This PR removes legacy dependency version pins that were required for python2 support.