### PR TITLE
Fix compatibility with h5py-3.1.0

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -381,7 +381,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             # check that we can't then write the same data again
             with pytest.raises(IOError):
                 array.write(tmp)
-            with pytest.raises((IOError, OSError, RuntimeError)):
+            with pytest.raises((IOError, OSError, RuntimeError, ValueError)):
                 array.write(tmp, append=True)
 
             # check reading with start/end works


### PR DESCRIPTION
Minor change to `gwpy.timeseries` tests for compatibility with hdf5-3.1.0.