### PR TITLE
Add RST lint to github CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,9 @@
+# ---------------------------
+#
+# Check the source files for quality issues
+#
+# ---------------------------
+
 name: Lint
 
 on:
@@ -24,3 +30,21 @@ jobs:
         python -m pip install "flake8>=3.7.0"
     - name: Lint with flake8
       run: python -m flake8 .
+
+  rstcheck:
+    name: rstcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install \
+            "rstcheck" \
+        ;
+    - name: Lint with rstcheck
+      run: python -m rstcheck . --recursive --report severe

--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -213,7 +213,6 @@ HDF5 (GWOSC)
 |GWOSC|_ write data in HDF5 using a custom schema that is incompatible
 with `format='hdf5'`.
 
--------
 Reading
 -------
 


### PR DESCRIPTION
This PR adds a quality checks for the RST documentation source files to the CI workflow. I will then address any lint identified.