### PR TITLE
Update matplotlib usage for compatibility with 3.3.0

### DIFF
--- a/gwpy/conftest.py
+++ b/gwpy/conftest.py
@@ -26,7 +26,7 @@ import numpy
 from matplotlib import (use, rcParams)
 
 # force Agg for all tests
-use('agg', warn=False, force=True)
+use('agg', force=True)
 
 # register custom fixtures for all test modules
 from .testing.fixtures import *  # noqa: E402,F401,F403

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -108,7 +108,8 @@ class Plot(figure.Figure):
         self._init_figure(**figure_kw)
 
         # initialise axes with data
-        self._init_axes(data, **kwargs)
+        if data or kwargs.get("geometry"):
+            self._init_axes(data, **kwargs)
 
     def _init_figure(self, **kwargs):
         from matplotlib import pyplot

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -242,7 +242,7 @@ class TestAxes(AxesTestBase):
     def test_fmt_data(self, ax):
         value = 1234567890.123
         result = str(to_gps(value))
-        assert ax.format_xdata(value) == '1.23457e+09 '
+        assert ax.format_xdata(value) == str(value)
         ax.set_xscale('auto-gps')
         ax.set_yscale('auto-gps')
         assert ax.format_xdata(value) == result

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -764,7 +764,7 @@ class TestEventTable(TestTable):
         except (URLError, SSLError) as exc:  # pragma: no-cover
             pytest.skip(str(exc))
         assert len(table) == 1
-        assert table[0]["name"] == "GW170817_R1"
+        assert table[0]["name"] == "GW170817-v3"
         assert set(table.colnames) == {
             "name",
             "mass_1_source",

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1479,7 +1479,8 @@ class TimeSeriesBaseDict(OrderedDict):
 
         return plot
 
-    def step(self, label='key', figsize=(12, 4), xscale='auto-gps', **kwargs):
+    def step(self, label='key', where='post', figsize=(12, 4),
+             xscale='auto-gps', **kwargs):
         """Create a step plot of this dict.
 
         Parameters
@@ -1497,8 +1498,10 @@ class TimeSeriesBaseDict(OrderedDict):
             all other keyword arguments are passed to the plotter as
             appropriate
         """
-        kwargs.setdefault('linestyle', kwargs.pop('where', 'steps-post'))
-
+        kwargs.setdefault(
+            "drawstyle",
+            "steps-{}".format(where),
+        )
         tmp = type(self)()
         for key, series in self.items():
             tmp[key] = series.append(series.value[-1:], inplace=False)

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -461,7 +461,11 @@ class Series(Array):
     def step(self, **kwargs):
         """Create a step plot of this series
         """
-        kwargs.setdefault('linestyle', kwargs.pop('where', 'steps-post'))
+        where = kwargs.pop("where", "post")
+        kwargs.setdefault(
+            "drawstyle",
+            "steps-{}".format(where),
+        )
         data = self.append(self.value[-1:], inplace=False)
         return data.plot(**kwargs)
 


### PR DESCRIPTION
This PR updates the matplotlib usage to be compatible with matplotlib-3.3.0.

EDIT: this PR now includes #1258, mainly so that all of the tests pass. Closes #1258.