### PR TITLE
Update astropy requirement to 3.0.0

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -48,7 +48,7 @@ GWpy has the following strict requirements:
    ==================  ===========================
    Name                Constraints
    ==================  ===========================
-   |astropy|_          ``>=1.3.0``
+   |astropy|_          ``>=3.0.0``
    |dqsegdb2|_
    |gwdatafind|_
    |gwosc-mod|_        ``>=0.4.0``

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -38,7 +38,6 @@ if sys.version_info < (3, 6):  # python < 3.6
     pytest.skip('example tests will only run on python >= 3.6',
                 allow_module_level=True)
 pytest.importorskip("matplotlib", minversion="2.2.0")
-pytest.importorskip("astropy", minversion="2.0.0")
 
 use('agg')  # force non-interactive backend
 

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -34,18 +34,6 @@ __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 # -- test results -------------------------------------------------------------
 
-# hack up constants that changed between astropy 1.3 and 2.0
-# TODO: might want to do this in reverse, i.e. hard-coding the answers for 2.0
-from astropy import __version__ as astropy_version  # nopep8
-if astropy_version >= '2.0':
-    from astropy import constants
-    from astropy.constants import (si, astropyconst13)
-    units.M_sun._represents = units.Unit(astropyconst13.M_sun)
-    constants.M_sun = si.M_sun = astropyconst13.M_sun
-    constants.G = si.G = astropyconst13.G
-    constants.c = si.c = astropyconst13.c
-    constants.pc = si.pc = astropyconst13.pc
-
 TEST_RESULTS = {
     'inspiral_range': 19.63872448570372 * units.Mpc,
     'inspiral_range_psd': 7.92640311063505 * units.Mpc ** 2 / units.Hz,

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -35,10 +35,10 @@ __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 # -- test results -------------------------------------------------------------
 
 TEST_RESULTS = {
-    'inspiral_range': 19.63872448570372 * units.Mpc,
-    'inspiral_range_psd': 7.92640311063505 * units.Mpc ** 2 / units.Hz,
-    'burst_range': 13.815456279746522 * units.Mpc,
-    'burst_range_spectrum': 35.216492263916535 * units.Mpc,
+    'inspiral_range': 19.63418297300058 * units.Mpc,
+    'inspiral_range_psd': 7.922730174148789 * units.Mpc ** 2 / units.Hz,
+    'burst_range': 13.81353542862508 * units.Mpc,
+    'burst_range_spectrum': 35.211595883103456 * units.Mpc,
 }
 
 

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -21,7 +21,6 @@
 
 import pytest
 
-from astropy import __version__ as astropy_version
 from astropy.table import (Table, vstack)
 
 from ...testing.utils import (assert_table_equal, TemporaryFilename)
@@ -93,8 +92,7 @@ def test_read_multi_not_a_file():
     """Check that a strange input gets passed along properly
     so that errors can be raise by the reader.
     """
-    # astropy < 3 has a different error message
-    with pytest.raises(ValueError if astropy_version < '3.0' else TypeError):
+    with pytest.raises(TypeError):
         io_mp.read_multi(vstack, Table, None, format="ascii.csv", nproc=1)
 
 

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -52,7 +52,6 @@ JSON_RESPONSE = {
 }
 
 
-@utils.skip_minimum_version('astropy', '2.0.4')
 class TestGravitySpyTable(_TestEventTable):
     TABLE = GravitySpyTable
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -359,13 +359,9 @@ class TestEventTable(TestTable):
         assert t._get_time_column() == 'blah2'
 
         # check that two GPS columns causes issues
-        try:
-            t.add_column(t['blah2'], name='blah3')
-        except TypeError:  # astropy < 2.0 (or something like that)
-            pass
-        else:
-            with pytest.raises(ValueError):
-                t._get_time_column()
+        t.add_column(t['blah2'], name='blah3')
+        with pytest.raises(ValueError):
+            t._get_time_column()
 
     def test_filter(self, table):
         # check simple filter

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -148,7 +148,7 @@ def find_typed_function(pytype, prefix, suffix, module=lal):
 
 # -- units --------------------------------------------------------------------
 
-LAL_UNIT_INDEX = [
+LAL_UNIT_INDEX = [  # the order corresponds to how LAL stores compound units
     lal.MeterUnit,
     lal.KiloGramUnit,
     lal.SecondUnit,
@@ -157,7 +157,15 @@ LAL_UNIT_INDEX = [
     lal.StrainUnit,
     lal.ADCCountUnit,
 ]
-LAL_UNIT_FROM_ASTROPY = {units.Unit(str(u)): u for u in LAL_UNIT_INDEX}
+
+
+def _lal_unit_from_astropy(u):
+    """Convert an `astropy.units.Unit` into a `lal.Unit`
+    """
+    for lalu in LAL_UNIT_INDEX:
+        if u == units.Unit(str(lalu)):
+            return lalu
+    raise KeyError(str(u))
 
 
 def to_lal_unit(aunit):
@@ -189,20 +197,18 @@ def to_lal_unit(aunit):
     aunit = aunit.decompose()
     lunit = lal.Unit()
     for base, power in zip(aunit.bases, aunit.powers):
-        # try this base
-        try:
-            lalbase = LAL_UNIT_FROM_ASTROPY[base]
-        except KeyError:
-            lalbase = None
-            # otherwise loop through the equivalent bases
+        try:  # try this base
+            lalbase = _lal_unit_from_astropy(base)
+        except KeyError:  # otherwise loop through the equivalent bases
             for eqbase in base.find_equivalent_units():
                 try:
-                    lalbase = LAL_UNIT_FROM_ASTROPY[eqbase]
+                    lalbase = _lal_unit_from_astropy(eqbase)
                 except KeyError:
                     continue
-        # if we didn't find anything, raise an exception
-        if lalbase is None:
-            raise ValueError("LAL has no unit corresponding to %r" % base)
+                break
+            # if we didn't find anything, raise an exception
+            else:
+                raise ValueError("LAL has no unit corresponding to %r" % base)
         lunit *= lalbase ** power
     return lunit
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # GWpy core requirements
 #           [use requirements-dev.txt for a full development environment
 #            including docs and testing dependencies]
-astropy >= 1.3.0
+astropy >= 3.0.0
 dqsegdb2
 gwdatafind
 gwosc >= 0.4.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup_requires = get_setup_requires()
 
 # runtime dependencies
 install_requires = [
-    'astropy >= 1.3.0',
+    'astropy >= 3.0.0',
     'dqsegdb2',
     'gwdatafind',
     'gwosc >= 0.4.0',


### PR DESCRIPTION
This PR updates the `astropy` requirement to `>= 3.0.0`, mainly to remove annoying workarounds.