### PR TITLE
Fix detection of uproot4 writing capability

### DIFF
--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -81,7 +81,7 @@ def _import_uproot_that_can_write_root_files():
     """
     import uproot
     try:
-        uproot.create
+        uproot.newtree
     except AttributeError:
         try:
             import uproot3 as uproot


### PR DESCRIPTION
The latest uproot 4.x includes `create()` and `recreate()` functions, but don't include the `newtree` function that we need to translate numpy arrays into ROOT-serialisable objects, so this PR just updates the `_import_uproot_that_can_write_root_files()` function to check for `newtree`. 