### PR TITLE
Improve error reporting/handling when reading LIGO_LW Arrays

### DIFF
--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -271,27 +271,44 @@ class TestFrequencySeries(_TestSeries):
         assert array.epoch is None
 
     @utils.skip_missing_dependency('ligo.lw')
-    def test_read_ligolw_errors(self, ligolw):
+    def test_read_ligolw_error_multiple_array(self, ligolw):
         # assert errors
-        with pytest.raises(ValueError):  # multiple <Array> hits
+        with pytest.raises(ValueError) as exc:  # multiple <Array> hits
             FrequencySeries.read(ligolw)
-        with pytest.raises(ValueError):  # multiple <Array> hits
+        assert "'name'" in str(exc.value)
+
+        with pytest.raises(ValueError) as exc:  # multiple <Array> hits
             FrequencySeries.read(ligolw, "PSD2")
-        with pytest.raises(ValueError):  # no hits
+        assert "'epoch" in str(exc.value) and "'name'" not in str(exc.value)
+
+    @utils.skip_missing_dependency('ligo.lw')
+    def test_read_ligolw_error_no_array(self, ligolw):
+        with pytest.raises(ValueError) as exc:  # no hits
             FrequencySeries.read(ligolw, "blah")
+        assert str(exc.value).startswith("no <Array> elements found")
+
+    @utils.skip_missing_dependency('ligo.lw')
+    def test_read_ligolw_error_no_match(self, ligolw):
         with pytest.raises(ValueError):  # wrong epoch
             FrequencySeries.read(ligolw, epoch=0)
+
         with pytest.raises(ValueError):  # <Param>s don't match
             FrequencySeries.read(
                 ligolw,
                 "PSD1",
                 f0=0,
             )
+
+    @utils.skip_missing_dependency('ligo.lw')
+    def test_read_ligolw_error_no_param(self, ligolw):
         with pytest.raises(ValueError):  # no <Param>
             FrequencySeries.read(
                 ligolw,
                 "PSD2",
                 blah="blah",
             )
+
+    @utils.skip_missing_dependency('ligo.lw')
+    def test_read_ligolw_error_dim(self, ligolw):
         with pytest.raises(ValueError):  # wrong dimensionality
             FrequencySeries.read(ligolw, epoch=1000000001)

--- a/gwpy/types/io/ligolw.py
+++ b/gwpy/types/io/ligolw.py
@@ -57,6 +57,10 @@ def _match_name(elem, name):
 def _get_time(time):
     """Returns the Time element of a ``<LIGO_LW>``.
     """
+    from ligo.lw.ligolw import Time
+    if not isinstance(time, Time):
+        t, = time.getElementsByTagName(Time.tagName)
+        return _get_time(t)
     return to_gps(time.pcdata)
 
 
@@ -66,12 +70,10 @@ def _match_time(elem, gps):
     This will return `False` if not exactly one ``<Time>`` element
     is found.
     """
-    from ligo.lw.ligolw import Time
     try:
-        time, = elem.getElementsByTagName(Time.tagName)
-    except ValueError:  # multiple times
+        return _get_time(elem) == to_gps(gps)
+    except (AttributeError, ValueError):  # not exactly one Time
         return False
-    return _get_time(time) == to_gps(gps)
 
 
 def _match_array(xmldoc, name=None, epoch=None, **params):

--- a/gwpy/types/io/ligolw.py
+++ b/gwpy/types/io/ligolw.py
@@ -94,11 +94,14 @@ def _match_array(xmldoc, name=None, epoch=None, **params):
         return True
 
     # parse out correct element
-    matches = filter(_is_match, xmldoc.getElementsByTagName(Array.tagName))
+    matches = list(filter(
+        _is_match,
+        xmldoc.getElementsByTagName(Array.tagName),
+    ))
     try:
         arr, = matches
     except ValueError as exc:
-        if not list(matches):
+        if not matches:  # no arrays found
             exc.args = ("no <Array> elements found matching request",)
         else:
             exc.args = ("multiple <Array> elements found matching request, "


### PR DESCRIPTION
This PR fixes an issue seen by @rmacas when reading `<Array>` elements from LIGO_LW files. Fundamentally the problem was just that the wrong error message was printed when multiple `<Array>` elements were found and gwpy didn't know how to pick the right one (fixed in 288c3a20b1c578f977a909e7c8ebfdc185aa4949), but users probably require a wee bit more help to understand how to modify their code to avoid the error in the first place.