### PR TITLE
Raise DeprecationWarning for a future change to the default spectral averaging method

### DIFF
--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -34,7 +34,7 @@ from ..spectrogram import Spectrogram
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 
-DEFAULT_FFT_METHOD = "welch"
+DEFAULT_FFT_METHOD = None
 
 
 def _get_spectrogram(hoft, **kwargs):
@@ -347,7 +347,7 @@ def range_timeseries(hoft, stride=None, fftlength=None, overlap=None,
         formats
 
     method : `str`, optional
-        FFT-averaging method, see
+        FFT-averaging method, defaults to Welch's method, see
         :meth:`~gwpy.timeseries.TimeSeries.spectrogram` for
         more details
 
@@ -427,7 +427,7 @@ def range_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
         formats
 
     method : `str`, optional
-        FFT-averaging method, see
+        FFT-averaging method, defaults to Welch's method, see
         :meth:`~gwpy.timeseries.TimeSeries.spectrogram` for
         more details
 

--- a/gwpy/signal/spectral/_registry.py
+++ b/gwpy/signal/spectral/_registry.py
@@ -73,6 +73,16 @@ def register_method(func, name=None, deprecated=False):
 def get_method(name):
     """Return the PSD method registered with the given name.
     """
+    if name is None:
+        import warnings
+        warnings.warn(
+            "the default spectral averaging method is currently 'welch' "
+            "(mean averages of overlapping periodograms), but this will "
+            "change to 'median' as of gwpy-2.1.0",
+            DeprecationWarning,
+        )
+        name = "welch"
+
     # find method
     name = _format_name(name)
     try:

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -36,7 +36,7 @@ from .core import (TimeSeriesBase, TimeSeriesBaseDict, TimeSeriesBaseList,
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-DEFAULT_FFT_METHOD = "welch"
+DEFAULT_FFT_METHOD = None
 
 
 # -- utilities ----------------------------------------------------------------
@@ -272,7 +272,8 @@ class TimeSeries(TimeSeriesBase):
             formats
 
         method : `str`, optional
-            FFT-averaging method, see *Notes* for more details
+            FFT-averaging method (default: ``'welch'``),
+            see *Notes* for more details
 
         **kwargs
             other keyword arguments are passed to the underlying
@@ -318,7 +319,8 @@ class TimeSeries(TimeSeriesBase):
             formats
 
         method : `str`, optional
-            FFT-averaging method, see *Notes* for more details
+            FFT-averaging method (default: ``'welch'``),
+            see *Notes* for more details
 
         Returns
         -------
@@ -407,7 +409,8 @@ class TimeSeries(TimeSeriesBase):
             formats
 
         method : `str`, optional
-            FFT-averaging method, see *Notes* for more details
+            FFT-averaging method (default: ``'welch'``),
+            see *Notes* for more details
 
         nproc : `int`
             number of CPUs to use in parallel processing of FFTs
@@ -564,7 +567,8 @@ class TimeSeries(TimeSeriesBase):
             number of seconds in single FFT
 
         method : `str`, optional
-            FFT-averaging method, see *Notes* for more details
+            FFT-averaging method (default: ``'welch'``),
+            see *Notes* for more details
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, defaults to the
@@ -1577,7 +1581,7 @@ class TimeSeries(TimeSeriesBase):
             recommended overlap for the given window (if given), or 0
 
         method : `str`, optional
-            FFT-averaging method
+            FFT-averaging method (default: ``'welch'``)
 
         window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,


### PR DESCRIPTION
This PR raises a `DeprecationWarning` loudly warning users that the default spectral averaging method will change to `'median'` in gwpy-2.1.0.

This is related to #1228.

cc @duncanmmacleod 