### PR TITLE
Drop dependence on the six package and remove python < 3 workarounds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,6 @@ import glob
 import shutil
 import subprocess
 import warnings
-
 from configparser import (ConfigParser, NoOptionError)
 from string import Template
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ import glob
 import shutil
 import subprocess
 import warnings
-from string import Template
 
-from six.moves.configparser import (ConfigParser, NoOptionError)
+from string import Template
+from configparser import (ConfigParser, NoOptionError)
 
 import matplotlib
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,8 +25,8 @@ import shutil
 import subprocess
 import warnings
 
-from string import Template
 from configparser import (ConfigParser, NoOptionError)
+from string import Template
 
 import matplotlib
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -59,7 +59,6 @@ GWpy has the following strict requirements:
    |numpy|_            ``>=1.12.0``
    |dateutil|_
    |scipy|_            ``>=1.2.0``
-   |six|_              ``>=1.5``
    |tqdm|_             ``>=4.10.0``
    ==================  ===========================
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -34,9 +34,6 @@ from gwpy.io.nds2 import NDSWarning
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
-if sys.version_info < (3, 6):  # python < 3.6
-    pytest.skip('example tests will only run on python >= 3.6',
-                allow_module_level=True)
 pytest.importorskip("matplotlib", minversion="2.2.0")
 
 use('agg')  # force non-interactive backend
@@ -84,8 +81,6 @@ def test_example(script):
     with cwd(script.parent):
         with script.open('r') as example:
             raw = example.read()
-        if not isinstance(raw, bytes):  # python < 3
-            raw = raw.encode('utf-8')
         code = compile(raw, str(script), "exec")
         try:
             exec(code, globals())

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -21,7 +21,6 @@
 
 import os
 import re
-import sys
 import warnings
 from contextlib import contextmanager
 from pathlib import Path

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -55,11 +55,11 @@ EXAMPLES = sorted([
 @contextmanager
 def cwd(path):
     oldpwd = Path.cwd()
-    os.chdir(path)
+    os.chdir(str(path))
     try:
         yield
     finally:
-        os.chdir(oldpwd)
+        os.chdir(str(oldpwd))
 
 
 @pytest.fixture(autouse=True)

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -27,8 +27,6 @@ import warnings
 import sys
 from functools import wraps
 
-from six import add_metaclass
-
 from matplotlib import rcParams
 try:
     from matplotlib.cm import viridis as DEFAULT_CMAP
@@ -94,8 +92,7 @@ to_s = to_float('s')  # pylint: disable=invalid-name
 
 # -- base product class -------------------------------------------------------
 
-@add_metaclass(abc.ABCMeta)
-class CliProduct(object):
+class CliProduct(object, metaclass=abc.ABCMeta):
     """Base class for all cli plot products
 
     Parameters
@@ -761,15 +758,14 @@ class CliProduct(object):
 
 # -- extensions ---------------------------------------------------------------
 
-@add_metaclass(abc.ABCMeta)
-class ImageProduct(CliProduct):
+class ImageProduct(CliProduct, metaclass=abc.ABCMeta):
     """Base class for all x/y/color plots
     """
     MAX_DATASETS = 1
 
     @classmethod
     def init_plot_options(cls, parser):
-        super(ImageProduct, cls).init_plot_options(parser)
+        super().init_plot_options(parser)
         cls.arg_color_axis(parser)
 
     @classmethod
@@ -797,7 +793,7 @@ class ImageProduct(CliProduct):
     def _finalize_arguments(self, args):
         if args.cmap is None:
             args.cmap = DEFAULT_CMAP.name
-        return super(ImageProduct, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     @staticmethod
     def get_color_label():
@@ -809,7 +805,7 @@ class ImageProduct(CliProduct):
         """Set properties for each axis (scale, limits, label) and create
         a colorbar.
         """
-        super(ImageProduct, self).set_axes_properties()
+        super().set_axes_properties()
         if not self.args.nocolorbar:
             self.set_colorbar()
 
@@ -824,8 +820,7 @@ class ImageProduct(CliProduct):
         return  # image plots don't have legends
 
 
-@add_metaclass(abc.ABCMeta)
-class FFTMixin(object):
+class FFTMixin(object, metaclass=abc.ABCMeta):
     """Mixin for `CliProduct` class that will perform FFTs
 
     This just adds FFT-based command line options
@@ -834,7 +829,7 @@ class FFTMixin(object):
     def init_data_options(cls, parser):
         """Set up data input and signal processing options including FFTs
         """
-        super(FFTMixin, cls).init_data_options(parser)
+        super().init_data_options(parser)
         cls.arg_fft(parser)
 
     @classmethod
@@ -899,11 +894,10 @@ class FFTMixin(object):
                 args.overlap = recommended_overlap(args.window)
             except ValueError:
                 args.overlap = .5
-        return super(FFTMixin, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
 
-@add_metaclass(abc.ABCMeta)
-class TimeDomainProduct(CliProduct):
+class TimeDomainProduct(CliProduct, metaclass=abc.ABCMeta):
     """`CliProduct` with time on the X-axis
     """
     @classmethod
@@ -913,7 +907,7 @@ class TimeDomainProduct(CliProduct):
         This method includes the standard X-axis options, as well as a new
         ``--epoch`` option for the time axis.
         """
-        group = super(TimeDomainProduct, cls).arg_xaxis(parser)
+        group = super().arg_xaxis(parser)
         group.add_argument('--epoch', type=to_gps,
                            help='center X axis on this GPS time, may be'
                                 'absolute date/time or delta')
@@ -937,7 +931,7 @@ class TimeDomainProduct(CliProduct):
 
         if args.xmax is None:
             args.xmax = max(starts) + args.duration
-        return super(TimeDomainProduct, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     def get_xlabel(self):
         """Default X-axis label for plot
@@ -953,8 +947,7 @@ class TimeDomainProduct(CliProduct):
         return ''
 
 
-@add_metaclass(abc.ABCMeta)
-class FrequencyDomainProduct(CliProduct):
+class FrequencyDomainProduct(CliProduct, metaclass=abc.ABCMeta):
     """`CliProduct` with frequency on the X-axis
     """
     def get_xlabel(self):

--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -37,7 +37,7 @@ class Coherence(Spectrum):
     MIN_DATASETS = 2
 
     def __init__(self, *args, **kwargs):
-        super(Coherence, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.ref_chan = self.args.ref or self.chan_list[0]
         # deal with channel type appendages
         if ',' in self.ref_chan:
@@ -45,7 +45,7 @@ class Coherence(Spectrum):
 
     @classmethod
     def arg_channels(cls, parser):
-        group = super(Coherence, cls).arg_channels(parser)
+        group = super().arg_channels(parser)
         group.add_argument('--ref', help='Reference channel against which '
                                          'others will be compared')
         return group
@@ -58,7 +58,7 @@ class Coherence(Spectrum):
                 args.ymin = 0
             if not args.ymax:
                 args.ymax = 1.05
-        return super(Coherence, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     def get_ylabel(self):
         """Text for y-axis label
@@ -125,7 +125,7 @@ class Coherence(Spectrum):
     def set_legend(self):
         """Create a legend for this product
         """
-        leg = super(Coherence, self).set_legend()
+        leg = super().set_legend()
         if leg is not None:
             leg.set_title('Coherence with:')
         return leg

--- a/gwpy/cli/coherencegram.py
+++ b/gwpy/cli/coherencegram.py
@@ -37,7 +37,7 @@ class Coherencegram(Spectrogram):
     action = 'coherencegram'
 
     def __init__(self, *args, **kwargs):
-        super(Coherencegram, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.ref_chan = self.args.ref or self.chan_list[0]
         # deal with channel type (e.g. m-trend)
         if ',' in self.ref_chan:
@@ -45,7 +45,7 @@ class Coherencegram(Spectrogram):
 
     @classmethod
     def arg_channels(cls, parser):
-        group = super(Coherencegram, cls).arg_channels(parser)
+        group = super().arg_channels(parser)
         group.add_argument('--ref', help='Reference channel against which '
                                          'others will be compared')
         return group
@@ -60,7 +60,7 @@ class Coherencegram(Spectrogram):
                 args.imax = 1.
         if args.cmap is None and DEFAULT_CMAP is not None:
             args.cmap = DEFAULT_CMAP.name
-        return super(Coherencegram, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     def get_ylabel(self):
         """Text for y-axis label

--- a/gwpy/cli/gwpy_plot.py
+++ b/gwpy/cli/gwpy_plot.py
@@ -68,7 +68,7 @@ class HelpFormatter(ArgumentDefaultsHelpFormatter, RawTextHelpFormatter):
     def _format_usage(self, usage, actions, groups, prefix):
         if prefix is None:
             prefix = "Usage: "
-        return super(HelpFormatter, self)._format_usage(
+        return super()._format_usage(
             usage,
             actions,
             groups,
@@ -78,7 +78,7 @@ class HelpFormatter(ArgumentDefaultsHelpFormatter, RawTextHelpFormatter):
 
 class _ArgumentParser(ArgumentParser):
     def __init__(self, *args, **kwargs):
-        super(_ArgumentParser, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._positionals.title = 'Positional arguments'
         self._optionals.title = 'Options'
 

--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -36,7 +36,7 @@ class Qtransform(Spectrogram):
     action = 'qtransform'
 
     def __init__(self, *args, **kwargs):
-        super(Qtransform, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         args = self.args
         self.qxfrm_args = {
@@ -69,13 +69,13 @@ class Qtransform(Spectrogram):
 
     @classmethod
     def arg_signal(cls, parser):
-        group = super(Qtransform, cls).arg_signal(parser)
+        group = super().arg_signal(parser)
         group.add_argument('--sample-freq', type=float, default=2048,
                            help='Downsample freq')
 
     @classmethod
     def arg_plot(cls, parser):
-        group = super(Qtransform, cls).arg_plot(parser)
+        group = super().arg_plot(parser)
 
         # remove --out option
         outopt = [act for act in group._actions if act.dest == 'out'][0]
@@ -144,7 +144,7 @@ class Qtransform(Spectrogram):
         xmin = args.xmin
         xmax = args.xmax
 
-        super(Qtransform, self)._finalize_arguments(args)
+        super()._finalize_arguments(args)
 
         # unset defaults from `TimeDomainProduct`
         args.xmin = xmin
@@ -231,7 +231,7 @@ class Qtransform(Spectrogram):
 
     def scale_axes_from_data(self):
         self.args.xmin, self.args.xmax = self.result.xspan
-        return super(Qtransform, self).scale_axes_from_data()
+        return super().scale_axes_from_data()
 
     def has_more_plots(self):
         """any ranges left to plot?
@@ -244,4 +244,4 @@ class Qtransform(Spectrogram):
         png = '{0}-{1}-{2}.png'.format(cname, float(self.args.gps),
                                        self.args.plot[self.plot_num])
         outfile = os.path.join(outdir, png)
-        return super(Qtransform, self).save(outfile)
+        return super().save(outfile)

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -33,7 +33,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
     action = 'spectrogram'
 
     def __init__(self, *args, **kwargs):
-        super(Spectrogram, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         #: attribute to hold calculated Spectrogram data array
         self.result = None
@@ -45,7 +45,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
     def _finalize_arguments(self, args):
         if args.color_scale is None:
             args.color_scale = 'log'
-        super(Spectrogram, self)._finalize_arguments(args)
+        super()._finalize_arguments(args)
 
     @property
     def units(self):
@@ -73,7 +73,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
                 self.units[0].to_string('latex').strip('$'))
         elif len(self.units) == 1:
             return 'ASD ({0})'.format(self.units[0].to_string('generic'))
-        return super(Spectrogram, self).get_color_label()
+        return super().get_color_label()
 
     def get_stride(self):
         """Calculate the stride for the spectrogram

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -36,7 +36,7 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
     action = 'spectrum'
 
     def __init__(self, *args, **kwargs):
-        super(Spectrum, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.spectra = []
 
     @property
@@ -56,7 +56,7 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
     def _finalize_arguments(self, args):
         if args.yscale is None:
             args.yscale = 'log'
-        super(Spectrum, self)._finalize_arguments(args)
+        super()._finalize_arguments(args)
 
     def get_ylabel(self):
         """Text for y-axis label

--- a/gwpy/cli/tests/test_gwpy_plot.py
+++ b/gwpy/cli/tests/test_gwpy_plot.py
@@ -20,10 +20,7 @@
 """
 
 from pathlib import Path
-try:
-    from unittest import mock
-except ImportError:  # python < 3
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -44,7 +44,7 @@ class TimeSeries(TimeDomainProduct):
             return units[0].to_string()
         elif len(units) > 1:
             return 'Multiple units'
-        return super(TimeSeries, self).get_ylabel()
+        return super().get_ylabel()
 
     def get_suptitle(self):
         """Start of default super title, first channel is appended to it
@@ -52,7 +52,7 @@ class TimeSeries(TimeDomainProduct):
         return 'Time series: {0}'.format(self.chan_list[0])
 
     def get_title(self):
-        suffix = super(TimeSeries, self).get_title()
+        suffix = super().get_title()
         # limit significant digits for minute trends
         rates = {ts.sample_rate.round(3) for ts in self.timeseries}
         fss = '({0})'.format('), ('.join(map(str, rates)))

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -22,7 +22,6 @@
 import re
 from copy import copy
 from math import ceil
-
 from urllib.parse import urlparse
 
 from astropy import units

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -23,7 +23,7 @@ import re
 from copy import copy
 from math import ceil
 
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from astropy import units
 from astropy.io import registry as io_registry

--- a/gwpy/detector/io/cis.py
+++ b/gwpy/detector/io/cis.py
@@ -19,9 +19,6 @@
 """Interface to the LIGO Channel Information System
 """
 
-import json
-from urllib.error import HTTPError
-
 import numpy
 
 from .. import (Channel, ChannelList)

--- a/gwpy/detector/io/cis.py
+++ b/gwpy/detector/io/cis.py
@@ -19,6 +19,9 @@
 """Interface to the LIGO Channel Information System
 """
 
+import json
+from urllib.error import HTTPError
+
 import numpy
 
 from .. import (Channel, ChannelList)

--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -66,10 +66,8 @@ For example,
 """
 
 import re
+import configparser
 from collections import OrderedDict
-
-from six import string_types
-from six.moves import configparser
 
 from numpy import inf
 
@@ -107,7 +105,7 @@ def read_channel_list_file(*source):
         if 'flow' in params or 'fhigh' in params:
             low = params.pop('flow', 0)
             high = params.pop('fhigh', inf)
-            if isinstance(high, string_types) and high.lower() == 'nyquist':
+            if isinstance(high, str) and high.lower() == 'nyquist':
                 high = inf
             frange = float(low), float(high)
         else:

--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -103,7 +103,7 @@ class FrequencySeries(Series):
             kwargs['xindex'] = frequencies
 
         # generate FrequencySeries
-        return super(FrequencySeries, cls).__new__(
+        return super().__new__(
             cls, data, unit=unit, name=name, channel=channel,
             epoch=epoch, **kwargs)
 
@@ -201,7 +201,7 @@ class FrequencySeries(Series):
                 kwargs.setdefault('yscale', 'log')
 
         kwargs.update(xscale=xscale)
-        return super(FrequencySeries, self).plot(**kwargs)
+        return super().plot(**kwargs)
 
     def ifft(self):
         """Compute the one-dimensional discrete inverse Fourier

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -19,8 +19,6 @@
 """This module provides a spectral-variation histogram class
 """
 
-from six.moves import range
-
 import numpy
 
 from astropy.io import registry as io_registry

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -215,7 +215,7 @@ class SpectralVariance(Array2D):
     def __getitem__(self, item):
         # disable slicing bins
         if not isinstance(item, tuple) or null_slice(item[1]):
-            return super(SpectralVariance, self).__getitem__(item)
+            return super().__getitem__(item)
         raise NotImplementedError("cannot slice SpectralVariance across bins")
     __getitem__.__doc__ = Array2D.__getitem__.__doc__
 
@@ -357,4 +357,4 @@ class SpectralVariance(Array2D):
                 numpy.allclose(numpy.diff(numpy.log10(bins), n=2), 0)):
             kwargs.setdefault('yscale', 'log')
         kwargs.update(method=method, xscale=xscale)
-        return super(SpectralVariance, self).plot(**kwargs)
+        return super().plot(**kwargs)

--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -44,14 +44,14 @@ class TestSpectralVariance(_TestArray2D):
 
     @classmethod
     def setup_class(cls):
-        super(TestSpectralVariance, cls).setup_class()
+        super().setup_class()
         cls.bins = numpy.linspace(0, 1e5, cls.data.shape[1] + 1, endpoint=True)
 
     @classmethod
     def create(cls, *args, **kwargs):
         args = list(args)
         args.insert(0, cls.bins)
-        return super(TestSpectralVariance, cls).create(*args, **kwargs)
+        return super().create(*args, **kwargs)
 
     # -- test properties ------------------------
 

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -28,8 +28,6 @@ import warnings
 from collections import (namedtuple, OrderedDict)
 from pathlib import Path
 
-from six import string_types
-
 from ..time import LIGOTimeGPS
 from .utils import (FILE_LIKE, file_path)
 
@@ -239,7 +237,7 @@ def write_cache(cache, fobj, format=None):
         - ``'ffl'`` : write an FFL-format cache
     """
     # open file
-    if isinstance(fobj, string_types):
+    if isinstance(fobj, str):
         with open(fobj, 'w') as fobj2:
             return write_cache(cache, fobj2, format=format)
 
@@ -274,7 +272,7 @@ def is_cache(cache):
         `True` if the input object is a cache, or a file in LAL cache format,
         otherwise `False`
     """
-    if isinstance(cache, string_types + FILE_LIKE):
+    if isinstance(cache, str + FILE_LIKE):
         try:
             return bool(len(read_cache(cache)))
         except (TypeError, ValueError, UnicodeDecodeError, ImportError):

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -272,7 +272,7 @@ def is_cache(cache):
         `True` if the input object is a cache, or a file in LAL cache format,
         otherwise `False`
     """
-    if isinstance(cache, str + FILE_LIKE):
+    if isinstance(cache, (str,) + FILE_LIKE):
         try:
             return bool(len(read_cache(cache)))
         except (TypeError, ValueError, UnicodeDecodeError, ImportError):

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -40,8 +40,8 @@ import re
 import warnings
 from functools import wraps
 
-from six.moves.http_client import HTTPException
-from six.moves.urllib.parse import urlparse
+from http.client import HTTPException
+from urllib.parse import urlparse
 
 from ligo.segments import (
     segment as LigoSegment,

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -39,7 +39,6 @@ import os.path
 import re
 import warnings
 from functools import wraps
-
 from http.client import HTTPException
 from urllib.parse import urlparse
 

--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -20,9 +20,7 @@
 """
 
 import warnings
-
-import six
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 import numpy
 
@@ -33,10 +31,7 @@ from .cache import read_cache
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 # first 4 bytes of any valid GWF file (see LIGO-T970130 §4.3.1)
-if six.PY2:
-    GWF_SIGNATURE = 'IGWD'
-else:
-    GWF_SIGNATURE = b'IGWD'
+GWF_SIGNATURE = b'IGWD'
 
 
 # -- i/o ----------------------------------------------------------------------

--- a/gwpy/io/kerberos.py
+++ b/gwpy/io/kerberos.py
@@ -31,8 +31,6 @@ import subprocess
 import sys
 from collections import OrderedDict
 
-from six.moves import input
-
 from ..utils.shell import which
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -22,21 +22,13 @@ All specific unified input/output for class objects should be placed in
 an 'io' subdirectory of the containing directory for that class.
 """
 
+import builtins
 import os.path
 import re
 from contextlib import contextmanager
 from functools import wraps
 from importlib import import_module
 from numbers import Integral
-
-# note: because the "future" module provides a builtins namespace,
-# we need to do this the other way around compared to normal
-try:
-    import __builtin__ as builtins
-except ImportError:  # python >= 3
-    import builtins
-
-from six import string_types
 
 import numpy
 
@@ -415,7 +407,7 @@ def open_xmldoc(fobj, **kwargs):
     use_in(kwargs.setdefault('contenthandler', LIGOLWContentHandler))
 
     try:  # try and load existing file
-        if isinstance(fobj, string_types):
+        if isinstance(fobj, str):
             return load_filename(fobj, **kwargs)
         if isinstance(fobj, FILE_LIKE):
             return load_fileobj(fobj, **kwargs)[0]
@@ -530,7 +522,7 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
             target, contenthandler=kwargs.pop('contenthandler',
                                               LIGOLWContentHandler))
     # fail on existing document and not overwriting
-    elif (not overwrite and isinstance(target, string_types) and
+    elif (not overwrite and isinstance(target, str) and
           os.path.isfile(target)):
         raise IOError("File exists: {}".format(target))
     else:  # or create a new document
@@ -540,7 +532,7 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
     write_tables_to_document(xmldoc, tables, overwrite=overwrite)
 
     # write file
-    if isinstance(target, string_types):
+    if isinstance(target, str):
         kwargs.setdefault('gz', target.endswith('.gz'))
         ligolw_utils.write_filename(xmldoc, target, **kwargs)
     elif isinstance(target, FILE_LIKE):

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -199,7 +199,7 @@ def build_content_handler(parent, filter_func):
     class _ContentHandler(parent):
         # pylint: disable=too-few-public-methods
         def __init__(self, document):
-            super(_ContentHandler, self).__init__(document, filter_func)
+            super().__init__(document, filter_func)
 
     return use_in(_ContentHandler)
 

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -28,8 +28,6 @@ import warnings
 from collections import OrderedDict
 from functools import wraps
 
-from six.moves import reduce
-
 from ..time import to_gps
 from ..utils.enum import NumpyTypeEnum
 from .kerberos import kinit

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -26,7 +26,7 @@ import os
 import re
 import warnings
 from collections import OrderedDict
-from functools import wraps
+from functools import (reduce, wraps)
 
 from ..time import to_gps
 from ..utils.enum import NumpyTypeEnum

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -22,9 +22,7 @@
 import os
 from io import BytesIO
 from itertools import cycle
-
-import six
-from six.moves.http_client import (HTTPConnection, HTTPException)
+from http.client import (HTTPConnection, HTTPException)
 
 import pytest
 
@@ -36,10 +34,7 @@ from .. import datafind as io_datafind
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-if six.PY2:
-    OPEN = '__builtin__.open'
-else:
-    OPEN = 'builtins.open'
+OPEN = 'builtins.open'
 
 # -- mock the environment -----------------------------------------------------
 

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -20,9 +20,9 @@
 """
 
 import os
+from http.client import (HTTPConnection, HTTPException)
 from io import BytesIO
 from itertools import cycle
-from http.client import (HTTPConnection, HTTPException)
 
 import pytest
 

--- a/gwpy/io/tests/test_gwf.py
+++ b/gwpy/io/tests/test_gwf.py
@@ -19,7 +19,7 @@
 """Unit tests for :mod:`gwpy.io.gwf`
 """
 
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 
 import pytest
 

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -21,24 +21,16 @@
 
 import gzip
 import tempfile
-
-from six import string_types
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 # build list of file-like types
-try:  # python < 3
-    FILE_LIKE = (
-        file, gzip.GzipFile,
-        tempfile._TemporaryFileWrapper,  # pylint: disable=protected-access
-    )
-except NameError:  # python >= 3
-    from io import IOBase
-    FILE_LIKE = (
-        IOBase, gzip.GzipFile,
-        tempfile._TemporaryFileWrapper,  # pylint: disable=protected-access
-    )
+from io import IOBase
+FILE_LIKE = (
+    IOBase, gzip.GzipFile,
+    tempfile._TemporaryFileWrapper,  # pylint: disable=protected-access
+)
 
 GZIP_SIGNATURE = b'\x1f\x8b\x08'
 
@@ -64,7 +56,7 @@ def identify_factory(*extensions):
         """Identify the given extensions in a file object/path
         """
         # pylint: disable=unused-argument
-        if (isinstance(filepath, string_types) and
+        if (isinstance(filepath, str) and
                 filepath.endswith(extensions)):
             return True
         return False
@@ -134,13 +126,13 @@ def file_list(flist):
         if the input `flist` cannot be interpreted as any of the above inputs
     """
     # open a cache file and return list of paths
-    if (isinstance(flist, string_types) and
+    if (isinstance(flist, str) and
             flist.endswith(('.cache', '.lcf', '.ffl'))):
         from .cache import read_cache
         return read_cache(flist)
 
     # separate comma-separate list of names
-    if isinstance(flist, string_types):
+    if isinstance(flist, str):
         return flist.split(',')
 
     # parse list of entries (of some format)
@@ -189,9 +181,9 @@ def file_path(fobj):
     >>> file_path("file:///home/user/test.txt")
     '/home/user/test.txt'
     """
-    if isinstance(fobj, string_types) and fobj.startswith("file:"):
+    if isinstance(fobj, str) and fobj.startswith("file:"):
         return urlparse(fobj).path
-    if isinstance(fobj, string_types):
+    if isinstance(fobj, str):
         return fobj
     if (isinstance(fobj, FILE_LIKE) and hasattr(fobj, "name")):
         return fobj.name

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -103,7 +103,7 @@ def restore_grid(func):
 
 class Axes(_Axes):
     def __init__(self, *args, **kwargs):
-        super(Axes, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # handle Series in `ax.plot()`
         self._get_lines = PlotArgsProcessor(self)
@@ -129,7 +129,7 @@ class Axes(_Axes):
                     unit, utc, epoch))
 
         try:
-            super(Axes, self).draw(*args, **kwargs)
+            super().draw(*args, **kwargs)
         finally:
             for ax in labels:  # reset labels
                 ax.isDefault_label = True
@@ -191,7 +191,7 @@ class Axes(_Axes):
                 y = numpy.asarray(y)[sortidx]
                 c = numpy.asarray(c)[sortidx]
 
-        return super(Axes, self).scatter(x, y, c=c, **kwargs)
+        return super().scatter(x, y, c=c, **kwargs)
 
     scatter.__doc__ = _Axes.scatter.__doc__.replace(
         'marker :',
@@ -233,7 +233,7 @@ class Axes(_Axes):
         if hasattr(array, "yspan"):  # Array2D
             return self._imshow_array2d(array, *args, **kwargs)
 
-        image = super(Axes, self).imshow(array, *args, **kwargs)
+        image = super().imshow(array, *args, **kwargs)
         self.autoscale(enable=None, axis='both', tight=None)
         return image
 
@@ -278,7 +278,7 @@ class Axes(_Axes):
         """
         if len(args) == 1 and hasattr(args[0], "yindex"):  # Array2D
             return self._pcolormesh_array2d(*args, **kwargs)
-        return super(Axes, self).pcolormesh(*args, **kwargs)
+        return super().pcolormesh(*args, **kwargs)
 
     def _pcolormesh_array2d(self, array, *args, **kwargs):
         """Render an `~gwpy.types.Array2D` using `Axes.pcolormesh`
@@ -323,7 +323,7 @@ class Axes(_Axes):
                 log(hrange[0], logbase), log(hrange[1], logbase),
                 nbins+1, endpoint=True)
 
-        return super(Axes, self).hist(x, *args, **kwargs)
+        return super().hist(x, *args, **kwargs)
 
     hist.__doc__ = _Axes.hist.__doc__.replace(
         'color :',
@@ -523,7 +523,7 @@ class Axes(_Axes):
             handler_map.setdefault(Line2D, HandlerLine2D(linewidth or 6))
 
         # create legend
-        return super(Axes, self).legend(*args, **kwargs)
+        return super().legend(*args, **kwargs)
 
     legend.__doc__ = _Axes.legend.__doc__.replace(
         "Call signatures",
@@ -613,4 +613,4 @@ class PlotArgsProcessor(_process_plot_var_args):
                 args = args[1:]
             newargs.extend(this)
 
-        return super(PlotArgsProcessor, self).__call__(*newargs, **kwargs)
+        return super().__call__(*newargs, **kwargs)

--- a/gwpy/plot/bode.py
+++ b/gwpy/plot/bode.py
@@ -105,7 +105,7 @@ class BodePlot(Plot):
                 figargs[key] = kwargs.pop(key)
 
         # generate figure
-        super(BodePlot, self).__init__(**figargs)
+        super().__init__(**figargs)
 
         # delete the axes, and create two more
         self.add_subplot(2, 1, 1)

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -84,7 +84,7 @@ class GPSMixin(object):
         self.set_unit(kwargs.pop('unit', None))
         self.set_epoch(kwargs.pop('epoch', None))
         try:  # call super for __init__ if this is part of a larger MRO
-            super(GPSMixin, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
         except TypeError:  # otherwise return
             pass
 
@@ -188,7 +188,7 @@ class GPSTransformBase(GPSMixin, Transform):
         # format ticks using decimal for precision display
         if isinstance(values, (Number, Decimal)):
             return self._transform_decimal(values, self.epoch or 0, self.scale)
-        return super(GPSTransformBase, self).transform(values)
+        return super().transform(values)
 
     def transform_non_affine(self, values):
         """Transform an array of GPS times.
@@ -291,8 +291,7 @@ class GPSAutoLocator(ticker.MaxNLocator):
         Each of the `epoch` and `scale` keyword arguments should match those
         passed to the `GPSFormatter`
         """
-        super(GPSAutoLocator, self).__init__(nbins=nbins, steps=steps,
-                                             **kwargs)
+        super().__init__(nbins=nbins, steps=steps, **kwargs)
 
     def tick_values(self, vmin, vmax):
         transform = self.axis.get_transform()
@@ -308,7 +307,7 @@ class GPSAutoLocator(ticker.MaxNLocator):
             self.set_params(steps=None)
 
         try:
-            ticks = super(GPSAutoLocator, self).tick_values(vmin, vmax)
+            ticks = super().tick_values(vmin, vmax)
         finally:
             self._steps = steps
         return transform.inverted().transform(ticks)
@@ -395,7 +394,7 @@ class GPSScale(GPSMixin, LinearScale):
         unit:
             either name (`str`) or scale (float in seconds)
         """
-        super(GPSScale, self).__init__(unit=unit, epoch=epoch)
+        super().__init__(unit=unit, epoch=epoch)
         self.axis = axis
         # set tight scaling on parent axes
         getattr(axis.axes, 'set_{0}margin'.format(axis.axis_name))(0)
@@ -487,7 +486,7 @@ def _gps_scale_factory(unit):
         def __init__(self, axis, epoch=None):
             """
             """
-            super(FixedGPSScale, self).__init__(axis, epoch=epoch, unit=unit)
+            super().__init__(axis, epoch=epoch, unit=unit)
     return FixedGPSScale
 
 

--- a/gwpy/plot/legend.py
+++ b/gwpy/plot/legend.py
@@ -41,11 +41,11 @@ class HandlerLine2D(legend_handler.HandlerLine2D):
         for all information
     """
     def __init__(self, linewidth=6., **kw):
-        super(HandlerLine2D, self).__init__(**kw)
+        super().__init__(**kw)
         self._linewidth = linewidth
 
     def create_artists(self, *args, **kwargs):
-        line, marker = super(HandlerLine2D, self).create_artists(
+        line, marker = super().create_artists(
             *args,
             **kwargs
         )

--- a/gwpy/plot/log.py
+++ b/gwpy/plot/log.py
@@ -67,7 +67,7 @@ class MinorLogFormatterMathtext(GWpyLogFormatterMathtext):
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('labelOnlyBase', False)
-        super(MinorLogFormatterMathtext, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __call__(self, x, pos=None):
         """Format the minor tick label if less than 2 visible major ticks.
@@ -81,7 +81,7 @@ class MinorLogFormatterMathtext(GWpyLogFormatterMathtext):
         # if already two major ticks, don't need minor labels
         if nticks >= 2 or (halfdecade and not is_decade(x * 2, self._base)):
             return ''
-        return super(MinorLogFormatterMathtext, self).__call__(x, pos=pos)
+        return super().__call__(x, pos=pos)
 
 
 class CombinedLogFormatterMathtext(MinorLogFormatterMathtext):
@@ -98,7 +98,7 @@ class CombinedLogFormatterMathtext(MinorLogFormatterMathtext):
         if is_decade(x, self._base):
             # pylint: disable=bad-super-call
             return super(MinorLogFormatterMathtext, self).__call__(x, pos=pos)
-        return super(CombinedLogFormatterMathtext, self).__call__(x, pos=pos)
+        return super().__call__(x, pos=pos)
 
 
 class GWpyLogScale(LogScale):

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -122,7 +122,7 @@ class Plot(figure.Figure):
         # create Figure
         num = kwargs.pop('num', max(pyplot.get_fignums() or {0}) + 1)
         self._parse_subplotpars(kwargs)
-        super(Plot, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.number = num
 
         # add interactivity (scraped from pyplot.figure())
@@ -278,7 +278,7 @@ class Plot(figure.Figure):
                 block = False
 
         # render
-        super(Plot, self).show(warn=warn)
+        super().show(warn=warn)
 
         # don't block on ipython with interactive backends
         if block is None and interactive_backend():
@@ -400,7 +400,7 @@ class Plot(figure.Figure):
             self, mappable, ax, cax=cax, fraction=fraction, **kwargs)
 
         # generate colour bar
-        cbar = super(Plot, self).colorbar(mappable, **kwargs)
+        cbar = super().colorbar(mappable, **kwargs)
         self.colorbars.append(cbar)
         if label:  # mpl<1.3 doesn't accept label in Colorbar constructor
             cbar.set_label(label)

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -22,12 +22,8 @@
 import itertools
 import importlib
 import warnings
-try:
-    from collections.abc import (KeysView, ValuesView)
-except ImportError:  # python < 3.3
-    from collections import (KeysView, ValuesView)
-
-from six.moves import zip_longest
+from collections.abc import (KeysView, ValuesView)
+from itertools import zip_longest
 
 import numpy
 

--- a/gwpy/plot/segments.py
+++ b/gwpy/plot/segments.py
@@ -71,7 +71,7 @@ class SegmentAxes(Axes):
         kwargs.setdefault('insetlabels', False)
 
         # make axes
-        super(SegmentAxes, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # set y-axis labels
         self.yaxis.set_major_locator(MultipleLocator())
@@ -130,7 +130,7 @@ class SegmentAxes(Axes):
             out.append(plotter(args[0], **kwargs))
             args.pop(0)
         if args:
-            out.extend(super(SegmentAxes, self).plot(*args, **kwargs))
+            out.extend(super().plot(*args, **kwargs))
         self.autoscale(enable=None, axis='both', tight=False)
         return out
 
@@ -434,7 +434,7 @@ class SegmentAxes(Axes):
                     del tick._orig_bbox
                     del tick._orig_ha
                     del tick._orig_pos
-        return super(SegmentAxes, self).draw(*args, **kwargs)
+        return super().draw(*args, **kwargs)
 
     draw.__doc__ = Axes.draw.__doc__
 
@@ -499,6 +499,6 @@ class SegmentRectangle(Rectangle):
                              "'bottom'")
         width = segment[1] - segment[0]
 
-        super(SegmentRectangle, self).__init__((segment[0], y0), width=width,
-                                               height=height, **kwargs)
+        super().__init__((segment[0], y0), width=width,
+                         height=height, **kwargs)
         self.segment = segment

--- a/gwpy/plot/units.py
+++ b/gwpy/plot/units.py
@@ -31,7 +31,7 @@ class LatexInlineDimensional(LatexInline):
 
     @classmethod
     def to_string(cls, unit):
-        u = '[{0}]'.format(super(LatexInlineDimensional, cls).to_string(unit))
+        u = '[{0}]'.format(super().to_string(unit))
 
         if unit.physical_type not in {None, 'unknown', 'dimensionless'}:
             ptype = cls._latex_escape(unit.physical_type.title())

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -35,6 +35,7 @@ import warnings
 from io import BytesIO
 from collections import OrderedDict
 from copy import (copy as shallowcopy, deepcopy)
+from functools import reduce
 from math import (floor, ceil)
 from queue import Queue
 from threading import Thread

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -36,12 +36,10 @@ from io import BytesIO
 from collections import OrderedDict
 from copy import (copy as shallowcopy, deepcopy)
 from math import (floor, ceil)
+from queue import Queue
 from threading import Thread
-
-from six.moves import reduce
-from six.moves.urllib.error import (URLError, HTTPError)
-from six.moves.urllib.parse import urlparse
-from six.moves.queue import Queue
+from urllib.error import (URLError, HTTPError)
+from urllib.parse import urlparse
 
 from numpy import inf
 

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1704,7 +1704,7 @@ class DataQualityDict(OrderedDict):
         """
         if deep:
             return deepcopy(self)
-        return super(DataQualityDict, self).copy()
+        return super().copy()
 
     def __iand__(self, other):
         for key, value in other.items():

--- a/gwpy/segments/io/json.py
+++ b/gwpy/segments/io/json.py
@@ -21,8 +21,6 @@
 
 import json
 
-from six import string_types
-
 from ...io import registry
 from ...io.utils import identify_factory
 from .. import DataQualityFlag
@@ -36,7 +34,7 @@ def read_json_flag(fobj):
     """Read a `DataQualityFlag` from a segments-web.ligo.org JSON file
     """
     # read from filename
-    if isinstance(fobj, string_types):
+    if isinstance(fobj, str):
         with open(fobj, 'r') as fobj2:
             return read_json_flag(fobj2)
 
@@ -85,7 +83,7 @@ def write_json_flag(flag, fobj, **kwargs):
         for details on acceptable keyword arguments
     """
     # write to filename
-    if isinstance(fobj, string_types):
+    if isinstance(fobj, str):
         with open(fobj, 'w') as fobj2:
             return write_json_flag(flag, fobj2, **kwargs)
 

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -21,8 +21,6 @@
 
 import operator
 
-from six.moves import reduce
-
 from astropy.io import registry as io_registry
 
 from ...io.ligolw import (is_xml, build_content_handler, read_ligolw,

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -20,6 +20,7 @@
 """
 
 import operator
+from functools import reduce
 
 from astropy.io import registry as io_registry
 

--- a/gwpy/segments/io/segwizard.py
+++ b/gwpy/segments/io/segwizard.py
@@ -21,8 +21,6 @@
 
 import re
 
-from six import string_types
-
 from .. import (Segment, SegmentList)
 from ...io import registry
 from ...io.utils import identify_factory
@@ -71,7 +69,7 @@ def from_segwizard(source, gpstype=LIGOTimeGPS, strict=True):
     distributed under GPLv3.
     """
     # read file path
-    if isinstance(source, string_types):
+    if isinstance(source, str):
         with open(source, 'r') as fobj:
             return from_segwizard(fobj, gpstype=gpstype, strict=strict)
 
@@ -141,7 +139,7 @@ def to_segwizard(segs, target, header=True, coltype=LIGOTimeGPS):
     distributed under GPLv3.
     """
     # write file path
-    if isinstance(target, string_types):
+    if isinstance(target, str):
         with open(target, 'w') as fobj:
             return to_segwizard(segs, fobj, header=header, coltype=coltype)
 

--- a/gwpy/segments/segments.py
+++ b/gwpy/segments/segments.py
@@ -138,7 +138,7 @@ class SegmentList(segmentlist):
     extent = return_as(Segment)(segmentlist.extent)
 
     def coalesce(self):
-        super(SegmentList, self).coalesce()
+        super().coalesce()
         for i, seg in enumerate(self):
             self[i] = Segment(seg[0], seg[1])
         return self

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -24,8 +24,7 @@ import re
 import tempfile
 from io import BytesIO
 from ssl import SSLError
-
-from six.moves.urllib.error import (URLError, HTTPError)
+from urllib.error import (URLError, HTTPError)
 
 import pytest
 

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -22,8 +22,6 @@
 import operator
 from math import (pi, log10)
 
-from six.moves import reduce
-
 import numpy
 from numpy import fft as npfft
 

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -20,6 +20,7 @@
 """
 
 import operator
+from functools import reduce
 from math import (pi, log10)
 
 import numpy

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -76,7 +76,7 @@ class QBase(QObject):
     This class just provides a property for Q-prime = Q / sqrt(11)
     """
     def __init__(self, q, duration, sampling, mismatch=DEFAULT_MISMATCH):
-        super(QBase, self).__init__(duration, sampling, mismatch=mismatch)
+        super().__init__(duration, sampling, mismatch=mismatch)
         self.q = float(q)
 
     @property
@@ -113,7 +113,7 @@ class QTiling(QObject):
                  qrange=DEFAULT_QRANGE,
                  frange=DEFAULT_FRANGE,
                  mismatch=DEFAULT_MISMATCH):
-        super(QTiling, self).__init__(duration, sampling, mismatch=mismatch)
+        super().__init__(duration, sampling, mismatch=mismatch)
         self.qrange = (float(qrange[0]), float(qrange[1]))
         self.frange = [float(frange[0]), float(frange[1])]
 
@@ -228,7 +228,7 @@ class QPlane(QBase):
     """
     def __init__(self, q, frange, duration, sampling,
                  mismatch=DEFAULT_MISMATCH):
-        super(QPlane, self).__init__(q, duration, sampling, mismatch=mismatch)
+        super().__init__(q, duration, sampling, mismatch=mismatch)
         self.frange = [float(frange[0]), float(frange[1])]
 
         if self.frange[0] == 0:  # set non-zero lower frequency
@@ -336,7 +336,7 @@ class QTile(QBase):
     """
     def __init__(self, q, frequency, duration, sampling,
                  mismatch=DEFAULT_MISMATCH):
-        super(QTile, self).__init__(q, duration, sampling, mismatch=mismatch)
+        super().__init__(q, duration, sampling, mismatch=mismatch)
         self.frequency = frequency
 
     @property

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -26,9 +26,6 @@ authors.
 import warnings
 from math import (log, ceil, pi, isinf, exp)
 
-from six import string_types
-from six.moves import xrange
-
 import numpy
 from numpy import fft as npfft
 
@@ -150,7 +147,7 @@ class QTiling(QObject):
         cumum = log(self.qrange[1] / self.qrange[0]) / 2**(1/2.)
         nplanes = int(max(ceil(cumum / self.deltam), 1))
         dq = cumum / nplanes  # pylint: disable=invalid-name
-        for i in xrange(nplanes):
+        for i in range(nplanes):
             yield self.qrange[0] * exp(2**(1/2.) * dq * (i + .5))
 
     def __iter__(self):
@@ -257,7 +254,7 @@ class QPlane(QBase):
         fstepmin = 1 / self.duration
         # for each frequency, yield a QTile
         last = None
-        for i in xrange(nfreq):
+        for i in range(nfreq):
             this = (
                 minf * exp(2 / (2 + self.q**2)**(1/2.) * (i + .5) * fstep) //
                 fstepmin * fstepmin
@@ -441,7 +438,7 @@ class QTile(QBase):
             x0=cenergy.x0, dx=cenergy.dx, copy=False)
 
         if norm:
-            norm = norm.lower() if isinstance(norm, string_types) else norm
+            norm = norm.lower() if isinstance(norm, str) else norm
             if norm in (True, 'median'):
                 narray = energy / energy.median()
             elif norm in ('mean',):

--- a/gwpy/signal/spectral/_ui.py
+++ b/gwpy/signal/spectral/_ui.py
@@ -24,8 +24,6 @@ so isn't really for direct user interaction.
 
 from functools import wraps
 
-from six import string_types
-
 import numpy
 
 from scipy.signal import (
@@ -178,7 +176,7 @@ def _normalize_overlap(overlap, window, nfft, samp, method='welch'):
     """
     if method == 'bartlett':
         return 0
-    if overlap is None and isinstance(window, string_types):
+    if overlap is None and isinstance(window, str):
         return recommended_overlap(window, nfft)
     if overlap is None:
         return 0
@@ -214,9 +212,9 @@ def _normalize_window(window, nfft, library, dtype):
     if library == '_lal':
         from ._lal import generate_window
         return generate_window(nfft, window=window, dtype=dtype)
-    if isinstance(window, string_types):
+    if isinstance(window, str):
         window = canonical_name(window)
-    if isinstance(window, string_types + (tuple,)):
+    if isinstance(window, (str, tuple)):
         return get_window(window, nfft)
     return window
 

--- a/gwpy/signal/tests/test_spectral_median_mean.py
+++ b/gwpy/signal/tests/test_spectral_median_mean.py
@@ -19,10 +19,7 @@
 """Unit test for :mod:`gwpy.signal.spectral._median_mean`
 """
 
-try:
-    from unittest import mock
-except ImportError:  # python < 3
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/gwpy/spectrogram/spectrogram.py
+++ b/gwpy/spectrogram/spectrogram.py
@@ -21,8 +21,6 @@
 
 import warnings
 
-from six import string_types
-
 import numpy
 
 from astropy import units
@@ -307,7 +305,7 @@ class Spectrogram(Array2D):
         ValueError
             if ``operand`` is given as a `str` that isn't supported
         """
-        if isinstance(operand, string_types):
+        if isinstance(operand, str):
             if operand == 'mean':
                 operand = self.mean(axis=0)
             elif operand == 'median':

--- a/gwpy/spectrogram/spectrogram.py
+++ b/gwpy/spectrogram/spectrogram.py
@@ -159,8 +159,8 @@ class Spectrogram(Array2D):
             kwargs['yindex'] = frequencies
 
         # generate Spectrogram
-        return super(Spectrogram, cls).__new__(cls, data, unit=unit, name=name,
-                                               channel=channel, **kwargs)
+        return super().__new__(cls, data, unit=unit, name=name,
+                               channel=channel, **kwargs)
 
     # -- Spectrogram properties -----------------
 
@@ -353,7 +353,7 @@ class Spectrogram(Array2D):
             kwargs.setdefault('method', 'imshow' if kwargs.pop('imshow') else
                                         'pcolormesh')
         kwargs.update(figsize=figsize, xscale=xscale)
-        return super(Spectrogram, self).plot(**kwargs)
+        return super().plot(**kwargs)
 
     @classmethod
     def from_spectra(cls, *spectra, **kwargs):
@@ -592,8 +592,7 @@ class Spectrogram(Array2D):
     # -- Spectrogram ufuncs ---------------------
 
     def _wrap_function(self, function, *args, **kwargs):
-        out = super(Spectrogram, self)._wrap_function(
-            function, *args, **kwargs)
+        out = super()._wrap_function(function, *args, **kwargs)
         # requested frequency axis, return a FrequencySeries
         if out.ndim == 1 and out.x0.unit == self.y0.unit:
             return FrequencySeries(out.value, name=out.name, unit=out.unit,
@@ -610,7 +609,7 @@ class Spectrogram(Array2D):
     # -- other ----------------------------------
 
     def __getitem__(self, item):
-        out = super(Spectrogram, self).__getitem__(item)
+        out = super().__getitem__(item)
 
         # set epoch manually, because Spectrogram doesn't store self._epoch
         if isinstance(out, self._columnclass):

--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -44,7 +44,7 @@ class TestSpectrogram(_TestArray2D):
     TEST_CLASS = Spectrogram
 
     def test_new(self):
-        super(TestSpectrogram, self).test_new()
+        super().test_new()
 
         # check handling of epoch vs t0
         a = self.create(epoch=10)
@@ -63,7 +63,7 @@ class TestSpectrogram(_TestArray2D):
         assert array.epoch.gps == array.x0.value
 
     def test_value_at(self, array):
-        super(TestSpectrogram, self).test_value_at(array)
+        super().test_value_at(array)
         v = array.value_at(5000 * units.millisecond,
                            2000 * units.milliHertz)
         assert v == self.data[5][2] * array.unit

--- a/gwpy/table/filter.py
+++ b/gwpy/table/filter.py
@@ -20,13 +20,11 @@
 """
 
 import operator
-import token
 import re
-from tokenize import generate_tokens
+import token
 from collections import OrderedDict
-
-from six import string_types
-from six.moves import StringIO
+from io import StringIO
+from tokenize import generate_tokens
 
 import numpy
 
@@ -194,10 +192,10 @@ def parse_column_filters(*definitions):
 def _flatten(container):
     """Flatten arbitrary nested list of filters into a 1-D list
     """
-    if isinstance(container, string_types):
+    if isinstance(container, str):
         container = [container]
     for elem in container:
-        if isinstance(elem, string_types) or is_filter_tuple(elem):
+        if isinstance(elem, str) or is_filter_tuple(elem):
             yield elem
         else:
             for elem2 in _flatten(elem):
@@ -209,7 +207,7 @@ def is_filter_tuple(tup):
     """
     return isinstance(tup, (tuple, list)) and (
         len(tup) == 3 and
-        isinstance(tup[0], string_types) and
+        isinstance(tup[0], str) and
         callable(tup[1]))
 
 

--- a/gwpy/table/gravityspy.py
+++ b/gwpy/table/gravityspy.py
@@ -19,12 +19,18 @@
 """Extend :mod:`astropy.table` with the `GravitySpyTable`
 """
 
-import os.path
+import json
+import os
+from urllib.error import HTTPError
+from urllib.parse import urlencode
 from urllib.request import urlopen
+
+import numpy as np
+
+from astropy.utils.data import get_readable_fileobj
 
 from ..utils import mp as mp_utils
 from .table import EventTable
-import numpy as np
 
 __author__ = 'Scott Coughlin <scott.coughlin@ligo.org>'
 __all__ = ['GravitySpyTable']
@@ -71,7 +77,6 @@ class GravitySpyTable(EventTable):
         -------
         Folder containing omega scans sorted by label
         """
-        import os
         # back to pandas
         try:
             images_db = self.to_pandas()
@@ -191,11 +196,6 @@ class GravitySpyTable(EventTable):
         an evaluation of the Euclidean distance of the input image
         to all other images in some Feature Space
         """
-        from astropy.utils.data import get_readable_fileobj
-        import json
-        import urllib
-        from urllib.error import HTTPError
-
         # Need to build the url call for the restful API
         base = 'https://gravityspytools.ciera.northwestern.edu' + \
             '/search/similarity_search_restful_API'
@@ -218,7 +218,7 @@ class GravitySpyTable(EventTable):
             'database': 'similarity_index_o3',
         }
 
-        search = urllib.parse.urlencode(parts)
+        search = urlencode(parts)
 
         url = '{}/?{}'.format(base, search)
 

--- a/gwpy/table/gravityspy.py
+++ b/gwpy/table/gravityspy.py
@@ -20,8 +20,7 @@
 """
 
 import os.path
-
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 
 from ..utils import mp as mp_utils
 from .table import EventTable
@@ -194,8 +193,8 @@ class GravitySpyTable(EventTable):
         """
         from astropy.utils.data import get_readable_fileobj
         import json
-        from six.moves.urllib.error import HTTPError
-        from six.moves import urllib
+        import urllib
+        from urllib.error import HTTPError
 
         # Need to build the url call for the restful API
         base = 'https://gravityspytools.ciera.northwestern.edu' + \

--- a/gwpy/table/io/fetch.py
+++ b/gwpy/table/io/fetch.py
@@ -21,8 +21,6 @@
 
 import re
 
-from six import string_types
-
 from astropy.io import registry as io_registry
 from astropy.table import Table
 
@@ -98,7 +96,7 @@ def _update__doc__(data_class):
     fetch = data_class.fetch
 
     # if __doc__ isn't a string, bail-out now
-    if not isinstance(fetch.__doc__, string_types):
+    if not isinstance(fetch.__doc__, str):
         return
 
     # remove the old format list

--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -19,8 +19,6 @@
 """Read events from ROOT trees into Tables
 """
 
-from six import string_types
-
 from ...io import registry
 from ...io.utils import identify_factory
 from ..filter import (OPERATORS, parse_column_filters, filter_table)
@@ -54,7 +52,7 @@ def table_from_root(source, treename=None, columns=None, **kwargs):
         kwargs['selection'] = ' && '.join(rootfilters)
 
     # pass file name (not path)
-    if not isinstance(source, string_types):
+    if not isinstance(source, str):
         source = source.name
 
     # find single tree (if only one tree present)

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -112,7 +112,7 @@ class EventColumn(Column):
     def __new__(cls, *args, **kwargs):
         warnings.warn("the EventColumn is deprecated, and will be removed in "
                       "a future gwpy release", DeprecationWarning)
-        super(EventColumn, cls).__new__(*args, **kwargs)
+        super().__new__(*args, **kwargs)
 
     def in_segmentlist(self, segmentlist):
         """Return the index of values lying inside the given segmentlist

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -24,8 +24,6 @@ from functools import wraps
 from operator import attrgetter
 from math import ceil
 
-from six import string_types
-
 import numpy
 
 from gwosc.api import DEFAULT_URL as DEFAULT_GWOSC_URL
@@ -508,7 +506,7 @@ class EventTable(Table):
             bins = [(-numpy.inf, numpy.inf)]
         if operator == 'in' and not isinstance(bins[0], tuple):
             bins = [(bin_, bins[i+1]) for i, bin_ in enumerate(bins[:-1])]
-        elif isinstance(operator, string_types):
+        elif isinstance(operator, str):
             op_func = parse_operator(operator)
         else:
             op_func = operator

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -21,8 +21,7 @@
 
 from socket import timeout
 from ssl import SSLError
-
-from six.moves.urllib.error import URLError
+from urllib.error import URLError
 
 import pytest
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -26,8 +26,6 @@ from io import BytesIO
 from ssl import SSLError
 from urllib.error import URLError
 
-from six import PY2
-
 import pytest
 
 import sqlparse
@@ -169,8 +167,6 @@ class TestTable(object):
                 t3 = self.TABLE.read([tmp, tmp], format='ligolw',
                                      tablename='sngl_burst')
             except NameError as e:
-                if not PY2:  # ligolw not patched for python3 just yet
-                    pytest.xfail(str(e))
                 raise
             utils.assert_table_equal(vstack((t2, t2)), t3)
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -163,11 +163,8 @@ class TestTable(object):
                 t3['peak'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
 
             # check reading multiple tables works
-            try:
-                t3 = self.TABLE.read([tmp, tmp], format='ligolw',
-                                     tablename='sngl_burst')
-            except NameError as e:
-                raise
+            t3 = self.TABLE.read([tmp, tmp], format='ligolw',
+                                 tablename='sngl_burst')
             utils.assert_table_equal(vstack((t2, t2)), t3)
 
             # check writing to existing file raises IOError
@@ -176,14 +173,7 @@ class TestTable(object):
             assert str(exc.value) == 'File exists: %s' % tmp
 
             # check overwrite=True, append=False rewrites table
-            try:
-                _write(overwrite=True)
-            except TypeError as e:
-                # ligolw is not python3-compatbile, so skip if it fails
-                if not PY2 and (
-                        str(e) == 'write() argument must be str, not bytes'):
-                    pytest.xfail(str(e))
-                raise
+            _write(overwrite=True)
             t3 = _read()
             utils.assert_table_equal(t2, t3)
 
@@ -383,7 +373,7 @@ class TestEventTable(TestTable):
         utils.assert_table_equal(
             midf, table.filter('frequency > 100').filter('frequency < 1000'))
 
-        # check unicode parsing (PY2)
+        # check unicode parsing
         table.filter(u'snr > 100')
 
     def test_filter_in_segmentlist(self, table):

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -373,9 +373,6 @@ class TestEventTable(TestTable):
         utils.assert_table_equal(
             midf, table.filter('frequency > 100').filter('frequency < 1000'))
 
-        # check unicode parsing
-        table.filter(u'snr > 100')
-
     def test_filter_in_segmentlist(self, table):
         # check filtering on segments works
         segs = SegmentList([Segment(100, 200), Segment(400, 500)])

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -24,9 +24,9 @@ import shutil
 import tempfile
 from io import BytesIO
 from ssl import SSLError
+from urllib.error import URLError
 
 from six import PY2
-from six.moves.urllib.error import URLError
 
 import pytest
 

--- a/gwpy/testing/compat.py
+++ b/gwpy/testing/compat.py
@@ -19,7 +19,4 @@
 """Unit testing compatibility module
 """
 
-try:
-    from unittest import mock  # noqa
-except ImportError:  # python < 3
-    import mock  # noqa
+from unittest import mock  # noqa

--- a/gwpy/testing/mocks.py
+++ b/gwpy/testing/mocks.py
@@ -20,8 +20,7 @@
 """
 
 import inspect
-
-from six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError
 
 from ..detector import Channel
 from ..time import LIGOTimeGPS

--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -26,8 +26,6 @@ from distutils.version import LooseVersion
 from importlib import import_module
 from itertools import zip_longest
 
-from six import PY2
-
 import pytest
 
 import numpy
@@ -314,10 +312,6 @@ def test_read_write(data, format,
         try:
             data.write(fp, *write_args, format=format, **write_kw)
         except TypeError as e:
-            # ligolw is not python3-compatbile, so skip if it fails
-            if not PY2 and format == 'ligolw' and (
-                    str(e) == 'write() argument must be str, not bytes'):
-                pytest.xfail(str(e))
             raise
 
         # try again with automatic format identification

--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -309,10 +309,7 @@ def test_read_write(data, format,
     DataClass = type(data)
 
     with TemporaryFilename(suffix=extension) as fp:
-        try:
-            data.write(fp, *write_args, format=format, **write_kw)
-        except TypeError as e:
-            raise
+        data.write(fp, *write_args, format=format, **write_kw)
 
         # try again with automatic format identification
         if autoidentify:

--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -24,9 +24,9 @@ import tempfile
 from contextlib import contextmanager
 from distutils.version import LooseVersion
 from importlib import import_module
+from itertools import zip_longest
 
 from six import PY2
-from six.moves import zip_longest
 
 import pytest
 

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -27,8 +27,6 @@ import warnings
 from decimal import Decimal
 from numbers import Number
 
-from six import string_types
-
 from dateutil import parser as dateparser
 
 from astropy.units import Quantity
@@ -143,7 +141,7 @@ def to_gps(t, *args, **kwargs):
     """
     # -- convert input to Time, or something we can pass to LIGOTimeGPS
 
-    if isinstance(t, string_types):
+    if isinstance(t, str):
         try:  # if str represents a number, leave it for LIGOTimeGPS to handle
             float(t)
         except ValueError:  # str -> datetime.datetime
@@ -162,12 +160,8 @@ def to_gps(t, *args, **kwargs):
         t = t.to('second').value
 
     # Number/Decimal -> str
-    if isinstance(t, Decimal):
+    if isinstance(t, (Decimal, Number)):
         t = str(t)
-    if isinstance(t, Number):
-        # note, on python < 3, str(<float>) isn't very good, so we use repr
-        # for python > 3 we can just use str for both Decimal and Number
-        t = repr(t)
 
     # -- convert to LIGOTimeGPS
 

--- a/gwpy/time/tests/test_main.py
+++ b/gwpy/time/tests/test_main.py
@@ -19,10 +19,7 @@
 """Tests for the `gwpy.time` command-line interface
 """
 
-try:
-    from unittest import mock
-except ImportError:  # python < 3
-    import mock
+from unittest import mock
 
 import pytest
 from dateutil import tz

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -182,9 +182,8 @@ class TimeSeriesBase(Series):
             kwargs['xindex'] = times
 
         # generate TimeSeries
-        new = super(TimeSeriesBase, cls).__new__(cls, data, name=name,
-                                                 unit=unit, channel=channel,
-                                                 **kwargs)
+        new = super().__new__(cls, data, name=name, unit=unit,
+                              channel=channel, **kwargs)
 
         # manually set sample_rate if given
         if sample_rate is not None:
@@ -642,7 +641,7 @@ class TimeSeriesBase(Series):
             for documentation of keyword arguments used in rendering the data
         """
         kwargs.update(figsize=figsize, xscale=xscale)
-        return super(TimeSeriesBase, self).plot(method=method, **kwargs)
+        return super().plot(method=method, **kwargs)
 
     @classmethod
     def from_nds2_buffer(cls, buffer_, scaled=None, copy=True, **metadata):
@@ -777,8 +776,7 @@ class TimeSeriesBase(Series):
     # -- TimeSeries operations ------------------
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        out = super(TimeSeriesBase, self).__array_ufunc__(
-            ufunc, method, *inputs, **kwargs)
+        out = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
         if out.dtype is numpy.dtype(bool) and len(inputs) == 2:
             from .statevector import StateTimeSeries
             orig, value = inputs
@@ -811,8 +809,7 @@ class TimeSeriesBase(Series):
             result.name = '{0!s} {1!s} {2!s}'.format(oname, op_, vname)
         # otherwise, return a regular TimeSeries
         else:
-            result = super(TimeSeriesBase, self).__array_wrap__(
-                obj, context=context)
+            result = super().__array_wrap__(obj, context=context)
         return result
 
 
@@ -1532,7 +1529,7 @@ class TimeSeriesBaseList(list):
     def __init__(self, *items):
         """Initialise a new list
         """
-        super(TimeSeriesBaseList, self).__init__()
+        super().__init__()
         for item in items:
             self.append(item)
 
@@ -1547,13 +1544,13 @@ class TimeSeriesBaseList(list):
         if not isinstance(item, self.EntryClass):
             raise TypeError("Cannot append type '%s' to %s"
                             % (type(item).__name__, type(self).__name__))
-        super(TimeSeriesBaseList, self).append(item)
+        super().append(item)
         return self
     append.__doc__ = list.append.__doc__
 
     def extend(self, item):
         item = TimeSeriesBaseList(*item)
-        super(TimeSeriesBaseList, self).extend(item)
+        super().extend(item)
     extend.__doc__ = list.extend.__doc__
 
     def coalesce(self):
@@ -1622,13 +1619,13 @@ class TimeSeriesBaseList(list):
         return out
 
     def __getslice__(self, i, j):
-        return type(self)(*super(TimeSeriesBaseList, self).__getslice__(i, j))
+        return type(self)(*super().__getslice__(i, j))
 
     def __getitem__(self, key):
         if isinstance(key, slice):
             return type(self)(
-                *super(TimeSeriesBaseList, self).__getitem__(key))
-        return super(TimeSeriesBaseList, self).__getitem__(key)
+                *super().__getitem__(key))
+        return super().__getitem__(key)
 
     def copy(self):
         """Return a copy of this list with each element copied to new memory

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -50,7 +50,7 @@ def preformat_cache(cache, start=None, end=None):
         A parsed, sieved list of paths based on the input arguments.
     """
     # open cache file
-    if isinstance(cache, str + FILE_LIKE):
+    if isinstance(cache, (str,) + FILE_LIKE):
         return read_cache(cache, sort=file_segment,
                           segment=Segment(start, end))
 

--- a/gwpy/timeseries/io/cache.py
+++ b/gwpy/timeseries/io/cache.py
@@ -19,8 +19,6 @@
 """I/O utilities for reading `TimeSeries` from a `list` of file paths.
 """
 
-from six import string_types
-
 from ...io.cache import (FILE_LIKE, read_cache, file_segment, sieve)
 from ...segments import Segment
 
@@ -52,7 +50,7 @@ def preformat_cache(cache, start=None, end=None):
         A parsed, sieved list of paths based on the input arguments.
     """
     # open cache file
-    if isinstance(cache, FILE_LIKE + string_types):
+    if isinstance(cache, str + FILE_LIKE):
         return read_cache(cache, sort=file_segment,
                           segment=Segment(start, end))
 

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -34,8 +34,6 @@ on a system.
 import importlib
 import warnings
 
-from six import string_types
-
 import numpy
 
 from astropy.io.registry import (get_reader, get_writer)
@@ -244,7 +242,7 @@ def register_gwf_api(library):
             gap = 'raise'
 
         # read cache file up-front
-        if (isinstance(source, string_types) and
+        if (isinstance(source, str) and
                 source.endswith(('.lcf', '.cache'))) or (
                     isinstance(source, io_cache.FILE_LIKE) and
                     source.name.endswith(('.lcf', '.cache'))):

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -24,8 +24,6 @@ The frame format is defined in LIGO-T970130 available from dcc.ligo.org.
 import os.path
 import warnings
 
-from six import string_types
-
 # import in this order so that lalframe throws the ImportError
 # to give the user a bit more information
 import lalframe
@@ -70,7 +68,7 @@ def open_data_source(source):
         pass
 
     # import cache from file
-    if (isinstance(source, string_types) and
+    if (isinstance(source, str) and
             source.endswith(('.lcf', '.cache'))):
         source = lal.CacheImport(source)
 
@@ -88,7 +86,7 @@ def open_data_source(source):
         return lalframe.FrStreamCacheOpen(source)
 
     # read single file
-    if isinstance(source, string_types):
+    if isinstance(source, str):
         return lalframe.FrStreamOpen(*map(str, os.path.split(source)))
 
     raise ValueError("Don't know how to open data source of type %r"

--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -24,8 +24,7 @@ For more details, see https://losc.ligo.org
 import os.path
 import re
 from math import ceil
-
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from astropy.io import registry
 from astropy.units import Quantity

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -22,8 +22,6 @@
 import operator
 import warnings
 
-from six.moves import reduce
-
 from numpy import ones as numpy_ones
 
 from ...detector import Channel

--- a/gwpy/timeseries/io/nds2.py
+++ b/gwpy/timeseries/io/nds2.py
@@ -21,6 +21,7 @@
 
 import operator
 import warnings
+from functools import reduce
 
 from numpy import ones as numpy_ones
 

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -175,7 +175,7 @@ class StateTimeSeries(TimeSeriesBase):
             data = numpy.asarray(data)
         if not isinstance(data, cls):
             data = data.astype(bool)
-        return super(StateTimeSeries, cls).__new__(
+        return super().__new__(
             cls, data, t0=t0, dt=dt, sample_rate=sample_rate, times=times,
             name=name, channel=channel, **kwargs)
 
@@ -199,15 +199,13 @@ class StateTimeSeries(TimeSeriesBase):
     # -- math handling (always boolean) ---------
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        out = super(StateTimeSeries, self).__array_ufunc__(
-            ufunc, method, *inputs, **kwargs)
+        out = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
         if out.ndim:
             return out.view(bool)
         return out
 
     def __array_wrap__(self, obj, context=None):
-        return super(StateTimeSeries, self).__array_wrap__(
-            obj, context=context).view(bool)
+        return super().__array_wrap__(obj, context=context).view(bool)
 
     def diff(self, n=1, axis=-1):
         slice1 = (slice(1, None),)
@@ -303,13 +301,13 @@ class StateTimeSeries(TimeSeriesBase):
     @wraps(TimeSeriesBase.from_nds2_buffer)
     def from_nds2_buffer(cls, buffer, **metadata):
         metadata.setdefault('unit', None)
-        return super(StateTimeSeries, cls).from_nds2_buffer(buffer, **metadata)
+        return super().from_nds2_buffer(buffer, **metadata)
 
     def __getitem__(self, item):
         if isinstance(item, (float, int)):
             return numpy.ndarray.__getitem__(self, item)
         else:
-            return super(StateTimeSeries, self).__getitem__(item)
+            return super().__getitem__(item)
 
     def tolist(self):
         return self.value.tolist()
@@ -506,10 +504,10 @@ class StateVector(TimeSeriesBase):
                 times=None, channel=None, name=None, **kwargs):
         """Generate a new `StateVector`.
         """
-        new = super(StateVector, cls).__new__(cls, data, t0=t0, dt=dt,
-                                              sample_rate=sample_rate,
-                                              times=times, channel=channel,
-                                              name=name, **kwargs)
+        new = super().__new__(cls, data, t0=t0, dt=dt,
+                              sample_rate=sample_rate,
+                              times=times, channel=channel,
+                              name=name, **kwargs)
         new.bits = bits
         return new
 
@@ -692,7 +690,7 @@ class StateVector(TimeSeriesBase):
 
         Notes
         -----"""
-        return super(StateVector, cls).read(source, *args, **kwargs)
+        return super().read(source, *args, **kwargs)
 
     def to_dqflags(self, bits=None, minlen=1, dtype=float, round=False):
         """Convert this `StateVector` into a `~gwpy.segments.DataQualityDict`
@@ -872,7 +870,7 @@ class StateVector(TimeSeriesBase):
             statevector flag.
         """
         if format == 'timeseries':
-            return super(StateVector, self).plot(**kwargs)
+            return super().plot(**kwargs)
         if format == 'segments':
             from ..plot import Plot
             kwargs.setdefault('xscale', 'auto-gps')
@@ -1020,7 +1018,7 @@ class StateVectorDict(TimeSeriesBaseDict):
 
         Notes
         -----"""
-        return super(StateVectorDict, cls).read(source, *args, **kwargs)
+        return super().read(source, *args, **kwargs)
 
 
 class StateVectorList(TimeSeriesBaseList):

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -30,8 +30,6 @@ statement of instrumental operation
 from functools import wraps
 from math import (ceil, log)
 
-from six.moves import range
-
 import numpy
 
 from astropy import units

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -53,7 +53,7 @@ class TestTimeSeriesBase(_TestSeries):
     def test_new(self):
         """Test `gwpy.timeseries.TimeSeriesBase` constructor
         """
-        array = super(TestTimeSeriesBase, self).test_new()
+        array = super().test_new()
 
         # check time-domain metadata
         assert array.epoch == GPS_EPOCH

--- a/gwpy/timeseries/tests/test_io_gwf_lalframe.py
+++ b/gwpy/timeseries/tests/test_io_gwf_lalframe.py
@@ -20,8 +20,7 @@
 """
 
 from pathlib import Path
-
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 import pytest
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -22,9 +22,7 @@
 import os.path
 from itertools import (chain, product)
 from ssl import SSLError
-
-import six
-from six.moves.urllib.error import URLError
+from urllib.error import URLError
 
 import pytest
 
@@ -167,10 +165,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
             def read_(**kwargs):
                 return type(array).read(tmp, array.name, format=fmt,
                                         **kwargs)
-
-            # test reading unicode (python2)
-            if six.PY2:
-                type(array).read(six.u(tmp), array.name, format=fmt)
 
             # test start, end
             start, end = array.span.contract(10)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -21,8 +21,6 @@
 
 import warnings
 
-from six.moves import range
-
 import numpy
 from numpy import fft as npfft
 from scipy import signal

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -119,9 +119,8 @@ class Array(Quantity):
             unit = parse_unit(unit, parse_strict='warn')
 
         # create new array
-        new = super(Array, cls).__new__(cls, value, unit=unit, dtype=dtype,
-                                        copy=False, order=order, subok=subok,
-                                        ndmin=ndmin)
+        new = super().__new__(cls, value, unit=unit, dtype=dtype, copy=False,
+                              order=order, subok=subok, ndmin=ndmin)
 
         # explicitly copy here to get ownership of the data,
         # see (astropy/astropy#7244)
@@ -146,7 +145,7 @@ class Array(Quantity):
     def _wrap_function(self, function, *args, **kwargs):
         # if the output of the function is a scalar, return it as a Quantity
         # not whatever class this is
-        out = super(Array, self)._wrap_function(function, *args, **kwargs)
+        out = super()._wrap_function(function, *args, **kwargs)
         if out.ndim == 0:
             return Quantity(out.value, out.unit)
         return out
@@ -162,7 +161,7 @@ class Array(Quantity):
             return
 
         # call Quantity.__array_finalize__ to handle the units
-        super(Array, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
 
         # then update metadata
         if isinstance(obj, Quantity):
@@ -192,12 +191,12 @@ class Array(Quantity):
                         setattr(self, _attr, val)
 
     def __getattr__(self, attr):
-        return super(Array, self).__getattribute__(attr)
+        return super().__getattribute__(attr)
 
     def __getitem__(self, item):
         if isinstance(item, list):
             item = tuple(item)
-        new = super(Array, self).__getitem__(item)
+        new = super().__getitem__(item)
 
         # return scalar as a Quantity
         if numpy.ndim(new) == 0:
@@ -395,8 +394,7 @@ class Array(Quantity):
     # -- array methods --------------------------
 
     def __array_ufunc__(self, function, method, *inputs, **kwargs):
-        out = super(Array, self).__array_ufunc__(function, method,
-                                                 *inputs, **kwargs)
+        out = super().__array_ufunc__(function, method, *inputs, **kwargs)
         # if a ufunc returns a scalar, return a Quantity
         if not out.ndim:
             return Quantity(out, copy=False)
@@ -415,12 +413,12 @@ class Array(Quantity):
         if self.unit is None:
             try:
                 self.unit = ''
-                return super(Array, self)._to_own_unit(
+                return super()._to_own_unit(
                     value, check_precision=check_precision)
             finally:
                 del self.unit
         else:
-            return super(Array, self)._to_own_unit(
+            return super()._to_own_unit(
                 value, check_precision=check_precision)
     _to_own_unit.__doc__ = Quantity._to_own_unit.__doc__
 
@@ -480,10 +478,10 @@ class Array(Quantity):
         >>> a.flatten()
         <Quantity [1., 2., 3., 4.] m>
         """
-        return super(Array, self).flatten(order=order).view(Quantity)
+        return super().flatten(order=order).view(Quantity)
 
     def copy(self, order='C'):
-        out = super(Array, self).copy(order=order)
+        out = super().copy(order=order)
         for slot in self._metadata_slots:
             old = getattr(self, '_{0}'.format(slot), None)
             if old is not None:

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -113,8 +113,8 @@ class Array2D(Series):
         """
 
         # create new object
-        new = super(Array2D, cls).__new__(cls, data, unit=unit, xindex=xindex,
-                                          xunit=xunit, x0=x0, dx=dx, **kwargs)
+        new = super().__new__(cls, data, unit=unit, xindex=xindex,
+                              xunit=xunit, x0=x0, dx=dx, **kwargs)
 
         # set y-axis metadata from yindex
         if yindex is not None:
@@ -148,7 +148,7 @@ class Array2D(Series):
 
     # rebuild getitem to handle complex slicing
     def __getitem__(self, item):
-        new = super(Array2D, self).__getitem__(item)
+        new = super().__getitem__(item)
 
         # slice axis 1 metadata
         colslice, rowslice = sliceutils.format_nd_slice(item, self.ndim)
@@ -172,7 +172,7 @@ class Array2D(Series):
         return new
 
     def __array_finalize__(self, obj):
-        super(Array2D, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
         # Series.__array_finalize__ might set _yindex to None, so delete it
         if getattr(self, '_yindex', 0) is None:
             del self.yindex
@@ -308,7 +308,7 @@ class Array2D(Series):
     def is_compatible(self, other):
         """Check whether this array and ``other`` have compatible metadata
         """
-        super(Array2D, self).is_compatible(other)
+        super().is_compatible(other)
         # check y-axis metadata
         if isinstance(other, type(self)):
             try:
@@ -373,7 +373,7 @@ class Array2D(Series):
     # all of these try to return Quantities rather than simple numbers
 
     def _wrap_function(self, function, *args, **kwargs):
-        out = super(Array2D, self)._wrap_function(function, *args, **kwargs)
+        out = super()._wrap_function(function, *args, **kwargs)
         if out.ndim == 1:  # return Series
             # HACK: need to check astropy will always pass axis as first arg
             axis = args[0]

--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -86,7 +86,7 @@ class Index(Quantity):
         return numpy.isclose(numpy.diff(self.value, n=2), 0).all()
 
     def __getitem__(self, key):
-        item = super(Index, self).__getitem__(key)
+        item = super().__getitem__(key)
         if item.isscalar:
             return item.view(Quantity)
         return item

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -119,7 +119,7 @@ class Series(Array):
                              % (cls.__name__, len(shape)))
 
         # create new object
-        new = super(Series, cls).__new__(cls, value, unit=unit, **kwargs)
+        new = super().__new__(cls, value, unit=unit, **kwargs)
 
         # set x-axis metadata from xindex
         if xindex is not None:
@@ -153,7 +153,7 @@ class Series(Array):
     # -- series creation ------------------------
 
     def __array_finalize__(self, obj):
-        super(Series, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
         # Array.__array_finalize__ might set _xindex to None, so delete it
         if getattr(self, '_xindex', None) is None:
             del self.xindex
@@ -514,7 +514,7 @@ class Series(Array):
         return self[idx]
 
     def copy(self, order='C'):
-        new = super(Series, self).copy(order=order)
+        new = super().copy(order=order)
         try:
             new._xindex = self._xindex.copy()
         except AttributeError:
@@ -571,7 +571,7 @@ class Series(Array):
         numpy.diff
             for documentation on the underlying method
         """
-        out = super(Array, self).diff(n=n, axis=axis)
+        out = super().diff(n=n, axis=axis)
         try:
             out.x0 = self.x0 + self.dx * n
         except AttributeError:  # irregular xindex
@@ -579,7 +579,7 @@ class Series(Array):
         return out
 
     def __getslice__(self, i, j):
-        new = super(Series, self).__getslice__(i, j)
+        new = super().__getslice__(i, j)
         if i:
             try:
                 new.x0 = self.x0 + i * self.dx
@@ -588,7 +588,7 @@ class Series(Array):
         return new
 
     def __getitem__(self, item):
-        new = super(Series, self).__getitem__(item)
+        new = super().__getitem__(item)
 
         # slice axis 0 metadata
         slice_, = sliceutils.format_nd_slice(item, 1)

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -186,7 +186,7 @@ class TestArray2D(_TestSeries):
             exclude=['epoch'])
 
     def test_is_compatible(self, array):
-        super(TestArray2D, self).test_is_compatible(array)
+        super().test_is_compatible(array)
 
         a2 = self.create(dy=2)
         with pytest.raises(ValueError):

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -37,7 +37,7 @@ class TestSeries(_TestArray):
     TEST_CLASS = Series
 
     def test_new(self):
-        array = super(TestSeries, self).test_new()
+        array = super().test_new()
         assert array.x0 == units.Quantity(0, self.TEST_CLASS._default_xunit)
         assert array.dx == units.Quantity(1, self.TEST_CLASS._default_xunit)
         return array

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -90,27 +90,27 @@ def deprecated_function(func, warning=DEPRECATED_FUNCTION_WARNING):
     return wrapped_func
 
 
-def return_as(func, returntype):
+def return_as(returntype):
     """Decorator to cast return of function as the given type
 
     Parameters
     ----------
-    func : `callable`
-        the function to decorate
-
     returntype : `type`
-        desired return type of the decorated function
+        the desired return type of the decorated function
     """
-    @wraps(func)
-    def wrapped_func(*args, **kwargs):
-        result = func(*args, **kwargs)
-        try:
-            return returntype(result)
-        except (TypeError, ValueError) as exc:
-            exc.args = (
-                'failed to cast return from {0} as {1}: {2}'.format(
-                    func.__name__, returntype.__name__, str(exc)),
-            )
-            raise
+    def decorator(func):
+        # @wraps(func) <- we can't use this as normal because it doesn't work
+        #                 for instance methods, see workaround below
+        def wrapped(*args, **kwargs):
+            result = func(*args, **kwargs)
+            try:
+                return returntype(result)
+            except (TypeError, ValueError) as exc:
+                exc.args = (
+                    'failed to cast return from {0} as {1}: {2}'.format(
+                        func.__name__, returntype.__name__, str(exc)),
+                )
+                raise
+        return wraps(func)(wrapped)
 
-    return wrapped_func
+    return decorator

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -99,8 +99,7 @@ def return_as(returntype):
         the desired return type of the decorated function
     """
     def decorator(func):
-        # @wraps(func) <- we can't use this as normal because it doesn't work
-        #                 for instance methods, see workaround below
+        @wraps(func)
         def wrapped(*args, **kwargs):
             result = func(*args, **kwargs)
             try:
@@ -111,6 +110,6 @@ def return_as(returntype):
                         func.__name__, returntype.__name__, str(exc)),
                 )
                 raise
-        return wraps(func)(wrapped)
+        return wrapped
 
     return decorator

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -90,13 +90,16 @@ def deprecated_function(func, warning=DEPRECATED_FUNCTION_WARNING):
     return wrapped_func
 
 
-def return_as(returntype):
+def return_as(func, returntype):
     """Decorator to cast return of function as the given type
 
     Parameters
     ----------
+    func : `callable`
+        the function to decorate
+
     returntype : `type`
-        the desired return type of the decorated function
+        desired return type of the decorated function
     """
     @wraps(func)
     def wrapped_func(*args, **kwargs):

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -98,24 +98,16 @@ def return_as(returntype):
     returntype : `type`
         the desired return type of the decorated function
     """
-    def decorator(func):
-        # @wraps(func) <- we can't use this as normal because it doesn't work
-        #                 on python < 3 for instance methods,
-        #                 see workaround below
-        def wrapped(*args, **kwargs):
-            result = func(*args, **kwargs)
-            try:
-                return returntype(result)
-            except (TypeError, ValueError) as exc:
-                exc.args = (
-                    'failed to cast return from {0} as {1}: {2}'.format(
-                        func.__name__, returntype.__name__, str(exc)),
-                )
-                raise
+    @wraps(func)
+    def wrapped_func(*args, **kwargs):
+        result = func(*args, **kwargs)
         try:
-            return wraps(func)(wrapped)
-        except AttributeError:  # python < 3.0.0
-            wrapped.__doc__ == func.__doc__
-            return wrapped
+            return returntype(result)
+        except (TypeError, ValueError) as exc:
+            exc.args = (
+                'failed to cast return from {0} as {1}: {2}'.format(
+                    func.__name__, returntype.__name__, str(exc)),
+            )
+            raise
 
-    return decorator
+    return wrapped_func

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -58,7 +58,7 @@ class deprecated_property(property):  # pylint: disable=invalid-name
         if not fset and not fdel:  # only wrap once
             fget = _warn(fget)
 
-        super(deprecated_property, self).__init__(fget, fset, fdel, doc)
+        super().__init__(fget, fset, fdel, doc)
 
 
 def deprecated_function(func, warning=DEPRECATED_FUNCTION_WARNING):

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -23,6 +23,7 @@ This module requires lal >= 6.14.0
 
 import operator
 from collections import OrderedDict
+from functools import reduce
 
 import numpy
 

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -24,9 +24,6 @@ This module requires lal >= 6.14.0
 import operator
 from collections import OrderedDict
 
-from six import string_types
-from six.moves import reduce
-
 import numpy
 
 from astropy import units
@@ -192,7 +189,7 @@ def to_lal_unit(aunit):
     ValueError
         if LAL doesn't understand the base units for the input
     """
-    if isinstance(aunit, string_types):
+    if isinstance(aunit, str):
         aunit = units.Unit(aunit)
     aunit = aunit.decompose()
     lunit = lal.Unit()

--- a/gwpy/utils/tests/test_env.py
+++ b/gwpy/utils/tests/test_env.py
@@ -19,10 +19,7 @@
 """Tests for :mod:`gwpy.utils.env`
 """
 
-try:
-    from unittest import mock
-except ImportError:  # python < 3
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
 numpy >= 1.12.0
 python-dateutil
 scipy >= 1.2.0
-six >= 1.5
 tqdm >= 4.10.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ install_requires = [
     'numpy >= 1.12.0',
     'python-dateutil',
     'scipy >= 1.2.0',
-    'six >= 1.5',
     'tqdm >= 4.10.0',
 ]
 


### PR DESCRIPTION
This PR drops dependence on the `six` package and removes all workarounds for python < 3, including those related to `python-ligo-lw` which should now be python3 compatible.

Fixes #1170, fixes #1173

cc @duncanmmacleod 