### PR TITLE
Add --dt option to TimeSeries plot different times

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -730,7 +730,6 @@ class CliProduct(object, metaclass=abc.ABCMeta):
             end = 0
             for ts in self.timeseries:
                 if start is not None:
-                    # NB: quantity truth value is deprecated
                     start = min(ts.t0, start)
                     end = max(ts.t0+ts.duration, end)
                 else:

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -729,7 +729,7 @@ class CliProduct(object, metaclass=abc.ABCMeta):
             start = None
             end = 0
             for ts in self.timeseries:
-                if start:
+                if start is not None:       # NB quantity truth value is deprecated
                     start = min(ts.t0, start)
                     end = max(ts.t0+ts.duration, end)
                 else:

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -653,7 +653,6 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         else:
             self.ax.grid(b=False)
 
-
     def save(self, outfile):
         """Save this product to the target `outfile`.
         """

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -527,7 +527,7 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         self.set_legend()
         self.set_title(self.args.title)
         self.set_suptitle(self.args.suptitle)
-        self.set_grid(self.args.nogrid)
+        self.set_grid(not self.args.nogrid)
 
     def set_axes_properties(self):
         """Set properties for each axis (scale, limits, label)
@@ -646,8 +646,13 @@ class CliProduct(object, metaclass=abc.ABCMeta):
     def set_grid(self, enable):
         """Set the grid parameters for this plot.
         """
-        self.ax.grid(b=enable, which='major', color='k', linestyle='solid')
-        self.ax.grid(b=enable, which='minor', color='0.06', linestyle='dotted')
+        if enable:
+            self.ax.grid(b=True, which='major', color='k', linestyle='solid')
+            self.ax.grid(b=enable, which='minor', color='0.06',
+                         linestyle='dotted')
+        else:
+            self.ax.grid(b=False)
+
 
     def save(self, outfile):
         """Save this product to the target `outfile`.

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -729,7 +729,8 @@ class CliProduct(object, metaclass=abc.ABCMeta):
             start = None
             end = 0
             for ts in self.timeseries:
-                if start is not None:       # NB quantity truth value is deprecated
+                if start is not None:
+                    # NB: quantity truth value is deprecated
                     start = min(ts.t0, start)
                     end = max(ts.t0+ts.duration, end)
                 else:

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -909,13 +909,17 @@ class TimeDomainProduct(CliProduct, metaclass=abc.ABCMeta):
             args.xscale = 'auto-gps'
         if args.xmin is None:
             args.xmin = min(starts)
+        elif args.xmin < 1e6:
+            args.xmin += min(starts)
+        if args.xmax is None:
+            args.xmax = max(starts) + args.duration
+        elif args.xmax < 1e6:
+            args.xmax += min(starts)
         if args.epoch is None:
             args.epoch = args.xmin
         elif args.epoch < 1e8:
             args.epoch += min(starts)
 
-        if args.xmax is None:
-            args.xmax = max(starts) + args.duration
         return super()._finalize_arguments(args)
 
     def get_xlabel(self):

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -126,12 +126,8 @@ class TimeSeries(TimeDomainProduct):
         # get tight limits for X-axis
         if self.args.xmin is None:
             self.args.xmin = min(ts.xspan[0] for ts in self.timeseries)
-        elif self.args.xmin < 1e6:
-            self.args.xmin += min(ts.xspan[0] for ts in self.timeseries)
         if self.args.xmax is None:
             self.args.xmax = max(ts.xspan[1] for ts in self.timeseries)
-        elif self.args.xmax < 1e6:
-            self.args.xmax += min(ts.xspan[0] for ts in self.timeseries)
 
         # autoscale view for Y-axis
         cropped = [ts.crop(self.args.xmin, self.args.xmax) for

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -100,11 +100,8 @@ class TimeSeries(TimeDomainProduct):
             nlegargs = 0    # don't use  them
 
         if self.args.overlay_times:
-
-            min_t0 = self.timeseries[0].t0
-            for ts in self.timeseries:
-                min_to = min(min_t0, ts.t0)
-
+            starts = [ts.t0.value for ts in self.timeseries]
+            min_t0 = min(starts)
             for ts in self.timeseries:
                 ts.t0 = min_t0
 

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -126,8 +126,12 @@ class TimeSeries(TimeDomainProduct):
         # get tight limits for X-axis
         if self.args.xmin is None:
             self.args.xmin = min(ts.xspan[0] for ts in self.timeseries)
+        elif self.args.xmin < 1e6:
+            self.args.xmin += min(ts.xspan[0] for ts in self.timeseries)
         if self.args.xmax is None:
             self.args.xmax = max(ts.xspan[1] for ts in self.timeseries)
+        elif self.args.xmax < 1e6:
+            self.args.xmax += min(ts.xspan[0] for ts in self.timeseries)
 
         # autoscale view for Y-axis
         cropped = [ts.crop(self.args.xmin, self.args.xmax) for

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -271,27 +271,44 @@ class TestFrequencySeries(_TestSeries):
         assert array.epoch is None
 
     @utils.skip_missing_dependency('ligo.lw')
-    def test_read_ligolw_errors(self, ligolw):
+    def test_read_ligolw_error_multiple_array(self, ligolw):
         # assert errors
-        with pytest.raises(ValueError):  # multiple <Array> hits
+        with pytest.raises(ValueError) as exc:  # multiple <Array> hits
             FrequencySeries.read(ligolw)
-        with pytest.raises(ValueError):  # multiple <Array> hits
+        assert "'name'" in str(exc.value)
+
+        with pytest.raises(ValueError) as exc:  # multiple <Array> hits
             FrequencySeries.read(ligolw, "PSD2")
-        with pytest.raises(ValueError):  # no hits
+        assert "'epoch" in str(exc.value) and "'name'" not in str(exc.value)
+
+    @utils.skip_missing_dependency('ligo.lw')
+    def test_read_ligolw_error_no_array(self, ligolw):
+        with pytest.raises(ValueError) as exc:  # no hits
             FrequencySeries.read(ligolw, "blah")
+        assert str(exc.value).startswith("no <Array> elements found")
+
+    @utils.skip_missing_dependency('ligo.lw')
+    def test_read_ligolw_error_no_match(self, ligolw):
         with pytest.raises(ValueError):  # wrong epoch
             FrequencySeries.read(ligolw, epoch=0)
+
         with pytest.raises(ValueError):  # <Param>s don't match
             FrequencySeries.read(
                 ligolw,
                 "PSD1",
                 f0=0,
             )
+
+    @utils.skip_missing_dependency('ligo.lw')
+    def test_read_ligolw_error_no_param(self, ligolw):
         with pytest.raises(ValueError):  # no <Param>
             FrequencySeries.read(
                 ligolw,
                 "PSD2",
                 blah="blah",
             )
+
+    @utils.skip_missing_dependency('ligo.lw')
+    def test_read_ligolw_error_dim(self, ligolw):
         with pytest.raises(ValueError):  # wrong dimensionality
             FrequencySeries.read(ligolw, epoch=1000000001)

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -81,8 +81,16 @@ def restore_grid(func):
     """
     @wraps(func)
     def wrapped_func(self, *args, **kwargs):
-        grid = (self.xaxis._gridOnMinor, self.xaxis._gridOnMajor,
-                self.yaxis._gridOnMinor, self.yaxis._gridOnMajor)
+        try:
+            grid = (
+                self.xaxis._minor_tick_kw["gridOn"],
+                self.xaxis._major_tick_kw["gridOn"],
+                self.yaxis._minor_tick_kw["gridOn"],
+                self.yaxis._major_tick_kw["gridOn"],
+            )
+        except KeyError:  # matplotlib < 3.3.3
+            grid = (self.xaxis._gridOnMinor, self.xaxis._gridOnMajor,
+                    self.yaxis._gridOnMinor, self.yaxis._gridOnMajor)
         try:
             return func(self, *args, **kwargs)
         finally:

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -126,12 +126,20 @@ class TestAxes(AxesTestBase):
         utils.assert_array_equal(mesh.get_paths()[-1].vertices[2],
                                  (array.xspan[1], array.yspan[1]))
         # check that restore_grid decorator did its job
-        assert all((
-            ax.xaxis._gridOnMajor,
-            ax.xaxis._gridOnMinor,
-            ax.yaxis._gridOnMajor,
-            ax.yaxis._gridOnMinor,
-        ))
+        try:
+            assert all((
+                ax.xaxis._major_tick_kw["gridOn"],
+                ax.xaxis._minor_tick_kw["gridOn"],
+                ax.yaxis._major_tick_kw["gridOn"],
+                ax.yaxis._minor_tick_kw["gridOn"],
+            ))
+        except KeyError:  # matplotlib < 3.3.3
+            assert all((
+                ax.xaxis._gridOnMajor,
+                ax.xaxis._gridOnMinor,
+                ax.yaxis._gridOnMajor,
+                ax.yaxis._gridOnMinor,
+            ))
 
     def test_hist(self, ax):
         x = numpy.random.random(100) + 1

--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -101,7 +101,7 @@ def rayleigh(timeseries, segmentlength, noverlap=0, window='hann'):
     segmentlength : `int`
         number of samples in single average.
 
-    noverlap : `int
+    noverlap : `int`
         number of samples to overlap between segments, passing `None` will
         choose based on the window method, default: ``0``
 

--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -90,7 +90,7 @@ for func in (welch, bartlett, median):
 
 # -- others -------------------------------------------------------------------
 
-def rayleigh(timeseries, segmentlength, noverlap=0):
+def rayleigh(timeseries, segmentlength, noverlap=0, window='hann'):
     """Calculate a Rayleigh statistic spectrum
 
     Parameters
@@ -103,6 +103,11 @@ def rayleigh(timeseries, segmentlength, noverlap=0):
 
     noverlap : `int`
         number of samples to overlap between segments, defaults to 50%.
+
+    window : `str`, `numpy.ndarray`, optional
+        window function to apply to ``timeseries`` prior to FFT,
+        see :func:`scipy.signal.get_window` for details on acceptable
+        formats
 
     Returns
     -------
@@ -118,7 +123,7 @@ def rayleigh(timeseries, segmentlength, noverlap=0):
     for i in range(numsegs):
         tmpdata[i, :] = welch(
             timeseries[i*stepsize:i*stepsize+segmentlength],
-            segmentlength)
+            segmentlength, window=window)
     std = tmpdata.std(axis=0)
     mean = tmpdata.mean(axis=0)
     return FrequencySeries(std/mean, unit='', copy=False, f0=0,

--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -101,8 +101,9 @@ def rayleigh(timeseries, segmentlength, noverlap=0, window='hann'):
     segmentlength : `int`
         number of samples in single average.
 
-    noverlap : `int`
-        number of samples to overlap between segments, defaults to 50%.
+    noverlap : `int
+        number of samples to overlap between segments, passing `None` will
+        choose based on the window method, default: ``0``
 
     window : `str`, `numpy.ndarray`, optional
         window function to apply to ``timeseries`` prior to FFT,

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -381,7 +381,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             # check that we can't then write the same data again
             with pytest.raises(IOError):
                 array.write(tmp)
-            with pytest.raises((IOError, OSError, RuntimeError)):
+            with pytest.raises((IOError, OSError, RuntimeError, ValueError)):
                 array.write(tmp, append=True)
 
             # check reading with start/end works

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -634,7 +634,7 @@ class TimeSeries(TimeSeriesBase):
         return specgram.variance(bins=bins, low=low, high=high, nbins=nbins,
                                  log=log, norm=norm, density=density)
 
-    def rayleigh_spectrum(self, fftlength=None, overlap=None):
+    def rayleigh_spectrum(self, fftlength=None, overlap=None, window='hann'):
         """Calculate the Rayleigh `FrequencySeries` for this `TimeSeries`.
 
         The Rayleigh statistic is calculated as the ratio of the standard
@@ -650,6 +650,11 @@ class TimeSeries(TimeSeriesBase):
             number of seconds of overlap between FFTs, defaults to that of
             the relevant method.
 
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
         Returns
         -------
         psd :  `~gwpy.frequencyseries.FrequencySeries`
@@ -660,10 +665,11 @@ class TimeSeries(TimeSeriesBase):
             spectral.rayleigh,
             fftlength=fftlength,
             overlap=overlap,
+            window=window,
         )
 
     def rayleigh_spectrogram(self, stride, fftlength=None, overlap=0,
-                             nproc=1, **kwargs):
+                             window='hann', nproc=1, **kwargs):
         """Calculate the Rayleigh statistic spectrogram of this `TimeSeries`
 
         Parameters
@@ -676,6 +682,11 @@ class TimeSeries(TimeSeriesBase):
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, default: ``0``
+
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
 
         nproc : `int`, optional
             maximum number of independent frame reading processes, default
@@ -698,6 +709,7 @@ class TimeSeries(TimeSeriesBase):
             stride,
             fftlength=fftlength,
             overlap=overlap,
+            window=window,
             nproc=nproc,
             **kwargs
         )

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -664,7 +664,7 @@ class TimeSeries(TimeSeriesBase):
             self,
             spectral.rayleigh,
             fftlength=fftlength,
-            overlap=overlap,
+            overlap=overlap or 0,
             window=window,
         )
 
@@ -708,7 +708,7 @@ class TimeSeries(TimeSeriesBase):
             spectral.rayleigh,
             stride,
             fftlength=fftlength,
-            overlap=overlap,
+            overlap=overlap or 0,
             window=window,
             nproc=nproc,
             **kwargs

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -634,7 +634,7 @@ class TimeSeries(TimeSeriesBase):
         return specgram.variance(bins=bins, low=low, high=high, nbins=nbins,
                                  log=log, norm=norm, density=density)
 
-    def rayleigh_spectrum(self, fftlength=None, overlap=None, window='hann'):
+    def rayleigh_spectrum(self, fftlength=None, overlap=0, window='hann'):
         """Calculate the Rayleigh `FrequencySeries` for this `TimeSeries`.
 
         The Rayleigh statistic is calculated as the ratio of the standard
@@ -647,8 +647,8 @@ class TimeSeries(TimeSeriesBase):
             covering the full duration
 
         overlap : `float`, optional
-            number of seconds of overlap between FFTs, defaults to that of
-            the relevant method.
+            number of seconds of overlap between FFTs, passing `None` will
+            choose based on the window method, default: ``0``
 
         window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,
@@ -664,7 +664,7 @@ class TimeSeries(TimeSeriesBase):
             self,
             spectral.rayleigh,
             fftlength=fftlength,
-            overlap=overlap or 0,
+            overlap=overlap,
             window=window,
         )
 
@@ -681,7 +681,8 @@ class TimeSeries(TimeSeriesBase):
             number of seconds in single FFT.
 
         overlap : `float`, optional
-            number of seconds of overlap between FFTs, default: ``0``
+            number of seconds of overlap between FFTs, passing `None` will
+            choose based on the window method, default: ``0``
 
         window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,
@@ -708,7 +709,7 @@ class TimeSeries(TimeSeriesBase):
             spectral.rayleigh,
             stride,
             fftlength=fftlength,
-            overlap=overlap or 0,
+            overlap=overlap,
             window=window,
             nproc=nproc,
             **kwargs

--- a/gwpy/types/io/ligolw.py
+++ b/gwpy/types/io/ligolw.py
@@ -57,6 +57,10 @@ def _match_name(elem, name):
 def _get_time(time):
     """Returns the Time element of a ``<LIGO_LW>``.
     """
+    from ligo.lw.ligolw import Time
+    if not isinstance(time, Time):
+        t, = time.getElementsByTagName(Time.tagName)
+        return _get_time(t)
     return to_gps(time.pcdata)
 
 
@@ -66,12 +70,10 @@ def _match_time(elem, gps):
     This will return `False` if not exactly one ``<Time>`` element
     is found.
     """
-    from ligo.lw.ligolw import Time
     try:
-        time, = elem.getElementsByTagName(Time.tagName)
-    except ValueError:  # multiple times
+        return _get_time(elem) == to_gps(gps)
+    except (AttributeError, ValueError):  # not exactly one Time
         return False
-    return _get_time(time) == to_gps(gps)
 
 
 def _match_array(xmldoc, name=None, epoch=None, **params):

--- a/gwpy/types/io/ligolw.py
+++ b/gwpy/types/io/ligolw.py
@@ -94,11 +94,14 @@ def _match_array(xmldoc, name=None, epoch=None, **params):
         return True
 
     # parse out correct element
-    matches = filter(_is_match, xmldoc.getElementsByTagName(Array.tagName))
+    matches = list(filter(
+        _is_match,
+        xmldoc.getElementsByTagName(Array.tagName),
+    ))
     try:
         arr, = matches
     except ValueError as exc:
-        if not list(matches):
+        if not matches:  # no arrays found
             exc.args = ("no <Array> elements found matching request",)
         else:
             exc.args = ("multiple <Array> elements found matching request, "

--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -61,7 +61,7 @@ class deprecated_property(property):  # pylint: disable=invalid-name
         super().__init__(fget, fset, fdel, doc)
 
 
-def deprecated_function(func, warning=DEPRECATED_FUNCTION_WARNING):
+def deprecated_function(func=None, message=DEPRECATED_FUNCTION_WARNING):
     """Adds a `DeprecationWarning` to a function
 
     Parameters
@@ -69,25 +69,28 @@ def deprecated_function(func, warning=DEPRECATED_FUNCTION_WARNING):
     func : `callable`
         the function to decorate with a `DeprecationWarning`
 
-    warning : `str`, optional
-        the warning to present
+    message : `str`, optional
+        the warning message to present
 
     Notes
     -----
-    The final warning message is formatted as ``warning.format(func)``
+    The final warning message is formatted as ``message.format(func)``
     so you can use attribute references to the function itself.
     See the default message as an example.
     """
-    @wraps(func)
-    def wrapped_func(*args, **kwargs):
-        warnings.warn(
-            DEPRECATED_FUNCTION_WARNING.format(func),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return func(*args, **kwargs)
-
-    return wrapped_func
+    def _decorator(func):
+        @wraps(func)
+        def wrapped_func(*args, **kwargs):
+            warnings.warn(
+                message.format(func),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+        return wrapped_func
+    if func:
+        return _decorator(func)
+    return _decorator
 
 
 def return_as(returntype):

--- a/gwpy/utils/tests/test_decorators.py
+++ b/gwpy/utils/tests/test_decorators.py
@@ -49,3 +49,30 @@ def test_return_as_error():
     with pytest.raises(ValueError) as exc:
         myfunc('test')
     assert 'failed to cast return from myfunc as int: ' in str(exc.value)
+
+
+def test_deprecated_function():
+    """Test that `deprecated_function` works without a message
+
+    (and without any functional brackets)
+    """
+    @decorators.deprecated_function
+    def myfunc(value):
+        return str(value)
+
+    with pytest.warns(DeprecationWarning) as record:
+        myfunc('test')
+    assert len(record) == 1
+    assert "myfunc has been deprecated" in str(record[0].message)
+
+
+def test_deprecated_function_message():
+    """Test that `deprecated_function` works with a message
+    """
+    @decorators.deprecated_function(message="don't use {0.__name__}")
+    def myfunc(value):
+        return str(value)
+
+    with pytest.warns(DeprecationWarning) as record:
+        myfunc('test')
+    assert str(record[0].message) == "don't use myfunc"


### PR DESCRIPTION
This is in response to a long standinf requests to be able compare time series of the same channel at different times.
An example is https://ldvw-dev.ligo.caltech.edu/ldvw/view?act=getImg&imgId=152709

It uses a switch on the command line (--dt) which forces all time series object to be plotted as though they have the same start time, with the legends extended to show the actual start time.