### PR TITLE
Fix Docs of class BodePlot

### DIFF
--- a/gwpy/plot/bode.py
+++ b/gwpy/plot/bode.py
@@ -73,7 +73,7 @@ class BodePlot(Plot):
     frequencies : `numpy.ndarray`, optional
         list of frequencies (in Hertz) at which to plot
 
-    db : `bool`, optional, default: `True`
+    dB : `bool`, optional, default: `True`
         if `True`, display magnitude in decibels, otherwise display
         amplitude.
 


### PR DESCRIPTION
Fixed the typo where argument `dB` was written as `db`, which would mislead the user when using this class. This pull request is in reference to #1332.

EDIT (@duncanmmacleod): closes #1332.