### PR TITLE
Minor typo fix in Rayleigh spectrum docstring

### DIFF
--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -101,7 +101,7 @@ def rayleigh(timeseries, segmentlength, noverlap=0, window='hann'):
     segmentlength : `int`
         number of samples in single average.
 
-    noverlap : `int
+    noverlap : `int`
         number of samples to overlap between segments, passing `None` will
         choose based on the window method, default: ``0``
 


### PR DESCRIPTION
This PR is a trivial docstring typo fix that I just noticed which went in with #1285.