### PR TITLE
Fix NDS2Warnings in TimeSeries tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,33 @@ jobs:
             texlive-latex-extra \
         ;
 
+    - name: Install CVMFS (Linux)
+      if: matrix.os == 'Ubuntu'
+      run: |
+        # configure CVMFS Apt repo
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -y -q install lsb-release
+        curl -LO https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+        sudo dpkg -i cvmfs-release-latest_all.deb
+        rm -f cvmfs-release-latest_all.deb
+        # configure CVMFS-contrib Apt repo
+        curl -LO https://ecsft.cern.ch/dist/cvmfs/cvmfs-contrib-release/cvmfs-contrib-release-latest_all.deb
+        sudo dpkg -i cvmfs-contrib-release-latest_all.deb
+        rm -f cvmfs-contrib-release-latest_all.deb
+        # install cvmfs
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -y -q -q update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -y -q install \
+            cvmfs \
+            cvmfs-config-osg \
+        ;
+        # configure CVMFS client
+        sudo cvmfs_config setup
+        sudo bash -c 'cat > /etc/cvmfs/default.local' << EOF
+        CVMFS_REPOSITORIES=gwosc.osgstorage.org
+        CVMFS_QUOTA_LIMIT=20000
+        CVMFS_HTTP_PROXY=DIRECT
+        EOF
+        sudo cvmfs_config probe
+
     - name: Install GWpy
       run: python -m pip install .[dev] --no-build-isolation -vv
 

--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -20,6 +20,7 @@
 """
 
 import os.path
+import subprocess
 import tempfile
 from contextlib import contextmanager
 from distutils.version import LooseVersion
@@ -73,6 +74,31 @@ def skip_minimum_version(module, minversion):
     return pytest.mark.skipif(
         module_older_than(module, minversion),
         reason='requires {} >= {}'.format(module, minversion))
+
+
+def _has_kerberos_credential():
+    """Return `True` if the current user has a valid kerberos credential
+
+    This function just calls ``klist -s`` and returns `True` if the
+    command returns a zero exit code, and `False` if it doesn't, or
+    the call fails in any other way.
+    """
+    try:
+        subprocess.check_call(
+            ["klist", "-s"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return True
+
+
+#: skip a test function if no kerberos credential is found
+skip_kerberos_credential = pytest.mark.skipif(
+    not _has_kerberos_credential(),
+    reason="no kerberos credential",
+)
 
 
 # -- assertions ---------------------------------------------------------------

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -313,7 +313,6 @@ class TestStateVector(_TestTimeSeriesBase):
 
     # -- data access ----------------------------
 
-    @utils.skip_minimum_version("gwosc", "0.4.0")
     @pytest.mark.parametrize('format', [
         'hdf5',
         pytest.param(  # only frameCPP actually reads units properly

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -40,15 +40,15 @@ from .test_core import (TestTimeSeriesBase as _TestTimeSeriesBase,
                         TestTimeSeriesBaseDict as _TestTimeSeriesBaseDict,
                         TestTimeSeriesBaseList as _TestTimeSeriesBaseList)
 from .test_timeseries import (
-    LOSC_IFO,
-    LOSC_GW150914_SEGMENT,
+    GWOSC_GW150914_IFO,
+    GWOSC_GW150914_SEGMENT,
 )
 
-LOSC_GW150914_DQ_NAME = {
+GWOSC_GW150914_DQ_NAME = {
     'hdf5': 'Data quality',
     'gwf': 'L1:GWOSC-4KHZ_R1_DQMASK',
 }
-LOSC_GW150914_DQ_BITS = {
+GWOSC_GW150914_DQ_BITS = {
     'hdf5': [
         'Passes DATA test',
         'Passes CBC_CAT1 test',
@@ -322,18 +322,18 @@ class TestStateVector(_TestTimeSeriesBase):
     @pytest_skip_network_error
     def test_fetch_open_data(self, format):
         sv = self.TEST_CLASS.fetch_open_data(
-            LOSC_IFO,
-            *LOSC_GW150914_SEGMENT,
+            GWOSC_GW150914_IFO,
+            *GWOSC_GW150914_SEGMENT,
             format=format,
             version=3,
         )
         ref = StateVector(
             [127, 127, 127, 127],
             unit='',
-            t0=LOSC_GW150914_SEGMENT[0],
+            t0=GWOSC_GW150914_SEGMENT[0],
             dt=1,
-            name=LOSC_GW150914_DQ_NAME[format],
-            bits=LOSC_GW150914_DQ_BITS[format],
+            name=GWOSC_GW150914_DQ_NAME[format],
+            bits=GWOSC_GW150914_DQ_BITS[format],
         )
         utils.assert_quantity_sub_equal(sv, ref, exclude=['channel', 'bits'])
         assert sorted(map(str, sv.bits)) == sorted(map(str, ref.bits))

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -48,6 +48,10 @@ from .test_core import (TestTimeSeriesBase as _TestTimeSeriesBase,
                         TestTimeSeriesBaseDict as _TestTimeSeriesBaseDict,
                         TestTimeSeriesBaseList as _TestTimeSeriesBaseList)
 
+SKIP_CVMFS_GWOSC = pytest.mark.skipif(
+    not os.path.isdir('/cvmfs/gwosc.osgstorage.org/'),
+    reason="GWOSC CVMFS repository not available",
+)
 SKIP_FRAMECPP = utils.skip_missing_dependency('LDAStools.frameCPP')
 SKIP_FRAMEL = utils.skip_missing_dependency('framel')
 SKIP_LAL = utils.skip_missing_dependency('lal')
@@ -565,23 +569,14 @@ class TestTimeSeries(_TestTimeSeriesBase):
                 self.TEST_CLASS.fetch('L1:TEST', 0, 1, host='nds.gwpy')
             assert 'no data received' in str(exc.value)
 
-    def _find_or_skip(self, *args, **kwargs):
-        """Execute `self.TEST_CLASS.find()` catching credential errors
-        """
-        try:
-            return self.TEST_CLASS.find(*args, **kwargs)
-        except RuntimeError as exc:  # pragma: no-cover
-            if "credential" in str(exc):
-                pytest.skip(str(exc))
-            raise
-
+    @SKIP_CVMFS_GWOSC
     @SKIP_FRAMECPP
     @mock.patch.dict(
         "os.environ",
         {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
     )
     def test_find(self, losc_16384):
-        ts = self._find_or_skip(
+        ts = self.TEST_CLASS.find(
             GWOSC_GW150914_CHANNEL,
             *GWOSC_GW150914_SEGMENT,
             frametype=GWOSC_GW150914_FRAMETYPE,
@@ -605,13 +600,14 @@ class TestTimeSeries(_TestTimeSeriesBase):
                 observatory='X',
             )
 
+    @SKIP_CVMFS_GWOSC
     @SKIP_FRAMECPP
     @mock.patch.dict(
         "os.environ",
         {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
     )
     def test_find_best_frametype_in_find(self, losc_16384):
-        ts = self._find_or_skip(
+        ts = self.TEST_CLASS.find(
             GWOSC_GW150914_CHANNEL,
             *GWOSC_GW150914_SEGMENT,
         )
@@ -621,6 +617,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             exclude=['name', 'channel', 'unit'],
         )
 
+    @SKIP_CVMFS_GWOSC
     @mock.patch.dict(
         # force 'import nds2' to fail so that we are actually testing
         # the gwdatafind API or nothing

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -648,6 +648,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         )
 
     @utils.skip_missing_dependency('nds2')
+    @utils.skip_kerberos_credential
     @mock.patch.dict(os.environ)
     def test_get_nds2(self, losc_16384):
         # get using NDS2 (if datafind could have been used to start with)

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -32,7 +32,6 @@ from scipy import signal
 
 from astropy import units
 
-from ...io.nds2 import NDSWarning
 from ...frequencyseries import (FrequencySeries, SpectralVariance)
 from ...segments import (Segment, SegmentList, DataQualityFlag)
 from ...signal import filter_design
@@ -70,8 +69,6 @@ GWF_APIS = [
     pytest.param('framel', marks=SKIP_FRAMEL),
 ]
 
-FIND_CHANNEL = 'L1:DCS-CALIB_STRAIN_C02'
-FIND_FRAMETYPE = 'L1_HOFT_C02'
 
 LIVETIME = DataQualityFlag(
     name='X1:TEST-FLAG:1',
@@ -83,10 +80,14 @@ LIVETIME = DataQualityFlag(
     isgood=True,
 )
 
-LOSC_IFO = 'L1'
-LOSC_GW150914 = 1126259462
-LOSC_GW150914_SEGMENT = Segment(LOSC_GW150914-2, LOSC_GW150914+2)
-LOSC_GW150914_DQ_BITS = {
+GWOSC_DATAFIND_SERVER = "datafind.gw-openscience.org"
+GWOSC_GW150914_IFO = "L1"
+GWOSC_GW150914_CHANNEL = "L1:GWOSC-16KHZ_R1_STRAIN"
+NDS2_GW150914_CHANNEL = "L1:DCS-CALIB_STRAIN_C02"
+GWOSC_GW150914_FRAMETYPE = "L1_LOSC_16_V1"
+GWOSC_GW150914 = 1126259462
+GWOSC_GW150914_SEGMENT = Segment(GWOSC_GW150914-2, GWOSC_GW150914+2)
+GWOSC_GW150914_DQ_BITS = {
     'hdf5': [
         'data present',
         'passes cbc CAT1 test',
@@ -119,16 +120,16 @@ class TestTimeSeries(_TestTimeSeriesBase):
     @pytest_skip_network_error
     def losc(self):
         return self.TEST_CLASS.fetch_open_data(
-            LOSC_IFO,
-            *LOSC_GW150914_SEGMENT,
+            GWOSC_GW150914_IFO,
+            *GWOSC_GW150914_SEGMENT,
         )
 
     @pytest.fixture(scope='class')
     @pytest_skip_network_error
     def losc_16384(self):
         return self.TEST_CLASS.fetch_open_data(
-            LOSC_IFO,
-            *LOSC_GW150914_SEGMENT,
+            GWOSC_GW150914_IFO,
+            *GWOSC_GW150914_SEGMENT,
             sample_rate=16384,
         )
 
@@ -483,8 +484,8 @@ class TestTimeSeries(_TestTimeSeriesBase):
     @pytest_skip_network_error
     def test_fetch_open_data(self, losc, format):
         ts = self.TEST_CLASS.fetch_open_data(
-            LOSC_IFO,
-            *LOSC_GW150914_SEGMENT,
+            GWOSC_GW150914_IFO,
+            *GWOSC_GW150914_SEGMENT,
             format=format,
             verbose=True,
         )
@@ -493,14 +494,26 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
         # try again with 16384 Hz data
         ts = self.TEST_CLASS.fetch_open_data(
-            LOSC_IFO, *LOSC_GW150914_SEGMENT, format=format, sample_rate=16384)
+            GWOSC_GW150914_IFO,
+            *GWOSC_GW150914_SEGMENT,
+            format=format,
+            sample_rate=16384,
+        )
         assert ts.sample_rate == 16384 * units.Hz
 
         # make sure errors happen
         with pytest.raises(ValueError) as exc:
-            self.TEST_CLASS.fetch_open_data(LOSC_IFO, 0, 1, format=format)
+            self.TEST_CLASS.fetch_open_data(
+                GWOSC_GW150914_IFO,
+                0,
+                1,
+                format=format,
+            )
         assert str(exc.value) == (
-            "Cannot find a LOSC dataset for %s covering [0, 1)" % LOSC_IFO)
+            "Cannot find a LOSC dataset for {} covering [0, 1)".format(
+                GWOSC_GW150914_IFO,
+            )
+        )
 
     @utils.skip_missing_dependency('nds2')
     @pytest.mark.parametrize('protocol', (1, 2))
@@ -564,41 +577,68 @@ class TestTimeSeries(_TestTimeSeriesBase):
             raise
 
     @SKIP_FRAMECPP
-    @pytest.mark.skipif('LIGO_DATAFIND_SERVER' not in os.environ,
-                        reason='No LIGO datafind server configured '
-                               'on this host')
+    @mock.patch.dict(
+        "os.environ",
+        {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
+    )
     def test_find(self, losc_16384):
-        ts = self._find_or_skip(FIND_CHANNEL, *LOSC_GW150914_SEGMENT,
-                                frametype=FIND_FRAMETYPE)
+        ts = self._find_or_skip(
+            GWOSC_GW150914_CHANNEL,
+            *GWOSC_GW150914_SEGMENT,
+            frametype=GWOSC_GW150914_FRAMETYPE,
+        )
         utils.assert_quantity_sub_equal(ts, losc_16384,
                                         exclude=['name', 'channel', 'unit'])
 
         # test observatory
-        ts2 = self.TEST_CLASS.find(FIND_CHANNEL, *LOSC_GW150914_SEGMENT,
-                                   frametype=FIND_FRAMETYPE,
-                                   observatory=FIND_CHANNEL[0])
+        ts2 = self.TEST_CLASS.find(
+            GWOSC_GW150914_CHANNEL,
+            *GWOSC_GW150914_SEGMENT,
+            frametype=GWOSC_GW150914_FRAMETYPE,
+            observatory=GWOSC_GW150914_IFO[0],
+        )
         utils.assert_quantity_sub_equal(ts, ts2)
         with pytest.raises(RuntimeError):
-            self.TEST_CLASS.find(FIND_CHANNEL, *LOSC_GW150914_SEGMENT,
-                                 frametype=FIND_FRAMETYPE, observatory='X')
+            self.TEST_CLASS.find(
+                GWOSC_GW150914_CHANNEL,
+                *GWOSC_GW150914_SEGMENT,
+                frametype=GWOSC_GW150914_FRAMETYPE,
+                observatory='X',
+            )
 
     @SKIP_FRAMECPP
-    @pytest.mark.skipif('LIGO_DATAFIND_SERVER' not in os.environ,
-                        reason='No LIGO datafind server configured '
-                               'on this host')
+    @mock.patch.dict(
+        "os.environ",
+        {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
+    )
     def test_find_best_frametype_in_find(self, losc_16384):
-        ts = self._find_or_skip(FIND_CHANNEL, *LOSC_GW150914_SEGMENT)
-        utils.assert_quantity_sub_equal(ts, losc_16384,
-                                        exclude=['name', 'channel', 'unit'])
+        ts = self._find_or_skip(
+            GWOSC_GW150914_CHANNEL,
+            *GWOSC_GW150914_SEGMENT,
+        )
+        utils.assert_quantity_sub_equal(
+            ts,
+            losc_16384,
+            exclude=['name', 'channel', 'unit'],
+        )
 
     @mock.patch.dict(
-        os.environ,
-        {"LIGO_DATAFIND_SERVER": "datafind.gw-openscience.org:80"},
+        # force 'import nds2' to fail so that we are actually testing
+        # the gwdatafind API or nothing
+        "sys.modules",
+        {"nds2": None},
+    )
+    @mock.patch.dict(
+        "os.environ",
+        {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
     )
     def test_get_datafind(self, losc_16384):
         try:
-            ts = self.TEST_CLASS.get(FIND_CHANNEL, *LOSC_GW150914_SEGMENT,
-                                     frametype_match=r'C01\Z')
+            ts = self.TEST_CLASS.get(
+                GWOSC_GW150914_CHANNEL,
+                *GWOSC_GW150914_SEGMENT,
+                frametype_match=r'V1\Z',
+            )
         except (ImportError, RuntimeError) as e:  # pragma: no-cover
             pytest.skip(str(e))
         utils.assert_quantity_sub_equal(
@@ -607,11 +647,15 @@ class TestTimeSeries(_TestTimeSeriesBase):
             exclude=['name', 'channel', 'unit'],
         )
 
+    @utils.skip_missing_dependency('nds2')
     @mock.patch.dict(os.environ)
     def test_get_nds2(self, losc_16384):
         # get using NDS2 (if datafind could have been used to start with)
-        dfs = os.environ.pop('LIGO_DATAFIND_SERVER', None)
-        ts = self.TEST_CLASS.get(FIND_CHANNEL, *LOSC_GW150914_SEGMENT)
+        os.environ.pop('LIGO_DATAFIND_SERVER', None)
+        ts = self.TEST_CLASS.get(
+            NDS2_GW150914_CHANNEL,
+            *GWOSC_GW150914_SEGMENT,
+        )
         utils.assert_quantity_sub_equal(
             ts,
             losc_16384,

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -476,7 +476,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
     # -- test remote data access ----------------
 
-    @utils.skip_minimum_version("gwosc", "0.4.0")
     @pytest.mark.parametrize('format', [
         'hdf5',
         pytest.param('gwf', marks=SKIP_FRAMECPP),


### PR DESCRIPTION
This PR fixes a test suite failure introduced by #1290 that an `NDSWarning` isn't emitted when you can actually use gwdatafind. This also updates the `LOSC_` variables in the timeseries test suite to use `GWOSC_` as the prefix.