### PR TITLE
Install python-nds2-client in CI on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,7 @@ install:
   # manually install other things we can get on windows
   - conda install --quiet --yes --name gwpy
         "python-framel >=8.40.1"
+        "python-nds2-client"
   # print everything we have
   - conda info --all
   - conda list


### PR DESCRIPTION
This PR adds `python-nds2-client` to the list of extra packages to install on Appveyor, which should help with test coverage on Windows.