### PR TITLE
Fix two issues with test suites

### DIFF
--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -55,12 +55,14 @@ rm -f conda-reqs.txt  # clean up
 
 # install other conda packages that aren't represented in the requirements file
 conda install --name gwpyci --quiet --yes \
-    python-lal \
-    python-lalframe \
-    python-lalsimulation \
-    python-ldas-tools-framecpp \
-    python-nds2-client \
-    root_numpy
+    "python-lal" \
+    "python-lalframe" \
+    "python-lalsimulation" \
+    "python-ldas-tools-framecpp" \
+    "python-nds2-client" \
+    "root>=6.20" \
+    "root_numpy" \
+;
 
 # activate the environment
 . ${CONDA_PATH}/etc/profile.d/conda.sh

--- a/ci/parse-conda-requirements.py
+++ b/ci/parse-conda-requirements.py
@@ -15,6 +15,10 @@ from distutils.spawn import find_executable
 
 import pkg_resources
 
+CONDA_PACKAGE_MAP = {
+    "matplotlib": "matplotlib-base",
+}
+
 
 def parse_requirements(file):
     for line in file:
@@ -48,7 +52,8 @@ with open(args.filename, "r") as reqf:
         # if requirement is a URL, skip
         if item.url:
             continue
-        requirements.append('{0.name}{0.specifier}'.format(item))
+        name = CONDA_PACKAGE_MAP.get(item.name, item.name)
+        requirements.append('{}{}'.format(name, item.specifier))
 
 tmp = tempfile.mktemp()
 

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -319,7 +319,7 @@ class TestStateVector(_TestTimeSeriesBase):
     def test_fetch_open_data(self, format):
         try:
             sv = self.TEST_CLASS.fetch_open_data(
-                LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, version=1)
+                LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, version=3)
         except LOSC_FETCH_ERROR as e:  # pragma: no-cover
             pytest.skip(str(e))
         ref = StateVector(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 astropy >= 3.0.0
 dqsegdb2
 gwdatafind
-gwosc >= 0.4.0
+gwosc >= 0.5.3
 h5py >= 1.3
 ligo-segments >= 1.0.0
 ligotimegps >= 1.2.1


### PR DESCRIPTION
This PR updates the `parse-conda-requirements.py` script to use `pkg_resources` to parse requirements files, rather than the internal API from `pip`, which breaks every now and then.

ADDENDUM: this also fixes a failing `StateVector` test by correcting a dataset version reference which was incorrect (prior to gwosc-0.5.3 that client didn't actually return the right dataset, so we didn't notice that ours was wrong).