### PR TITLE
Don't modify incoming VetoDef object when converting to DataQualityFlag

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -650,9 +650,7 @@ class DataQualityFlag(object):
             name += ':%d' % int(veto.version)
         except TypeError:
             pass
-        if veto.end_time == 0:
-            veto.end_time = +inf
-        known = Segment(veto.start_time, veto.end_time)
+        known = Segment(veto.start_time, veto.end_time or +inf)
         pad = (veto.start_pad, veto.end_pad)
         return cls(name=name, known=[known], category=veto.category,
                    description=veto.comment, padding=pad)

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -19,6 +19,7 @@
 """Tests for :mod:`gwpy.segments`
 """
 
+import importlib
 import os.path
 import re
 import tempfile
@@ -438,8 +439,12 @@ class TestDataQualityFlag(object):
             flag.pad(*PADDING, kwarg='test')
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    def test_from_veto_def(self):
-        from ligo.lw.lsctables import VetoDef
+    @pytest.mark.parametrize("lsctables", (
+        pytest.param("glue.ligolw.lsctables", id="glue.ligolw"),
+        pytest.param("ligo.lw.lsctables", id="python-ligo-lw"),
+    ))
+    def test_from_veto_def(self, lsctables):
+        VetoDef = importlib.import_module(lsctables).VetoDef
 
         def veto_def(ifo, name, version, **kwargs):
             vdef = VetoDef()


### PR DESCRIPTION
This PR fixes a minor issue in the `DataQualityFlag.from_veto_def` whereby the incoming `VetoDef` object was being modified in-place, which causes issues when you try and fake it using a `namedtuple` (see #1268).