### PR TITLE
Add new gwpy.testing.errors module to provide error-handling utilities for the test suite

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -99,4 +99,29 @@ jobs:
         python -m pip install -r requirements-test.txt
 
     - name: Run test suite
-      run: python -m pytest -ra --color yes --pyargs gwpy --junitxml=pytest.xml
+      run: |
+        python -m pytest \
+            -ra \
+            --color yes \
+            --cov gwpy \
+            --cov-report=xml \
+            --disable-socket \
+            --junitxml=pytest.xml \
+            --pyargs gwpy \
+        ;
+
+    - name: Coverage report
+      run: python -m coverage report --show-missing
+
+    - name: Publish coverage to Codecov
+      uses: codecov/codecov-action@v1.2.1
+      with:
+        files: coverage.xml
+        flags: ${{ runner.os }},python${{ matrix.python-version }}
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: pytest-conda-${{ matrix.os }}-${{ matrix.python-version }}
+        path: pytest.xml

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -23,9 +23,8 @@ import os.path
 import re
 import tempfile
 from io import BytesIO
-from ssl import SSLError
 from unittest import mock
-from urllib.error import (URLError, HTTPError)
+from urllib.error import HTTPError
 
 import pytest
 
@@ -37,6 +36,7 @@ from ...plot import SegmentAxes
 from ...segments import (Segment, SegmentList,
                          DataQualityFlag, DataQualityDict)
 from ...testing import (mocks, utils)
+from ...testing.errors import pytest_skip_network_error
 from ...utils.misc import null_context
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -628,12 +628,13 @@ class TestDataQualityFlag(object):
         utils.assert_segmentlist_equal(result.known, RESULT.known & segs)
         utils.assert_segmentlist_equal(result.active, RESULT.active & segs)
 
+    @pytest_skip_network_error
     def test_fetch_open_data(self):
-        try:
-            segs = self.TEST_CLASS.fetch_open_data(
-                'H1_DATA', 946339215, 946368015)
-        except (URLError, SSLError) as exc:  # pragma: no-cover
-            pytest.skip(str(exc))
+        segs = self.TEST_CLASS.fetch_open_data(
+            'H1_DATA',
+            946339215,
+            946368015,
+        )
         assert segs.ifo == 'H1'
         assert segs.name == 'H1:DATA'
         assert segs.label == 'H1_DATA'

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -19,13 +19,8 @@
 """Unit tests for `gwpy.table`
 """
 
-from socket import timeout
-from ssl import SSLError
-from urllib.error import URLError
-
-import pytest
-
 from ...testing import utils
+from ...testing.errors import pytest_skip_network_error
 from .. import GravitySpyTable
 from .test_table import TestEventTable as _TestEventTable
 
@@ -54,14 +49,11 @@ JSON_RESPONSE = {
 class TestGravitySpyTable(_TestEventTable):
     TABLE = GravitySpyTable
 
+    @pytest_skip_network_error
     def test_search(self):
-        try:
-            table = self.TABLE.search(
-                gravityspy_id="8FHTgA8MEu",
-                howmany=1,
-                remote_timeout=60,
-            )
-        except (URLError, SSLError, timeout) as e:  # pragma: no-cover
-            pytest.skip(str(e))
-
+        table = self.TABLE.search(
+            gravityspy_id="8FHTgA8MEu",
+            howmany=1,
+            remote_timeout=60,
+        )
         utils.assert_table_equal(table, self.TABLE(JSON_RESPONSE))

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -24,9 +24,7 @@ import re
 import shutil
 import tempfile
 from io import BytesIO
-from ssl import SSLError
 from unittest import mock
-from urllib.error import URLError
 
 import pytest
 
@@ -42,6 +40,7 @@ from ...frequencyseries import FrequencySeries
 from ...io import ligolw as io_ligolw
 from ...segments import (Segment, SegmentList)
 from ...testing import utils
+from ...testing.errors import pytest_skip_network_error
 from ...time import LIGOTimeGPS
 from ...timeseries import (TimeSeries, TimeSeriesDict)
 from .. import (Table, EventTable, filters)
@@ -790,11 +789,9 @@ class TestEventTable(TestTable):
             t2,
         )
 
+    @pytest_skip_network_error
     def test_fetch_open_data(self):
-        try:
-            table = self.TABLE.fetch_open_data("GWTC-1-confident")
-        except (URLError, SSLError) as exc:  # pragma: no-cover
-            pytest.skip(str(exc))
+        table = self.TABLE.fetch_open_data("GWTC-1-confident")
         assert len(table)
         assert {
             "mass_1_source",
@@ -804,20 +801,18 @@ class TestEventTable(TestTable):
         # check unit parsing worked
         assert table["luminosity_distance"].unit == "Mpc"
 
+    @pytest_skip_network_error
     def test_fetch_open_data_kwargs(self):
-        try:
-            table = self.TABLE.fetch_open_data(
-                "GWTC-1-confident",
-                selection="mass_1_source < 5",
-                columns=[
-                    "name",
-                    "mass_1_source",
-                    "mass_2_source",
-                    "luminosity_distance"
-                ]
-            )
-        except (URLError, SSLError) as exc:  # pragma: no-cover
-            pytest.skip(str(exc))
+        table = self.TABLE.fetch_open_data(
+            "GWTC-1-confident",
+            selection="mass_1_source < 5",
+            columns=[
+                "name",
+                "mass_1_source",
+                "mass_2_source",
+                "luminosity_distance"
+            ],
+        )
         assert len(table) == 1
         assert table[0]["name"] == "GW170817-v3"
         assert set(table.colnames) == {

--- a/gwpy/testing/errors.py
+++ b/gwpy/testing/errors.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2021)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Error handling for the GWpy test suite
+"""
+
+import socket
+from functools import wraps
+from ssl import SSLError
+from urllib.error import URLError
+
+import pytest
+
+NETWORK_ERROR = (
+    socket.timeout,
+    SSLError,
+    URLError,
+)
+
+# attempt to also catch errors from pytest_socket,
+# this should enable the test suite to run on machines that
+# don't allow network access, e.g. debian build machines
+try:
+    from pytest_socket import (
+        SocketBlockedError,
+        SocketConnectBlockedError,
+    )
+except ModuleNotFoundError:  # pragma: no cover
+    # pytest-socket not installed
+    pass
+except ImportError as exc:  # pragma: no cover
+    # pytest-socket installed but errors not found,
+    # print a warning to tell the devs to update this module
+    import warnings
+    warnings.warn(
+        "failed to import exception types from pytest_socket: "
+        "{}".format(str(exc)),
+    )
+else:
+    NETWORK_ERROR = NETWORK_ERROR + (
+        SocketBlockedError,
+        SocketConnectBlockedError,
+    )
+
+
+def pytest_skip_network_error(func):
+    """Execute `func` but skip if it raises one of the network exceptions
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except NETWORK_ERROR as exc:  # pragma: no cover
+            pytest.skip(str(exc))
+
+    return wrapper

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -32,14 +32,17 @@ from astropy import units
 from ...detector import Channel
 from ...time import (Time, LIGOTimeGPS)
 from ...testing import (mocks, utils)
+from ...testing.errors import pytest_skip_network_error
 from ...types import Array2D
 from .. import (StateVector, StateVectorDict, StateVectorList,
                 StateTimeSeries, StateTimeSeriesDict, Bits)
 from .test_core import (TestTimeSeriesBase as _TestTimeSeriesBase,
                         TestTimeSeriesBaseDict as _TestTimeSeriesBaseDict,
                         TestTimeSeriesBaseList as _TestTimeSeriesBaseList)
-from .test_timeseries import (LOSC_IFO, LOSC_GW150914_SEGMENT,
-                              LOSC_FETCH_ERROR)
+from .test_timeseries import (
+    LOSC_IFO,
+    LOSC_GW150914_SEGMENT,
+)
 
 LOSC_GW150914_DQ_NAME = {
     'hdf5': 'Data quality',
@@ -316,12 +319,14 @@ class TestStateVector(_TestTimeSeriesBase):
         pytest.param(  # only frameCPP actually reads units properly
             'gwf', marks=utils.skip_missing_dependency('LDAStools.frameCPP')),
     ])
+    @pytest_skip_network_error
     def test_fetch_open_data(self, format):
-        try:
-            sv = self.TEST_CLASS.fetch_open_data(
-                LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, version=3)
-        except LOSC_FETCH_ERROR as e:  # pragma: no-cover
-            pytest.skip(str(e))
+        sv = self.TEST_CLASS.fetch_open_data(
+            LOSC_IFO,
+            *LOSC_GW150914_SEGMENT,
+            format=format,
+            version=3,
+        )
         ref = StateVector(
             [127, 127, 127, 127],
             unit='',

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,6 @@ beautifulsoup4
 freezegun >= 0.3.0
 pytest >= 3.6.3
 pytest-cov >= 2.4.0
+pytest-socket
 pytest-xdist
 requests-mock


### PR DESCRIPTION
This PR adds a new `gwpy.testing.errors` module that provides a decorator function to catch and apply `pytest.skip` when common network errors are found - we typically don't want to fail the suite because of these. This allows us to clean up a bunch of repeated usage through the test suite.