### PR TITLE
Enable FFT options for gwpy-plot qtransform product

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -821,6 +821,8 @@ class FFTMixin(object, metaclass=abc.ABCMeta):
 
     This just adds FFT-based command line options
     """
+    DEFAULT_FFTLENGTH = 1.
+
     @classmethod
     def init_data_options(cls, parser):
         """Set up data input and signal processing options including FFTs
@@ -833,7 +835,8 @@ class FFTMixin(object, metaclass=abc.ABCMeta):
         """Add an `~argparse.ArgumentGroup` for FFT options
         """
         group = parser.add_argument_group('Fourier transform options')
-        group.add_argument('--secpfft', type=float, default=1.,
+        group.add_argument('--secpfft', type=float,
+                           default=cls.DEFAULT_FFTLENGTH,
                            help='length of FFT in seconds')
         group.add_argument('--overlap', type=float,
                            help='overlap as fraction of FFT length [0-1)')

--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -35,6 +35,7 @@ class TestCliQtransform(_TestCliSpectrogram):
     TEST_ARGS = [
         '--chan', 'X1:TEST-CHANNEL', '--gps', '5', '--search', '10',
         '--nds2-server', 'nds.test.gwpy', '--outdir', os.path.curdir,
+        '--average-method', 'median',
     ]
 
     def test_finalize_arguments(self, prod):


### PR DESCRIPTION
This PR enables the FFT command-line options for the `gwpy-plot` qtransform product to allow specification of fftlength/overlap/method for the whitening ASD calculation.

This is dependent upon #1329.