### PR TITLE
Fix handling of figsize=None in matplotlib 3.4.0

### DIFF
--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -218,7 +218,7 @@ class Plot(figure.Figure):
     def _parse_subplotpars(kwargs):
         # dynamically set the subplot positions based on the figure size
         # -- only if the user hasn't customised the subplot params
-        figsize = kwargs.get('figsize', rcParams['figure.figsize'])
+        figsize = kwargs.get('figsize') or rcParams['figure.figsize']
         subplotpars = get_subplot_params(figsize)
         use_subplotpars = 'subplotpars' not in kwargs and all([
             rcParams['figure.subplot.%s' % pos] ==


### PR DESCRIPTION
This PR fixes an incompatibility with the release candidate for matplotlib-3.4.0 in which it seems that `figsize=None` is actively passed a lot more to figure constructors. Luckily, it's an almost trivial fix.