### PR TITLE
Simplify Axes.scatter to better handle arguments

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -176,27 +176,38 @@ class Axes(_Axes):
 
     # -- overloaded plotting methods ------------
 
-    def scatter(self, x, y, c=None, **kwargs):
-        # scatter with auto-sorting by colour
-        try:
-            if c is None:
-                raise ValueError
-            c_array = numpy.asanyarray(c, dtype=float)
-        except ValueError:  # no colour array
-            pass
-        else:
-            c_sort = kwargs.pop('c_sort', True)
-            if c_sort:
-                sortidx = c_array.argsort()
-                x = numpy.asarray(x)[sortidx]
-                y = numpy.asarray(y)[sortidx]
-                c = numpy.asarray(c)[sortidx]
+    def scatter(self, x, y, s=None, c=None, **kwargs):
+        # This method overloads Axes.scatter to enable quick
+        # sorting of data by the 'colour' array before scatter
+        # plotting.
 
-        return super().scatter(x, y, c=c, **kwargs)
+        # if we weren't asked to sort, or don't have any colours, don't
+        sort = kwargs.pop("sortbycolor", False)
+        if not sort:
+            return super().scatter(x, y, s=s, c=c, **kwargs)
+
+        # try and sort the colour array by value
+        try:
+            sortidx = numpy.asanyarray(c, dtype=float).argsort()
+        except ValueError as exc:
+            exc.args = (
+                "Axes.scatter argument 'sortbycolor' can only be used "
+                "with a simple array of floats in the colour array 'c'",
+            )
+            raise
+
+        def _sort(arr):
+            if arr is None or isinstance(arr, Number):
+                return arr
+            return numpy.asarray(arr)[sortidx]
+
+        # apply the sorting to each data array, and scatter
+        x, y, c, s = map(_sort, (x, y, c, s))
+        return super().scatter(x, y, s=s, c=c, **kwargs)
 
     scatter.__doc__ = _Axes.scatter.__doc__.replace(
         'marker :',
-        'c_sort : `bool`, optional, default: True\n'
+        'sortbycolor : `bool`, optional, default: False\n'
         '    Sort scatter points by `c` array value, if given.\n\n'
         'marker :',
     )

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -76,22 +76,51 @@ class TestAxes(AxesTestBase):
         utils.assert_array_equal(linex, [1, 2, 3])
         utils.assert_array_equal(liney, [4, 5, 6])
 
-    @pytest.mark.parametrize('c_sort', (False, True))
-    def test_scatter(self, ax, c_sort):
+    @pytest.mark.parametrize('sortbycolor', (False, True))
+    def test_scatter(self, ax, sortbycolor):
         x = numpy.arange(10)
         y = numpy.arange(10)
-        z = numpy.random.random(10)
-        coll = ax.scatter(x, y, c=z, c_sort=c_sort)
-        if c_sort:
-            utils.assert_array_equal(coll.get_array(), z[numpy.argsort(z)])
-        else:
-            utils.assert_array_equal(coll.get_array(), z)
+        c = numpy.random.random(10)
+        coll = ax.scatter(x, y, c=c, sortbycolor=sortbycolor)
+        if sortbycolor:  # sort the colours now
+            c = c[numpy.argsort(c)]
+        # check that the colour array is in the right order
+        utils.assert_array_equal(coll.get_array(), c)
 
+    @pytest.mark.parametrize('sortbycolor', (False, True))
+    def test_scatter_no_color(self, ax, sortbycolor):
         # check that c=None works
-        ax.scatter(x, y, c=None)
+        x = numpy.arange(10)
+        y = numpy.arange(10)
+        ax.scatter(x, y, c=None, sortbycolor=sortbycolor)
 
+    @pytest.mark.parametrize('sortbycolor', (False, True))
+    def test_scatter_non_array(self, ax, sortbycolor):
         # check that using non-array data works
-        ax.scatter([1], [1], c=[1])
+        ax.scatter([1], [1], c=[1], sortbycolor=sortbycolor)
+
+    @pytest.mark.parametrize('sortbycolor', (False, True))
+    def test_scatter_positional(self, ax, sortbycolor):
+        # check that using positional arguments works
+        x = numpy.arange(10)
+        y = numpy.arange(10)
+        s = numpy.random.random(10)
+        c = numpy.random.random(10)
+        ax.scatter(x, y, s, c, sortbycolor=sortbycolor)
+
+    @pytest.mark.parametrize('sortbycolor', (False, True))
+    def test_scatter_errors(self, ax, sortbycolor):
+        # check that errors are handled properly
+        x = 1
+        y = 'B'
+        c = 'something else'
+        with pytest.raises(ValueError) as exc:
+            ax.scatter(x, y, c=c, sortbycolor=sortbycolor)
+        if sortbycolor:  # gwpy error
+            msg = "Axes.scatter argument 'sortbycolor'"
+        else:  # matplotlib error
+            msg = "'c' argument must be a "
+        assert str(exc.value).startswith(msg)
 
     def test_imshow(self, ax):
         # standard imshow call


### PR DESCRIPTION
This PR simplifies the overloaded `Axes.scatter` method as follows:

- handle an `s` (size) array as well, seaborn 0.11.1 expects these to be acceptable as positional arguments,
- renamed `c_sort{=True}` to `sortbycolor=False`, to have a better name and have the same default action as matplotlib's `Axes.scatter`

@alurban @eagoetz, this probably has implications for the summary pages, which I think rely upon the default sorting by colour.