### PR TITLE
Add support for reading gstlal trigger files

### DIFF
--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -594,9 +594,9 @@ Writing tables in PyCBC Live HDF5 format is not supported at this time.
 
 .. _gwpy-table-io-gstlal:
 
-=================
+========================
 GstLAL (``LIGO_LW`` XML)
-=================
+========================
 
 GstLAL is a low-latency search for gravitational waves from compact
 binary coalescences, built using |GStreamer|_ elements and tools from the |LALSuite|_ library.
@@ -610,7 +610,7 @@ To read an `EventTable` from a ``gstlal`` format ``LIGO_LW`` XML file, use the
 ``format='ligolw.gstlal'`` keyword:
 
 .. code-block:: python
-      :name: gwpy-table-io-gstlal-read
+   :name: gwpy-table-io-gstlal-read
    :caption: Reading an `EventTable` from a GstLAL ``LIGO_LW`` XML file.
 
    >>> t = EventTable.read("H1L1-GstLAL-1234567890-4.xml.gz", format="ligolw.gstlal")
@@ -624,7 +624,7 @@ To instead read information about triggers from multiple detectors, you can inst
 the ``triggers='coinc'`` keyword:
 
 .. code-block:: python
-         :name: gwpy-table-io-gstlal-read-coinc-table
+   :name: gwpy-table-io-gstlal-read-coinc-table
    :caption: Reading coincident triggers into an `EventTable` GstLAL ``LIGO_LW`` XML HDF5.
 
    >>> t = EventTable.read(
@@ -636,7 +636,7 @@ the ``triggers='coinc'`` keyword:
 To restrict the returned columns, use the ``columns`` keyword argument:
 
 .. code-block:: python
-      :name: gwpy-table-io-gstlal-read-columns
+   :name: gwpy-table-io-gstlal-read-columns
    :caption: Reading specific columns into an `EventTable` GstLAL ``LIGO_LW`` XML HDF5.
 
    >>> t = EventTable.read(

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -229,6 +229,7 @@ formats:
 - :ref:`gwpy-table-io-ascii-cwb`
 - :ref:`gwpy-table-io-root`
 - :ref:`gwpy-table-io-pycbc_live`
+- :ref:`gwpy-table-io-gstlal`
 - :ref:`gwpy-table-io-gwf`
 
 Each of the sub-sections below outlines how to read and write in these
@@ -590,6 +591,76 @@ Writing
 -------
 
 Writing tables in PyCBC Live HDF5 format is not supported at this time.
+
+.. _gwpy-table-io-gstlal:
+
+=================
+GstLAL (``LIGO_LW`` XML)
+=================
+
+GstLAL is a low-latency search for gravitational waves from compact
+binary coalescences, built using |GStreamer|_ elements and tools from the |LALSuite|_ library.
+This search writes files on the LIGO Data Grid (LIGO.ORG-authenticated users
+only) in ``LIGO_LW`` XML format, containing tables of events.
+
+Reading
+-------
+
+To read an `EventTable` from a ``gstlal`` format ``LIGO_LW`` XML file, use the
+``format='ligolw.gstlal'`` keyword:
+
+.. code-block:: python
+      :name: gwpy-table-io-gstlal-read
+   :caption: Reading an `EventTable` from a GstLAL ``LIGO_LW`` XML file.
+
+   >>> t = EventTable.read("H1L1-GstLAL-1234567890-4.xml.gz", format="ligolw.gstlal")
+
+GstLAL ``LIGO_LW`` XML files contain information about triggers from each detector separately
+as well as from a combination of detectors. 
+Accessing these different sets of information can be done using the ``triggers`` keyword. 
+By default, information about triggers from each detector separately is read in.
+This is equivalent to using ``triggers='sngl'``. 
+To instead read information about triggers from multiple detectors, you can instead use
+the ``triggers='coinc'`` keyword:
+
+.. code-block:: python
+         :name: gwpy-table-io-gstlal-read-coinc-table
+   :caption: Reading coincident triggers into an `EventTable` GstLAL ``LIGO_LW`` XML HDF5.
+
+   >>> t = EventTable.read(
+   ...     "H1L1-GstLAL-1234567890-4.xml.gz",
+   ...     format="gstlal.gstlal",
+   ...     triggers='coinc',
+   ... )
+
+To restrict the returned columns, use the ``columns`` keyword argument:
+
+.. code-block:: python
+      :name: gwpy-table-io-gstlal-read-columns
+   :caption: Reading specific columns into an `EventTable` GstLAL ``LIGO_LW`` XML HDF5.
+
+   >>> t = EventTable.read(
+   ...     "H1L1-GstLAL-1234567890-4.xml.gz",
+   ...     format="gstlal.gstlal",
+   ...     columns=["end_time", "snr", "chisq"],
+   ... )
+
+Similarly to the :ref:`gwpy-table-io-ligolw` format, some processed columns
+can be specified that are not included in the XML files, but are created
+on-the-fly.
+In addition to processed columns support by :ref:`gwpy-table-io-ligolw`, 
+the additional supported processed columns are:
+
+- ``mchirp``
+- ``snr_chi``
+- ``chi_snr``
+
+These can be specified without having to specify any of the input columns.
+
+Writing
+-------
+
+Writing tables in GstLAL ``LIGO_LW`` XML format is not supported at this time.
 
 .. _gwpy-table-io-snax:
 

--- a/gwpy/table/io/__init__.py
+++ b/gwpy/table/io/__init__.py
@@ -33,6 +33,7 @@ from . import (
     omega,  # Omega ASCII format
     cwb,  # cWB ROOT and ASCII formats
     pycbc,  # PyCBC (Live) HDF5
+    gstlal,  # GstLAL ligo.lw XML format
     hacr,  # Hierarchichal Algorithm for Curves and Ridges
     gwf,  # GWF FrEvents (e.g. MBTA)
     gravityspy,  # Gravity Spy Triggers

--- a/gwpy/table/io/gstlal.py
+++ b/gwpy/table/io/gstlal.py
@@ -199,7 +199,7 @@ def get_snr_chi(events, snr_pow=2., chi_pow=2.):
     """
     snr = events['snr'][:]
     chisq = events['chisq'][:]
-    snr_chi = snr**snr_pow / chisq**chi_pow 
+    snr_chi = snr**snr_pow / chisq**(chi_pow/2.) 
     return snr_chi
 
 GET_COLUMN['snr_chi'] = get_snr_chi

--- a/gwpy/table/io/gstlal.py
+++ b/gwpy/table/io/gstlal.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2014-2020)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Read events from the PyCBC live online GW search
+"""
+
+import re
+from os.path import basename
+
+import numpy
+from astropy.table import join
+
+from ...io.registry import (register_reader, register_identifier)
+from .. import (Table, EventTable)
+from ligo.lw import lsctables
+from . import read_table
+
+__author__ = 'Derk Davis <derek.davis@ligo.org>'
+__credits__ = 'Patrick Godwin <patrick.godwin@ligo.org>'
+
+GSTLAL_FORMAT = 'ligolw.gstlal'
+
+GSTLAL_FILENAME = re.compile('([A-Z][0-9])+-[0-9.]+-LLOID-[0-9.]+-[0-9.]+.xml')
+
+@read_with_selection
+def read_gstlal(source, triggers=None, **kwargs):
+    """Read a `Table` from one or more LIGO_LW XML documents
+
+    source : `file`, `str`, :class:`~ligo.lw.ligolw.Document`, `list`
+        one or more open files, file paths, or LIGO_LW `Document` objects
+
+    triggers : `str`, optional
+        the `Name` of the relevant `Table` to read, if not given a table will
+        be returned if only one exists in the document(s).
+        'single' for sngl_inpsiral triggers, 
+        'coinc' for coinc triggers
+
+    **kwargs
+        keyword arguments for the read, or conversion functions
+
+    See also
+    --------
+    gwpy.io.ligolw.read_table
+        for details of keyword arguments for the read operation
+    gwpy.table.io.ligolw.to_astropy_table
+        for details of keyword arguments for the conversion operation
+    """
+
+    extra_cols = []
+    if triggers == 'single':
+        derived_cols = []
+        if kwargs['columns']:
+            for name in kwargs['columns']:
+                if name not in lsctables.TableByName['sngl_inspiral'].validcolum:
+                    if name in GET_COLUMN:
+                        derived_cols.append(name)
+                        kwargs['columns'].pop(name)
+                        required_cols = GET_COLUMN_EXTRA[name]
+                        for r_col in required_col if r_col not in kwargs['columns']:
+                            kwargs['columns'].append(r_col)
+                            extra_cols.append(r_col)
+                    else:
+                        raise
+        events = read_table(source, tablename='sngl_inspiral', **kwargs)
+        for col_name in derived_cols:
+            col_data = GET_COLUMN[col_name](events)
+            events.add_column(col_data,name=col_name)
+    if triggers == 'coinc':
+        if kwargs['columns']:
+            columns = kwargs['columns']
+            kwargs.pop('columns')
+            # Divvy up columnss
+            if 'coinc_event_id' not in columns:
+                columns.append('coinc_event_id')
+                extra_cols.append('coinc_event_id')
+            inspiral_cols = [col if col in lsctables.TableByName['coinc_inspiral'].validcolumn
+                             for col in columns]]
+            event_cols = [col if col in lsctables.TableByName['coinc_event'].validcolumn
+                             for col in columns]]
+            if 'end' in columns:
+                inspiral_cols.append('end')
+            coinc_inspiral = read_table(source, tablename='coinc_inspiral', columns=inspiral_cols, **kwargs)
+            coinc_event = read_table(source, tablename='coinc_event', columns=event_cols, **kwargs)
+        else:
+            coinc_inspiral = read_table(source, tablename='coinc_inspiral', **kwargs)
+            coinc_event = read_table(source, tablename='coinc_event', **kwargs)
+        events = join(coinc_inspiral, coinc_event, keys="coinc_event_id",
+                      metadata_conflicts='silent')
+        events.meta['tablename'] = 'gstlal_coinc_inspiral'
+    else:
+        raise
+    for col_name in extra_cols::
+        events = events.remove_column(col_name)
+    return events
+
+
+### !!! unclear how to set up register
+def identify_gstlal(origin, filepath, fileobj, *args, **kwargs):
+    """Identify a PyCBC Live file as an HDF5 with the correct name
+    """
+    if identify_hdf5(origin, filepath, fileobj, *args, **kwargs) and (
+            filepath is not None and PYCBC_FILENAME.match(basename(filepath))):
+        return True
+    return False
+
+
+# register for unified I/O
+register_identifier(GSTLAL_FORMAT, EventTable, identify_gstlal)
+register_reader(GSTLAL_FORMAT, EventTable, table_from_file)
+
+# -- processed columns --------------------------------------------------------
+#
+# Here we define methods required to build commonly desired columns that
+# are just a combination of the basic columns.
+#
+# Each method should take in a `~gwpy.table.Table` and return a `numpy.ndarray`
+
+GET_COLUMN = {}
+GET_COLUMN_EXTRA = {}
+
+def get_eta(events):  
+    """Calculate the 'eta' column for this GstLAL ligolw table group
+    """
+    eta = events['chisq'][:]
+    return eta
+
+GET_COLUMN['eta'] = get_eta
+GET_COLUMN_EXTRA['eta'] = ['chisq']
+
+def get_eta_snr(events, snr_pow=2., eta_pow=2.): 
+    """Calculate the 'new SNR' column for this GstLAL ligolw table group
+    """
+    snr = events['snr'][:]
+    eta = events['chisq'][:]
+    eta_snr = snr**snr_pow / eta**eta_pow 
+    return eta_snr
+
+GET_COLUMN['eta_snr'] = get_eta_snr
+GET_COLUMN_EXTRA['eta_snr'] = ['snr','chisq']
+
+def get_mchirp(events):
+    """Calculate the chipr mass column for this GstLAL ligolw table group
+    """
+    mass1 = events['mass1'][:]
+    mass2 = events['mass2'][:]
+    return (mass1 * mass2) ** (3/5.) / (mass1 + mass2) ** (1/5.)
+
+GET_COLUMN['mchirp'] = get_mchirp
+GET_COLUMN_EXTRA['mchirp'] = ['mass1','mass2']

--- a/gwpy/table/io/gstlal.py
+++ b/gwpy/table/io/gstlal.py
@@ -29,7 +29,7 @@ from astropy.table import join
 from ...io.registry import (register_reader, register_identifier)
 from ...io.ligolw import is_ligolw
 from .ligolw import read_table
-from .. import (Table, EventTable)
+from .. import EventTable
 from .pycbc import get_mchirp
 from ligo.lw import lsctables
 
@@ -44,7 +44,7 @@ GSTLAL_FILENAME = re.compile('([A-Z][0-9])+-LLOID-[0-9.]+-[0-9.]+.xml.gz')
 
 # singles format
 def read_gstlal_sngl(source, **kwargs):
-    """Read a `Table` from one or more LIGO_LW XML documents
+    """Read a `sngl_inspiral` table from one or more GstLAL LIGO_LW XML files
 
     source : `file`, `str`, :class:`~ligo.lw.ligolw.Document`, `list`
         one or more open files, file paths, or LIGO_LW `Document` objects
@@ -88,7 +88,8 @@ def read_gstlal_sngl(source, **kwargs):
 
 # coinc format
 def read_gstlal_coinc(source, **kwargs):
-    """Read a `Table` from one or more LIGO_LW XML documents
+    """Read a `Table` containing coincident event information 
+    from one or more GstLAL LIGO_LW XML files
 
     source : `file`, `str`, :class:`~ligo.lw.ligolw.Document`, `list`
         one or more open files, file paths, or LIGO_LW `Document` objects
@@ -120,8 +121,6 @@ def read_gstlal_coinc(source, **kwargs):
             extra_cols.append('coinc_event_id')
         inspiral_cols = [col for col in columns if col in val_cols_inspiral]
         event_cols = [col for col in columns if col in val_cols_event]
-        if 'end' in columns: # what is this doing?
-            inspiral_cols.append('end')
         inspiral_cols.append('coinc_event_id')
         coinc_inspiral = read_table(source, tablename='coinc_inspiral', 
                                     columns=inspiral_cols, **kwargs)
@@ -139,10 +138,8 @@ def read_gstlal_coinc(source, **kwargs):
     return events
 
 # combined format
-
-# could split this into ligolw.gstlal_single and ligolw.gstlal_coinc?
 def read_gstlal(source, triggers='sngl', **kwargs):
-    """Read a `Table` from one or more LIGO_LW XML documents
+    """Read a `Table` from one or more GstLAL LIGO_LW XML files
 
     source : `file`, `str`, :class:`~ligo.lw.ligolw.Document`, `list`
         one or more open files, file paths, or LIGO_LW `Document` objects
@@ -150,8 +147,8 @@ def read_gstlal(source, triggers='sngl', **kwargs):
     triggers : `str`, optional
         the `Name` of the relevant `Table` to read, if not given a table will
         be returned if only one exists in the document(s).
-        'sngl' for sngl_inpsiral triggers, 
-        'coinc' for coinc triggers
+        'sngl' for single-detector trigger information, 
+        'coinc' for coincident trigger information
 
     **kwargs
         keyword arguments for the read, or conversion functions
@@ -181,7 +178,7 @@ def identify_gstlal(origin, filepath, fileobj, *args, **kwargs):
     return False
 
 
-# register for unified I/O
+# registers for unified I/O
 register_identifier(GSTLAL_FORMAT, EventTable, identify_gstlal)
 register_reader(GSTLAL_SNGL_FORMAT, EventTable, read_gstlal_sngl)
 register_reader(GSTLAL_COINC_FORMAT, EventTable, read_gstlal_coinc)

--- a/gwpy/table/io/gstlal.py
+++ b/gwpy/table/io/gstlal.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) California Institute of Technology (2019-2022)
+#               Pensylvania State University (2019)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/table/io/gstlal.py
+++ b/gwpy/table/io/gstlal.py
@@ -194,16 +194,16 @@ register_reader(GSTLAL_FORMAT, EventTable, read_gstlal)
 GET_COLUMN = {}
 GET_COLUMN_EXTRA = {}
 
-def get_eta_snr(events, snr_pow=2., eta_pow=2.): 
+def get_snr_chi(events, snr_pow=2., chi_pow=2.): 
     """Calculate the 'new SNR' column for this GstLAL ligolw table group
     """
     snr = events['snr'][:]
-    eta = events['chisq'][:]
-    eta_snr = snr**snr_pow / eta**eta_pow 
-    return eta_snr
+    chisq = events['chisq'][:]
+    snr_chi = snr**snr_pow / chisq**chi_pow 
+    return snr_chi
 
-GET_COLUMN['eta_snr'] = get_eta_snr
-GET_COLUMN_EXTRA['eta_snr'] = ['snr','chisq']
+GET_COLUMN['snr_chi'] = get_snr_chi
+GET_COLUMN_EXTRA['snr_chi'] = ['snr','chisq']
 
 # use same function as pycbc
 GET_COLUMN['mchirp'] = get_mchirp

--- a/gwpy/table/io/gstlal.py
+++ b/gwpy/table/io/gstlal.py
@@ -195,7 +195,7 @@ GET_COLUMN = {}
 GET_COLUMN_EXTRA = {}
 
 def get_snr_chi(events, snr_pow=2., chi_pow=2.): 
-    """Calculate the 'new SNR' column for this GstLAL ligolw table group
+    """Calculate the 'SNR chi' column for this GstLAL ligolw table group
     """
     snr = events['snr'][:]
     chisq = events['chisq'][:]
@@ -204,6 +204,15 @@ def get_snr_chi(events, snr_pow=2., chi_pow=2.):
 
 GET_COLUMN['snr_chi'] = get_snr_chi
 GET_COLUMN_EXTRA['snr_chi'] = ['snr','chisq']
+
+def get_chi_snr(events, snr_pow=2., chi_pow=2.):
+    """Calculate the 'chi SNR' column for this GstLAL ligolw table group,
+    reciprocal of the 'SNR chi' column
+    """
+    return 1./get_snr_chi(events, snr_pow, chi_pow)
+
+GET_COLUMN['chi_snr'] = get_chi_snr
+GET_COLUMN_EXTRA['chi_snr'] = ['snr','chisq']
 
 # use same function as pycbc
 GET_COLUMN['mchirp'] = get_mchirp

--- a/gwpy/table/io/gstlal.py
+++ b/gwpy/table/io/gstlal.py
@@ -30,7 +30,6 @@ from ...io.ligolw import is_ligolw
 from .ligolw import read_table
 from .. import EventTable
 from .pycbc import get_mchirp
-from ligo.lw import lsctables
 
 __author__ = 'Derk Davis <derek.davis@ligo.org>'
 __credits__ = 'Patrick Godwin <patrick.godwin@ligo.org>'
@@ -59,7 +58,7 @@ def read_gstlal_sngl(source, **kwargs):
     gwpy.table.io.ligolw.to_astropy_table
         for details of keyword arguments for the conversion operation
     """
-
+    from ligo.lw import lsctables
     extra_cols = []
     derived_cols = []
     val_col = lsctables.TableByName['sngl_inspiral'].validcolumns
@@ -105,6 +104,7 @@ def read_gstlal_coinc(source, **kwargs):
     gwpy.table.io.ligolw.to_astropy_table
         for details of keyword arguments for the conversion operation
     """
+    from ligo.lw import lsctables
     extra_cols = []
     if 'columns' in kwargs:
         columns = kwargs['columns']

--- a/gwpy/table/tests/test_io_gstlal.py
+++ b/gwpy/table/tests/test_io_gstlal.py
@@ -159,9 +159,12 @@ def test_read_coinc_columns(gstlal_table):
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_derived_values(gstlal_table):
     table = EventTable.read(gstlal_table, format='ligolw.gstlal',
-                            triggers='sngl', columns=['snr_chi', 'mchirp'])
+                            triggers='sngl',
+                            columns=['snr_chi', 'chi_snr', 'mchirp'])
     nptest.assert_almost_equal(
-            table['snr_chi'][0], 2.25)
+            table['snr_chi'][0], 4.5)
+    nptest.assert_almost_equal(
+            table['chi_snr'][0], 1./4.5)
     nptest.assert_almost_equal(
             table['mchirp'][0], float32(8.705506))
 

--- a/gwpy/table/tests/test_io_gstlal.py
+++ b/gwpy/table/tests/test_io_gstlal.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) California Institute of Technology (2022)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwpy.table.io.gstlal`
+"""
+
+import re
+import warnings
+from io import BytesIO
+from unittest import mock
+#from urllib.error import HTTPError
+
+import pytest
+
+import numpy as np
+
+#from matplotlib import rc_context
+
+from numpy import testing as nptest
+
+from ..io import gstlal as gstlalio
+from gwpy.table import EventTable
+from ...testing import utils
+from ...testing.errors import pytest_skip_network_error
+
+__author__ = 'Derek Davis <derek.davis@ligo.org>'
+
+
+# -- gstlal file fixture -----------------------------------------------------
+
+
+GSTLAL_FILE = """<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE LIGO_LW SYSTEM "http://ldas-sw.ligo.caltech.edu/doc/ligolwAPI/html/ligolw_dtd.txt">
+<LIGO_LW>
+        <Table Name="coinc_inspiral:table">
+                <Column Name="coinc_event:coinc_event_id" Type="int_8s"/>
+                <Column Name="combined_far" Type="real_8"/>
+                <Column Name="end_time" Type="int_4s"/>
+                <Column Name="end_time_ns" Type="int_4s"/>
+                <Column Name="false_alarm_rate" Type="real_8"/>
+                <Column Name="ifos" Type="lstring"/>
+                <Column Name="mass" Type="real_8"/>
+                <Column Name="mchirp" Type="real_8"/>
+                <Column Name="minimum_duration" Type="real_8"/>
+                <Column Name="snr" Type="real_8"/>
+                <Stream Name="coinc_inspiral:table" Delimiter="," Type="Local">
+                        1,1,100,0,1,"H1,L1",1,1,1,1,
+                        2,1,100,0,1,"H1,L1",1,1,1,1,
+                </Stream>
+        </Table>
+        <Table Name="coinc_event:table">
+                <Column Name="coinc_definer:coinc_def_id" Type="int_8s"/>
+                <Column Name="coinc_event_id" Type="int_8s"/>
+                <Column Name="instruments" Type="lstring"/>
+                <Column Name="likelihood" Type="real_8"/>
+                <Column Name="nevents" Type="int_4u"/>
+                <Column Name="process:process_id" Type="int_8s"/>
+                <Column Name="time_slide:time_slide_id" Type="int_8s"/>
+                <Stream Name="coinc_event:table" Delimiter="," Type="Local">
+                        0,1,"H1,L1",1,1,0,0,
+                        1,1,"H1,L1",1,1,0,0
+                </Stream>
+        </Table>
+        <Table Name="sngl_inspiral:table">
+                <Column Name="process:process_id" Type="int_8s"/>
+                <Column Name="ifo" Type="lstring"/>
+                <Column Name="end_time" Type="int_4s"/>
+                <Column Name="end_time_ns" Type="int_4s"/>
+                <Column Name="eff_distance" Type="real_4"/>
+                <Column Name="coa_phase" Type="real_4"/>
+                <Column Name="mass1" Type="real_4"/>
+                <Column Name="mass2" Type="real_4"/>
+                <Column Name="snr" Type="real_4"/>
+                <Column Name="chisq" Type="real_4"/>
+                <Column Name="chisq_dof" Type="int_4s"/>
+                <Column Name="bank_chisq" Type="real_4"/>
+                <Column Name="bank_chisq_dof" Type="int_4s"/>
+                <Column Name="sigmasq" Type="real_8"/>
+                <Column Name="spin1x" Type="real_4"/>
+                <Column Name="spin1y" Type="real_4"/>
+                <Column Name="spin1z" Type="real_4"/>
+                <Column Name="spin2x" Type="real_4"/>
+                <Column Name="spin2y" Type="real_4"/>
+                <Column Name="spin2z" Type="real_4"/>
+                <Column Name="template_duration" Type="real_8"/>
+                <Column Name="event_id" Type="int_8s"/>
+                <Column Name="Gamma0" Type="real_4"/>
+                <Column Name="Gamma1" Type="real_4"/>
+                <Column Name="Gamma2" Type="real_4"/>
+                <Stream Name="sngl_inspiral:table" Delimiter="," Type="Local">
+                        1,"L1",100,0,nan,0,10,10,3,2,1,1,1,1,0,0,0,0,0,0,1,1,1,1,1,
+                        1,"H1",100,0,nan,0,10,10,3,2,1,1,1,1,0,0,0,0,0,0,1,1,1,1,1,
+                        1,"V1",100,0,nan,0,10,10,3,2,1,1,1,1,0,0,0,0,0,0,1,1,1,1,1
+                </Stream>
+        </Table>
+</LIGO_LW>
+"""  # noqa: E501
+
+@pytest.fixture
+def gstlal_table(tmp_path):
+    tmp = tmp_path / "H1L1V1-LLOID-1-1.xml.gz"
+    tmp.write_text(GSTLAL_FILE)
+    return tmp
+
+
+# -- test data ----------------------------------------------------------------
+
+SNGL_LEN = 3
+COINC_LEN = 2
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_sngl_function(gstlal_table):
+    table = gstlalio.read_gstlal_sngl(gstlal_table)
+    assert len(table) == SNGL_LEN
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_read_sngl_eventtable(gstlal_table):
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal', 
+                            triggers='sngl')
+    assert len(table) == SNGL_LEN
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_read_sngl_format(gstlal_table):
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal.sngl')
+    assert len(table) == SNGL_LEN
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_read_sngl_columns(gstlal_table):
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal.sngl',
+                            columns=['snr','end_time'])
+    assert list(table.keys()) == ['snr','end_time']
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_sngl_function(gstlal_table):
+    table = gstlalio.read_gstlal_coinc(gstlal_table)
+    assert len(table) == COINC_LEN
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_read_coinc_eventtable(gstlal_table):
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal', 
+                            triggers='coinc')
+    assert len(table) == COINC_LEN
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_read_coinc_format(gstlal_table):
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal.coinc')
+    assert len(table) == COINC_LEN
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_read_coinc_columns(gstlal_table):
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal.coinc',
+                            columns=['snr','end_time'])
+    assert list(table.keys()) == ['snr','end_time']
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_derived_values(gstlal_table):
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal',
+                            triggers='sngl', columns=['eta_snr', 'mchirp'])
+    nptest.assert_almost_equal(
+            table['eta_snr'][0], 2.25)
+    nptest.assert_almost_equal(
+            table['mchirp'][0], np.float32(8.705506))
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_incorrect_sngl_column(gstlal_table):
+    with pytest.raises(
+         ValueError,
+         match="is not a valid column name",
+     ):
+        table = EventTable.read(gstlal_table, format='ligolw.gstlal.sngl',
+                                columns=['nan'])
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_incorrect_coinc_column(gstlal_table):
+    with pytest.raises(
+         ValueError,
+         match="is not a valid column name",
+     ):
+        table = EventTable.read(gstlal_table, format='ligolw.gstlal.coinc',
+                                columns=['nan'])
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_incorrect_trigger_name(gstlal_table):
+    with pytest.raises(
+         ValueError,
+         match="^The 'triggers' argument",
+     ):
+        table = EventTable.read(gstlal_table, format='ligolw.gstlal',
+                                triggers='nan')
+
+@pytest.mark.requires("ligo.lw.lsctables")
+def test_identify(gstlal_table):
+    table = EventTable.read(gstlal_table)
+    assert len(table) == SNGL_LEN
+

--- a/gwpy/table/tests/test_io_gstlal.py
+++ b/gwpy/table/tests/test_io_gstlal.py
@@ -159,9 +159,9 @@ def test_read_coinc_columns(gstlal_table):
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_derived_values(gstlal_table):
     table = EventTable.read(gstlal_table, format='ligolw.gstlal',
-                            triggers='sngl', columns=['eta_snr', 'mchirp'])
+                            triggers='sngl', columns=['snr_chi', 'mchirp'])
     nptest.assert_almost_equal(
-            table['eta_snr'][0], 2.25)
+            table['snr_chi'][0], 2.25)
     nptest.assert_almost_equal(
             table['mchirp'][0], float32(8.705506))
 

--- a/gwpy/table/tests/test_io_gstlal.py
+++ b/gwpy/table/tests/test_io_gstlal.py
@@ -19,24 +19,13 @@
 """Tests for :mod:`gwpy.table.io.gstlal`
 """
 
-import re
-import warnings
-from io import BytesIO
-from unittest import mock
-#from urllib.error import HTTPError
-
 import pytest
 
-import numpy as np
-
-#from matplotlib import rc_context
-
 from numpy import testing as nptest
+from numpy import float32
 
 from ..io import gstlal as gstlalio
 from gwpy.table import EventTable
-from ...testing import utils
-from ...testing.errors import pytest_skip_network_error
 
 __author__ = 'Derek Davis <derek.davis@ligo.org>'
 
@@ -174,7 +163,7 @@ def test_derived_values(gstlal_table):
     nptest.assert_almost_equal(
             table['eta_snr'][0], 2.25)
     nptest.assert_almost_equal(
-            table['mchirp'][0], np.float32(8.705506))
+            table['mchirp'][0], float32(8.705506))
 
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_incorrect_sngl_column(gstlal_table):
@@ -202,9 +191,3 @@ def test_incorrect_trigger_name(gstlal_table):
      ):
         table = EventTable.read(gstlal_table, format='ligolw.gstlal',
                                 triggers='nan')
-
-@pytest.mark.requires("ligo.lw.lsctables")
-def test_identify(gstlal_table):
-    table = EventTable.read(gstlal_table)
-    assert len(table) == SNGL_LEN
-

--- a/gwpy/table/tests/test_io_gstlal.py
+++ b/gwpy/table/tests/test_io_gstlal.py
@@ -100,6 +100,7 @@ GSTLAL_FILE = """<?xml version='1.0' encoding='utf-8'?>
 </LIGO_LW>
 """  # noqa: E501
 
+
 @pytest.fixture
 def gstlal_table(tmp_path):
     tmp = tmp_path / "H1L1V1-LLOID-1-1.xml.gz"
@@ -112,49 +113,58 @@ def gstlal_table(tmp_path):
 SNGL_LEN = 3
 COINC_LEN = 2
 
+
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_sngl_function(gstlal_table):
     table = gstlalio.read_gstlal_sngl(gstlal_table)
     assert len(table) == SNGL_LEN
 
+
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_read_sngl_eventtable(gstlal_table):
-    table = EventTable.read(gstlal_table, format='ligolw.gstlal', 
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal',
                             triggers='sngl')
     assert len(table) == SNGL_LEN
+
 
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_read_sngl_format(gstlal_table):
     table = EventTable.read(gstlal_table, format='ligolw.gstlal.sngl')
     assert len(table) == SNGL_LEN
 
+
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_read_sngl_columns(gstlal_table):
     table = EventTable.read(gstlal_table, format='ligolw.gstlal.sngl',
-                            columns=['snr','end_time'])
-    assert list(table.keys()) == ['snr','end_time']
+                            columns=['snr', 'end_time'])
+    assert list(table.keys()) == ['snr', 'end_time']
+
 
 @pytest.mark.requires("ligo.lw.lsctables")
-def test_sngl_function(gstlal_table):
+def test_coinc_function(gstlal_table):
     table = gstlalio.read_gstlal_coinc(gstlal_table)
     assert len(table) == COINC_LEN
 
+
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_read_coinc_eventtable(gstlal_table):
-    table = EventTable.read(gstlal_table, format='ligolw.gstlal', 
+    table = EventTable.read(gstlal_table, format='ligolw.gstlal',
                             triggers='coinc')
     assert len(table) == COINC_LEN
+
 
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_read_coinc_format(gstlal_table):
     table = EventTable.read(gstlal_table, format='ligolw.gstlal.coinc')
     assert len(table) == COINC_LEN
 
+
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_read_coinc_columns(gstlal_table):
     table = EventTable.read(gstlal_table, format='ligolw.gstlal.coinc',
-                            columns=['snr','end_time'])
-    assert list(table.keys()) == ['snr','end_time']
+                            columns=['snr', 'end_time'])
+    assert list(table.keys()) == ['snr', 'end_time']
+
 
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_derived_values(gstlal_table):
@@ -162,35 +172,38 @@ def test_derived_values(gstlal_table):
                             triggers='sngl',
                             columns=['snr_chi', 'chi_snr', 'mchirp'])
     nptest.assert_almost_equal(
-            table['snr_chi'][0], 4.5)
+        table['snr_chi'][0], 4.5)
     nptest.assert_almost_equal(
-            table['chi_snr'][0], 1./4.5)
+        table['chi_snr'][0], 1./4.5)
     nptest.assert_almost_equal(
-            table['mchirp'][0], float32(8.705506))
+        table['mchirp'][0], float32(8.705506))
+
 
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_incorrect_sngl_column(gstlal_table):
     with pytest.raises(
          ValueError,
          match="is not a valid column name",
-     ):
-        table = EventTable.read(gstlal_table, format='ligolw.gstlal.sngl',
-                                columns=['nan'])
+         ):
+        EventTable.read(gstlal_table, format='ligolw.gstlal.sngl',
+                        columns=['nan'])
+
 
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_incorrect_coinc_column(gstlal_table):
     with pytest.raises(
          ValueError,
          match="is not a valid column name",
-     ):
-        table = EventTable.read(gstlal_table, format='ligolw.gstlal.coinc',
-                                columns=['nan'])
+         ):
+        EventTable.read(gstlal_table, format='ligolw.gstlal.coinc',
+                        columns=['nan'])
+
 
 @pytest.mark.requires("ligo.lw.lsctables")
 def test_incorrect_trigger_name(gstlal_table):
     with pytest.raises(
          ValueError,
          match="^The 'triggers' argument",
-     ):
-        table = EventTable.read(gstlal_table, format='ligolw.gstlal',
-                                triggers='nan')
+         ):
+        EventTable.read(gstlal_table, format='ligolw.gstlal',
+                        triggers='nan')


### PR DESCRIPTION
This pull request aims to add support for reading gstlal trigger files.

The rationale for a specific gstlal format is 

* A desire to calculate some useful derived quantities. This feature is available for only pycbc trigger files at present. 
* The gstlal statistic requires additional inputs beyond what is included in trigger files in order to calculate the ranking statistic. However, the comparable quantity is stored in the `coinc_event` table. Hence reading in both the `coinc_event` and `coinc_inspiral` tables at once would be a useful feature. 

Thew new proposed format heavily relies upon the current ligolw functionality, with the addition of the two features above. 