### PR TITLE
Replace use of numpy alias type with builtin

### DIFF
--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -231,7 +231,7 @@ class TimeSeries(TimeSeriesBase):
             nfreqs = (nfft + 1) // 2
         else:
             nfreqs = nfft // 2 + 1
-        ffts = Spectrogram(numpy.zeros((navg, nfreqs), dtype=numpy.complex),
+        ffts = Spectrogram(numpy.zeros((navg, nfreqs), dtype=numpy.complex128),
                            channel=self.channel, epoch=self.epoch, f0=0,
                            df=1 / fftlength, dt=1, copy=True)
         # stride through TimeSeries, recording FFTs as columns of Spectrogram


### PR DESCRIPTION
This PR replaces `numpy.complex` with `numpy.complex128` to resolve a deprecation warning from numpy 1.20.0, see
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated.