### PR TITLE
Migrate ROOT I/O to uproot

### DIFF
--- a/ci/install-conda.sh
+++ b/ci/install-conda.sh
@@ -61,8 +61,6 @@ conda install --name gwpyci --quiet --yes \
     "python-lalsimulation" \
     "python-ldas-tools-framecpp" \
     "python-nds2-client" \
-    "root>=6.20" \
-    "root_numpy" \
 ;
 
 # activate the environment

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -318,7 +318,7 @@ intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'pycbc': ('http://pycbc.org/pycbc/latest/html/', None),
     'python': ('https://docs.python.org/3/', None),
-    'root_numpy': ('http://scikit-hep.org/root_numpy/', None),
+    'uproot': ('https://uproot.readthedocs.io/en/stable/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 }
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -71,5 +71,5 @@ GWpy also depends on the following other packages for optional features:
 - |LDAStools.frameCPP|_: to read/write data in GWF format
 - |nds2|_: to provide remote data access for `TimeSeries`
   (see :ref:`gwpy-timeseries-remote`)
-- |root_numpy|_: to read/write :class:`~gwpy.table.EventTable` with ROOT
+- |uproot|_: to read/write :class:`~gwpy.table.EventTable` with ROOT
   format (see :ref:`gwpy-table-io-root`)

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -71,9 +71,6 @@
 .. |pycbc| replace:: `pycbc`
 .. _pycbc: https://pycbc.org/
 
-.. |root_numpy| replace:: `root_numpy`
-.. _root_numpy: https://rootpy.github.io/root_numpy/
-
 .. |sphinx| replace:: `sphinx`
 .. _sphinx: http://www.sphinx-doc.org/
 
@@ -85,6 +82,9 @@
 
 .. |sphinx-automodapi| replace:: `sphinx-automodapi`
 .. _sphinx-automodapi: http://sphinx-automodapi.readthedocs.io/
+
+.. |uproot| replace:: `uproot`
+.. _uproot: https://uproot.readthedocs.io/
 
 .. -- Other references --------------------------
 

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -199,7 +199,7 @@ To write a table using the cWB ASCII format:
 ROOT
 ====
 
-**Additional dependencies:** |root_numpy|_
+**Additional dependencies:** |uproot|_
 
 Reading
 -------
@@ -210,11 +210,7 @@ To read a `ROOT <https://root.cern.ch/>`_ tree into a `Table` (or `EventTable`),
 
 If ``treename=None`` is given (default), a single tree will be read if only one exists in the file, otherwise a `ValueError` will be raised.
 
-To specify the branches to read, use the ``branches`` keyword argument::
-
-    >>> t = Table.read('my-data.root', treename='triggers', branches=['time', 'frequency', 'snr'])
-
-Any other keyword arguments will be passed directly to :func:`root_numpy.root2array`.
+Any other keyword arguments will be passed directly to :meth:`uproot.tree.TTreeMethods.arrays`.
 
 Writing
 -------
@@ -229,7 +225,7 @@ By default, an existing file with an existing tree of the given name will be app
 
     >>> t.write('new-table.root', treename='triggers', mode='recreate')
 
-Any other keyword arguments will be passed directly to :func:`root_numpy.array2root`.
+Any other keyword arguments will be passed directly to :class:`uproot.newtree`.
 
 .. _gwpy-table-io-pycbc_live:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ pymysql
 pyRXP
 python-ligo-lw >= 1.5.0 ; sys_platform != 'win32'
 sqlalchemy
+uproot >= 3.11, == 3.*


### PR DESCRIPTION
This PR closes #1200 by re-implementing the ROOT-format input/output routines for `Table` and subclasses to use `uproot`. This is a much lighter library that is available on all platforms and doesn't require a working ROOT installation.

This should be API compatible, since everything is under-the-hood, but there are likely small differences that may trip up users who use ROOT I/O heavily - I don't actually know of anyone doing that.