### PR TITLE
Fix compatibility with matplotlib 3.3.3

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -81,8 +81,16 @@ def restore_grid(func):
     """
     @wraps(func)
     def wrapped_func(self, *args, **kwargs):
-        grid = (self.xaxis._gridOnMinor, self.xaxis._gridOnMajor,
-                self.yaxis._gridOnMinor, self.yaxis._gridOnMajor)
+        try:
+            grid = (
+                self.xaxis._minor_tick_kw["gridOn"],
+                self.xaxis._major_tick_kw["gridOn"],
+                self.yaxis._minor_tick_kw["gridOn"],
+                self.yaxis._major_tick_kw["gridOn"],
+            )
+        except KeyError:  # matplotlib < 3.3.3
+            grid = (self.xaxis._gridOnMinor, self.xaxis._gridOnMajor,
+                    self.yaxis._gridOnMinor, self.yaxis._gridOnMajor)
         try:
             return func(self, *args, **kwargs)
         finally:

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -126,12 +126,20 @@ class TestAxes(AxesTestBase):
         utils.assert_array_equal(mesh.get_paths()[-1].vertices[2],
                                  (array.xspan[1], array.yspan[1]))
         # check that restore_grid decorator did its job
-        assert all((
-            ax.xaxis._gridOnMajor,
-            ax.xaxis._gridOnMinor,
-            ax.yaxis._gridOnMajor,
-            ax.yaxis._gridOnMinor,
-        ))
+        try:
+            assert all((
+                ax.xaxis._major_tick_kw["gridOn"],
+                ax.xaxis._minor_tick_kw["gridOn"],
+                ax.yaxis._major_tick_kw["gridOn"],
+                ax.yaxis._minor_tick_kw["gridOn"],
+            ))
+        except KeyError:  # matplotlib < 3.3.3
+            assert all((
+                ax.xaxis._gridOnMajor,
+                ax.xaxis._gridOnMinor,
+                ax.yaxis._gridOnMajor,
+                ax.yaxis._gridOnMinor,
+            ))
 
     def test_hist(self, ax):
         x = numpy.random.random(100) + 1


### PR DESCRIPTION
This PR fixes #1277 by addressing the new incompatibility with matplotlib 3.3.3. I was hoping to find a better way to do this that doesn't just rely on a different private attribute, but didn't.