### PR TITLE
Fix internal use of urlparse(x).path to strip file url schemes

### DIFF
--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -40,7 +40,6 @@ import re
 import warnings
 from functools import wraps
 from http.client import HTTPException
-from urllib.parse import urlparse
 
 from ligo.segments import (
     segment as LigoSegment,
@@ -49,6 +48,7 @@ from ligo.segments import (
 from ..time import to_gps
 from .cache import (cache_segments, read_cache_entry, _iter_cache)
 from .gwf import (num_channels, iter_channel_names)
+from .utils import file_path
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -665,7 +665,7 @@ def find_latest(observatory, frametype, gpstime=None, allow_tape=False,
         raise RuntimeError(
             "no files found for {}-{}".format(observatory, frametype))
 
-    path = urlparse(path).path
+    path = file_path(path)
     if not allow_tape and on_tape(path):
         raise IOError("Latest frame file for {}-{} is on tape "
                       "(pass allow_tape=True to force): "

--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -20,13 +20,13 @@
 """
 
 import warnings
-from urllib.parse import urlparse
 
 import numpy
 
 from ..segments import (Segment, SegmentList)
 from ..time import (to_gps, LIGOTimeGPS)
 from .cache import read_cache
+from .utils import file_path
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -87,7 +87,7 @@ def open_gwf(filename, mode='r'):
     if mode not in ('r', 'w'):
         raise ValueError("mode must be either 'r' or 'w'")
     from LDAStools import frameCPP
-    filename = urlparse(filename).path  # strip file://localhost or similar
+    filename = file_path(filename)
     if mode == 'r':
         return frameCPP.IFrameFStream(str(filename))
     return frameCPP.OFrameFStream(str(filename))


### PR DESCRIPTION
This PR modifies two internal uses of `urlparse(x).path` to instead use the `gwpy.io.utils.file_path` function. Just stripping the scheme out (which is what `urlparse(x).path` does) sometimes causes problems on Windows when it gets passes a string with a drive name in it (e.g. `C:\Users\me\myfile.txt`). This should have no impact on anybody (except future me).