### PR TITLE
Bump minimum scipy and numpy version requirements

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -56,9 +56,9 @@ GWpy has the following strict requirements:
    |ligo-segments|_    ``>=1.0.0``
    |ligotimegps|_      ``>=1.2.1``
    |matplotlib|_       ``!=2.1.0,!=2.1.1,>=1.2.0``
-   |numpy|_            ``>=1.7.1``
+   |numpy|_            ``>=1.12.0``
    |dateutil|_
-   |scipy|_            ``>=0.12.1``
+   |scipy|_            ``>=1.2.0``
    |six|_              ``>=1.5``
    |tqdm|_             ``>=4.10.0``
    ==================  ===========================

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -21,8 +21,6 @@
 
 import pytest
 
-from scipy import __version__ as scipy_version
-
 from astropy import units
 
 from ... import astro
@@ -48,21 +46,12 @@ if astropy_version >= '2.0':
     constants.c = si.c = astropyconst13.c
     constants.pc = si.pc = astropyconst13.pc
 
-# something changed in scipy 0.19, something FFT-related
-if scipy_version < '0.19':
-    TEST_RESULTS = {
-        'inspiral_range': 19.63704209223392 * units.Mpc,
-        'inspiral_range_psd': 7.915847068684727 * units.Mpc ** 2 / units.Hz,
-        'burst_range': 13.813232309724613 * units.Mpc,
-        'burst_range_spectrum': 35.19303454822539 * units.Mpc,
-    }
-else:
-    TEST_RESULTS = {
-        'inspiral_range': 19.63872448570372 * units.Mpc,
-        'inspiral_range_psd': 7.92640311063505 * units.Mpc ** 2 / units.Hz,
-        'burst_range': 13.815456279746522 * units.Mpc,
-        'burst_range_spectrum': 35.216492263916535 * units.Mpc,
-    }
+TEST_RESULTS = {
+    'inspiral_range': 19.63872448570372 * units.Mpc,
+    'inspiral_range_psd': 7.92640311063505 * units.Mpc ** 2 / units.Hz,
+    'burst_range': 13.815456279746522 * units.Mpc,
+    'burst_range_spectrum': 35.216492263916535 * units.Mpc,
+}
 
 
 # -- utilities ----------------------------------------------------------------

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -24,11 +24,7 @@ from io import BytesIO
 import pytest
 
 import numpy
-
-try:
-    from numpy import shares_memory
-except ImportError:  # old numpy
-    from numpy import may_share_memory as shares_memory
+from numpy import shares_memory
 
 from scipy import signal
 

--- a/gwpy/plot/bode.py
+++ b/gwpy/plot/bode.py
@@ -194,16 +194,7 @@ class BodePlot(Plot):
         mag, phase : `tuple` of `lines <matplotlib.lines.Line2D>`
             the lines drawn for the magnitude and phase of the filter.
         """
-        try:
-            from scipy.signal import (lti, dlti)
-        except ImportError as exc:  # scipy < 0.18.0
-            exc.args = (
-                "scipy >= 0.18.0 is required to use {}.add_filter: {}".format(
-                    type(self).__name__,
-                    str(exc),
-                ),
-            )
-            raise
+        from scipy.signal import (lti, dlti)
         from gwpy.signal.filter_design import parse_filter
 
         if not analog:

--- a/gwpy/plot/tests/test_bode.py
+++ b/gwpy/plot/tests/test_bode.py
@@ -25,7 +25,6 @@ from numpy import testing as nptest
 from scipy import signal
 
 from ...frequencyseries import FrequencySeries
-from ...testing.utils import skip_minimum_version
 from .. import BodePlot
 from .utils import FigureTestBase
 
@@ -51,7 +50,6 @@ class TestBodePlot(FigureTestBase):
         assert paxes.get_yscale() == 'linear'
         assert paxes.get_ylabel() == 'Phase [deg]'
 
-    @skip_minimum_version("scipy", "0.18.0")
     def test_add_filter(self, fig):
         lm, lp = fig.add_filter(ZPK, analog=True)
         assert lm is fig.maxes.get_lines()[-1]
@@ -61,7 +59,6 @@ class TestBodePlot(FigureTestBase):
         nptest.assert_array_equal(lp.get_xdata(), FREQUENCIES)
         nptest.assert_array_almost_equal(lp.get_ydata(), PHASE)
 
-    @skip_minimum_version("scipy", "0.18.0")
     def test_init_with_filter(self):
         fig = self.FIGURE_CLASS(ZPK, analog=True, title='ZPK')
         lm = fig.maxes.get_lines()[0]

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -28,10 +28,7 @@ import numpy
 from numpy import fft as npfft
 
 from scipy import signal
-try:
-    from scipy.signal.ltisys import LinearTimeInvariant
-except ImportError:  # scipy < 0.18
-    from scipy.signal import lti as LinearTimeInvariant
+from scipy.signal.ltisys import LinearTimeInvariant
 
 from astropy.units import (Unit, Quantity)
 
@@ -356,10 +353,7 @@ def parse_filter(args, analog=False, sample_rate=None):
         lti = signal.lti(*args)
 
     # convert to zpk format
-    try:
-        lti = lti.to_zpk()
-    except AttributeError:  # scipy < 0.18, doesn't matter
-        pass
+    lti = lti.to_zpk()
 
     # convert to digital components
     if analog:

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -577,11 +577,11 @@ class QGram(object):
         else:
             if fres == "<default>":
                 fres = 500
-            # using `~numpy.logspace` here to support numpy-1.7.1 for EPEL7,
-            # but numpy-1.12.0 introduced the function `~numpy.geomspace`
-            logfmin = numpy.log10(self.plane.frange[0])
-            logfmax = numpy.log10(self.plane.frange[1])
-            outfreq = numpy.logspace(logfmin, logfmax, num=int(fres))
+            outfreq = numpy.geomspace(
+                self.plane.frange[0],
+                self.plane.frange[1],
+                num=int(fres),
+            )
         new = type(out)(
             interp(xout, outfreq).T.astype(
                 dtype, casting="same_kind", copy=False),

--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -62,7 +62,7 @@ def _spectral_density(timeseries, segmentlength, noverlap=None, name=None,
 def welch(timeseries, segmentlength, **kwargs):
     """Calculate a PSD using Welch's method
     """
-    kwargs.setdefault('average', 'welch')
+    kwargs.setdefault('average', 'mean')
     return _spectral_density(timeseries, segmentlength, **kwargs)
 
 

--- a/gwpy/signal/tests/test_spectral_scipy.py
+++ b/gwpy/signal/tests/test_spectral_scipy.py
@@ -19,12 +19,11 @@
 """Tests for :mod:`gwpy.signal.spectral.scipy`
 
 Here we check `welch` thoroughly, and the others less so, because
-they just call out to that method anyway.
+they just call out to the same method anyway.
 """
 
 import pytest
 
-from ...testing.utils import skip_minimum_version
 from ..spectral import _scipy as fft_scipy
 
 
@@ -45,7 +44,6 @@ def test_bartlett(noisy_sinusoid):
     assert psd.max() == psd.value_at(500.)
 
 
-@skip_minimum_version("scipy", "1.2.0")
 def test_median(noisy_sinusoid):
     psd = fft_scipy.median(noisy_sinusoid, 4096, noverlap=2048)
     assert psd.max() == psd.value_at(500.)

--- a/gwpy/signal/window.py
+++ b/gwpy/signal/window.py
@@ -23,10 +23,7 @@ import numpy
 
 from math import ceil
 
-try:  # scipy 1.1.0rc1
-    from scipy.signal.windows import windows as scipy_windows
-except ImportError:  # scipy <= 1.0.x
-    from scipy.signal import windows as scipy_windows
+from scipy.signal.windows import windows as scipy_windows
 
 from scipy.special import expit
 
@@ -64,16 +61,9 @@ def canonical_name(name):
     try:  # use equivalence introduced in scipy 0.16.0
         # pylint: disable=protected-access
         return scipy_windows._win_equiv[name.lower()].__name__
-    except AttributeError:  # old scipy
-        try:
-            return getattr(scipy_windows, name.lower()).__name__
-        except AttributeError:  # no match
-            pass  # raise later
     except KeyError:  # no match
-        pass  # raise later
-
-    raise ValueError('no window function in scipy.signal equivalent to %r'
-                     % name,)
+        raise ValueError('no window function in scipy.signal equivalent to %r'
+                         % name,)
 
 
 # -- recommended overlap ------------------------------------------------------

--- a/gwpy/spectrogram/spectrogram.py
+++ b/gwpy/spectrogram/spectrogram.py
@@ -25,8 +25,6 @@ from six import string_types
 
 import numpy
 
-import scipy
-
 from astropy import units
 from astropy.io import registry as io_registry
 
@@ -414,7 +412,7 @@ class Spectrogram(Array2D):
             the given percentile `FrequencySeries` calculated from this
             `SpectralVaraicence`
         """
-        out = scipy.percentile(self.value, percentile, axis=0)
+        out = numpy.percentile(self.value, percentile, axis=0)
         if self.name is not None:
             name = '{}: {} percentile'.format(self.name, _ordinal(percentile))
         else:

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -26,10 +26,7 @@ from io import BytesIO
 import pytest
 
 import numpy
-try:
-    from numpy import shares_memory
-except ImportError:  # numpy < 1.11.0
-    from numpy import may_share_memory as shares_memory
+from numpy import shares_memory
 
 from matplotlib import rc_context
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -31,7 +31,7 @@ import pytest
 import numpy
 from numpy import testing as nptest
 
-from scipy import (signal, __version__ as scipy_version)
+from scipy import signal
 
 from astropy import units
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -55,10 +55,7 @@ SKIP_LAL = utils.skip_missing_dependency('lal')
 SKIP_LALFRAME = utils.skip_missing_dependency('lalframe')
 SKIP_PYCBC_PSD = utils.skip_missing_dependency('pycbc.psd')
 
-if scipy_version < '1.2.0':
-    SCIPY_METHODS = ('welch', 'bartlett')
-else:
-    SCIPY_METHODS = ('welch', 'bartlett', 'median')
+SCIPY_METHODS = ('welch', 'bartlett', 'median')
 
 FIND_CHANNEL = 'L1:DCS-CALIB_STRAIN_C02'
 FIND_FRAMETYPE = 'L1_HOFT_C02'
@@ -338,7 +335,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
             t = type(array).read(tmp, start=start, end=end)
             utils.assert_quantity_sub_equal(t, array.crop(start, end))
 
-    @utils.skip_minimum_version('scipy', '0.13.0')
     def test_read_write_wav(self):
         array = self.create(dtype='float32')
         utils.test_read_write(
@@ -641,7 +637,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
         fs = losc.asd(1)
         utils.assert_quantity_sub_equal(fs, losc.psd(1) ** (1/2.))
 
-    @utils.skip_minimum_version('scipy', '0.16')
     def test_csd(self, noisy_sinusoid, corrupt_noisy_sinusoid):
         # test that csd(self) is the same as psd()
         fs = noisy_sinusoid.csd(noisy_sinusoid)
@@ -669,6 +664,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
     @pytest.mark.parametrize('method', [
         'scipy-welch',
         'scipy-bartlett',
+        'scipy-median',
         pytest.param('lal-welch', marks=SKIP_LAL),
         pytest.param('lal-bartlett', marks=SKIP_LAL),
         pytest.param('lal-median', marks=SKIP_LAL),
@@ -771,7 +767,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
         # note: bizarre stride length because 4096/100 gets rounded
         assert sg.dt == 0.010009765625 * units.second
 
-    @utils.skip_minimum_version('scipy', '0.16')
     def test_fftgram(self, losc):
         fgram = losc.fftgram(1)
         fs = int(losc.sample_rate.value)
@@ -826,7 +821,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
         nptest.assert_almost_equal(ray.max().value, 1.8814775174483833)
         assert ray.frequencies[ray.argmax()] == 136 * units.Hz
 
-    @utils.skip_minimum_version('scipy', '0.16')
     def test_csd_spectrogram(self, losc):
         # test defaults
         sg = losc.csd_spectrogram(losc, 1)
@@ -993,7 +987,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
         utils.assert_allclose(new_data.value[ind], waveform.value)
         utils.assert_allclose(data.value, numpy.zeros(duration*sample_rate))
 
-    @utils.skip_minimum_version("scipy", "1.1.0")
     def test_gate(self):
         # generate Gaussian noise with std = 0.5
         noise = self.TEST_CLASS(numpy.random.normal(scale=0.5, size=16384*64),
@@ -1097,10 +1090,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
         # check SOS filters can be used directly
         zpk = filter_design.highpass(50, sample_rate=losc.sample_rate)
-        try:
-            sos = signal.zpk2sos(*zpk)
-        except AttributeError:  # scipy < 0.16
-            pass
+        sos = signal.zpk2sos(*zpk)
         else:
             utils.assert_quantity_almost_equal(losc.filter(zpk),
                                                losc.filter(sos))

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1091,9 +1091,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         # check SOS filters can be used directly
         zpk = filter_design.highpass(50, sample_rate=losc.sample_rate)
         sos = signal.zpk2sos(*zpk)
-        else:
-            utils.assert_quantity_almost_equal(losc.filter(zpk),
-                                               losc.filter(sos))
+        utils.assert_quantity_almost_equal(losc.filter(zpk), losc.filter(sos))
 
     def test_zpk(self, losc):
         zpk = [10, 10], [1, 1], 100

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -55,8 +55,6 @@ SKIP_LAL = utils.skip_missing_dependency('lal')
 SKIP_LALFRAME = utils.skip_missing_dependency('lalframe')
 SKIP_PYCBC_PSD = utils.skip_missing_dependency('pycbc.psd')
 
-SCIPY_METHODS = ('welch', 'bartlett', 'median')
-
 FIND_CHANNEL = 'L1:DCS-CALIB_STRAIN_C02'
 FIND_FRAMETYPE = 'L1_HOFT_C02'
 
@@ -591,7 +589,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         with pytest.warns(UserWarning):
             losc.psd(1, .5, method='lal_median_mean')
 
-    @pytest.mark.parametrize('method', SCIPY_METHODS)
+    @pytest.mark.parametrize('method', ('welch', 'bartlett', 'median'))
     def test_psd(self, noisy_sinusoid, method):
         fftlength = .5
         overlap = .25

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -523,11 +523,7 @@ class TimeSeries(TimeSeriesBase):
             a Fourier-gram
         """
         from ..spectrogram import Spectrogram
-        try:
-            from scipy.signal import spectrogram
-        except ImportError:
-            raise ImportError("Must have scipy>=0.16 to utilize "
-                              "this method.")
+        from scipy.signal import spectrogram
 
         # format lengths
         if isinstance(fftlength, units.Quantity):
@@ -789,12 +785,6 @@ class TimeSeries(TimeSeriesBase):
             for details on the filter design
         TimeSeries.filter
             for details on how the filter is applied
-
-        Notes
-        -----
-        When using `scipy < 0.16.0` some higher-order filters may be
-        unstable. With `scipy >= 0.16.0` higher-order filters are
-        decomposed into second-order-sections, and so are much more stable.
         """
         # design filter
         filt = filter_design.highpass(frequency, self.sample_rate,
@@ -839,12 +829,6 @@ class TimeSeries(TimeSeriesBase):
             for details on the filter design
         TimeSeries.filter
             for details on how the filter is applied
-
-        Notes
-        -----
-        When using `scipy < 0.16.0` some higher-order filters may be
-        unstable. With `scipy >= 0.16.0` higher-order filters are
-        decomposed into second-order-sections, and so are much more stable.
         """
         # design filter
         filt = filter_design.lowpass(frequency, self.sample_rate,
@@ -892,12 +876,6 @@ class TimeSeries(TimeSeriesBase):
             for details on the filter design
         TimeSeries.filter
             for details on how the filter is applied
-
-        Notes
-        -----
-        When using `scipy < 0.16.0` some higher-order filters may be
-        unstable. With `scipy >= 0.16.0` higher-order filters are
-        decomposed into second-order-sections, and so are much more stable.
         """
         # design filter
         filt = filter_design.bandpass(flow, fhigh, self.sample_rate,
@@ -1039,14 +1017,8 @@ class TimeSeries(TimeSeriesBase):
 
         Notes
         -----
-        IIR filters are converted either into cascading
-        second-order sections (if `scipy >= 0.16` is installed), or into the
-        ``(numerator, denominator)`` representation before being applied
-        to this `TimeSeries`.
-
-        When using `scipy < 0.16` some higher-order filters may be
-        unstable. With `scipy >= 0.16` higher-order filters are
-        decomposed into second-order-sections, and so are much more stable.
+        IIR filters are converted into cascading second-order sections before
+        being applied to this `TimeSeries`.
 
         FIR filters are passed directly to :func:`scipy.signal.lfilter` or
         :func:`scipy.signal.filtfilt` without any conversions.
@@ -1055,11 +1027,10 @@ class TimeSeries(TimeSeriesBase):
         --------
         scipy.signal.sosfilt
             for details on filtering with second-order sections
-            (`scipy >= 0.16` only)
 
         scipy.signal.sosfiltfilt
             for details on forward-backward filtering with second-order
-            sections (`scipy >= 0.18` only)
+            sections
 
         scipy.signal.lfilter
             for details on filtering (without SOS)
@@ -1105,11 +1076,7 @@ class TimeSeries(TimeSeriesBase):
                 sample_rate=self.sample_rate.to('Hz').value,
         )
         if form == 'zpk':
-            try:
-                sos = signal.zpk2sos(*filt)
-            except AttributeError:  # scipy < 0.16, no SOS filtering
-                sos = None
-                b, a = signal.zpk2tf(*filt)
+            sos = signal.zpk2sos(*filt)
         else:
             sos = None
             b, a = filt
@@ -1755,11 +1722,7 @@ class TimeSeries(TimeSeriesBase):
         >>> ax.legend()
         >>> overlay.show()
         """
-        try:
-            from scipy.signal import find_peaks
-        except ImportError as exc:
-            exc.args = ("Must have scipy>=1.1.0 to utilize this method.",)
-            raise
+        from scipy.signal import find_peaks
         # Find points to gate based on a threshold
         data = self.whiten(**whiten_kwargs) if whiten else self
         window_samples = cluster_window * data.sample_rate.value

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ h5py >= 1.3
 ligo-segments >= 1.0.0
 ligotimegps >= 1.2.1
 matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
-numpy >= 1.7.1
+numpy >= 1.12.0
 python-dateutil
-scipy >= 0.12.1
+scipy >= 1.2.0
 six >= 1.5
 tqdm >= 4.10.0

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ install_requires = [
     'ligo-segments >= 1.0.0',
     'ligotimegps >= 1.2.1',
     'matplotlib >= 1.2.0, != 2.1.0, != 2.1.1',
-    'numpy >= 1.7.1',
+    'numpy >= 1.12.0',
     'python-dateutil',
-    'scipy >= 0.12.1',
+    'scipy >= 1.2.0',
     'six >= 1.5',
     'tqdm >= 4.10.0',
 ]


### PR DESCRIPTION
This PR bumps the minimum scipy version requirement to 1.2.0, and the minimum numpy version requirement to 1.12.0. The former is dictated by a need to support median averaging in spectrograms, and the latter is determined by a desire to support `numpy.geomspace`, both the most encompassing requirements I could find scattered throughout gwpy.

Per instructions left in comment lines, this includes a somewhat large-scale refactoring of `gwpy/signal/spectral/_scipy.py`.

cc @duncanmmacleod 