### PR TITLE
Add --average-method command-line option for gwpy-plot products

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -841,6 +841,7 @@ class FFTMixin(object, metaclass=abc.ABCMeta):
                            help='window function to use when overlapping FFTs')
         group.add_argument('--average-method', dest='method',
                            default=DEFAULT_FFT_METHOD,
+                           choices=('median', 'welch', 'bartlett'),
                            help='FFT averaging method')
         return group
 

--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -36,6 +36,7 @@ from ..signal import filter_design
 from ..signal.window import recommended_overlap
 from ..time import to_gps
 from ..timeseries import TimeSeriesDict
+from ..timeseries.timeseries import DEFAULT_FFT_METHOD
 from ..plot.gps import (GPS_SCALES, GPSTransform)
 from ..plot.tex import label_to_latex
 from ..segments import DataQualityFlag
@@ -838,6 +839,9 @@ class FFTMixin(object, metaclass=abc.ABCMeta):
                            help='overlap as fraction of FFT length [0-1)')
         group.add_argument('--window', type=str, default='hann',
                            help='window function to use when overlapping FFTs')
+        group.add_argument('--average-method', dest='method',
+                           default=DEFAULT_FFT_METHOD,
+                           help='FFT averaging method')
         return group
 
     @classmethod

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -109,8 +109,12 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
 
         if stride:
             specgram = self.timeseries[0].spectrogram(
-                stride, fftlength=fftlength, overlap=overlap,
-                window=args.window)
+                stride,
+                fftlength=fftlength,
+                overlap=overlap,
+                method=args.method,
+                window=args.window,
+            )
             nfft = stride * (stride // (fftlength - overlap))
             self.log(3, 'Spectrogram calc, stride: %s, fftlength: %s, '
                         'overlap: %sf, #fft: %d' % (stride, fftlength,

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -88,6 +88,7 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
 
         fftlength = float(args.secpfft)
         overlap = args.overlap
+        method = args.method
         self.log(2, "Calculating spectrum secpfft: {0}, overlap: {1}".format(
             fftlength, overlap))
         overlap *= fftlength
@@ -121,7 +122,11 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
                 if len(self.start_list) > 1:
                     label += ', {0}'.format(series.epoch.gps)
 
-            asd = series.asd(fftlength=fftlength, overlap=overlap)
+            asd = series.asd(
+                fftlength=fftlength,
+                overlap=overlap,
+                method=method,
+            )
             self.spectra.append(asd)
 
             if self.usetex:


### PR DESCRIPTION
This PR adds a `--average-method` command-line option for the relevant `gwpy-plot` products, which defaults to the `DEFAULT_FFT_METHOD` from `gwpy.timeseries.timeseries`. This is currently `None` (`'welch'`) but is due to change in #1282 to `'median'`.