### PR TITLE
Fix deprecated_function decorator

### DIFF
--- a/gwpy/utils/decorators.py
+++ b/gwpy/utils/decorators.py
@@ -61,7 +61,7 @@ class deprecated_property(property):  # pylint: disable=invalid-name
         super().__init__(fget, fset, fdel, doc)
 
 
-def deprecated_function(func, warning=DEPRECATED_FUNCTION_WARNING):
+def deprecated_function(func=None, message=DEPRECATED_FUNCTION_WARNING):
     """Adds a `DeprecationWarning` to a function
 
     Parameters
@@ -69,25 +69,28 @@ def deprecated_function(func, warning=DEPRECATED_FUNCTION_WARNING):
     func : `callable`
         the function to decorate with a `DeprecationWarning`
 
-    warning : `str`, optional
-        the warning to present
+    message : `str`, optional
+        the warning message to present
 
     Notes
     -----
-    The final warning message is formatted as ``warning.format(func)``
+    The final warning message is formatted as ``message.format(func)``
     so you can use attribute references to the function itself.
     See the default message as an example.
     """
-    @wraps(func)
-    def wrapped_func(*args, **kwargs):
-        warnings.warn(
-            DEPRECATED_FUNCTION_WARNING.format(func),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return func(*args, **kwargs)
-
-    return wrapped_func
+    def _decorator(func):
+        @wraps(func)
+        def wrapped_func(*args, **kwargs):
+            warnings.warn(
+                message.format(func),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+        return wrapped_func
+    if func:
+        return _decorator(func)
+    return _decorator
 
 
 def return_as(returntype):

--- a/gwpy/utils/tests/test_decorators.py
+++ b/gwpy/utils/tests/test_decorators.py
@@ -49,3 +49,30 @@ def test_return_as_error():
     with pytest.raises(ValueError) as exc:
         myfunc('test')
     assert 'failed to cast return from myfunc as int: ' in str(exc.value)
+
+
+def test_deprecated_function():
+    """Test that `deprecated_function` works without a message
+
+    (and without any functional brackets)
+    """
+    @decorators.deprecated_function
+    def myfunc(value):
+        return str(value)
+
+    with pytest.warns(DeprecationWarning) as record:
+        myfunc('test')
+    assert len(record) == 1
+    assert "myfunc has been deprecated" in str(record[0].message)
+
+
+def test_deprecated_function_message():
+    """Test that `deprecated_function` works with a message
+    """
+    @decorators.deprecated_function(message="don't use {0.__name__}")
+    def myfunc(value):
+        return str(value)
+
+    with pytest.warns(DeprecationWarning) as record:
+        myfunc('test')
+    assert str(record[0].message) == "don't use myfunc"


### PR DESCRIPTION
This PR fixes the handling of custom messages being passed to the `gwpy.utils.decorators.deprecated_function` decorator - this was clearly never tested properly.