### PR TITLE
Change default spectral averaging method to 'median'

### DIFF
--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -40,7 +40,7 @@ from ..utils.decorators import deprecated_function
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 
-DEFAULT_FFT_METHOD = None
+DEFAULT_FFT_METHOD = "median"
 
 
 def _get_isco_frequency(mass1, mass2):
@@ -381,7 +381,7 @@ def range_timeseries(hoft, stride=None, fftlength=None, overlap=None,
         formats
 
     method : `str`, optional
-        FFT-averaging method, defaults to Welch's method, see
+        FFT-averaging method, defaults to median averaging, see
         :meth:`~gwpy.timeseries.TimeSeries.spectrogram` for
         more details
 
@@ -460,7 +460,7 @@ def range_spectrogram(hoft, stride=None, fftlength=None, overlap=None,
         formats
 
     method : `str`, optional
-        FFT-averaging method, defaults to Welch's method, see
+        FFT-averaging method, defaults to median averaging, see
         :meth:`~gwpy.timeseries.TimeSeries.spectrogram` for
         more details
 

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -37,8 +37,8 @@ __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 # -- test results -------------------------------------------------------------
 
 TEST_RESULTS = {
-    'sensemon_range': 19.634311605544845 * units.Mpc,
-    'burst_range': 13.81353542862508 * units.Mpc,
+    'sensemon_range': 19.332958991178117 * units.Mpc,
+    'burst_range': 13.592140825568954 * units.Mpc,
 }
 
 
@@ -58,7 +58,7 @@ def psd(hoft):
     return hoft.psd(
         .4,
         overlap=.2,
-        method="welch",
+        method="median",
         window=('kaiser', 24),
     )
 
@@ -121,7 +121,7 @@ def test_range_timeseries(hoft, rangekwargs):
             0.5,
             fftlength=0.25,
             overlap=0.125,
-            method="welch",
+            method="median",
             nproc=2,
             **rangekwargs,
         )
@@ -145,7 +145,7 @@ def test_range_spectrogram(hoft, rangekwargs, outunit):
             0.5,
             fftlength=0.25,
             overlap=0.125,
-            method="welch",
+            method="median",
             nproc=2,
             **rangekwargs,
         )

--- a/gwpy/signal/spectral/_registry.py
+++ b/gwpy/signal/spectral/_registry.py
@@ -73,16 +73,6 @@ def register_method(func, name=None, deprecated=False):
 def get_method(name):
     """Return the PSD method registered with the given name.
     """
-    if name is None:
-        import warnings
-        warnings.warn(
-            "the default spectral averaging method is currently 'welch' "
-            "(mean averages of overlapping periodograms), but this will "
-            "change to 'median' as of gwpy-2.1.0",
-            DeprecationWarning,
-        )
-        name = "welch"
-
     # find method
     name = _format_name(name)
     try:

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -36,7 +36,7 @@ from .core import (TimeSeriesBase, TimeSeriesBaseDict, TimeSeriesBaseList,
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-DEFAULT_FFT_METHOD = None
+DEFAULT_FFT_METHOD = "median"
 
 
 # -- utilities ----------------------------------------------------------------
@@ -272,7 +272,7 @@ class TimeSeries(TimeSeriesBase):
             formats
 
         method : `str`, optional
-            FFT-averaging method (default: ``'welch'``),
+            FFT-averaging method (default: ``'median'``),
             see *Notes* for more details
 
         **kwargs
@@ -319,7 +319,7 @@ class TimeSeries(TimeSeriesBase):
             formats
 
         method : `str`, optional
-            FFT-averaging method (default: ``'welch'``),
+            FFT-averaging method (default: ``'median'``),
             see *Notes* for more details
 
         Returns
@@ -409,7 +409,7 @@ class TimeSeries(TimeSeriesBase):
             formats
 
         method : `str`, optional
-            FFT-averaging method (default: ``'welch'``),
+            FFT-averaging method (default: ``'median'``),
             see *Notes* for more details
 
         nproc : `int`
@@ -567,7 +567,7 @@ class TimeSeries(TimeSeriesBase):
             number of seconds in single FFT
 
         method : `str`, optional
-            FFT-averaging method (default: ``'welch'``),
+            FFT-averaging method (default: ``'median'``),
             see *Notes* for more details
 
         overlap : `float`, optional
@@ -1695,7 +1695,7 @@ class TimeSeries(TimeSeriesBase):
             recommended overlap for the given window (if given), or 0
 
         method : `str`, optional
-            FFT-averaging method (default: ``'welch'``)
+            FFT-averaging method (default: ``'median'``)
 
         window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,


### PR DESCRIPTION
This PR fixes #1228 by changing the default spectral averaging method to `'median'` across the codebase. This includes changes to reference values in the unit tests for `gwpy.astro` to reflect median averaging.