### PR TITLE
Prevent GPS precision errors by using to_gps as middleware

### DIFF
--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -238,7 +238,7 @@ def create_fradcdata(series, frame_epoch=0,
         (1 / series.dx.to('s')).value
     )
     frdata.SetTimeOffset(
-        float(LIGOTimeGPS(series.x0.value) - LIGOTimeGPS(frame_epoch)),
+        float(to_gps(series.x0.value) - to_gps(frame_epoch)),
     )
     return frdata
 
@@ -322,7 +322,7 @@ def create_frprocdata(series, frame_epoch=0, comment=None,
         str(comment or series.name),
         _get_frprocdata_type(series, type),
         _get_frprocdata_subtype(series, subtype),
-        float(LIGOTimeGPS(series.x0.value) - LIGOTimeGPS(frame_epoch)),
+        float(to_gps(series.x0.value) - to_gps(frame_epoch)),
         trange,
         fshift,
         phase,
@@ -373,7 +373,7 @@ def create_frsimdata(series, frame_epoch=0, comment=None, fshift=0, phase=0):
         _series_name(series),
         str(comment or series.name),
         (1 / series.dx.to('s')).value,
-        float(LIGOTimeGPS(series.x0.value) - LIGOTimeGPS(frame_epoch)),
+        float(to_gps(series.x0.value) - to_gps(frame_epoch)),
         fshift,
         phase,
     )

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -40,7 +40,7 @@ from . import (Plot, colorbar as gcbar)
 from .colors import format_norm
 from .gps import GPS_SCALES
 from .legend import HandlerLine2D
-from ..time import (LIGOTimeGPS, to_gps)
+from ..time import to_gps
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -133,12 +133,12 @@ class Axes(_Axes):
 
     def _fmt_xdata(self, x):
         if self.get_xscale() in GPS_SCALES:
-            return str(LIGOTimeGPS(x))
+            return str(to_gps(x))
         return self.xaxis.get_major_formatter().format_data_short(x)
 
     def _fmt_ydata(self, y):
         if self.get_yscale() in GPS_SCALES:
-            return str(LIGOTimeGPS(y))
+            return str(to_gps(y))
         return self.yaxis.get_major_formatter().format_data_short(y)
 
     set_xlim = xlim_as_gps(_Axes.set_xlim)

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -27,7 +27,7 @@ from matplotlib import rcParams
 from matplotlib.collections import PolyCollection
 from matplotlib.lines import Line2D
 
-from ...time import LIGOTimeGPS
+from ...time import to_gps
 from ...types import (Series, Array2D)
 from ...testing import utils
 from .. import Axes
@@ -241,7 +241,7 @@ class TestAxes(AxesTestBase):
 
     def test_fmt_data(self, ax):
         value = 1234567890.123
-        result = str(LIGOTimeGPS(value))
+        result = str(to_gps(value))
         assert ax.format_xdata(value) == '1.23457e+09 '
         ax.set_xscale('auto-gps')
         ax.set_yscale('auto-gps')

--- a/gwpy/plot/tests/test_segments.py
+++ b/gwpy/plot/tests/test_segments.py
@@ -29,7 +29,7 @@ from matplotlib.collections import PatchCollection
 
 from ...segments import (Segment, SegmentList, SegmentListDict,
                          DataQualityFlag, DataQualityDict)
-from ...time import LIGOTimeGPS
+from ...time import to_gps
 from .. import SegmentAxes
 from ..segments import SegmentRectangle
 from .test_axes import TestAxes as _TestAxes
@@ -140,7 +140,7 @@ class TestSegmentAxes(_TestAxes):
     def test_fmt_data(self, ax):
         # just check that the LIGOTimeGPS repr is in place
         value = 1234567890.123
-        assert ax.format_xdata(value) == str(LIGOTimeGPS(value))
+        assert ax.format_xdata(value) == str(to_gps(value))
 
     # -- disable tests from upstream
 

--- a/gwpy/signal/spectral/_lal.py
+++ b/gwpy/signal/spectral/_lal.py
@@ -31,6 +31,7 @@ import warnings
 import numpy
 
 from ...frequencyseries import FrequencySeries
+from ...time import to_gps
 from ..window import canonical_name
 from ._utils import scale_timeseries_unit
 from . import _registry as fft_registry
@@ -217,9 +218,14 @@ def _lal_spectrum(timeseries, segmentlength, noverlap=None, method='welch',
 
     # generate output spectrum
     create = find_typed_function(timeseries.dtype, 'Create', 'FrequencySeries')
-    lalfs = create(timeseries.name, lal.LIGOTimeGPS(timeseries.epoch.gps), 0,
-                   1 / segmentlength, lal.StrainUnit,
-                   int(segmentlength // 2 + 1))
+    lalfs = create(
+        timeseries.name,
+        lal.LIGOTimeGPS(to_gps(timeseries.epoch.gps)),
+        0,
+        1 / segmentlength,
+        lal.StrainUnit,
+        int(segmentlength // 2 + 1),
+    )
 
     # find LAL method (e.g. median-mean -> lal.REAL8AverageSpectrumMedianMean)
     methodname = ''.join(map(str.title, re.split('[-_]', method)))

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -729,8 +729,14 @@ class TimeSeriesBase(Series):
 
         # create TimeSeries
         create = find_typed_function(self.dtype, 'Create', 'TimeSeries')
-        lalts = create(self.name, lal.LIGOTimeGPS(self.epoch.gps), 0,
-                       self.dt.value, unit, self.shape[0])
+        lalts = create(
+            self.name,
+            LIGOTimeGPS(to_gps(self.epoch.gps)),
+            0,
+            self.dt.value,
+            unit,
+            self.shape[0],
+        )
         lalts.data.data = self.value
         return lalts
 

--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -31,7 +31,7 @@ from ....io import gwf as io_gwf
 from ....io import _framecpp as io_framecpp
 from ....io.utils import file_list
 from ....segments import Segment
-from ....time import LIGOTimeGPS
+from ....time import (LIGOTimeGPS, to_gps)
 from ... import TimeSeries
 from ...core import _dynamic_scaled
 
@@ -491,8 +491,8 @@ def write(tsdict, outfile,
     # set frame header metadata
     if not start or not end:
         starts, ends = zip(*(ts.span for ts in tsdict.values()))
-        start = LIGOTimeGPS(start or min(starts))
-        end = LIGOTimeGPS(end or max(ends))
+        start = to_gps(start or min(starts))
+        end = to_gps(end or max(ends))
     duration = end - start
     ifos = {ts.channel.ifo for ts in tsdict.values() if
             ts.channel and ts.channel.ifo and


### PR DESCRIPTION
This PR resolves a few precision issues of the sort:

```python
>>> print(lal.LIGOTimeGPS(1126259640.413))
1126259640.413000107
```

by calling through `to_gps` which prevents these precision issues (by itself using `str` as a go-between). 