### PR TITLE
Use bash scripts on windows CI as well

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,30 +8,13 @@ environment:
 install:
   - "set PATH=%MINICONDA%\\condabin;%PATH%"
   - call "%MINICONDA%\\Scripts\\activate.bat"
-  - conda config --set always_yes yes
-  - conda config --add channels conda-forge
-  - conda create --quiet --yes --name gwpy
-        "python=%PYTHON_VERSION%"
-        "pip"
-        "setuptools"
-  - conda activate gwpy
-  - python ci\\parse-conda-requirements.py requirements-dev.txt -o conda-reqs.txt
-  - conda install --quiet --yes --name gwpy --file conda-reqs.txt
-  # manually install other things we can get on windows
-  - conda install --quiet --yes --name gwpy
-        "python-framel >=8.40.1"
-  # print everything we have
-  - conda info --all
-  - conda list
+  - bash -ex .\ci\install-conda.sh
+  - conda activate gwpyci
 build_script:
-  - python -m pip install .
+  - bash -ex .\ci\install.sh
 test_script:
-  # run scripts from a separate directory, so that we test the installed code
-  - mkdir "tests"
-  - pushd "tests" && python -m pytest --pyargs gwpy --cov gwpy --cov-report xml:coverage.xml --junitxml junit.xml --numprocesses 2 && popd
+  - bash -ex .\ci\test.sh
 after_test:
-  - "set _PYV=%PYTHON_VERSION:.=%"
-  - python -m pip install codecov
-  - python -m codecov --file .\tests\coverage.xml --flags Windows python%_PYV% conda
+  - bash -ex .\ci\codecov.sh
 on_finish:
   - ps: (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\tests\junit.xml))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,13 @@ aliases:
   - &install
       run:
         name: Install tarball
-        command: python -m pip install --progress-bar=off gwpy-*.tar.*
+        command: bash -ex ./ci/install.sh
 
   - &python-build
       docker:
         - image: python
+      environment:
+        USE_CONDA: false
       steps:
         - checkout
         - *attach_workspace
@@ -68,6 +70,8 @@ aliases:
   - &python-build-minimum-requirements
       docker:
         - image: python
+      environment:
+        USE_CONDA: false
       steps:
         - checkout
         - *attach_workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
     # enable slack notifications (I think)
     - secure: KXq3Kn+i5pDl7ApqYkMKAZlxC7OOLDmiBn46t/JYKyRAchacp1PR84vrwTNj7OfhZek0tlTkKwQtwpFaw6llhYSpB9xl9SsPNmoYsBtZb9zC8z/oRXlXgYudesPSt7cltlt0K21pV9gRflOezRjlJRDoccbw3pe90vYpMdvr7+0=
 
+    # where to install miniconda
+    - CONDA_ROOT="${HOME}/miniconda"
+
 # -- build --------------------------------------
 
 matrix:
@@ -30,15 +33,16 @@ matrix:
 install:
   - set -ex;
   # install miniconda, create env, and activate
-  - . ./ci/install-conda.sh
+  - bash -ex ./ci/install-conda.sh
+  - source ${HOME}/miniconda/etc/profile.d/conda.sh
   # install this package
-  - python -m pip install .
+  - bash -ex ./ci/install.sh
 
 script:  # run tests
   - bash -ex ./ci/test.sh
 
 after_success:
-  - bash -ex ci/codecov.sh
+  - bash -ex ./ci/codecov.sh
 
 notifications:
   slack:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,156 @@
+variables:
+  CONDA_PKGS_DIRS: $(Pipeline.Workspace)/.conda/pkgs
+  USE_CONDA: true
+
+stages:
+  - stage: Prep
+    displayName: Prep and lint
+    jobs:
+      - job: sdist
+        displayName: Create source tarball
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.x'
+          - bash: python setup.py --quiet sdist --dist-dir $(Build.ArtifactStagingDirectory)
+            displayName: Build Tarball
+          - task: PublishBuildArtifacts@1
+            displayName: Publish tarball
+            inputs:
+              artifactName: tarball
+              pathToPublish: $(Build.ArtifactStagingDirectory)
+
+      - job: lint
+        displayName: Lint
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.8'
+          - bash: python -m pip install "flake8>=3.7.0" flake8-junit-report
+            displayName: Install flake8
+          - bash: |
+              python -m flake8 --output-file flake8.txt
+              cat flake8.txt
+            displayName: Lint with flake8
+          - bash: python -m junit_conversor flake8.txt flake8.xml
+            condition: succeededOrFailed()
+            displayName: Convert flake8 report to XML
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFiles: "flake8.xml"
+              testRunTitle: "$(Agent.OS) | Python $(PYTHON_VERSION)"
+
+  - stage: Test
+    jobs:
+      - job:
+        strategy:
+          matrix:
+            # simple python builds
+            basic_python3.6:
+              imageName: 'ubuntu-latest'
+              PYTHON_VERSION: '3.6'
+              USE_CONDA: false
+            basic_python3.7:
+              imageName: 'ubuntu-latest'
+              PYTHON_VERSION: '3.7'
+              USE_CONDA: false
+            basic_python3.8:
+              imageName: 'ubuntu-latest'
+              PYTHON_VERSION: '3.8'
+              USE_CONDA: false
+            # conda Linux
+            linux_python3.6:
+              imageName: 'ubuntu-latest'
+              PYTHON_VERSION: '3.6'
+            linux_python3.7:
+              imageName: 'ubuntu-latest'
+              PYTHON_VERSION: '3.7'
+            linux_python3.8:
+              imageName: 'ubuntu-latest'
+              PYTHON_VERSION: '3.8'
+            # conda macOS
+            macos_python3.6:
+              imageName: 'macOS-latest'
+              PYTHON_VERSION: '3.6'
+            macos_python3.7:
+              imageName: 'macOS-latest'
+              PYTHON_VERSION: '3.7'
+            macos_python3.8:
+              imageName: 'macOS-latest'
+              PYTHON_VERSION: '3.8'
+            # conda Windows
+            win_python3.6:
+              imageName: 'windows-latest'
+              PYTHON_VERSION: '3.6'
+            win_python3.7:
+              imageName: 'windows-latest'
+              PYTHON_VERSION: '3.7'
+            win_python3.8:
+              imageName: 'windows-latest'
+              PYTHON_VERSION: '3.8'
+        pool:
+          vmImage: $(imageName)
+        steps:
+          - task: Cache@2
+            inputs:
+              key: 'conda | "$(Agent.OS)" | "python$(PYTHON_VERSION)"'
+              path: $(CONDA_PKGS_DIRS)
+              restoreKeys: |
+                conda | "$(Agent.OS)"
+            displayName: Cache Conda packages
+            condition: eq(variables['USE_CONDA'], true)
+
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              downloadType: 'single'
+              artifactName: tarball
+              downloadPath: '$(System.DefaultWorkingDirectory)'
+
+          - bash: |
+              cp tarball/gwpy-*.tar.* .
+              rm -rf tarball
+            displayName: Retrieve tarball
+
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '$(PYTHON_VERSION)'
+            condition: eq(variables['USE_CONDA'], false)
+
+          - bash: echo "##vso[task.prependpath]$CONDA/bin"
+            displayName: Add conda to PATH (Linux)
+            condition: and(eq(variables['USE_CONDA'], true), eq(variables['Agent.OS'], 'Linux'))
+
+          - bash: |
+              echo "##vso[task.prependpath]$CONDA/bin"
+              sudo chown -R $USER $CONDA
+            displayName: Add conda to PATH (macOS)
+            condition: and(eq(variables['USE_CONDA'], true), eq(variables['Agent.OS'], 'Darwin'))
+
+          - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+            displayName: Add conda to PATH (Windows)
+            condition: and(eq(variables['USE_CONDA'], true), eq(variables['Agent.OS'], 'Windows_NT'))
+
+          - bash: bash ci/install-conda.sh
+            displayName: Create conda environment
+            condition: eq(variables['USE_CONDA'], true)
+
+          - bash: bash ci/install.sh
+            displayName: "Install GWpy"
+
+          - bash: bash ci/test.sh
+            displayName: "Run tests"
+
+          - task: PublishTestResults@2
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFiles: "tests/junit.xml"
+              testRunTitle: "$(Agent.OS) | Python $(PYTHON_VERSION)"
+
+          - task: PublishCodeCoverageResults@1
+            inputs:
+              codeCoverageTool: Cobertura
+              summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+
+          - bash: bash ci/codecov.sh
+            displayName: 'Upload to codecov.io'

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) Duncan Macleod (2019-2020)
+# Copyright (C) Cardiff University (2019-2020)
 #
 # This file is part of GWpy.
 #
@@ -22,16 +22,17 @@ set -ex
 . ci/lib.sh
 
 #
-# Submit coverage data to codecov.io
+# Install this package
 #
 
 find_python_and_pip
 
-# install codecov
-${PIP} install coverage codecov
+# update pip to support --progress-bar
+${PIP} install --quiet "pip>=10.0.0" "wheel"
 
-# find job name
-_JOBNAME=${CIRCLE_JOB:-${TRAVIS_JOB_NAME}}
-
-# submit coverage results
-${PYTHON} -m codecov --file tests/coverage.xml --flags $(uname) python${PYTHON_VERSION/./} ${_JOBNAME%%:*}
+# install from tarball if exists, or cwd
+if ls gwpy-*.tar.* &> /dev/null; then
+    ${PIP} install --progress-bar=off gwpy-*.tar.*
+else
+    ${PIP} install --progress-bar=off .
+fi

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# common functions for continuous integration in bash for GWpy
+#
+# Copyright (C) Cardiff University (2020)
+#
+# Author: Duncan Macleod <duncan.macleod@ligo.org>
+#
+
+# initialisation
+export GWPY_CONDA_ENV_NAME="gwpyci"
+export PYTHON_VERSION=$(echo "${PYTHON_VERSION:-${TRAVIS_PYTHON_VERSION}}" | cut -d. -f-2)
+
+# functions
+
+function on_windows() {
+    if [[ "$(uname)" == "MSYS"* ]] || [[ "$(uname)" == "MINGW"* ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# --
+# get path to python and pip
+# (on Windows you don't get pythonX or pythonX.Y executables)
+# --
+function find_python_and_pip() {
+    conda_activate
+    if on_windows; then
+        export PYTHON="python"
+    else
+        export PYTHON=$(which "python${PYTHON_VERSION}")
+    fi
+    export PIP="${PYTHON} -m pip"
+}
+
+# --
+# install miniconda
+# --
+function install_miniconda() {
+    if ! find_conda 1> /dev/null; then
+        CONDA_ROOT=${CONDA_ROOT:-${HOME}/miniconda}
+        if test ! -f ${CONDA_ROOT}/etc/profile.d/conda.sh; then
+            # install conda
+            [ "$(uname)" == "Darwin" ] && MC_OSNAME="MacOSX" || MC_OSNAME="Linux"
+            MINICONDA="Miniconda${PYTHON_VERSION%%.*}-latest-${MC_OSNAME}-x86_64.sh"
+            curl -L https://repo.continuum.io/miniconda/${MINICONDA} -o miniconda.sh
+            bash miniconda.sh -b -u -p ${CONDA_ROOT}
+        fi
+    else
+        CONDA_ROOT=$(conda info --base)
+    fi
+    source ${CONDA_ROOT}/etc/profile.d/conda.sh
+    hash -r
+}
+
+# --
+# find conda on the PATH
+# --
+function find_conda() {
+    if [[ ! -z ${CONDA_EXE} ]]; then
+        echo ${CONDA_EXE}
+    else
+        which conda
+    fi
+}
+
+# --
+# initialise conda in this bash session
+# --
+function conda_init() {
+    if [[ "${USE_CONDA}"  == "false" ]]; then return 0; fi
+    CONDA_ROOT="${CONDA_ROOT:-$(${CONDA_EXE:=conda} info --base)}"
+    source ${CONDA_ROOT}/etc/profile.d/conda.sh
+}
+
+# --
+# activate the CI conda environment
+# --
+function conda_activate() {
+    if [[ "${USE_CONDA}"  == "false" ]]; then return 0; fi
+    conda_init
+    conda activate "${GWPY_CONDA_ENV_NAME}"
+}

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,7 @@
 # requirements for GWpy tests
 beautifulsoup4
 freezegun >= 0.2.3
-pytest >= 3.3.0 ; python_version >= '3.6'
-pytest >= 3.3.0, < 5.4.0a0 ; python_version < '3.6'
+pytest >= 3.3.0
 pytest-cov >= 2.4.0
 pytest-xdist
 requests-mock


### PR DESCRIPTION
This PR updates the current CI configurations to control everything using the `bash` scripts in the `ci/` subdirectory. This has meant a small amount of restructuring, but means that the CI runs are much more homogeneous across CI providers, especially on Windows.

There is a small amount of extra logic that might not make sense now, but supports a new Azure Pipelines configuration that has been introduced and will be configured properly once it hits the `master` branch of the main repo. I will propose in a following PR to remove the other CI configurations in favour of one-ci-to-rule-them-all from Azure. The current Azure build for this PR is manually configured from my fork, but outputs here: 

https://dev.azure.com/duncanmmacleod/Test/_build/results?buildId=44&view=results
