### PR TITLE
Run github actions on release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,11 @@ on:
   push:
     branches:
       - master
+      - release/**
   pull_request:
     branches:
       - master
+      - release/**
 
 jobs:
   conda:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -17,9 +17,11 @@ on:
   push:
     branches:
       - master
+      - release/**
   pull_request:
     branches:
       - master
+      - release/**
 
 jobs:
   minmax-dependencies:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -17,9 +17,11 @@ on:
   push:
     branches:
       - master
+      - release/**
   pull_request:
     branches:
       - master
+      - release/**
 
 jobs:
   tarball:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,11 @@ on:
   push:
     branches:
       - master
+      - release/**
   pull_request:
     branches:
       - master
+      - release/**
 
 jobs:
   flake8:


### PR DESCRIPTION
This PR cherry picks e5aa21fd04544aefcc99eb0f08b1ea9eebb31c18 from the `release/2.0.x` branch (see #1316) onto `master`.