### PR TITLE
Fix deprecation warning in sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -531,12 +531,12 @@ def setup_static_content(app):
     # add stylesheets
     cssdir = os.path.join(staticdir, 'css')
     for cssf in glob.glob(os.path.join(cssdir, '*.css')):
-        app.add_stylesheet(os.path.sep.join(cssf.rsplit(os.path.sep, 2)[-2:]))
+        app.add_js_file(os.path.sep.join(cssf.rsplit(os.path.sep, 2)[-2:]))
 
     # add custom javascript
     jsdir = os.path.join(staticdir, 'js')
     for jsf in glob.glob(os.path.join(jsdir, '*.js')):
-        app.add_javascript(os.path.sep.join(jsf.rsplit(os.path.sep, 2)[-2:]))
+        app.add_js_file(os.path.sep.join(jsf.rsplit(os.path.sep, 2)[-2:]))
 
 
 # -- setup --------------------------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ test =
 docs =
 	numpydoc >= 0.8.0
 	requests
-	sphinx >= 1.7.6
+	sphinx >= 1.8.0
 	sphinx-automodapi
 	sphinx_bootstrap_theme >= 0.6
 	sphinxcontrib-programoutput


### PR DESCRIPTION
This PR fixes a deprecation warning in the sphinx docs build by updating to at least sphinx 1.8.0 and renaming a function.