### PR TITLE
Fix a bug in reading data asking for a superset of the available segment

### DIFF
--- a/gwpy/timeseries/io/core.py
+++ b/gwpy/timeseries/io/core.py
@@ -61,25 +61,29 @@ def _join_factory(cls, gap, pad, start, end):
                 tsd = data.pop(0)
                 out.append(tsd, gap=gap, pad=pad)
                 del tsd
-            for key in out:
-                out[key] = _pad_series(
-                    out[key],
-                    pad,
-                    start,
-                    end,
-                )
+            if gap == "pad":
+                for key in out:
+                    out[key] = _pad_series(
+                        out[key],
+                        pad,
+                        start,
+                        end,
+                    )
             return out
     else:
         from .. import TimeSeriesBaseList
 
         def _join(arrays):
             list_ = TimeSeriesBaseList(*arrays)
-            return _pad_series(
-                list_.join(pad=pad, gap=gap),
-                pad,
-                start,
-                end,
-            )
+            joined = list_.join(pad=pad, gap=gap)
+            if gap == "pad":
+                return _pad_series(
+                    joined,
+                    pad,
+                    start,
+                    end,
+                )
+            return joined
     return _join
 
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -348,7 +348,13 @@ class TestTimeSeries(_TestTimeSeriesBase):
             assert_equal=utils.assert_quantity_sub_equal,
             assert_kw={'exclude': ['unit', 'name', 'channel', 'x0']})
 
-    def test_read_pad(self):
+    @pytest.mark.parametrize("pre, post", [
+        pytest.param(0, 0, id="none"),
+        pytest.param(0, 1, id="right"),
+        pytest.param(1, 0, id="left"),
+        pytest.param(1, 1, id="both"),
+    ])
+    def test_read_pad(self, pre, post):
         a = self.TEST_CLASS.read(
             utils.TEST_HDF5_FILE,
             "H1:LDAS-STRAIN",
@@ -357,12 +363,14 @@ class TestTimeSeries(_TestTimeSeriesBase):
             utils.TEST_HDF5_FILE,
             "H1:LDAS-STRAIN",
             pad=0.,
-            start=a.span[0]-1,
-            end=a.span[1]+1,
+            start=a.span[0]-pre,
+            end=a.span[1]+post,
         )
+        pres = int(pre * a.sample_rate.value)
+        posts = int(post * a.sample_rate.value)
         utils.assert_quantity_sub_equal(
             a.pad(
-                (int(a.sample_rate.value), int(a.sample_rate.value)),
+                (pres, posts),
                 mode="constant",
                 constant_values=(0,),
             ),

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -21,6 +21,7 @@
 
 import os.path
 from itertools import (chain, product)
+from math import isnan
 from ssl import SSLError
 from urllib.error import URLError
 
@@ -289,6 +290,19 @@ class TestTimeSeries(_TestTimeSeriesBase):
             new,
             exclude=("channel", "x0"),
         )
+
+    @SKIP_FRAMECPP
+    def test_read_gwf_sample_error(self):
+        """Regression against bug where final sample would be missed
+        when reading too close to the end of the vector
+        """
+        ts = self.TEST_CLASS.read(
+            utils.TEST_GWF_FILE,
+            "H1:LDAS-STRAIN",
+            start=968654552,
+            end=968654553.0001,
+        )
+        assert not isnan(ts[-1].value)
 
     @pytest.mark.parametrize('ext', ('hdf5', 'h5'))
     @pytest.mark.parametrize('channel', [

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -349,9 +349,10 @@ class TestTimeSeries(_TestTimeSeriesBase):
             assert_kw={'exclude': ['unit', 'name', 'channel', 'x0']})
 
     @pytest.mark.parametrize("pre, post", [
-        pytest.param(0, 0, id="none"),
-        pytest.param(0, 1, id="right"),
-        pytest.param(1, 0, id="left"),
+        pytest.param(None, None, id="none"),
+        pytest.param(0, 0, id="zero"),
+        pytest.param(None, 1, id="right"),
+        pytest.param(1, None, id="left"),
         pytest.param(1, 1, id="both"),
     ])
     def test_read_pad(self, pre, post):
@@ -359,15 +360,17 @@ class TestTimeSeries(_TestTimeSeriesBase):
             utils.TEST_HDF5_FILE,
             "H1:LDAS-STRAIN",
         )
+        start = None if pre is None else a.span[0] - pre
+        end = None if post is None else a.span[1] + post
         b = self.TEST_CLASS.read(
             utils.TEST_HDF5_FILE,
             "H1:LDAS-STRAIN",
             pad=0.,
-            start=a.span[0]-pre,
-            end=a.span[1]+post,
+            start=start,
+            end=end,
         )
-        pres = int(pre * a.sample_rate.value)
-        posts = int(post * a.sample_rate.value)
+        pres = 0 if not pre else int(pre * a.sample_rate.value)
+        posts = 0 if not post else int(post * a.sample_rate.value)
         utils.assert_quantity_sub_equal(
             a.pad(
                 (pres, posts),


### PR DESCRIPTION
This PR fixes a corner-case bug in reading data when the `[start, end)` request is a superset of the available data. In that case the data were automatically padded with `nan` which is bad, rather than just returning what we could.