### PR TITLE
Allow generic window control for Rayleigh spectra

### DIFF
--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -90,7 +90,7 @@ for func in (welch, bartlett, median):
 
 # -- others -------------------------------------------------------------------
 
-def rayleigh(timeseries, segmentlength, noverlap=0):
+def rayleigh(timeseries, segmentlength, noverlap=0, window='hann'):
     """Calculate a Rayleigh statistic spectrum
 
     Parameters
@@ -103,6 +103,11 @@ def rayleigh(timeseries, segmentlength, noverlap=0):
 
     noverlap : `int`
         number of samples to overlap between segments, defaults to 50%.
+
+    window : `str`, `numpy.ndarray`, optional
+        window function to apply to ``timeseries`` prior to FFT,
+        see :func:`scipy.signal.get_window` for details on acceptable
+        formats
 
     Returns
     -------
@@ -118,7 +123,7 @@ def rayleigh(timeseries, segmentlength, noverlap=0):
     for i in range(numsegs):
         tmpdata[i, :] = welch(
             timeseries[i*stepsize:i*stepsize+segmentlength],
-            segmentlength)
+            segmentlength, window=window)
     std = tmpdata.std(axis=0)
     mean = tmpdata.mean(axis=0)
     return FrequencySeries(std/mean, unit='', copy=False, f0=0,

--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -101,8 +101,9 @@ def rayleigh(timeseries, segmentlength, noverlap=0, window='hann'):
     segmentlength : `int`
         number of samples in single average.
 
-    noverlap : `int`
-        number of samples to overlap between segments, defaults to 50%.
+    noverlap : `int
+        number of samples to overlap between segments, passing `None` will
+        choose based on the window method, default: ``0``
 
     window : `str`, `numpy.ndarray`, optional
         window function to apply to ``timeseries`` prior to FFT,

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -634,7 +634,7 @@ class TimeSeries(TimeSeriesBase):
         return specgram.variance(bins=bins, low=low, high=high, nbins=nbins,
                                  log=log, norm=norm, density=density)
 
-    def rayleigh_spectrum(self, fftlength=None, overlap=None):
+    def rayleigh_spectrum(self, fftlength=None, overlap=None, window='hann'):
         """Calculate the Rayleigh `FrequencySeries` for this `TimeSeries`.
 
         The Rayleigh statistic is calculated as the ratio of the standard
@@ -650,6 +650,11 @@ class TimeSeries(TimeSeriesBase):
             number of seconds of overlap between FFTs, defaults to that of
             the relevant method.
 
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
         Returns
         -------
         psd :  `~gwpy.frequencyseries.FrequencySeries`
@@ -660,10 +665,11 @@ class TimeSeries(TimeSeriesBase):
             spectral.rayleigh,
             fftlength=fftlength,
             overlap=overlap,
+            window=window,
         )
 
     def rayleigh_spectrogram(self, stride, fftlength=None, overlap=0,
-                             nproc=1, **kwargs):
+                             window='hann', nproc=1, **kwargs):
         """Calculate the Rayleigh statistic spectrogram of this `TimeSeries`
 
         Parameters
@@ -676,6 +682,11 @@ class TimeSeries(TimeSeriesBase):
 
         overlap : `float`, optional
             number of seconds of overlap between FFTs, default: ``0``
+
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
 
         nproc : `int`, optional
             maximum number of independent frame reading processes, default
@@ -698,6 +709,7 @@ class TimeSeries(TimeSeriesBase):
             stride,
             fftlength=fftlength,
             overlap=overlap,
+            window=window,
             nproc=nproc,
             **kwargs
         )

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -664,7 +664,7 @@ class TimeSeries(TimeSeriesBase):
             self,
             spectral.rayleigh,
             fftlength=fftlength,
-            overlap=overlap,
+            overlap=overlap or 0,
             window=window,
         )
 
@@ -708,7 +708,7 @@ class TimeSeries(TimeSeriesBase):
             spectral.rayleigh,
             stride,
             fftlength=fftlength,
-            overlap=overlap,
+            overlap=overlap or 0,
             window=window,
             nproc=nproc,
             **kwargs

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -634,7 +634,7 @@ class TimeSeries(TimeSeriesBase):
         return specgram.variance(bins=bins, low=low, high=high, nbins=nbins,
                                  log=log, norm=norm, density=density)
 
-    def rayleigh_spectrum(self, fftlength=None, overlap=None, window='hann'):
+    def rayleigh_spectrum(self, fftlength=None, overlap=0, window='hann'):
         """Calculate the Rayleigh `FrequencySeries` for this `TimeSeries`.
 
         The Rayleigh statistic is calculated as the ratio of the standard
@@ -647,8 +647,8 @@ class TimeSeries(TimeSeriesBase):
             covering the full duration
 
         overlap : `float`, optional
-            number of seconds of overlap between FFTs, defaults to that of
-            the relevant method.
+            number of seconds of overlap between FFTs, passing `None` will
+            choose based on the window method, default: ``0``
 
         window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,
@@ -664,7 +664,7 @@ class TimeSeries(TimeSeriesBase):
             self,
             spectral.rayleigh,
             fftlength=fftlength,
-            overlap=overlap or 0,
+            overlap=overlap,
             window=window,
         )
 
@@ -681,7 +681,8 @@ class TimeSeries(TimeSeriesBase):
             number of seconds in single FFT.
 
         overlap : `float`, optional
-            number of seconds of overlap between FFTs, default: ``0``
+            number of seconds of overlap between FFTs, passing `None` will
+            choose based on the window method, default: ``0``
 
         window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,
@@ -708,7 +709,7 @@ class TimeSeries(TimeSeriesBase):
             spectral.rayleigh,
             stride,
             fftlength=fftlength,
-            overlap=overlap or 0,
+            overlap=overlap,
             window=window,
             nproc=nproc,
             **kwargs


### PR DESCRIPTION
This PR fixes #1242 by allowing users to select generic window functions when calculating Rayleigh spectra. As with other spectral density estimation methods, any window format recognized by [`scipy.signal.get_window`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.get_window.html) is acceptable.

Note, Rayleigh spectra are given a hard 0 seconds of overlap between segments by default. Users will be able to either choose their own overlap, or pass `None` to get scipy's default based on the window function. This is reflected in various docstrings.