### PR TITLE
Add a Histogram product to gwpy-plot

### DIFF
--- a/gwpy/cli/__init__.py
+++ b/gwpy/cli/__init__.py
@@ -30,6 +30,7 @@ from .spectrogram import Spectrogram
 from .coherence import Coherence
 from .coherencegram import Coherencegram
 from .qtransform import Qtransform
+from .histogram import Histogram
 
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 
@@ -40,4 +41,5 @@ PRODUCTS = _od((x.action, x) for x in (
     Coherence,
     Coherencegram,
     Qtransform,
+    Histogram,
 ))

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -646,8 +646,12 @@ class CliProduct(object, metaclass=abc.ABCMeta):
     def set_grid(self, enable):
         """Set the grid parameters for this plot.
         """
-        self.ax.grid(b=enable, which='major', color='k', linestyle='solid')
-        self.ax.grid(b=enable, which='minor', color='0.06', linestyle='dotted')
+        if enable:
+            self.ax.grid(b=enable, which='major', color='k', linestyle='solid')
+            self.ax.grid(b=enable, which='minor', color='0.06',
+                         linestyle='dotted')
+        else:
+            self.ax.grid(b=False, which='both')
 
     def save(self, outfile):
         """Save this product to the target `outfile`.

--- a/gwpy/cli/histogram.py
+++ b/gwpy/cli/histogram.py
@@ -31,6 +31,7 @@ __myname__ = 'histogram.py'
 import math
 import sys
 from scipy.stats import kurtosis, norm, skew
+from astropy.units import Quantity
 
 from .cliproduct import TimeDomainProduct
 from ..plot import Plot
@@ -45,11 +46,12 @@ class Histogram(TimeDomainProduct):
 
     def __init__(self, args):
         super().__init__(args)
-        self.mean = None
-        self.std = None
-        self.skew = None
-        self.kurtosis = None
-        self.nbins = None
+        self.args = args
+        self.mean = Quantity(0, '')    # value needed for pytests
+        self.std = Quantity(0, '')
+        self.skew = Quantity(0, '')
+        self.kurtosis = 0
+        self.nbins = 0
         self.ymin = sys.maxsize
         self.ymax = 0
 
@@ -67,14 +69,15 @@ class Histogram(TimeDomainProduct):
         """
         units = self.units
         ret = 'Timeseries amplitude'
-        if len(units) == 1 and str(units[0]) == '':  # dimensionless
-            pass
-        elif len(units) == 1 and self.usetex:
-            ret += ' [{}]'.format(units[0].to_string('latex'))
-        elif len(units) == 1:
-            return ' ({})'.format(units[0].to_string())
-        elif len(units) > 1:
-            ret += ' (multiple units)'
+        if isinstance(units, list):
+            if len(units) == 1 and str(units[0]) == '':  # dimensionless
+                pass
+            elif len(units) == 1 and self.usetex:
+                ret += ' [{}]'.format(units[0].to_string('latex'))
+            elif len(units) == 1:
+                return ' ({})'.format(units[0].to_string())
+            elif len(units) > 1:
+                ret += ' (multiple units)'
         return ret
 
     @classmethod
@@ -83,13 +86,11 @@ class Histogram(TimeDomainProduct):
         """
         return 'Count'
 
-    @classmethod
     def get_suptitle(self):
         """Start of default super title, first channel is appended to it
         """
         return 'Histogram: {0}'.format(self.chan_list[0])
 
-    @classmethod
     def get_title(self):
         suffix = super().get_title()
         # limit significant digits for minute trends
@@ -106,7 +107,6 @@ class Histogram(TimeDomainProduct):
                    self.skew, self.kurtosis)
         return ret
 
-    @classmethod
     def make_plot(self):
         """Generate the plot from time series and arguments
         """
@@ -161,14 +161,12 @@ class Histogram(TimeDomainProduct):
 
         return plot
 
-    @classmethod
     def _finalize_arguments(self, args):
         """ We cannot guess at default plot params
         until histogram is calculated"""
         if args.xscale is None:  # set default x-axis scale
             args.xscale = 'linear'
 
-    @classmethod
     def scale_axes_from_data(self):
         """Restrict data limits for Y-axis based on what you can see
         """

--- a/gwpy/cli/histogram.py
+++ b/gwpy/cli/histogram.py
@@ -37,6 +37,7 @@ from ..plot import Plot
 from ..plot.tex import label_to_latex
 import warnings
 
+
 class Histogram(TimeDomainProduct):
     """Plot a histogram of values for one or more time series
     """
@@ -55,7 +56,7 @@ class Histogram(TimeDomainProduct):
     @classmethod
     def init_cli(self, parser):
         """We add an option to add a fit ot gaussian PDF"""
-        super().init_cli(parser) # add all timeseries options
+        super().init_cli(parser)    # add all timeseries options
         group = parser.add_argument_group('Curve fit options')
         group.add_argument('--gauss', action='store_true',
                            help='Add gaussian fit')
@@ -65,15 +66,16 @@ class Histogram(TimeDomainProduct):
         """Text for x-axis label
         """
         units = self.units
+        ret = 'Timeseries amplitude'
         if len(units) == 1 and str(units[0]) == '':  # dimensionless
-            return 'Sample value'
-        if len(units) == 1 and self.usetex:
-            return 'Sample value ({})'.format(units[0].to_string('latex'))
+            pass
+        elif len(units) == 1 and self.usetex:
+            ret += ' [{}]'.format(units[0].to_string('latex'))
         elif len(units) == 1:
-            return 'Sample value ({})'.format(units[0].to_string())
+            return ' ({})'.format(units[0].to_string())
         elif len(units) > 1:
-            return 'Sample value (multiple units)'
-        return 'Sample value'
+            ret += ' (multiple units)'
+        return ret
 
     @classmethod
     def get_ylabel(self):
@@ -112,10 +114,8 @@ class Histogram(TimeDomainProduct):
         ax = plot.gca(xscale='linear')
 
         # handle user specified plot labels
-        if self.args.legend:
-            nlegargs = len(self.args.legend[0])
-        else:
-            nlegargs = 0
+        nlegargs = len(self.args.legend[0]) if self.args.legend else 0
+
         if nlegargs > 0 and nlegargs != self.n_datasets:
             warnings.warn('The number of legends specified must match '
                           'the number of time series'
@@ -126,13 +126,11 @@ class Histogram(TimeDomainProduct):
 
         for i in range(0, self.n_datasets):
             series = self.timeseries[i]
-            if nlegargs:
-                label = self.args.legend[0][i]
-            else:
-                label = series.channel.name
+            label = self.args.legend[0][i] if nlegargs else \
+                series.channel.name
             if self.usetex:
                 label = label_to_latex(label)
-            nbins = int(max(10, min(math.sqrt(len(series)), 2000)))
+            nbins = int(max(10., min(math.sqrt(len(series)), 2000)))
             n, bins, patches = ax.hist(series, bins=nbins, label=label,
                                        density=True, alpha=0.75)
             ymax = max(n)

--- a/gwpy/cli/histogram.py
+++ b/gwpy/cli/histogram.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+# vim: nu:ai:ts=4:sw=4
+
+#
+#  Copyright (C) 2021 Joseph Areeda <joseph.areeda@ligo.org>
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+"""The histogram CLI product
+"""
+
+
+__author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
+__email__ = 'joseph.areeda@ligo.org'
+__version__ = '0.0.1'
+__myname__ = 'histogram.py'
+
+import math
+import sys
+from scipy.stats import kurtosis, norm, skew
+
+from .cliproduct import TimeDomainProduct
+from ..plot import Plot
+from ..plot.tex import label_to_latex
+import warnings
+
+class Histogram(TimeDomainProduct):
+    """Plot a histogram of values for one or more time series
+    """
+    action = 'histogram'
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.mean = None
+        self.std = None
+        self.skew = None
+        self.kurtosis = None
+        self.nbins = None
+        self.ymin = sys.maxsize
+        self.ymax = 0
+
+    @classmethod
+    def init_cli(self, parser):
+        """We add an option to add a fit ot gaussian PDF"""
+        super().init_cli(parser) # add all timeseries options
+        group = parser.add_argument_group('Curve fit options')
+        group.add_argument('--gauss', action='store_true',
+                           help='Add gaussian fit')
+
+    @classmethod
+    def get_xlabel(self):
+        """Text for x-axis label
+        """
+        units = self.units
+        if len(units) == 1 and str(units[0]) == '':  # dimensionless
+            return 'Sample value'
+        if len(units) == 1 and self.usetex:
+            return 'Sample value ({})'.format(units[0].to_string('latex'))
+        elif len(units) == 1:
+            return 'Sample value ({})'.format(units[0].to_string())
+        elif len(units) > 1:
+            return 'Sample value (multiple units)'
+        return 'Sample value'
+
+    @classmethod
+    def get_ylabel(self):
+        """Text for y-axis label
+        """
+        return 'Count'
+
+    @classmethod
+    def get_suptitle(self):
+        """Start of default super title, first channel is appended to it
+        """
+        return 'Histogram: {0}'.format(self.chan_list[0])
+
+    @classmethod
+    def get_title(self):
+        suffix = super().get_title()
+        # limit significant digits for minute trends
+        rates = {ts.sample_rate.round(3) for ts in self.timeseries}
+        fss = '({0})'.format('), ('.join(map(str, rates)))
+        ret = ', '.join([
+            'Fs: {0}'.format(fss),
+            'dur: {0}'.format(self.duration),
+            suffix,
+        ])
+        ret = '{} bins: {}, mean: {:.3g}, sd: {:.3g}  ' \
+              'skew: {:.3g}, kurtosis: {:.3g}'.\
+            format(ret, self.nbins, self.mean.value, self.std.value,
+                   self.skew, self.kurtosis)
+        return ret
+
+    @classmethod
+    def make_plot(self):
+        """Generate the plot from time series and arguments
+        """
+        plot = Plot(figsize=self.figsize, dpi=self.dpi)
+        ax = plot.gca(xscale='linear')
+
+        # handle user specified plot labels
+        if self.args.legend:
+            nlegargs = len(self.args.legend[0])
+        else:
+            nlegargs = 0
+        if nlegargs > 0 and nlegargs != self.n_datasets:
+            warnings.warn('The number of legends specified must match '
+                          'the number of time series'
+                          ' (channels * start times).  '
+                          'There are {:d} series and {:d} legends'.format(
+                            len(self.timeseries), len(self.args.legend)))
+            nlegargs = 0    # don't use  them
+
+        for i in range(0, self.n_datasets):
+            series = self.timeseries[i]
+            if nlegargs:
+                label = self.args.legend[0][i]
+            else:
+                label = series.channel.name
+            if self.usetex:
+                label = label_to_latex(label)
+            nbins = int(max(10, min(math.sqrt(len(series)), 2000)))
+            n, bins, patches = ax.hist(series, bins=nbins, label=label,
+                                       density=True, alpha=0.75)
+            ymax = max(n)
+            self.ymax = max(self.ymax, ymax)
+            self.ymin = min(self.ymin, min(n[n > 0]))
+
+            if not self.nbins:
+                self.nbins = len(n)
+                self.skew = skew(series)
+                self.kurtosis = kurtosis(series)
+                self.mean = series.mean()
+                self.std = series.std()
+
+            if ymax > 0 and self.args.gauss:
+                mu, sigma = norm.fit(series)
+                fit = norm.pdf(bins, mu, sigma)
+                ax.plot(bins, fit)
+
+        if not self.args.ymin:
+            self.args.ymin = self.ymin
+        if not self.args.ymax:
+            self.args.ymax = self.ymax
+
+        if not self.args.xmin:
+            self.args.xmin = min(ts.min() for ts in self.timeseries).value
+        if not self.args.xmax:
+            self.args.xmax = max(ts.max() for ts in self.timeseries).value
+
+        return plot
+
+    @classmethod
+    def _finalize_arguments(self, args):
+        """ We cannot guess at default plot params
+        until histogram is calculated"""
+        if args.xscale is None:  # set default x-axis scale
+            args.xscale = 'linear'
+
+    @classmethod
+    def scale_axes_from_data(self):
+        """Restrict data limits for Y-axis based on what you can see
+        """
+        # get tight limits for X-axis if not specified by user
+        if not self.args.xmin:
+            self.args.xmin = min(ts.min().value for ts in self.timeseries)
+        if not self.args.xmax:
+            self.args.xmax = max(ts.max().value for ts in self.timeseries)
+
+        # autoscale view for Y-axis
+        ymin = self.args.ymin if self.args.ymin else self.ymin
+        ymax = self.args.ymax if self.args.ymax else self.ymax
+        self.plot.gca().yaxis.set_data_interval(ymin, ymax, ignore=True)
+        self.plot.gca().autoscale_view(scalex=False)

--- a/gwpy/cli/tests/test_histogram.py
+++ b/gwpy/cli/tests/test_histogram.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2018-2021)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for :mod:`gwpy.cli.histogram`
+"""
+
+from ... import cli
+from .base import (_TestTimeDomainProduct, update_namespace)
+
+
+class TestCliTimeSeries(_TestTimeDomainProduct):
+    TEST_CLASS = cli.TimeSeries
+    ACTION = 'histogram'
+
+    def test_get_title(self, prod):
+        update_namespace(prod.args, highpass=10, lowpass=100)
+        t = 'Fs: (), duration: {0}, band pass (10.0-100.0)'.format(
+            prod.args.duration)
+        assert prod.get_title() == t
+
+    def test_get_suptitle(self, prod):
+        assert prod.get_suptitle() == 'Time series: {0}'.format(
+            prod.chan_list[0])

--- a/gwpy/cli/tests/test_histogram.py
+++ b/gwpy/cli/tests/test_histogram.py
@@ -29,10 +29,15 @@ class TestCliTimeSeries(_TestTimeDomainProduct):
 
     def test_get_title(self, prod):
         update_namespace(prod.args, highpass=10, lowpass=100)
-        t = 'Fs: (), duration: {0}, band pass (10.0-100.0)'.format(
-            prod.args.duration)
-        assert prod.get_title() == t
+        t = 'Fs: (), dur: {:d}, band pass (10.0-100.0) bins: 0, mean: 0, ' \
+            'sd: 0  skew: 0, kurtosis: 0'.format(prod.args.duration)
+        u = prod.get_title()
+        assert u == t
 
     def test_get_suptitle(self, prod):
-        assert prod.get_suptitle() == 'Time series: {0}'.format(
+        st = prod.get_suptitle()
+        assert st == 'Histogram: {0}'.format(
             prod.chan_list[0])
+
+    def test_set_plot_properties(self, plotprod):
+        assert True

--- a/gwpy/cli/tests/test_histogram.py
+++ b/gwpy/cli/tests/test_histogram.py
@@ -24,7 +24,7 @@ from .base import (_TestTimeDomainProduct, update_namespace)
 
 
 class TestCliTimeSeries(_TestTimeDomainProduct):
-    TEST_CLASS = cli.TimeSeries
+    TEST_CLASS = cli.Histogram
     ACTION = 'histogram'
 
     def test_get_title(self, prod):


### PR DESCRIPTION
I've wanted to have this for a while.  It's a good way to look at the noise distributions. See [this set of plots](https://ldvw.ligo.caltech.edu/ldvw/view?act=imagehistory&strt=0&pageNum=1&usrSel=Joseph+Areeda+%284392%29&group=gaussian+noise+histograms+6&size=med&op_group=Favorites&newGrpName=%3Cnew+group+name%3E&pageNum2=1) comparing colored Gaussian noise to our Strain channel (LVK credentials needed)