### PR TITLE
Add CI job to test minimum requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,13 @@ aliases:
       store_artifacts:
         path: tests
 
+  - &install_minimum_requirements
+      run:
+        name: Install minimum requirements
+        command: |
+          sed 's/>=/==/g' requirements.txt > minimum-requirements.txt
+          python -m pip install -r minimum-requirements.txt --upgrade-strategy=only-if-needed
+
   - &install
       run:
         name: Install tarball
@@ -50,6 +57,22 @@ aliases:
         - checkout
         - *attach_workspace
         - *set_python_environment
+        - *install
+        - *run-tests
+        - *codecov
+        - store_test_results:
+            path: tests
+        - store_artifacts:
+            path: tests
+
+  - &python-build-minimum-requirements
+      docker:
+        - image: python
+      steps:
+        - checkout
+        - *attach_workspace
+        - *set_python_environment
+        - *install_minimum_requirements
         - *install
         - *run-tests
         - *codecov
@@ -150,6 +173,11 @@ jobs:
     docker:
       - image: python:3.8
 
+  python:3.6:minreq:
+    <<: *python-build-minimum-requirements
+    docker:
+      - image: python:3.6
+
   # -- conda ----------------
 
   conda:3.6:
@@ -178,6 +206,9 @@ workflows:
           requires:
             - sdist
       - python:3.8:
+          requires:
+            - sdist
+      - python:3.6:minreq:
           requires:
             - sdist
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
     docker:
       - image: python:3.8
 
-  python:3.6:minreq:
+  python:minreq:3.6:
     <<: *python-build-minimum-requirements
     docker:
       - image: python:3.6
@@ -208,7 +208,7 @@ workflows:
       - python:3.8:
           requires:
             - sdist
-      - python:3.6:minreq:
+      - python:minreq:3.6:
           requires:
             - sdist
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -52,7 +52,7 @@ GWpy has the following strict requirements:
    |dqsegdb2|_
    |gwdatafind|_
    |gwosc-mod|_        ``>=0.5.3``
-   |h5py|_             ``>=1.3``
+   |h5py|_             ``>=2.7.0``
    |ligo-segments|_    ``>=1.0.0``
    |ligotimegps|_      ``>=1.2.1``
    |matplotlib|_       ``>=3.1.0``

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -242,7 +242,9 @@ class TestAxes(AxesTestBase):
     def test_fmt_data(self, ax):
         value = 1234567890.123
         result = str(to_gps(value))
-        assert ax.format_xdata(value) == str(value)
+        assert ax.format_xdata(value) == (
+            ax.xaxis.get_major_formatter().format_data_short(value)
+        )
         ax.set_xscale('auto-gps')
         ax.set_yscale('auto-gps')
         assert ax.format_xdata(value) == result

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ astropy >= 3.0.0
 dqsegdb2
 gwdatafind
 gwosc >= 0.5.3
-h5py >= 1.3
+h5py >= 2.7.0
 ligo-segments >= 1.0.0
 ligotimegps >= 1.2.1
 matplotlib >= 3.1.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ install_requires = [
     'dqsegdb2',
     'gwdatafind',
     'gwosc >= 0.5.3',
-    'h5py >= 1.3',
+    'h5py >= 2.7.0',
     'ligo-segments >= 1.0.0',
     'ligotimegps >= 1.2.1',
     'matplotlib >= 3.1.0',


### PR DESCRIPTION
This PR adds a CI job to run the tests using the minimum requirements as declared in the `requirements.txt` file, mainly to check that they are correct.