### PR TITLE
Address DeprecationWarnings from Matplotlib 3.4

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -48,7 +48,7 @@ and visualisation:
 
    from gwpy.plot import Plot
    plot = Plot(figsize=(12, 4))
-   ax = plot.gca(xscale='auto-gps')
+   ax = plot.add_subplot(xscale='auto-gps')
    ax.plot(h1b, color='gwpy:ligo-hanford', label='LIGO-Hanford')
    ax.plot(l1b, color='gwpy:ligo-livingston', label='LIGO-Livingston')
    ax.set_epoch(1126259462.427)

--- a/docs/plot/colors.rst
+++ b/docs/plot/colors.rst
@@ -61,7 +61,7 @@ For example:
     l1 = TimeSeries.fetch_open_data('L1', 1126259457, 1126259467)
     l1b = l1.bandpass(50, 250).notch(60).notch(120)
     plot = Plot(figsize=(12, 4.8))
-    ax = plot.gca(xscale='auto-gps')
+    ax = plot.add_subplot(xscale='auto-gps')
     ax.plot(h1b, color='gwpy:ligo-hanford', label='LIGO-Hanford')
     ax.plot(l1b, color='gwpy:ligo-livingston', label='LIGO-Livingston')
     ax.set_epoch(1126259462.427)

--- a/examples/frequencyseries/percentiles.py
+++ b/examples/frequencyseries/percentiles.py
@@ -58,9 +58,11 @@ high = sg.percentile(95)
 
 from gwpy.plot import Plot
 plot = Plot()
-ax = plot.gca(xscale='log', xlim=(10, 1500), xlabel='Frequency [Hz]',
-              yscale='log', ylim=(3e-24, 2e-20),
-              ylabel=r'Strain noise [1/$\sqrt{\mathrm{Hz}}$]')
+ax = plot.add_subplot(
+    xscale='log', xlim=(10, 1500), xlabel='Frequency [Hz]',
+    yscale='log', ylim=(3e-24, 2e-20),
+    ylabel=r'Strain noise [1/$\sqrt{\mathrm{Hz}}$]',
+)
 ax.plot_mmm(median, low, high, color='gwpy:ligo-hanford')
 ax.set_title('LIGO-Hanford strain noise variation around GW170817',
              fontsize=16)

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -66,7 +66,7 @@ class TimeSeries(TimeDomainProduct):
         """Generate the plot from time series and arguments
         """
         plot = Plot(figsize=self.figsize, dpi=self.dpi)
-        ax = plot.gca(xscale='auto-gps')
+        ax = plot.add_subplot(xscale='auto-gps')
 
         # handle user specified plot labels
         if self.args.legend:

--- a/gwpy/plot/tests/test_gps.py
+++ b/gwpy/plot/tests/test_gps.py
@@ -148,7 +148,7 @@ def test_gps_scale(scale):
     u = Unit(scale[:-1])
 
     fig = pyplot.figure()
-    ax = fig.gca(xscale=scale)
+    ax = fig.add_subplot(xscale=scale)
     if scale == 'years':
         x = numpy.arange(50)
     else:
@@ -177,7 +177,7 @@ def test_gps_scale(scale):
 ])
 def test_auto_gps_scale(scale, unit):
     fig = pyplot.figure()
-    ax = fig.gca(xscale='auto-gps')
+    ax = fig.add_subplot(xscale='auto-gps')
     ax.plot(numpy.arange(1e2) * scale, numpy.arange(1e2))
     xscale = ax.get_xaxis()._scale
     transform = xscale.get_transform()

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -47,7 +47,7 @@ class TestPlot(FigureTestBase):
     def test_init_empty(self):
         plot = self.FIGURE_CLASS(geometry=(2, 2))
         assert len(plot.axes) == 4
-        assert plot.axes[-1].get_geometry() == (2, 2, 4)
+        assert plot.axes[-1].get_subplotspec().get_geometry() == (2, 2, 3, 3)
 
     def test_init_with_data(self):
         # list
@@ -79,7 +79,7 @@ class TestPlot(FigureTestBase):
         plot = self.FIGURE_CLASS(a, b, separate=True, sharex=True, sharey=True)
         assert len(plot.axes) == 2
         for i, ax in enumerate(plot.axes):
-            assert ax.get_geometry() == (2, 1, i+1)
+            assert ax.get_subplotspec().get_geometry() == (2, 1, i, i)
             assert len(ax.lines) == 1
         assert plot.axes[1]._sharex is plot.axes[0]
         plot.close()

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -120,7 +120,7 @@ class TestPlot(FigureTestBase):
         assert cbar.mappable is image
 
     def test_add_segments_bar(self, fig):
-        ax = fig.gca(xscale='auto-gps', epoch=150)
+        ax = fig.add_subplot(xscale='auto-gps', epoch=150)
         ax.set_xlim(100, 200)
         ax.set_xlabel('test')
         segs = SegmentList([Segment(10, 110), Segment(150, 400)])
@@ -139,7 +139,7 @@ class TestPlot(FigureTestBase):
             fig.add_segments_bar(segs, location='left')
 
     def test_add_state_segments(self, fig):
-        fig.gca(xscale='auto-gps')
+        fig.add_subplot(xscale='auto-gps')
         segs = SegmentList([Segment(10, 110), Segment(150, 400)])
         with pytest.deprecated_call():
             fig.add_state_segments(segs)

--- a/gwpy/plot/tests/utils.py
+++ b/gwpy/plot/tests/utils.py
@@ -67,5 +67,5 @@ class AxesTestBase(_Base):
     @pytest.fixture(scope='function')
     def ax(cls):
         fig = pyplot.figure(FigureClass=getattr(cls, 'FIGURE_CLASS', Plot))
-        yield fig.gca(projection=cls.AXES_CLASS.name)
+        yield fig.add_subplot(projection=cls.AXES_CLASS.name)
         cls.save_and_close(fig)


### PR DESCRIPTION
This PR updates some internal calls to address `DeprecationWarning`s from Matplotlib 3.4.