### PR TITLE
Update matplotlib requirement to 3.0.0

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -27,7 +27,6 @@ import sys
 from functools import wraps
 
 from matplotlib import (rcParams, style)
-from matplotlib.cm import viridis as DEFAULT_CMAP
 
 from astropy.time import Time
 from astropy.units import Quantity
@@ -750,6 +749,7 @@ class CliProduct(object, metaclass=abc.ABCMeta):
 class ImageProduct(CliProduct, metaclass=abc.ABCMeta):
     """Base class for all x/y/color plots
     """
+    DEFAULT_CMAP = "viridis"
     MAX_DATASETS = 1
 
     @classmethod
@@ -767,6 +767,7 @@ class ImageProduct(CliProduct, metaclass=abc.ABCMeta):
         group.add_argument('--imax', type=float,
                            help='maximum value for colorbar')
         group.add_argument('--cmap',
+                           default=cls.DEFAULT_CMAP,
                            help='Colormap. See '
                                 'https://matplotlib.org/examples/color/'
                                 'colormaps_reference.html for options')
@@ -778,11 +779,6 @@ class ImageProduct(CliProduct, metaclass=abc.ABCMeta):
                                 'that frequency bin')
         group.add_argument('--nocolorbar', action='store_true',
                            help='hide the colour bar')
-
-    def _finalize_arguments(self, args):
-        if args.cmap is None:
-            args.cmap = DEFAULT_CMAP.name
-        return super()._finalize_arguments(args)
 
     @staticmethod
     def get_color_label():

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -23,15 +23,11 @@ import abc
 import os.path
 import re
 import time
-import warnings
 import sys
 from functools import wraps
 
-from matplotlib import rcParams
-try:
-    from matplotlib.cm import viridis as DEFAULT_CMAP
-except ImportError:
-    from matplotlib.cm import YlOrRd as DEFAULT_CMAP
+from matplotlib import (rcParams, style)
+from matplotlib.cm import viridis as DEFAULT_CMAP
 
 from astropy.time import Time
 from astropy.units import Quantity
@@ -146,14 +142,7 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         self._finalize_arguments(args)  # post-process args
 
         if args.style:  # apply custom styling
-            try:
-                from matplotlib import style
-            except ImportError:
-                from matplotlib import __version__ as mpl_version
-                warnings.warn('--style can only be used with matplotlib >= '
-                              '1.4.0, you have {0}'.format(mpl_version))
-            else:
-                style.use(args.style)
+            style.use(args.style)
 
         #: the current figure object
         self.plot = None

--- a/gwpy/cli/coherencegram.py
+++ b/gwpy/cli/coherencegram.py
@@ -19,11 +19,6 @@
 """Coherence spectrogram
 """
 
-try:
-    from matplotlib.cm import plasma as DEFAULT_CMAP
-except ImportError:
-    DEFAULT_CMAP = None
-
 from .spectrogram import Spectrogram
 
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
@@ -32,6 +27,7 @@ __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 class Coherencegram(Spectrogram):
     """Plot the coherence-spectrogram comparing two time series
     """
+    DEFAULT_CMAP = "plasma"
     MIN_DATASETS = 2
     MAX_DATASETS = 2
     action = 'coherencegram'
@@ -58,8 +54,6 @@ class Coherencegram(Spectrogram):
                 args.imin = 0.
             if args.imax is None:
                 args.imax = 1.
-        if args.cmap is None and DEFAULT_CMAP is not None:
-            args.cmap = DEFAULT_CMAP.name
         return super()._finalize_arguments(args)
 
     def get_ylabel(self):

--- a/gwpy/cli/tests/base.py
+++ b/gwpy/cli/tests/base.py
@@ -278,10 +278,6 @@ class _TestImageProduct(_TestCliProduct):
         for key in ('nocolorbar', 'cmap', 'imin', 'imax'):
             assert hasattr(args, key)
 
-    def test_finalize_arguments(self, prod):
-        # finalize_arguments() called by __init__
-        assert prod.args.cmap == cliproduct.DEFAULT_CMAP.name
-
     @pytest.mark.parametrize('visible', [False, True])
     def test_set_plot_properties(self, plotprod, visible):
         update_namespace(plotprod.args, nocolorbar=not visible)

--- a/gwpy/cli/tests/test_coherencegram.py
+++ b/gwpy/cli/tests/test_coherencegram.py
@@ -20,7 +20,6 @@
 """
 
 from ... import cli
-from ...cli import cliproduct
 from .test_spectrogram import TestCliSpectrogram as _TestCliSpectrogram
 from .test_coherence import TestCliCoherence as _TestCliCoherence
 
@@ -31,11 +30,7 @@ class TestCliCoherencegram(_TestCliSpectrogram):
     TEST_ARGS = _TestCliCoherence.TEST_ARGS
 
     def test_finalize_arguments(self, prod):
-        from gwpy.cli.coherencegram import DEFAULT_CMAP as DEFAULT_COH_CMAP
-        if DEFAULT_COH_CMAP is None:
-            assert prod.args.cmap == cliproduct.DEFAULT_CMAP.name
-        else:
-            assert prod.args.cmap == DEFAULT_COH_CMAP.name
+        assert prod.args.cmap == "plasma"
         assert prod.args.color_scale == 'linear'
         assert prod.args.imin == 0.
         assert prod.args.imax == 1.

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -28,16 +28,13 @@ import numpy
 
 from astropy.time import Time
 
-from matplotlib import (__version__ as mpl_version, rcParams)
+from matplotlib import rcParams
 from matplotlib.artist import allow_rasterization
 from matplotlib.axes import Axes as _Axes
-from matplotlib.lines import Line2D
+from matplotlib.axes._base import _process_plot_var_args
 from matplotlib.collections import PolyCollection
+from matplotlib.lines import Line2D
 from matplotlib.projections import register_projection
-try:
-    from matplotlib.axes._base import _process_plot_var_args
-except ImportError:  # matplotlib-1.x
-    from matplotlib.axes import _process_plot_var_args
 
 from . import (Plot, colorbar as gcbar)
 from .colors import format_norm
@@ -46,8 +43,6 @@ from .legend import HandlerLine2D
 from ..time import (LIGOTimeGPS, to_gps)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
-
-DEFAULT_SCATTER_COLOR = 'b' if mpl_version < '2.0' else None
 
 
 def log_norm(func):
@@ -173,10 +168,8 @@ class Axes(_Axes):
 
     # -- overloaded plotting methods ------------
 
-    def scatter(self, x, y, c=DEFAULT_SCATTER_COLOR, **kwargs):
+    def scatter(self, x, y, c=None, **kwargs):
         # scatter with auto-sorting by colour
-        if c is None and mpl_version < '2.0':
-            c = DEFAULT_SCATTER_COLOR
         try:
             if c is None:
                 raise ValueError
@@ -508,8 +501,7 @@ class Axes(_Axes):
             )
         alpha = kwargs.pop("alpha", None)
         if alpha:
-            if mpl_version >= "1.3.0":  # matplotlib >= 1.3.0
-                kwargs.setdefault("framealpha", alpha)
+            kwargs.setdefault("framealpha", alpha)
             warnings.warn(
                 "the alpha keyword to gwpy.plot.Axes.legend has been "
                 "deprecated and will be removed in a future release; "

--- a/gwpy/plot/bode.py
+++ b/gwpy/plot/bode.py
@@ -133,12 +133,9 @@ class BodePlot(Plot):
         self.paxes.set_ylabel('Phase [deg]')
         self.maxes.set_xscale('log')
         self.paxes.set_xscale('log')
-        try:
-            self.paxes.yaxis.set_major_locator(
-                MaxNLocator(nbins='auto', steps=[4.5, 9]))
-        except ValueError:  # matplotlib < 2.0
-            self.paxes.yaxis.set_major_locator(
-                MaxNLocator(nbins=9, steps=[4.5, 9]))
+        self.paxes.yaxis.set_major_locator(
+            MaxNLocator(nbins='auto', steps=[4.5, 9]),
+        )
         self.paxes.yaxis.set_minor_locator(
             MaxNLocator(nbins=20, steps=[4.5, 9]))
         if title:

--- a/gwpy/plot/colorbar.py
+++ b/gwpy/plot/colorbar.py
@@ -21,7 +21,6 @@
 
 import warnings
 
-from matplotlib import __version__ as mpl_version
 from matplotlib.axes import SubplotBase
 from matplotlib.colors import LogNorm
 from matplotlib.legend import Legend
@@ -132,8 +131,7 @@ def _scale_height(value, ax):
 
 def make_axes_axesgrid(ax, **kwargs):
     kwargs.setdefault('location', 'right')
-    if mpl_version >= '1.3.0':
-        kwargs.setdefault('ticklocation', kwargs['location'])
+    kwargs.setdefault('ticklocation', kwargs['location'])
 
     fraction = kwargs.pop('fraction', 0.)
     try:

--- a/gwpy/plot/colors.py
+++ b/gwpy/plot/colors.py
@@ -21,34 +21,10 @@
 
 import numpy
 
-from matplotlib import (__version__ as mpl_version, rcParams)
 from matplotlib import colors
-try:
-    from matplotlib.colors import (_colors_full_map as color_map, to_rgb)
-except ImportError:  # mpl < 2
-    from matplotlib.colors import (cnames as color_map, ColorConverter)
-    to_rgb = ColorConverter().to_rgb
+from matplotlib.colors import (_colors_full_map as color_map, to_rgb)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-
-# build better default colour cycle for matplotlib < 2
-if mpl_version < '2.0':
-    DEFAULT_COLORS = [
-        '#1f77b4',  # blue
-        '#ffb200',  # yellow(ish)
-        '#33cc33',  # green
-        '#ff0000',  # red
-        '#8000bf',  # magenta
-        '#808080',  # gray
-        '#4cb2ff',  # light blue
-        '#ffc0cb',  # pink
-        '#232c16',  # dark green
-        '#ff7fe0',  # orange
-        '#8b4513',  # saddlebrown
-        '#000080',  # navy
-    ]
-else:  # just in case anyone expects DEFAULT_COLORS to exist for mpl 2
-    DEFAULT_COLORS = rcParams['axes.prop_cycle'].by_key()['color']
 
 # -- recommended defaults for current Gravitational-Wave Observatories --------
 # the below colours are designed to work well for the colour-blind, as well

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -264,10 +264,6 @@ class Plot(figure.Figure):
         # mainly for user convenience. However, as of matplotlib-3.0.0,
         # pyplot.show() ends up calling _back_ to Plot.show(),
         # so we have to be careful not to end up in a recursive loop
-        #
-        # Developer note: if we ever make it pinning to matplotlib >=3.0.0
-        #                 this method can likely be completely removed
-        #
         import inspect
         try:
             callframe = inspect.currentframe().f_back
@@ -287,10 +283,7 @@ class Plot(figure.Figure):
         # block in GUI loop (stolen from mpl.backend_bases._Backend.show)
         if block:
             backend_mod = get_backend_mod()
-            try:
-                backend_mod.Show().mainloop()
-            except AttributeError:  # matplotlib < 2.1.0
-                backend_mod.show.mainloop()
+            backend_mod.Show().mainloop()
 
     def save(self, *args, **kwargs):
         """Save the figure to disk.
@@ -334,7 +327,7 @@ class Plot(figure.Figure):
     # -- colour bars ----------------------------
 
     def colorbar(self, mappable=None, cax=None, ax=None, fraction=0.,
-                 label=None, emit=True, **kwargs):
+                 emit=True, **kwargs):
         """Add a colorbar to the current `Plot`
 
         A colorbar must be associated with an `Axes` on this `Plot`,
@@ -402,8 +395,6 @@ class Plot(figure.Figure):
         # generate colour bar
         cbar = super().colorbar(mappable, **kwargs)
         self.colorbars.append(cbar)
-        if label:  # mpl<1.3 doesn't accept label in Colorbar constructor
-            cbar.set_label(label)
 
         # update mappables for this axis
         if emit:

--- a/gwpy/plot/rc.py
+++ b/gwpy/plot/rc.py
@@ -19,8 +19,7 @@
 """Custom default figure configuration
 """
 
-from matplotlib import (rcParams, rc_params, RcParams,
-                        __version__ as mpl_version)
+from matplotlib import (rcParams, rc_params, RcParams)
 
 from . import tex
 from ..utils.env import bool_env
@@ -31,7 +30,7 @@ MPL_RCPARAMS = rc_params()
 # record the LaTeX preamble
 try:
     PREAMBLE = rcParams.get('text.latex.preamble', []) + tex.MACROS
-except TypeError:
+except TypeError:  # matplotlib < 3.1.0
     PREAMBLE = rcParams.get('text.latex.preamble', '') + '\n'.join(tex.MACROS)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -49,6 +48,7 @@ GWPY_RCPARAMS = RcParams(**{
     # ticks
     'axes.formatter.limits': (-3, 4),
     'axes.formatter.use_mathtext': True,
+    'axes.labelpad': 5,
     # fonts
     'axes.titlesize': 'large',
     'axes.labelsize': 'large',
@@ -61,20 +61,11 @@ GWPY_RCPARAMS = RcParams(**{
     ] + rcParams['font.sans-serif'],
     'font.size': 12,
     # legend (revert to mpl 1.5 formatting in parts)
+    'legend.edgecolor': 'inherit',
     'legend.numpoints': 2,
     'legend.handlelength': 1,
     'legend.fancybox': False,
 })
-
-# set parameters only supported in matplotlib >= 1.5
-# https://matplotlib.org/1.5.1/users/whats_new.html#configuration-rcparams
-try:
-    GWPY_RCPARAMS.update({
-        'axes.labelpad': 5,
-        'legend.edgecolor': 'inherit',
-    })
-except KeyError:  # matplotlib < 1.5
-    pass
 
 # set latex options
 GWPY_TEX_RCPARAMS = RcParams(**{
@@ -87,13 +78,6 @@ GWPY_TEX_RCPARAMS = RcParams(**{
     # don't use mathtext for offset
     'axes.formatter.use_mathtext': False,
 })
-if mpl_version < '2.0':
-    GWPY_TEX_RCPARAMS['font.serif'] = ['Computer Modern']
-
-if mpl_version < '1.3':
-    # really old matplotlib stored font.family as a str, not a list
-    GWPY_RCPARAMS['font.family'] = GWPY_RCPARAMS['font.family'][0]
-    GWPY_TEX_RCPARAMS['font.family'] = GWPY_TEX_RCPARAMS['font.family'][0]
 
 
 def rc_params(usetex=None):

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -23,7 +23,7 @@ import pytest
 
 import numpy
 
-from matplotlib import (rcParams, __version__ as mpl_version)
+from matplotlib import rcParams
 from matplotlib.collections import PolyCollection
 from matplotlib.lines import Line2D
 
@@ -151,11 +151,8 @@ class TestAxes(AxesTestBase):
         assert str(exc.value).startswith('cannot generate log-spaced '
                                          'histogram bins')
         # assert it works if we give the range manually
-        if mpl_version >= '1.5.0':
-            ax.hist([], logbins=True, range=(1, 100))
+        ax.hist([], logbins=True, range=(1, 100))
 
-    @pytest.mark.xfail(mpl_version < '1.4.0',
-                       reason='bugs in matplotlib-1.4.0')
     def test_tile(self, ax):
         x = numpy.arange(10)
         y = numpy.arange(x.size)
@@ -228,8 +225,7 @@ class TestAxes(AxesTestBase):
         ax.plot(numpy.arange(5), label='test')
         with pytest.deprecated_call():
             leg = ax.legend(alpha=.1)
-        if mpl_version >= "1.3.0":
-            assert leg.get_frame().get_alpha() == .1
+        assert leg.get_frame().get_alpha() == .1
 
     def test_plot_mmm(self, ax):
         mean_ = Series(numpy.random.random(10))

--- a/gwpy/plot/tests/test_log.py
+++ b/gwpy/plot/tests/test_log.py
@@ -21,12 +21,11 @@
 
 import pytest
 
-from matplotlib import (__version__ as mpl_version, pyplot, rc_context)
+from matplotlib import (pyplot, rc_context)
 
 from .. import log as plot_log
 
 
-@pytest.mark.xfail(mpl_version == '2.0.0', reason='bugs in matplotlib-2.0.0')
 @pytest.mark.parametrize('in_, out, texout', [
     (0., r'$\mathdefault{0}$', '$0$'),
     (0.1, r'$\mathdefault{0.1}$', '$0.1$'),

--- a/gwpy/plot/tests/test_segments.py
+++ b/gwpy/plot/tests/test_segments.py
@@ -23,7 +23,7 @@ import pytest
 
 import numpy
 
-from matplotlib import (rcParams, __version__ as mpl_version)
+from matplotlib import rcParams
 from matplotlib.colors import ColorConverter
 from matplotlib.collections import PatchCollection
 
@@ -36,15 +36,8 @@ from .test_axes import TestAxes as _TestAxes
 
 # extract color cycle
 COLOR_CONVERTER = ColorConverter()
-try:
-    COLOR_CYCLE = rcParams['axes.prop_cycle'].by_key()['color']
-except KeyError:  # mpl < 1.5
-    COLOR0 = COLOR_CONVERTER.to_rgba('b')
-else:
-    if mpl_version >= '2.0':
-        COLOR0 = COLOR_CONVERTER.to_rgba(COLOR_CYCLE[0])
-    else:
-        COLOR0 = COLOR_CONVERTER.to_rgba('b')
+COLOR_CYCLE = rcParams['axes.prop_cycle'].by_key()['color']
+COLOR0 = COLOR_CONVERTER.to_rgba(COLOR_CYCLE[0])
 
 
 class TestSegmentAxes(_TestAxes):
@@ -160,7 +153,7 @@ def test_segmentrectangle():
     assert patch.get_xy(), (1.1, 9.6)
     assert numpy.isclose(patch.get_height(), 0.8)
     assert numpy.isclose(patch.get_width(), 1.3)
-    assert patch.get_facecolor(), COLOR0
+    assert patch.get_facecolor() == COLOR0
 
     # check kwarg passing
     patch = SegmentRectangle((1.1, 2.4), 10, facecolor='red')

--- a/gwpy/plot/tests/test_utils.py
+++ b/gwpy/plot/tests/test_utils.py
@@ -22,7 +22,6 @@
 import itertools
 
 from matplotlib import (
-    __version__ as mpl_version,
     colors as mpl_colors,
 )
 
@@ -32,10 +31,7 @@ from .. import utils as plot_utils
 def test_color_cycle():
     cyc = plot_utils.color_cycle()
     assert isinstance(cyc, itertools.cycle)
-    if mpl_version < '1.5':
-        assert next(cyc) == 'b'
-    else:
-        assert next(cyc) == mpl_colors.to_hex("C0")
+    assert next(cyc) == mpl_colors.to_hex("C0")
 
 
 def test_color_cycle_arg():

--- a/gwpy/plot/utils.py
+++ b/gwpy/plot/utils.py
@@ -42,10 +42,7 @@ def color_cycle(colors=None):
     """
     if colors:
         return itertools.cycle(colors)
-    try:
-        return itertools.cycle(p["color"] for p in rcParams["axes.prop_cycle"])
-    except KeyError:  # matplotlib < 1.5
-        return itertools.cycle(rcParams["axes.color_cycle"])
+    return itertools.cycle(p["color"] for p in rcParams["axes.prop_cycle"])
 
 
 def marker_cycle(markers=None):

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -21,7 +21,6 @@
 
 from warnings import warn
 
-from matplotlib import __version__ as mpl_version
 
 from astropy.units import (Unit, Quantity)
 
@@ -30,8 +29,6 @@ from .series import Series
 from .index import Index
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
-
-DEFAULT_IMAGE_METHOD = 'imshow' if mpl_version >= '2.0' else 'pcolormesh'
 
 
 class Array2D(Series):
@@ -357,7 +354,7 @@ class Array2D(Series):
     def pcolormesh(self, **kwargs):
         return self.plot(method='pcolormesh', **kwargs)
 
-    def plot(self, method=DEFAULT_IMAGE_METHOD, **kwargs):
+    def plot(self, method="imshow", **kwargs):
         from ..plot import Plot
 
         # correct for log scales and zeros

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,8 @@
 # requirements for GWpy tests
 beautifulsoup4
 freezegun >= 0.2.3
-pytest >= 3.3.0
+pytest >= 3.3.0 ; python_version >= '3.6'
+pytest >= 3.3.0, < 5.4.0a0 ; python_version < '3.6'
 pytest-cov >= 2.4.0
 pytest-xdist
 requests-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gwosc >= 0.4.0
 h5py >= 1.3
 ligo-segments >= 1.0.0
 ligotimegps >= 1.2.1
-matplotlib >= 1.2.0, != 2.1.0, != 2.1.1
+matplotlib >= 3.0.0
 numpy >= 1.12.0
 python-dateutil
 scipy >= 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     'h5py >= 1.3',
     'ligo-segments >= 1.0.0',
     'ligotimegps >= 1.2.1',
-    'matplotlib >= 1.2.0, != 2.1.0, != 2.1.1',
+    'matplotlib >= 3.0.0',
     'numpy >= 1.12.0',
     'python-dateutil',
     'scipy >= 1.2.0',


### PR DESCRIPTION
This PR updates the `matplotlib` requirement to `>= 3.0.0`, mainly to remove annoying workarounds.

