### PR TITLE
Improve gwpy.io.ligolw

### DIFF
--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -42,6 +42,7 @@ except ImportError:  # no ligo.lw
     LIGOLWContentHandler = None
 
 from .utils import (file_list, FILE_LIKE)
+from ..utils.decorators import deprecated_function
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -264,7 +265,8 @@ def read_ligolw(source, contenthandler=LIGOLWContentHandler, **kwargs):
         types.ToPyType = topytype
 
 
-def with_read_ligolw(func=None, contenthandler=None):
+@deprecated_function
+def with_read_ligolw(func=None, contenthandler=None):  # pragma: no cover
     """Decorate a LIGO_LW-reading function to open a filepath if needed
 
     ``func`` should be written to presume a

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -713,7 +713,8 @@ def is_ligolw(origin, filepath, fileobj, *args, **kwargs):
     return len(args) > 0 and isinstance(args[0], element_types)
 
 
-def is_xml(origin, filepath, fileobj, *args, **kwargs):
+@deprecated_function
+def is_xml(origin, filepath, fileobj, *args, **kwargs):  # pragma: no cover
     """Identify a file object as XML (any format)
     """
     # pylint: disable=unused-argument

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -24,7 +24,7 @@ from functools import reduce
 
 from astropy.io import registry as io_registry
 
-from ...io.ligolw import (is_xml, build_content_handler, read_ligolw,
+from ...io.ligolw import (is_ligolw, build_content_handler, read_ligolw,
                           write_tables, patch_ligotimegps)
 from ...segments import (DataQualityFlag, DataQualityDict)
 
@@ -139,9 +139,9 @@ def write_ligolw(flags, target, attrs=None, ilwdchar_compat=None, **kwargs):
 # register methods for DataQualityDict
 io_registry.register_reader('ligolw', DataQualityFlag, read_ligolw_flag)
 io_registry.register_writer('ligolw', DataQualityFlag, write_ligolw)
-io_registry.register_identifier('ligolw', DataQualityFlag, is_xml)
+io_registry.register_identifier('ligolw', DataQualityFlag, is_ligolw)
 
 # register methods for DataQualityDict
 io_registry.register_reader('ligolw', DataQualityDict, read_ligolw_dict)
 io_registry.register_writer('ligolw', DataQualityDict, write_ligolw)
-io_registry.register_identifier('ligolw', DataQualityDict, is_xml)
+io_registry.register_identifier('ligolw', DataQualityDict, is_ligolw)


### PR DESCRIPTION
This PR introduces some general improvements to `gwpy.io.ligolw`, including

- deprecating a couple of unused functions
- improving functionality in a couple of places
- adding more tests

There should be no API changes, other than the addition of a new function `gwpy.io.ligolw.iter_tables`.