### PR TITLE
Improve detection of gwosc.osgstorage.org CVMFS repo

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -49,7 +49,7 @@ from .test_core import (TestTimeSeriesBase as _TestTimeSeriesBase,
                         TestTimeSeriesBaseList as _TestTimeSeriesBaseList)
 
 SKIP_CVMFS_GWOSC = pytest.mark.skipif(
-    not os.path.isdir('/cvmfs/gwosc.osgstorage.org/'),
+    not os.path.isdir('/cvmfs/gwosc.osgstorage.org/gwdata'),
     reason="GWOSC CVMFS repository not available",
 )
 SKIP_FRAMECPP = utils.skip_missing_dependency('LDAStools.frameCPP')


### PR DESCRIPTION
This PR improves the detection of a working `/cvmfs/gwosc.osgstorage.org` mount by going one directory deeper to make sure the mount actually works. This may (or may not) help prevent further occurances of errors like [this one](https://git.ligo.org/computing/conda/-/jobs/1404222) seen in the IGWN Conda Distribution integration tests.