### PR TITLE
Take advantage of super() functionality in python3.x

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -769,7 +769,7 @@ class ImageProduct(CliProduct):
 
     @classmethod
     def init_plot_options(cls, parser):
-        super().init_plot_options(parser)
+        super(ImageProduct, cls).init_plot_options(parser)
         cls.arg_color_axis(parser)
 
     @classmethod
@@ -797,7 +797,7 @@ class ImageProduct(CliProduct):
     def _finalize_arguments(self, args):
         if args.cmap is None:
             args.cmap = DEFAULT_CMAP.name
-        return super()._finalize_arguments(args)
+        return super(ImageProduct, self)._finalize_arguments(args)
 
     @staticmethod
     def get_color_label():
@@ -809,7 +809,7 @@ class ImageProduct(CliProduct):
         """Set properties for each axis (scale, limits, label) and create
         a colorbar.
         """
-        super().set_axes_properties()
+        super(ImageProduct, self).set_axes_properties()
         if not self.args.nocolorbar:
             self.set_colorbar()
 
@@ -834,7 +834,7 @@ class FFTMixin(object):
     def init_data_options(cls, parser):
         """Set up data input and signal processing options including FFTs
         """
-        super().init_data_options(parser)
+        super(FFTMixin, cls).init_data_options(parser)
         cls.arg_fft(parser)
 
     @classmethod
@@ -899,7 +899,7 @@ class FFTMixin(object):
                 args.overlap = recommended_overlap(args.window)
             except ValueError:
                 args.overlap = .5
-        return super()._finalize_arguments(args)
+        return super(FFTMixin, self)._finalize_arguments(args)
 
 
 @add_metaclass(abc.ABCMeta)
@@ -913,7 +913,7 @@ class TimeDomainProduct(CliProduct):
         This method includes the standard X-axis options, as well as a new
         ``--epoch`` option for the time axis.
         """
-        group = super().arg_xaxis(parser)
+        group = super(TimeDomainProduct, cls).arg_xaxis(parser)
         group.add_argument('--epoch', type=to_gps,
                            help='center X axis on this GPS time, may be'
                                 'absolute date/time or delta')
@@ -937,7 +937,7 @@ class TimeDomainProduct(CliProduct):
 
         if args.xmax is None:
             args.xmax = max(starts) + args.duration
-        return super()._finalize_arguments(args)
+        return super(TimeDomainProduct, self)._finalize_arguments(args)
 
     def get_xlabel(self):
         """Default X-axis label for plot

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -27,8 +27,6 @@ import warnings
 import sys
 from functools import wraps
 
-from six import add_metaclass
-
 from matplotlib import rcParams
 try:
     from matplotlib.cm import viridis as DEFAULT_CMAP
@@ -94,8 +92,7 @@ to_s = to_float('s')  # pylint: disable=invalid-name
 
 # -- base product class -------------------------------------------------------
 
-@add_metaclass(abc.ABCMeta)
-class CliProduct(object):
+class CliProduct(object, metaclass=abc.ABCMeta):
     """Base class for all cli plot products
 
     Parameters
@@ -761,15 +758,14 @@ class CliProduct(object):
 
 # -- extensions ---------------------------------------------------------------
 
-@add_metaclass(abc.ABCMeta)
-class ImageProduct(CliProduct):
+class ImageProduct(CliProduct, metaclass=abc.ABCMeta):
     """Base class for all x/y/color plots
     """
     MAX_DATASETS = 1
 
     @classmethod
     def init_plot_options(cls, parser):
-        super(ImageProduct, cls).init_plot_options(parser)
+        super().init_plot_options(parser)
         cls.arg_color_axis(parser)
 
     @classmethod
@@ -797,7 +793,7 @@ class ImageProduct(CliProduct):
     def _finalize_arguments(self, args):
         if args.cmap is None:
             args.cmap = DEFAULT_CMAP.name
-        return super(ImageProduct, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     @staticmethod
     def get_color_label():
@@ -809,7 +805,7 @@ class ImageProduct(CliProduct):
         """Set properties for each axis (scale, limits, label) and create
         a colorbar.
         """
-        super(ImageProduct, self).set_axes_properties()
+        super().set_axes_properties()
         if not self.args.nocolorbar:
             self.set_colorbar()
 
@@ -824,8 +820,7 @@ class ImageProduct(CliProduct):
         return  # image plots don't have legends
 
 
-@add_metaclass(abc.ABCMeta)
-class FFTMixin(object):
+class FFTMixin(object, metaclass=abc.ABCMeta):
     """Mixin for `CliProduct` class that will perform FFTs
 
     This just adds FFT-based command line options
@@ -834,7 +829,7 @@ class FFTMixin(object):
     def init_data_options(cls, parser):
         """Set up data input and signal processing options including FFTs
         """
-        super(FFTMixin, cls).init_data_options(parser)
+        super().init_data_options(parser)
         cls.arg_fft(parser)
 
     @classmethod
@@ -899,11 +894,10 @@ class FFTMixin(object):
                 args.overlap = recommended_overlap(args.window)
             except ValueError:
                 args.overlap = .5
-        return super(FFTMixin, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
 
-@add_metaclass(abc.ABCMeta)
-class TimeDomainProduct(CliProduct):
+class TimeDomainProduct(CliProduct, metaclass=abc.ABCMeta):
     """`CliProduct` with time on the X-axis
     """
     @classmethod
@@ -913,7 +907,7 @@ class TimeDomainProduct(CliProduct):
         This method includes the standard X-axis options, as well as a new
         ``--epoch`` option for the time axis.
         """
-        group = super(TimeDomainProduct, cls).arg_xaxis(parser)
+        group = super().arg_xaxis(parser)
         group.add_argument('--epoch', type=to_gps,
                            help='center X axis on this GPS time, may be'
                                 'absolute date/time or delta')
@@ -937,7 +931,7 @@ class TimeDomainProduct(CliProduct):
 
         if args.xmax is None:
             args.xmax = max(starts) + args.duration
-        return super(TimeDomainProduct, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     def get_xlabel(self):
         """Default X-axis label for plot
@@ -953,8 +947,7 @@ class TimeDomainProduct(CliProduct):
         return ''
 
 
-@add_metaclass(abc.ABCMeta)
-class FrequencyDomainProduct(CliProduct):
+class FrequencyDomainProduct(CliProduct, metaclass=abc.ABCMeta):
     """`CliProduct` with frequency on the X-axis
     """
     def get_xlabel(self):

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -769,7 +769,7 @@ class ImageProduct(CliProduct):
 
     @classmethod
     def init_plot_options(cls, parser):
-        super(ImageProduct, cls).init_plot_options(parser)
+        super().init_plot_options(parser)
         cls.arg_color_axis(parser)
 
     @classmethod
@@ -797,7 +797,7 @@ class ImageProduct(CliProduct):
     def _finalize_arguments(self, args):
         if args.cmap is None:
             args.cmap = DEFAULT_CMAP.name
-        return super(ImageProduct, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     @staticmethod
     def get_color_label():
@@ -809,7 +809,7 @@ class ImageProduct(CliProduct):
         """Set properties for each axis (scale, limits, label) and create
         a colorbar.
         """
-        super(ImageProduct, self).set_axes_properties()
+        super().set_axes_properties()
         if not self.args.nocolorbar:
             self.set_colorbar()
 
@@ -834,7 +834,7 @@ class FFTMixin(object):
     def init_data_options(cls, parser):
         """Set up data input and signal processing options including FFTs
         """
-        super(FFTMixin, cls).init_data_options(parser)
+        super().init_data_options(parser)
         cls.arg_fft(parser)
 
     @classmethod
@@ -899,7 +899,7 @@ class FFTMixin(object):
                 args.overlap = recommended_overlap(args.window)
             except ValueError:
                 args.overlap = .5
-        return super(FFTMixin, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
 
 @add_metaclass(abc.ABCMeta)
@@ -913,7 +913,7 @@ class TimeDomainProduct(CliProduct):
         This method includes the standard X-axis options, as well as a new
         ``--epoch`` option for the time axis.
         """
-        group = super(TimeDomainProduct, cls).arg_xaxis(parser)
+        group = super().arg_xaxis(parser)
         group.add_argument('--epoch', type=to_gps,
                            help='center X axis on this GPS time, may be'
                                 'absolute date/time or delta')
@@ -937,7 +937,7 @@ class TimeDomainProduct(CliProduct):
 
         if args.xmax is None:
             args.xmax = max(starts) + args.duration
-        return super(TimeDomainProduct, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     def get_xlabel(self):
         """Default X-axis label for plot

--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -37,7 +37,7 @@ class Coherence(Spectrum):
     MIN_DATASETS = 2
 
     def __init__(self, *args, **kwargs):
-        super(Coherence, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.ref_chan = self.args.ref or self.chan_list[0]
         # deal with channel type appendages
         if ',' in self.ref_chan:
@@ -45,7 +45,7 @@ class Coherence(Spectrum):
 
     @classmethod
     def arg_channels(cls, parser):
-        group = super(Coherence, cls).arg_channels(parser)
+        group = super().arg_channels(parser)
         group.add_argument('--ref', help='Reference channel against which '
                                          'others will be compared')
         return group
@@ -58,7 +58,7 @@ class Coherence(Spectrum):
                 args.ymin = 0
             if not args.ymax:
                 args.ymax = 1.05
-        return super(Coherence, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     def get_ylabel(self):
         """Text for y-axis label
@@ -125,7 +125,7 @@ class Coherence(Spectrum):
     def set_legend(self):
         """Create a legend for this product
         """
-        leg = super(Coherence, self).set_legend()
+        leg = super().set_legend()
         if leg is not None:
             leg.set_title('Coherence with:')
         return leg

--- a/gwpy/cli/coherencegram.py
+++ b/gwpy/cli/coherencegram.py
@@ -37,7 +37,7 @@ class Coherencegram(Spectrogram):
     action = 'coherencegram'
 
     def __init__(self, *args, **kwargs):
-        super(Coherencegram, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.ref_chan = self.args.ref or self.chan_list[0]
         # deal with channel type (e.g. m-trend)
         if ',' in self.ref_chan:
@@ -45,7 +45,7 @@ class Coherencegram(Spectrogram):
 
     @classmethod
     def arg_channels(cls, parser):
-        group = super(Coherencegram, cls).arg_channels(parser)
+        group = super().arg_channels(parser)
         group.add_argument('--ref', help='Reference channel against which '
                                          'others will be compared')
         return group
@@ -60,7 +60,7 @@ class Coherencegram(Spectrogram):
                 args.imax = 1.
         if args.cmap is None and DEFAULT_CMAP is not None:
             args.cmap = DEFAULT_CMAP.name
-        return super(Coherencegram, self)._finalize_arguments(args)
+        return super()._finalize_arguments(args)
 
     def get_ylabel(self):
         """Text for y-axis label

--- a/gwpy/cli/gwpy_plot.py
+++ b/gwpy/cli/gwpy_plot.py
@@ -68,7 +68,7 @@ class HelpFormatter(ArgumentDefaultsHelpFormatter, RawTextHelpFormatter):
     def _format_usage(self, usage, actions, groups, prefix):
         if prefix is None:
             prefix = "Usage: "
-        return super(HelpFormatter, self)._format_usage(
+        return super()._format_usage(
             usage,
             actions,
             groups,
@@ -78,7 +78,7 @@ class HelpFormatter(ArgumentDefaultsHelpFormatter, RawTextHelpFormatter):
 
 class _ArgumentParser(ArgumentParser):
     def __init__(self, *args, **kwargs):
-        super(_ArgumentParser, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._positionals.title = 'Positional arguments'
         self._optionals.title = 'Options'
 

--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -36,7 +36,7 @@ class Qtransform(Spectrogram):
     action = 'qtransform'
 
     def __init__(self, *args, **kwargs):
-        super(Qtransform, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         args = self.args
         self.qxfrm_args = {
@@ -54,7 +54,7 @@ class Qtransform(Spectrogram):
     @classmethod
     def init_data_options(cls, parser):
         # call super of FFTMixin to skip setting FFT arguments
-        super(FFTMixin, cls).init_data_options(parser)
+        super(FFTMixin).init_data_options(parser)
         cls.arg_qxform(parser)
 
     @classmethod
@@ -69,13 +69,13 @@ class Qtransform(Spectrogram):
 
     @classmethod
     def arg_signal(cls, parser):
-        group = super(Qtransform, cls).arg_signal(parser)
+        group = super().arg_signal(parser)
         group.add_argument('--sample-freq', type=float, default=2048,
                            help='Downsample freq')
 
     @classmethod
     def arg_plot(cls, parser):
-        group = super(Qtransform, cls).arg_plot(parser)
+        group = super().arg_plot(parser)
 
         # remove --out option
         outopt = [act for act in group._actions if act.dest == 'out'][0]
@@ -144,7 +144,7 @@ class Qtransform(Spectrogram):
         xmin = args.xmin
         xmax = args.xmax
 
-        super(Qtransform, self)._finalize_arguments(args)
+        super()._finalize_arguments(args)
 
         # unset defaults from `TimeDomainProduct`
         args.xmin = xmin
@@ -231,7 +231,7 @@ class Qtransform(Spectrogram):
 
     def scale_axes_from_data(self):
         self.args.xmin, self.args.xmax = self.result.xspan
-        return super(Qtransform, self).scale_axes_from_data()
+        return super().scale_axes_from_data()
 
     def has_more_plots(self):
         """any ranges left to plot?
@@ -244,4 +244,4 @@ class Qtransform(Spectrogram):
         png = '{0}-{1}-{2}.png'.format(cname, float(self.args.gps),
                                        self.args.plot[self.plot_num])
         outfile = os.path.join(outdir, png)
-        return super(Qtransform, self).save(outfile)
+        return super().save(outfile)

--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -54,7 +54,7 @@ class Qtransform(Spectrogram):
     @classmethod
     def init_data_options(cls, parser):
         # call super of FFTMixin to skip setting FFT arguments
-        super(FFTMixin).init_data_options(parser)
+        super(FFTMixin, cls).init_data_options(parser)
         cls.arg_qxform(parser)
 
     @classmethod

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -33,7 +33,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
     action = 'spectrogram'
 
     def __init__(self, *args, **kwargs):
-        super(Spectrogram, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         #: attribute to hold calculated Spectrogram data array
         self.result = None
@@ -45,7 +45,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
     def _finalize_arguments(self, args):
         if args.color_scale is None:
             args.color_scale = 'log'
-        super(Spectrogram, self)._finalize_arguments(args)
+        super()._finalize_arguments(args)
 
     @property
     def units(self):
@@ -73,7 +73,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
                 self.units[0].to_string('latex').strip('$'))
         elif len(self.units) == 1:
             return 'ASD ({0})'.format(self.units[0].to_string('generic'))
-        return super(Spectrogram, self).get_color_label()
+        return super().get_color_label()
 
     def get_stride(self):
         """Calculate the stride for the spectrogram

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -36,7 +36,7 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
     action = 'spectrum'
 
     def __init__(self, *args, **kwargs):
-        super(Spectrum, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.spectra = []
 
     @property
@@ -56,7 +56,7 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
     def _finalize_arguments(self, args):
         if args.yscale is None:
             args.yscale = 'log'
-        super(Spectrum, self)._finalize_arguments(args)
+        super()._finalize_arguments(args)
 
     def get_ylabel(self):
         """Text for y-axis label

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -44,7 +44,7 @@ class TimeSeries(TimeDomainProduct):
             return units[0].to_string()
         elif len(units) > 1:
             return 'Multiple units'
-        return super(TimeSeries, self).get_ylabel()
+        return super().get_ylabel()
 
     def get_suptitle(self):
         """Start of default super title, first channel is appended to it
@@ -52,7 +52,7 @@ class TimeSeries(TimeDomainProduct):
         return 'Time series: {0}'.format(self.chan_list[0])
 
     def get_title(self):
-        suffix = super(TimeSeries, self).get_title()
+        suffix = super().get_title()
         # limit significant digits for minute trends
         rates = {ts.sample_rate.round(3) for ts in self.timeseries}
         fss = '({0})'.format('), ('.join(map(str, rates)))

--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -103,7 +103,7 @@ class FrequencySeries(Series):
             kwargs['xindex'] = frequencies
 
         # generate FrequencySeries
-        return super(FrequencySeries, cls).__new__(
+        return super().__new__(
             cls, data, unit=unit, name=name, channel=channel,
             epoch=epoch, **kwargs)
 
@@ -201,7 +201,7 @@ class FrequencySeries(Series):
                 kwargs.setdefault('yscale', 'log')
 
         kwargs.update(xscale=xscale)
-        return super(FrequencySeries, self).plot(**kwargs)
+        return super().plot(**kwargs)
 
     def ifft(self):
         """Compute the one-dimensional discrete inverse Fourier

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -57,8 +57,9 @@ class SpectralVariance(Array2D):
             kwargs['xindex'] = frequencies
 
         # generate SpectralVariance using the Series constructor
-        new = super(Array2D).__new__(cls, data, unit=unit, name=name,
-                                     channel=channel, epoch=epoch, **kwargs)
+        new = super(Array2D, cls).__new__(cls, data, unit=unit, name=name,
+                                          channel=channel, epoch=epoch,
+                                          **kwargs)
 
         # set bins
         new.bins = bins

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -57,9 +57,8 @@ class SpectralVariance(Array2D):
             kwargs['xindex'] = frequencies
 
         # generate SpectralVariance using the Series constructor
-        new = super(Array2D, cls).__new__(cls, data, unit=unit, name=name,
-                                          channel=channel, epoch=epoch,
-                                          **kwargs)
+        new = super(Array2D).__new__(cls, data, unit=unit, name=name,
+                                     channel=channel, epoch=epoch, **kwargs)
 
         # set bins
         new.bins = bins
@@ -215,7 +214,7 @@ class SpectralVariance(Array2D):
     def __getitem__(self, item):
         # disable slicing bins
         if not isinstance(item, tuple) or null_slice(item[1]):
-            return super(SpectralVariance, self).__getitem__(item)
+            return super().__getitem__(item)
         raise NotImplementedError("cannot slice SpectralVariance across bins")
     __getitem__.__doc__ = Array2D.__getitem__.__doc__
 
@@ -357,4 +356,4 @@ class SpectralVariance(Array2D):
                 numpy.allclose(numpy.diff(numpy.log10(bins), n=2), 0)):
             kwargs.setdefault('yscale', 'log')
         kwargs.update(method=method, xscale=xscale)
-        return super(SpectralVariance, self).plot(**kwargs)
+        return super().plot(**kwargs)

--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -105,7 +105,7 @@ class TestSpectralVariance(_TestArray2D):
         assert array.dy == self.bins[1] - self.bins[0]
 
     def test_is_compatible(self, array):
-        return super(_TestArray2D).test_is_compatible(array)
+        return super(_TestArray2D, self).test_is_compatible(array)
 
     def test_plot(self, array):
         with rc_context(rc={'text.usetex': False}):

--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -44,14 +44,14 @@ class TestSpectralVariance(_TestArray2D):
 
     @classmethod
     def setup_class(cls):
-        super(TestSpectralVariance, cls).setup_class()
+        super().setup_class()
         cls.bins = numpy.linspace(0, 1e5, cls.data.shape[1] + 1, endpoint=True)
 
     @classmethod
     def create(cls, *args, **kwargs):
         args = list(args)
         args.insert(0, cls.bins)
-        return super(TestSpectralVariance, cls).create(*args, **kwargs)
+        return super().create(*args, **kwargs)
 
     # -- test properties ------------------------
 
@@ -105,7 +105,7 @@ class TestSpectralVariance(_TestArray2D):
         assert array.dy == self.bins[1] - self.bins[0]
 
     def test_is_compatible(self, array):
-        return super(_TestArray2D, self).test_is_compatible(array)
+        return super(_TestArray2D).test_is_compatible(array)
 
     def test_plot(self, array):
         with rc_context(rc={'text.usetex': False}):

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -199,7 +199,7 @@ def build_content_handler(parent, filter_func):
     class _ContentHandler(parent):
         # pylint: disable=too-few-public-methods
         def __init__(self, document):
-            super(_ContentHandler, self).__init__(document, filter_func)
+            super().__init__(document, filter_func)
 
     return use_in(_ContentHandler)
 

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -103,7 +103,7 @@ def restore_grid(func):
 
 class Axes(_Axes):
     def __init__(self, *args, **kwargs):
-        super(Axes, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # handle Series in `ax.plot()`
         self._get_lines = PlotArgsProcessor(self)
@@ -129,7 +129,7 @@ class Axes(_Axes):
                     unit, utc, epoch))
 
         try:
-            super(Axes, self).draw(*args, **kwargs)
+            super().draw(*args, **kwargs)
         finally:
             for ax in labels:  # reset labels
                 ax.isDefault_label = True
@@ -191,7 +191,7 @@ class Axes(_Axes):
                 y = numpy.asarray(y)[sortidx]
                 c = numpy.asarray(c)[sortidx]
 
-        return super(Axes, self).scatter(x, y, c=c, **kwargs)
+        return super().scatter(x, y, c=c, **kwargs)
 
     scatter.__doc__ = _Axes.scatter.__doc__.replace(
         'marker :',
@@ -233,7 +233,7 @@ class Axes(_Axes):
         if hasattr(array, "yspan"):  # Array2D
             return self._imshow_array2d(array, *args, **kwargs)
 
-        image = super(Axes, self).imshow(array, *args, **kwargs)
+        image = super().imshow(array, *args, **kwargs)
         self.autoscale(enable=None, axis='both', tight=None)
         return image
 
@@ -278,7 +278,7 @@ class Axes(_Axes):
         """
         if len(args) == 1 and hasattr(args[0], "yindex"):  # Array2D
             return self._pcolormesh_array2d(*args, **kwargs)
-        return super(Axes, self).pcolormesh(*args, **kwargs)
+        return super().pcolormesh(*args, **kwargs)
 
     def _pcolormesh_array2d(self, array, *args, **kwargs):
         """Render an `~gwpy.types.Array2D` using `Axes.pcolormesh`
@@ -323,7 +323,7 @@ class Axes(_Axes):
                 log(hrange[0], logbase), log(hrange[1], logbase),
                 nbins+1, endpoint=True)
 
-        return super(Axes, self).hist(x, *args, **kwargs)
+        return super().hist(x, *args, **kwargs)
 
     hist.__doc__ = _Axes.hist.__doc__.replace(
         'color :',
@@ -523,7 +523,7 @@ class Axes(_Axes):
             handler_map.setdefault(Line2D, HandlerLine2D(linewidth or 6))
 
         # create legend
-        return super(Axes, self).legend(*args, **kwargs)
+        return super().legend(*args, **kwargs)
 
     legend.__doc__ = _Axes.legend.__doc__.replace(
         "Call signatures",
@@ -613,4 +613,4 @@ class PlotArgsProcessor(_process_plot_var_args):
                 args = args[1:]
             newargs.extend(this)
 
-        return super(PlotArgsProcessor, self).__call__(*newargs, **kwargs)
+        return super().__call__(*newargs, **kwargs)

--- a/gwpy/plot/bode.py
+++ b/gwpy/plot/bode.py
@@ -105,7 +105,7 @@ class BodePlot(Plot):
                 figargs[key] = kwargs.pop(key)
 
         # generate figure
-        super(BodePlot, self).__init__(**figargs)
+        super().__init__(**figargs)
 
         # delete the axes, and create two more
         self.add_subplot(2, 1, 1)

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -84,7 +84,7 @@ class GPSMixin(object):
         self.set_unit(kwargs.pop('unit', None))
         self.set_epoch(kwargs.pop('epoch', None))
         try:  # call super for __init__ if this is part of a larger MRO
-            super(GPSMixin, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
         except TypeError:  # otherwise return
             pass
 
@@ -188,7 +188,7 @@ class GPSTransformBase(GPSMixin, Transform):
         # format ticks using decimal for precision display
         if isinstance(values, (Number, Decimal)):
             return self._transform_decimal(values, self.epoch or 0, self.scale)
-        return super(GPSTransformBase, self).transform(values)
+        return super().transform(values)
 
     def transform_non_affine(self, values):
         """Transform an array of GPS times.
@@ -291,8 +291,7 @@ class GPSAutoLocator(ticker.MaxNLocator):
         Each of the `epoch` and `scale` keyword arguments should match those
         passed to the `GPSFormatter`
         """
-        super(GPSAutoLocator, self).__init__(nbins=nbins, steps=steps,
-                                             **kwargs)
+        super().__init__(nbins=nbins, steps=steps, **kwargs)
 
     def tick_values(self, vmin, vmax):
         transform = self.axis.get_transform()
@@ -308,7 +307,7 @@ class GPSAutoLocator(ticker.MaxNLocator):
             self.set_params(steps=None)
 
         try:
-            ticks = super(GPSAutoLocator, self).tick_values(vmin, vmax)
+            ticks = super().tick_values(vmin, vmax)
         finally:
             self._steps = steps
         return transform.inverted().transform(ticks)
@@ -395,7 +394,7 @@ class GPSScale(GPSMixin, LinearScale):
         unit:
             either name (`str`) or scale (float in seconds)
         """
-        super(GPSScale, self).__init__(unit=unit, epoch=epoch)
+        super().__init__(unit=unit, epoch=epoch)
         self.axis = axis
         # set tight scaling on parent axes
         getattr(axis.axes, 'set_{0}margin'.format(axis.axis_name))(0)
@@ -487,7 +486,7 @@ def _gps_scale_factory(unit):
         def __init__(self, axis, epoch=None):
             """
             """
-            super(FixedGPSScale, self).__init__(axis, epoch=epoch, unit=unit)
+            super().__init__(axis, epoch=epoch, unit=unit)
     return FixedGPSScale
 
 

--- a/gwpy/plot/legend.py
+++ b/gwpy/plot/legend.py
@@ -41,11 +41,11 @@ class HandlerLine2D(legend_handler.HandlerLine2D):
         for all information
     """
     def __init__(self, linewidth=6., **kw):
-        super(HandlerLine2D, self).__init__(**kw)
+        super().__init__(**kw)
         self._linewidth = linewidth
 
     def create_artists(self, *args, **kwargs):
-        line, marker = super(HandlerLine2D, self).create_artists(
+        line, marker = super().create_artists(
             *args,
             **kwargs
         )

--- a/gwpy/plot/log.py
+++ b/gwpy/plot/log.py
@@ -97,7 +97,7 @@ class CombinedLogFormatterMathtext(MinorLogFormatterMathtext):
     def __call__(self, x, pos=None):
         if is_decade(x, self._base):
             # pylint: disable=bad-super-call
-            return super(MinorLogFormatterMathtext).__call__(x, pos=pos)
+            return super(MinorLogFormatterMathtext, self).__call__(x, pos=pos)
         return super().__call__(x, pos=pos)
 
 

--- a/gwpy/plot/log.py
+++ b/gwpy/plot/log.py
@@ -67,7 +67,7 @@ class MinorLogFormatterMathtext(GWpyLogFormatterMathtext):
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('labelOnlyBase', False)
-        super(MinorLogFormatterMathtext, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __call__(self, x, pos=None):
         """Format the minor tick label if less than 2 visible major ticks.
@@ -81,7 +81,7 @@ class MinorLogFormatterMathtext(GWpyLogFormatterMathtext):
         # if already two major ticks, don't need minor labels
         if nticks >= 2 or (halfdecade and not is_decade(x * 2, self._base)):
             return ''
-        return super(MinorLogFormatterMathtext, self).__call__(x, pos=pos)
+        return super().__call__(x, pos=pos)
 
 
 class CombinedLogFormatterMathtext(MinorLogFormatterMathtext):
@@ -97,8 +97,8 @@ class CombinedLogFormatterMathtext(MinorLogFormatterMathtext):
     def __call__(self, x, pos=None):
         if is_decade(x, self._base):
             # pylint: disable=bad-super-call
-            return super(MinorLogFormatterMathtext, self).__call__(x, pos=pos)
-        return super(CombinedLogFormatterMathtext, self).__call__(x, pos=pos)
+            return super(MinorLogFormatterMathtext).__call__(x, pos=pos)
+        return super().__call__(x, pos=pos)
 
 
 class GWpyLogScale(LogScale):

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -122,7 +122,7 @@ class Plot(figure.Figure):
         # create Figure
         num = kwargs.pop('num', max(pyplot.get_fignums() or {0}) + 1)
         self._parse_subplotpars(kwargs)
-        super(Plot, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.number = num
 
         # add interactivity (scraped from pyplot.figure())
@@ -278,7 +278,7 @@ class Plot(figure.Figure):
                 block = False
 
         # render
-        super(Plot, self).show(warn=warn)
+        super().show(warn=warn)
 
         # don't block on ipython with interactive backends
         if block is None and interactive_backend():
@@ -400,7 +400,7 @@ class Plot(figure.Figure):
             self, mappable, ax, cax=cax, fraction=fraction, **kwargs)
 
         # generate colour bar
-        cbar = super(Plot, self).colorbar(mappable, **kwargs)
+        cbar = super().colorbar(mappable, **kwargs)
         self.colorbars.append(cbar)
         if label:  # mpl<1.3 doesn't accept label in Colorbar constructor
             cbar.set_label(label)

--- a/gwpy/plot/segments.py
+++ b/gwpy/plot/segments.py
@@ -71,7 +71,7 @@ class SegmentAxes(Axes):
         kwargs.setdefault('insetlabels', False)
 
         # make axes
-        super(SegmentAxes, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # set y-axis labels
         self.yaxis.set_major_locator(MultipleLocator())
@@ -130,7 +130,7 @@ class SegmentAxes(Axes):
             out.append(plotter(args[0], **kwargs))
             args.pop(0)
         if args:
-            out.extend(super(SegmentAxes, self).plot(*args, **kwargs))
+            out.extend(super().plot(*args, **kwargs))
         self.autoscale(enable=None, axis='both', tight=False)
         return out
 
@@ -434,7 +434,7 @@ class SegmentAxes(Axes):
                     del tick._orig_bbox
                     del tick._orig_ha
                     del tick._orig_pos
-        return super(SegmentAxes, self).draw(*args, **kwargs)
+        return super().draw(*args, **kwargs)
 
     draw.__doc__ = Axes.draw.__doc__
 
@@ -499,6 +499,6 @@ class SegmentRectangle(Rectangle):
                              "'bottom'")
         width = segment[1] - segment[0]
 
-        super(SegmentRectangle, self).__init__((segment[0], y0), width=width,
-                                               height=height, **kwargs)
+        super().__init__((segment[0], y0), width=width,
+                         height=height, **kwargs)
         self.segment = segment

--- a/gwpy/plot/units.py
+++ b/gwpy/plot/units.py
@@ -31,7 +31,7 @@ class LatexInlineDimensional(LatexInline):
 
     @classmethod
     def to_string(cls, unit):
-        u = '[{0}]'.format(super(LatexInlineDimensional, cls).to_string(unit))
+        u = '[{0}]'.format(super().to_string(unit))
 
         if unit.physical_type not in {None, 'unknown', 'dimensionless'}:
             ptype = cls._latex_escape(unit.physical_type.title())

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1704,7 +1704,7 @@ class DataQualityDict(OrderedDict):
         """
         if deep:
             return deepcopy(self)
-        return super(DataQualityDict, self).copy()
+        return super().copy()
 
     def __iand__(self, other):
         for key, value in other.items():

--- a/gwpy/segments/segments.py
+++ b/gwpy/segments/segments.py
@@ -138,7 +138,7 @@ class SegmentList(segmentlist):
     extent = return_as(Segment)(segmentlist.extent)
 
     def coalesce(self):
-        super(SegmentList, self).coalesce()
+        super().coalesce()
         for i, seg in enumerate(self):
             self[i] = Segment(seg[0], seg[1])
         return self

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -76,7 +76,7 @@ class QBase(QObject):
     This class just provides a property for Q-prime = Q / sqrt(11)
     """
     def __init__(self, q, duration, sampling, mismatch=DEFAULT_MISMATCH):
-        super(QBase, self).__init__(duration, sampling, mismatch=mismatch)
+        super().__init__(duration, sampling, mismatch=mismatch)
         self.q = float(q)
 
     @property
@@ -113,7 +113,7 @@ class QTiling(QObject):
                  qrange=DEFAULT_QRANGE,
                  frange=DEFAULT_FRANGE,
                  mismatch=DEFAULT_MISMATCH):
-        super(QTiling, self).__init__(duration, sampling, mismatch=mismatch)
+        super().__init__(duration, sampling, mismatch=mismatch)
         self.qrange = (float(qrange[0]), float(qrange[1]))
         self.frange = [float(frange[0]), float(frange[1])]
 
@@ -228,7 +228,7 @@ class QPlane(QBase):
     """
     def __init__(self, q, frange, duration, sampling,
                  mismatch=DEFAULT_MISMATCH):
-        super(QPlane, self).__init__(q, duration, sampling, mismatch=mismatch)
+        super().__init__(q, duration, sampling, mismatch=mismatch)
         self.frange = [float(frange[0]), float(frange[1])]
 
         if self.frange[0] == 0:  # set non-zero lower frequency
@@ -336,7 +336,7 @@ class QTile(QBase):
     """
     def __init__(self, q, frequency, duration, sampling,
                  mismatch=DEFAULT_MISMATCH):
-        super(QTile, self).__init__(q, duration, sampling, mismatch=mismatch)
+        super().__init__(q, duration, sampling, mismatch=mismatch)
         self.frequency = frequency
 
     @property

--- a/gwpy/spectrogram/spectrogram.py
+++ b/gwpy/spectrogram/spectrogram.py
@@ -159,8 +159,8 @@ class Spectrogram(Array2D):
             kwargs['yindex'] = frequencies
 
         # generate Spectrogram
-        return super(Spectrogram, cls).__new__(cls, data, unit=unit, name=name,
-                                               channel=channel, **kwargs)
+        return super().__new__(cls, data, unit=unit, name=name,
+                               channel=channel, **kwargs)
 
     # -- Spectrogram properties -----------------
 
@@ -353,7 +353,7 @@ class Spectrogram(Array2D):
             kwargs.setdefault('method', 'imshow' if kwargs.pop('imshow') else
                                         'pcolormesh')
         kwargs.update(figsize=figsize, xscale=xscale)
-        return super(Spectrogram, self).plot(**kwargs)
+        return super().plot(**kwargs)
 
     @classmethod
     def from_spectra(cls, *spectra, **kwargs):
@@ -592,8 +592,7 @@ class Spectrogram(Array2D):
     # -- Spectrogram ufuncs ---------------------
 
     def _wrap_function(self, function, *args, **kwargs):
-        out = super(Spectrogram, self)._wrap_function(
-            function, *args, **kwargs)
+        out = super()._wrap_function(function, *args, **kwargs)
         # requested frequency axis, return a FrequencySeries
         if out.ndim == 1 and out.x0.unit == self.y0.unit:
             return FrequencySeries(out.value, name=out.name, unit=out.unit,
@@ -610,7 +609,7 @@ class Spectrogram(Array2D):
     # -- other ----------------------------------
 
     def __getitem__(self, item):
-        out = super(Spectrogram, self).__getitem__(item)
+        out = super().__getitem__(item)
 
         # set epoch manually, because Spectrogram doesn't store self._epoch
         if isinstance(out, self._columnclass):

--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -44,7 +44,7 @@ class TestSpectrogram(_TestArray2D):
     TEST_CLASS = Spectrogram
 
     def test_new(self):
-        super(TestSpectrogram, self).test_new()
+        super().test_new()
 
         # check handling of epoch vs t0
         a = self.create(epoch=10)
@@ -63,7 +63,7 @@ class TestSpectrogram(_TestArray2D):
         assert array.epoch.gps == array.x0.value
 
     def test_value_at(self, array):
-        super(TestSpectrogram, self).test_value_at(array)
+        super().test_value_at(array)
         v = array.value_at(5000 * units.millisecond,
                            2000 * units.milliHertz)
         assert v == self.data[5][2] * array.unit

--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -112,7 +112,7 @@ class EventColumn(Column):
     def __new__(cls, *args, **kwargs):
         warnings.warn("the EventColumn is deprecated, and will be removed in "
                       "a future gwpy release", DeprecationWarning)
-        super(EventColumn, cls).__new__(*args, **kwargs)
+        super().__new__(*args, **kwargs)
 
     def in_segmentlist(self, segmentlist):
         """Return the index of values lying inside the given segmentlist

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -182,9 +182,8 @@ class TimeSeriesBase(Series):
             kwargs['xindex'] = times
 
         # generate TimeSeries
-        new = super(TimeSeriesBase, cls).__new__(cls, data, name=name,
-                                                 unit=unit, channel=channel,
-                                                 **kwargs)
+        new = super().__new__(cls, data, name=name, unit=unit,
+                              channel=channel, **kwargs)
 
         # manually set sample_rate if given
         if sample_rate is not None:
@@ -642,7 +641,7 @@ class TimeSeriesBase(Series):
             for documentation of keyword arguments used in rendering the data
         """
         kwargs.update(figsize=figsize, xscale=xscale)
-        return super(TimeSeriesBase, self).plot(method=method, **kwargs)
+        return super().plot(method=method, **kwargs)
 
     @classmethod
     def from_nds2_buffer(cls, buffer_, scaled=None, copy=True, **metadata):
@@ -777,8 +776,7 @@ class TimeSeriesBase(Series):
     # -- TimeSeries operations ------------------
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        out = super(TimeSeriesBase, self).__array_ufunc__(
-            ufunc, method, *inputs, **kwargs)
+        out = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
         if out.dtype is numpy.dtype(bool) and len(inputs) == 2:
             from .statevector import StateTimeSeries
             orig, value = inputs
@@ -811,8 +809,7 @@ class TimeSeriesBase(Series):
             result.name = '{0!s} {1!s} {2!s}'.format(oname, op_, vname)
         # otherwise, return a regular TimeSeries
         else:
-            result = super(TimeSeriesBase, self).__array_wrap__(
-                obj, context=context)
+            result = super().__array_wrap__(obj, context=context)
         return result
 
 
@@ -1532,7 +1529,7 @@ class TimeSeriesBaseList(list):
     def __init__(self, *items):
         """Initialise a new list
         """
-        super(TimeSeriesBaseList, self).__init__()
+        super().__init__()
         for item in items:
             self.append(item)
 
@@ -1547,13 +1544,13 @@ class TimeSeriesBaseList(list):
         if not isinstance(item, self.EntryClass):
             raise TypeError("Cannot append type '%s' to %s"
                             % (type(item).__name__, type(self).__name__))
-        super(TimeSeriesBaseList, self).append(item)
+        super().append(item)
         return self
     append.__doc__ = list.append.__doc__
 
     def extend(self, item):
         item = TimeSeriesBaseList(*item)
-        super(TimeSeriesBaseList, self).extend(item)
+        super().extend(item)
     extend.__doc__ = list.extend.__doc__
 
     def coalesce(self):
@@ -1622,13 +1619,13 @@ class TimeSeriesBaseList(list):
         return out
 
     def __getslice__(self, i, j):
-        return type(self)(*super(TimeSeriesBaseList, self).__getslice__(i, j))
+        return type(self)(*super().__getslice__(i, j))
 
     def __getitem__(self, key):
         if isinstance(key, slice):
             return type(self)(
-                *super(TimeSeriesBaseList, self).__getitem__(key))
-        return super(TimeSeriesBaseList, self).__getitem__(key)
+                *super().__getitem__(key))
+        return super().__getitem__(key)
 
     def copy(self):
         """Return a copy of this list with each element copied to new memory

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -175,7 +175,7 @@ class StateTimeSeries(TimeSeriesBase):
             data = numpy.asarray(data)
         if not isinstance(data, cls):
             data = data.astype(bool)
-        return super(StateTimeSeries, cls).__new__(
+        return super().__new__(
             cls, data, t0=t0, dt=dt, sample_rate=sample_rate, times=times,
             name=name, channel=channel, **kwargs)
 
@@ -199,15 +199,13 @@ class StateTimeSeries(TimeSeriesBase):
     # -- math handling (always boolean) ---------
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        out = super(StateTimeSeries, self).__array_ufunc__(
-            ufunc, method, *inputs, **kwargs)
+        out = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
         if out.ndim:
             return out.view(bool)
         return out
 
     def __array_wrap__(self, obj, context=None):
-        return super(StateTimeSeries, self).__array_wrap__(
-            obj, context=context).view(bool)
+        return super().__array_wrap__(obj, context=context).view(bool)
 
     def diff(self, n=1, axis=-1):
         slice1 = (slice(1, None),)
@@ -303,13 +301,13 @@ class StateTimeSeries(TimeSeriesBase):
     @wraps(TimeSeriesBase.from_nds2_buffer)
     def from_nds2_buffer(cls, buffer, **metadata):
         metadata.setdefault('unit', None)
-        return super(StateTimeSeries, cls).from_nds2_buffer(buffer, **metadata)
+        return super().from_nds2_buffer(buffer, **metadata)
 
     def __getitem__(self, item):
         if isinstance(item, (float, int)):
             return numpy.ndarray.__getitem__(self, item)
         else:
-            return super(StateTimeSeries, self).__getitem__(item)
+            return super().__getitem__(item)
 
     def tolist(self):
         return self.value.tolist()
@@ -506,10 +504,10 @@ class StateVector(TimeSeriesBase):
                 times=None, channel=None, name=None, **kwargs):
         """Generate a new `StateVector`.
         """
-        new = super(StateVector, cls).__new__(cls, data, t0=t0, dt=dt,
-                                              sample_rate=sample_rate,
-                                              times=times, channel=channel,
-                                              name=name, **kwargs)
+        new = super().__new__(cls, data, t0=t0, dt=dt,
+                              sample_rate=sample_rate,
+                              times=times, channel=channel,
+                              name=name, **kwargs)
         new.bits = bits
         return new
 
@@ -692,7 +690,7 @@ class StateVector(TimeSeriesBase):
 
         Notes
         -----"""
-        return super(StateVector, cls).read(source, *args, **kwargs)
+        return super().read(source, *args, **kwargs)
 
     def to_dqflags(self, bits=None, minlen=1, dtype=float, round=False):
         """Convert this `StateVector` into a `~gwpy.segments.DataQualityDict`
@@ -872,7 +870,7 @@ class StateVector(TimeSeriesBase):
             statevector flag.
         """
         if format == 'timeseries':
-            return super(StateVector, self).plot(**kwargs)
+            return super().plot(**kwargs)
         if format == 'segments':
             from ..plot import Plot
             kwargs.setdefault('xscale', 'auto-gps')
@@ -1020,7 +1018,7 @@ class StateVectorDict(TimeSeriesBaseDict):
 
         Notes
         -----"""
-        return super(StateVectorDict, cls).read(source, *args, **kwargs)
+        return super().read(source, *args, **kwargs)
 
 
 class StateVectorList(TimeSeriesBaseList):

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -53,7 +53,7 @@ class TestTimeSeriesBase(_TestSeries):
     def test_new(self):
         """Test `gwpy.timeseries.TimeSeriesBase` constructor
         """
-        array = super(TestTimeSeriesBase, self).test_new()
+        array = super().test_new()
 
         # check time-domain metadata
         assert array.epoch == GPS_EPOCH

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -268,11 +268,11 @@ class Array(Quantity):
     # -- Pickle helpers -------------------------
 
     def dumps(self):
-        return super(Quantity).dumps()
+        return super(Quantity, self).dumps()
     dumps.__doc__ = numpy.ndarray.dumps.__doc__
 
     def tostring(self, order='C'):
-        return super(Quantity).tostring(order=order)
+        return super(Quantity, self).tostring(order=order)
     tostring.__doc__ = numpy.ndarray.tostring.__doc__
 
     # -- new properties -------------------------

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -119,9 +119,8 @@ class Array(Quantity):
             unit = parse_unit(unit, parse_strict='warn')
 
         # create new array
-        new = super(Array, cls).__new__(cls, value, unit=unit, dtype=dtype,
-                                        copy=False, order=order, subok=subok,
-                                        ndmin=ndmin)
+        new = super().__new__(cls, value, unit=unit, dtype=dtype, copy=False,
+                              order=order, subok=subok, ndmin=ndmin)
 
         # explicitly copy here to get ownership of the data,
         # see (astropy/astropy#7244)
@@ -146,7 +145,7 @@ class Array(Quantity):
     def _wrap_function(self, function, *args, **kwargs):
         # if the output of the function is a scalar, return it as a Quantity
         # not whatever class this is
-        out = super(Array, self)._wrap_function(function, *args, **kwargs)
+        out = super()._wrap_function(function, *args, **kwargs)
         if out.ndim == 0:
             return Quantity(out.value, out.unit)
         return out
@@ -162,7 +161,7 @@ class Array(Quantity):
             return
 
         # call Quantity.__array_finalize__ to handle the units
-        super(Array, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
 
         # then update metadata
         if isinstance(obj, Quantity):
@@ -192,12 +191,12 @@ class Array(Quantity):
                         setattr(self, _attr, val)
 
     def __getattr__(self, attr):
-        return super(Array, self).__getattribute__(attr)
+        return super().__getattribute__(attr)
 
     def __getitem__(self, item):
         if isinstance(item, list):
             item = tuple(item)
-        new = super(Array, self).__getitem__(item)
+        new = super().__getitem__(item)
 
         # return scalar as a Quantity
         if numpy.ndim(new) == 0:
@@ -269,11 +268,11 @@ class Array(Quantity):
     # -- Pickle helpers -------------------------
 
     def dumps(self):
-        return super(Quantity, self).dumps()
+        return super(Quantity).dumps()
     dumps.__doc__ = numpy.ndarray.dumps.__doc__
 
     def tostring(self, order='C'):
-        return super(Quantity, self).tostring(order=order)
+        return super(Quantity).tostring(order=order)
     tostring.__doc__ = numpy.ndarray.tostring.__doc__
 
     # -- new properties -------------------------
@@ -395,8 +394,7 @@ class Array(Quantity):
     # -- array methods --------------------------
 
     def __array_ufunc__(self, function, method, *inputs, **kwargs):
-        out = super(Array, self).__array_ufunc__(function, method,
-                                                 *inputs, **kwargs)
+        out = super().__array_ufunc__(function, method, *inputs, **kwargs)
         # if a ufunc returns a scalar, return a Quantity
         if not out.ndim:
             return Quantity(out, copy=False)
@@ -415,12 +413,12 @@ class Array(Quantity):
         if self.unit is None:
             try:
                 self.unit = ''
-                return super(Array, self)._to_own_unit(
+                return super()._to_own_unit(
                     value, check_precision=check_precision)
             finally:
                 del self.unit
         else:
-            return super(Array, self)._to_own_unit(
+            return super()._to_own_unit(
                 value, check_precision=check_precision)
     _to_own_unit.__doc__ = Quantity._to_own_unit.__doc__
 
@@ -480,10 +478,10 @@ class Array(Quantity):
         >>> a.flatten()
         <Quantity [1., 2., 3., 4.] m>
         """
-        return super(Array, self).flatten(order=order).view(Quantity)
+        return super().flatten(order=order).view(Quantity)
 
     def copy(self, order='C'):
-        out = super(Array, self).copy(order=order)
+        out = super().copy(order=order)
         for slot in self._metadata_slots:
             old = getattr(self, '_{0}'.format(slot), None)
             if old is not None:

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -180,7 +180,7 @@ class Array2D(Series):
     def __iter__(self):
         # astropy Quantity.__iter__ does something fancy that we don't need
         # because we overload __getitem__
-        return super().__iter__()
+        return super(Quantity, self).__iter__()
 
     # -- Array2d properties ---------------------
 

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -113,8 +113,8 @@ class Array2D(Series):
         """
 
         # create new object
-        new = super(Array2D, cls).__new__(cls, data, unit=unit, xindex=xindex,
-                                          xunit=xunit, x0=x0, dx=dx, **kwargs)
+        new = super().__new__(cls, data, unit=unit, xindex=xindex,
+                              xunit=xunit, x0=x0, dx=dx, **kwargs)
 
         # set y-axis metadata from yindex
         if yindex is not None:
@@ -148,7 +148,7 @@ class Array2D(Series):
 
     # rebuild getitem to handle complex slicing
     def __getitem__(self, item):
-        new = super(Array2D, self).__getitem__(item)
+        new = super().__getitem__(item)
 
         # slice axis 1 metadata
         colslice, rowslice = sliceutils.format_nd_slice(item, self.ndim)
@@ -172,7 +172,7 @@ class Array2D(Series):
         return new
 
     def __array_finalize__(self, obj):
-        super(Array2D, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
         # Series.__array_finalize__ might set _yindex to None, so delete it
         if getattr(self, '_yindex', 0) is None:
             del self.yindex
@@ -180,7 +180,7 @@ class Array2D(Series):
     def __iter__(self):
         # astropy Quantity.__iter__ does something fancy that we don't need
         # because we overload __getitem__
-        return super(Quantity, self).__iter__()
+        return super().__iter__()
 
     # -- Array2d properties ---------------------
 
@@ -308,7 +308,7 @@ class Array2D(Series):
     def is_compatible(self, other):
         """Check whether this array and ``other`` have compatible metadata
         """
-        super(Array2D, self).is_compatible(other)
+        super().is_compatible(other)
         # check y-axis metadata
         if isinstance(other, type(self)):
             try:
@@ -373,7 +373,7 @@ class Array2D(Series):
     # all of these try to return Quantities rather than simple numbers
 
     def _wrap_function(self, function, *args, **kwargs):
-        out = super(Array2D, self)._wrap_function(function, *args, **kwargs)
+        out = super()._wrap_function(function, *args, **kwargs)
         if out.ndim == 1:  # return Series
             # HACK: need to check astropy will always pass axis as first arg
             axis = args[0]

--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -86,7 +86,7 @@ class Index(Quantity):
         return numpy.isclose(numpy.diff(self.value, n=2), 0).all()
 
     def __getitem__(self, key):
-        item = super(Index, self).__getitem__(key)
+        item = super().__getitem__(key)
         if item.isscalar:
             return item.view(Quantity)
         return item

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -119,7 +119,7 @@ class Series(Array):
                              % (cls.__name__, len(shape)))
 
         # create new object
-        new = super(Series, cls).__new__(cls, value, unit=unit, **kwargs)
+        new = super().__new__(cls, value, unit=unit, **kwargs)
 
         # set x-axis metadata from xindex
         if xindex is not None:
@@ -153,7 +153,7 @@ class Series(Array):
     # -- series creation ------------------------
 
     def __array_finalize__(self, obj):
-        super(Series, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
         # Array.__array_finalize__ might set _xindex to None, so delete it
         if getattr(self, '_xindex', None) is None:
             del self.xindex
@@ -514,7 +514,7 @@ class Series(Array):
         return self[idx]
 
     def copy(self, order='C'):
-        new = super(Series, self).copy(order=order)
+        new = super().copy(order=order)
         try:
             new._xindex = self._xindex.copy()
         except AttributeError:
@@ -571,7 +571,7 @@ class Series(Array):
         numpy.diff
             for documentation on the underlying method
         """
-        out = super(Array, self).diff(n=n, axis=axis)
+        out = super().diff(n=n, axis=axis)
         try:
             out.x0 = self.x0 + self.dx * n
         except AttributeError:  # irregular xindex
@@ -579,7 +579,7 @@ class Series(Array):
         return out
 
     def __getslice__(self, i, j):
-        new = super(Series, self).__getslice__(i, j)
+        new = super().__getslice__(i, j)
         if i:
             try:
                 new.x0 = self.x0 + i * self.dx
@@ -588,7 +588,7 @@ class Series(Array):
         return new
 
     def __getitem__(self, item):
-        new = super(Series, self).__getitem__(item)
+        new = super().__getitem__(item)
 
         # slice axis 0 metadata
         slice_, = sliceutils.format_nd_slice(item, 1)

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -186,7 +186,7 @@ class TestArray2D(_TestSeries):
             exclude=['epoch'])
 
     def test_is_compatible(self, array):
-        super(TestArray2D, self).test_is_compatible(array)
+        super().test_is_compatible(array)
 
         a2 = self.create(dy=2)
         with pytest.raises(ValueError):

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -37,7 +37,7 @@ class TestSeries(_TestArray):
     TEST_CLASS = Series
 
     def test_new(self):
-        array = super(TestSeries, self).test_new()
+        array = super().test_new()
         assert array.x0 == units.Quantity(0, self.TEST_CLASS._default_xunit)
         assert array.dx == units.Quantity(1, self.TEST_CLASS._default_xunit)
         return array

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -58,7 +58,7 @@ class deprecated_property(property):  # pylint: disable=invalid-name
         if not fset and not fdel:  # only wrap once
             fget = _warn(fget)
 
-        super(deprecated_property, self).__init__(fget, fset, fdel, doc)
+        super().__init__(fget, fset, fdel, doc)
 
 
 def deprecated_function(func, warning=DEPRECATED_FUNCTION_WARNING):


### PR DESCRIPTION
This PR utilizes python3.x-specific behavior of the builtin `super()` function. In short, as of python3.x, if `super()` is being called with no arguments from within a class definition it will automatically infer the parent class and current instance.

Two special cases to note:

* Python2.7-style metaclasses interfere with single inheritance, so in order to use `super` in its zero-argument form, I've removed any dependence on `six.add_metaclass` from `gwpy/cli/cliproduct.py`. This duplicates part of #1222.
* Occasionally we want to avoid inheriting from the direct parent, e.g. when it does fancy things we don't strictly need. In these cases `super` is still called in its two-argument form.

More information can be found in [**the Python documentation**](https://docs.python.org/3/library/functions.html#super).

cc @duncanmmacleod 