### PR TITLE
Switch default filter design to use Second Order Sections not ZPK.

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -483,15 +483,13 @@ class CliProduct(object, metaclass=abc.ABCMeta):
                                         ftype='butter', output='sos')
 
         if sos is not None:
-            ret = data.filter(sos)
-        elif notch:
-            ret = data
+            data = data.filter(sos)
 
         for freq in notch or []:
             sos = filter_design.notch(freq, data.sample_rate)
-            ret = ret.filter(sos)
+            data = data.filter(sos)
 
-        return ret
+        return data
 
     # -- plotting -------------------------------
 


### PR DESCRIPTION
Previously we combined the ZPKs and applied them all at once.  This PR uses SOS implementations and applies them one at a time.  The differences are real but fairly subtle.

Here's a comparison using scipy's freqz (which shows no difference) and  impulse response functions which show amplitude differences: [ldvw group #1](https://ldvw.ligo.caltech.edu/ldvw/view?act=imagehistory&strt=0&pageNum=1&usrSel=Joseph+Areeda+%284364%29&group=zpk-sos+compare&size=med&op_group=Favorites&newGrpName=%3Cnew+group+name%3E&pageNum2=1)

This example compares the two on an actual channel showing that SOS preserves features in highly attenuated frequencies: [PEM accelerometer](https://ldvw.ligo.caltech.edu/ldvw/view?act=imagehistory&strt=0&pageNum=1&usrSel=Joseph+Areeda+%284364%29&group=zpk-sos+compare-example&size=med&op_group=Favorites&newGrpName=%3Cnew+group+name%3E)