### PR TITLE
EventTable.read(): modify API for `hdf5.snax` format

### DIFF
--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -281,13 +281,17 @@ This search writes files on the LIGO Data Grid (LIGO.ORG-authenticated users onl
 Reading
 -------
 
-To read an `EventTable` from a ``snax`` format HDF5 file, specify a ``channel`` and use the ``format='hdf5.snax'`` keyword::
+To read an `EventTable` from a ``snax`` format HDF5 file, use the ``format='hdf5.snax'`` keyword::
 
-   >>> t = EventTable.read('H-GSTLAL_IDQ_FEATURES-1255853400-20.h5', 'H1:CAL-DELTAL_EXTERNAL_DQ', format='hdf5.snax')
+   >>> t = EventTable.read('H-SNAX_FEATURES-1255853400-20.h5', format='hdf5.snax')
+
+By default, all channels contained in the file are read in. To restrict the returned channels, use the ``channels`` keyword argument::
+
+   >>> t = EventTable.read('H-SNAX_FEATURES-1255853400-20.h5', format='hdf5.snax', channels='H1:CAL-DELTAL_EXTERNAL_DQ')
 
 To restrict the returned columns, use the ``columns`` keyword argument::
 
-   >>> t = EventTable.read('H-GSTLAL_IDQ_FEATURES-1255853400-20.h5', 'H1:CAL-DELTAL_EXTERNAL_DQ', format='hdf5.snax', columns=['time', 'snr'])
+   >>> t = EventTable.read('H-SNAX_FEATURES-1255853400-20.h5', format='hdf5.snax', columns=['channel', 'time', 'snr'])
 
 Writing
 -------

--- a/gwpy/table/io/snax.py
+++ b/gwpy/table/io/snax.py
@@ -35,7 +35,7 @@ __author__ = 'Patrick Godwin <patrick.godwin@ligo.org>'
 @read_with_columns
 @read_with_selection
 @with_read_hdf5
-def table_from_file(source, channels=None, on_missing="error"):
+def table_from_file(source, channels=None, on_missing="error", compact=False):
     """Read an `EventTable` from a SNAX HDF5 file
 
     Parameters
@@ -52,6 +52,11 @@ def table_from_file(source, channels=None, on_missing="error"):
             * ``'warn'``: emit a warning when missing channels are discovered
             * ``'error'``: raise an exception
         default is 'error'.
+
+    compact : `bool`, optional, default: False
+        whether to store a compact integer representation in the channel
+        column rather than the full channel name, instead storing a mapping
+        (`channel_map`) in the table metadata.
 
     Returns
     -------
@@ -93,7 +98,14 @@ def table_from_file(source, channels=None, on_missing="error"):
             join_type="exact",
             metadata_conflicts="error",
         )
-        table["channel"] = channel
+        # determine whether to store a compact
+        # representation of the channel, storing
+        # the mapping to table metadata instead
+        if compact:
+            table["channel"] = hash(channel)
+            table.meta["channel_map"] = {hash(channel): channel}
+        else:
+            table["channel"] = channel
         tables.append(table)
 
     # combine results

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -769,6 +769,19 @@ class TestEventTable(TestTable):
                 filter_table(table, 'snr>.5')[('time', 'snr')],
             )
 
+            # check error handling when missing channels are encountered
+            missing = [channel, 'H1:MISSING']
+            with pytest.raises(ValueError):
+                self.TABLE.read(fp, channels=missing, format='hdf5.snax')
+
+            with pytest.warns(UserWarning):
+                self.TABLE.read(
+                    fp,
+                    channels=missing,
+                    format='hdf5.snax',
+                    on_missing='warn',
+                )
+
         finally:
             if os.path.isdir(os.path.dirname(fp)):
                 shutil.rmtree(os.path.dirname(fp))

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -738,20 +738,28 @@ class TestEventTable(TestTable):
         table = self.create(
             100, names=['time', 'snr', 'frequency'])
         fp = os.path.join(tempfile.mkdtemp(), 'SNAX-0-0.h5')
+        channel = 'H1:FAKE'
         try:
             # write table in snax format (by hand)
             with h5py.File(fp, 'w') as h5f:
-                group = h5f.create_group('H1:FAKE')
+                group = h5f.create_group(channel)
                 group.create_dataset(data=table, name='0.0_20.0')
 
-            # check that we can read
-            t2 = self.TABLE.read(fp, 'H1:FAKE', format='hdf5.snax')
+            # manually add 'channel' column to table
+            table["channel"] = channel
+
+            # check reading capabilities with and
+            # without specifying channels
+            t2 = self.TABLE.read(fp, format='hdf5.snax')
+            utils.assert_table_equal(table, t2)
+
+            t2 = self.TABLE.read(fp, channels=channel, format='hdf5.snax')
             utils.assert_table_equal(table, t2)
 
             # test with selection and columns
             t2 = self.TABLE.read(
                 fp,
-                'H1:FAKE',
+                channels=channel,
                 format='hdf5.snax',
                 selection='snr>.5',
                 columns=('time', 'snr'),


### PR DESCRIPTION
This modifies the `channel` argument to be optional (now `channels`) and allows for more flexible behavior for reading SNAX files. In particular, this allows reading multiple channels at once from a single hdf5 file by providing a list of channels. If `channels` is not specified, this will attempt to read in all channels from the file.
    
In order to preserve the uniqueness across channels, a 'channel' column is added into the `EventTable` during the read process.
    
Also update relevant unit tests for all modified behavior as well as the docs on "Reading and writing Table and EventTable objects" in the SNAX section.