### PR TITLE
Resolve various warnings during build-and-test

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -69,6 +69,7 @@ def example_context():
         with warnings.catch_warnings():
             warnings.filterwarnings('error', category=NDSWarning)
             warnings.filterwarnings('ignore', message=".*non-GUI backend.*")
+            warnings.filterwarnings("ignore", message="numpy.ufunc size")
             yield
     finally:
         # close all open figures regardless of test status

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -734,9 +734,9 @@ class CliProduct(object, metaclass=abc.ABCMeta):
             start = None
             end = 0
             for ts in self.timeseries:
-                if start:
+                if start is not None:
                     start = min(ts.t0, start)
-                    end = max(ts.t0+ts.duration, end)
+                    end = max(ts.t0 + ts.duration, end)
                 else:
                     start = ts.t0
                     end = start + ts.duration

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -646,8 +646,13 @@ class CliProduct(object, metaclass=abc.ABCMeta):
     def set_grid(self, enable):
         """Set the grid parameters for this plot.
         """
-        self.ax.grid(b=enable, which='major', color='k', linestyle='solid')
-        self.ax.grid(b=enable, which='minor', color='0.06', linestyle='dotted')
+        if enable:
+            self.ax.grid(b=True, which='major',
+                         color='k', linestyle='solid')
+            self.ax.grid(b=True, which='minor',
+                         color='0.06', linestyle='dotted')
+        else:
+            self.ax.grid(b=False)
 
     def save(self, outfile):
         """Save this product to the target `outfile`.

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -533,10 +533,16 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
 
     # write file
     if isinstance(target, str):
-        kwargs.setdefault('compress', target.endswith('.gz'))
+        kwargs.setdefault(
+            'compress',
+            "gz" if target.endswith('.gz') else False,
+        )
         ligolw_utils.write_filename(xmldoc, target, **kwargs)
     elif isinstance(target, FILE_LIKE):
-        kwargs.setdefault('compress', target.name.endswith('.gz'))
+        kwargs.setdefault(
+            'compress',
+            "gz" if target.name.endswith('.gz') else False,
+        )
         ligolw_utils.write_fileobj(xmldoc, target, **kwargs)
 
 

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -531,19 +531,22 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
     # convert table to format
     write_tables_to_document(xmldoc, tables, overwrite=overwrite)
 
-    # write file
-    if isinstance(target, str):
-        kwargs.setdefault(
-            'compress',
-            'gz' if target.endswith('.gz') else False,
-        )
-        ligolw_utils.write_filename(xmldoc, target, **kwargs)
-    elif isinstance(target, FILE_LIKE):
-        kwargs.setdefault(
-            'compress',
-            'gz' if target.name.endswith('.gz') else False,
-        )
-        ligolw_utils.write_fileobj(xmldoc, target, **kwargs)
+    # find writer function and target filename
+    if isinstance(target, FILE_LIKE):
+        writer = ligolw_utils.write_fileobj
+        name = target.name
+    else:
+        writer = ligolw_utils.write_filename
+        name = str(target)
+
+    # handle gzip compression kwargs
+    if name.endswith('.gz') and writer.__module__.startswith('glue'):
+        kwargs.setdefault('gz', True)
+    elif name.endswith('.gz'):
+        kwargs.setdefault('compress', 'gz')
+
+    # write XML
+    writer(xmldoc, target, **kwargs)
 
 
 # -- utilities ----------------------------------------------------------------

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -535,13 +535,13 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
     if isinstance(target, str):
         kwargs.setdefault(
             'compress',
-            "gz" if target.endswith('.gz') else False,
+            'gz' if target.endswith('.gz') else False,
         )
         ligolw_utils.write_filename(xmldoc, target, **kwargs)
     elif isinstance(target, FILE_LIKE):
         kwargs.setdefault(
             'compress',
-            "gz" if target.name.endswith('.gz') else False,
+            'gz' if target.name.endswith('.gz') else False,
         )
         ligolw_utils.write_fileobj(xmldoc, target, **kwargs)
 

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -533,10 +533,10 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
 
     # write file
     if isinstance(target, str):
-        kwargs.setdefault('gz', target.endswith('.gz'))
+        kwargs.setdefault('compress', target.endswith('.gz'))
         ligolw_utils.write_filename(xmldoc, target, **kwargs)
     elif isinstance(target, FILE_LIKE):
-        kwargs.setdefault('gz', target.name.endswith('.gz'))
+        kwargs.setdefault('compress', target.name.endswith('.gz'))
         ligolw_utils.write_fileobj(xmldoc, target, **kwargs)
 
 

--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -314,10 +314,10 @@ class Axes(_Axes):
                     raise
             # log-scale the axis and extract the base
             if kwargs.get('orientation') == 'horizontal':
-                self.set_yscale('log', nonposy='clip')
+                self.set_yscale('log', nonpositive='clip')
                 logbase = self.yaxis._scale.base
             else:
-                self.set_xscale('log', nonposx='clip')
+                self.set_xscale('log', nonpositive='clip')
                 logbase = self.xaxis._scale.base
             # generate the bins
             kwargs['bins'] = numpy.logspace(

--- a/gwpy/plot/colorbar.py
+++ b/gwpy/plot/colorbar.py
@@ -59,7 +59,7 @@ def process_colorbar_kwargs(figure, mappable=None, ax=None, use_axesgrid=True,
 
     norm, kwargs = format_norm(kwargs, mappable.norm)
     mappable.set_norm(norm)
-    mappable.set_cmap(kwargs.setdefault('cmap', mappable.get_cmap()))
+    mappable.set_cmap(kwargs.pop('cmap', mappable.get_cmap()))
 
     # -- set tick formatting
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -34,6 +34,7 @@ from scipy import signal
 
 from astropy import units
 
+from ...io.nds2 import NDSWarning
 from ...frequencyseries import (FrequencySeries, SpectralVariance)
 from ...segments import (Segment, SegmentList, DataQualityFlag)
 from ...signal import filter_design
@@ -592,13 +593,14 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
     def test_get(self, losc_16384):
         # get using datafind (maybe)
-        try:
-            ts = self.TEST_CLASS.get(FIND_CHANNEL, *LOSC_GW150914_SEGMENT,
-                                     frametype_match=r'C01\Z')
-        except (ImportError, RuntimeError) as e:  # pragma: no-cover
-            pytest.skip(str(e))
-        utils.assert_quantity_sub_equal(ts, losc_16384,
-                                        exclude=['name', 'channel', 'unit'])
+        with pytest.warns(NDSWarning):
+            try:
+                ts = self.TEST_CLASS.get(FIND_CHANNEL, *LOSC_GW150914_SEGMENT,
+                                         frametype_match=r'C01\Z')
+            except (ImportError, RuntimeError) as e:  # pragma: no-cover
+                pytest.skip(str(e))
+            utils.assert_quantity_sub_equal(
+                ts, losc_16384, exclude=['name', 'channel', 'unit'])
 
         # get using NDS2 (if datafind could have been used to start with)
         try:

--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -272,8 +272,8 @@ class Array(Quantity):
     dumps.__doc__ = numpy.ndarray.dumps.__doc__
 
     def tostring(self, order='C'):
-        return super(Quantity, self).tostring(order=order)
-    tostring.__doc__ = numpy.ndarray.tostring.__doc__
+        return super(Quantity, self).tobytes(order=order)
+    tostring.__doc__ = numpy.ndarray.tobytes.__doc__
 
     # -- new properties -------------------------
 

--- a/gwpy/types/tests/test_array.py
+++ b/gwpy/types/tests/test_array.py
@@ -237,7 +237,7 @@ class TestArray(object):
     # -- test methods ---------------------------
 
     def test_tostring(self, array):
-        assert array.tostring() == array.value.tostring()
+        assert array.tostring() == array.value.tobytes()
 
     def test_abs(self, array):
         utils.assert_quantity_equal(array.abs(), numpy.abs(array))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,6 @@ psycopg2
 pycbc >= 1.13.4 ; python_version >= '3' and sys_platform != 'win32'
 pymysql
 pyRXP
-python-ligo-lw >= 1.5.0 ; sys_platform != 'win32'
+python-ligo-lw >= 1.7.0 ; sys_platform != 'win32'
 sqlalchemy
 uproot >= 3.11, == 3.* ; python_version < '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ h5py >= 2.7.0
 ligo-segments >= 1.0.0
 ligotimegps >= 1.2.1
 matplotlib >= 3.3.0
-numpy >= 1.12.0
+numpy >= 1.15.0
 python-dateutil
 scipy >= 1.2.0
 tqdm >= 4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gwosc >= 0.5.3
 h5py >= 2.7.0
 ligo-segments >= 1.0.0
 ligotimegps >= 1.2.1
-matplotlib >= 3.1.0
+matplotlib >= 3.3.0
 numpy >= 1.12.0
 python-dateutil
 scipy >= 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     'h5py >= 2.7.0',
     'ligo-segments >= 1.0.0',
     'ligotimegps >= 1.2.1',
-    'matplotlib >= 3.1.0',
+    'matplotlib >= 3.3.0',
     'numpy >= 1.12.0',
     'python-dateutil',
     'scipy >= 1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     'ligo-segments >= 1.0.0',
     'ligotimegps >= 1.2.1',
     'matplotlib >= 3.3.0',
-    'numpy >= 1.12.0',
+    'numpy >= 1.15.0',
     'python-dateutil',
     'scipy >= 1.2.0',
     'tqdm >= 4.10.0',


### PR DESCRIPTION
This PR addresses several runtime warnings that arise during build-and-test:

* Do not duplicate the `'cmap'` parameter between the `mappable` and `ax.colorbar()` (see [matplotlib release notes](https://matplotlib.org/3.3.0/api/prev_api_changes/api_changes_3.3.0/deprecations.html#effectless-parameters-of-figure-colorbar-and-matplotlib-colorbar-colorbar))
* Log-scaled plot axes have deprecated kwargs (see [matplotlib release notes](https://matplotlib.org/3.3.1/api/api_changes.html#log-symlog-scale-base-ticks-and-nonpos-specification))
* The `numpy.ndarray.tostring()` method is deprecated as of 1.19, and its replacement `tobytes` has been available since 1.9 (see [numpy documentation](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tostring.html))
* Warnings about `numpy.ufunc` size changes are benign (they arise from downstream packages built against earlier numpy versions) and can be ignored, see [this stackoverflow post](https://stackoverflow.com/questions/40845304/runtimewarning-numpy-dtype-size-changed-may-indicate-binary-incompatibility)
* CLI plot products carry a redundancy in grid kwargs when the grid is turned off
* CLI coherencegrams carry an ambiguous truth value of an `astropy.units.Quantity`

Other warnings arise from an advertised change to the default spectral averaging method (addressed in #1282) and deprecated behavior related to `gwosc` and `uproot`, which can be handled in a separate PR. There are also upstream warnings arising from `glue.ligolw` running python-3.8, presumably because the package was built with an earlier version of python.

Note, this updates the Matplotlib version requirement to 3.3.0, numpy to 1.15.0 (for consistency with Matplotlib), and `python-ligo-lw` to 1.7.0.

This fixes #1289.