### PR TITLE
Add ConnectionError to  pytest network errors list

### DIFF
--- a/gwpy/testing/errors.py
+++ b/gwpy/testing/errors.py
@@ -27,6 +27,7 @@ from urllib.error import URLError
 import pytest
 
 NETWORK_ERROR = (
+    ConnectionError,
     socket.timeout,
     SSLError,
     URLError,


### PR DESCRIPTION
This PR adds `ConnectionError` to the list of errors to `pytest.skip` gracefully if a remote network connection fails. This was seen in a local conda-build test of gwpy-2.0.4.