### PR TITLE
Add custom pytest marks

### DIFF
--- a/gwpy/conftest.py
+++ b/gwpy/conftest.py
@@ -30,6 +30,8 @@ use('agg', force=True)
 
 # register custom fixtures for all test modules
 from .testing.fixtures import *  # noqa: E402,F401,F403
+# define marks (registered below)
+from .testing.marks import _register_marks  # noqa: E402
 
 # set random seed to 1 for reproducability
 numpy.random.seed(1)
@@ -46,3 +48,9 @@ warnings.filterwarnings('ignore', message=".*non-GUI backend.*")
 rcParams.update({
     'text.usetex': False,  # TeX is slow most of the time
 })
+
+
+# -- pytest configuration
+
+def pytest_configure(config):
+    _register_marks(config)

--- a/gwpy/testing/marks.py
+++ b/gwpy/testing/marks.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2021)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Custom pytest marks for GWpy
+
+This is mainly to allow downstream users/builders/packagers to skip tests
+that require annoying/flaky configuration, or just take too long, e.g.
+tests that use CVMFS could be skipped via
+
+    $ python -m pytest --pyargs gwpy -m 'not cvmfs'
+
+This module is imported in :mod:`gwpy.conftest` such that all marks are
+registered up front and visible via ``python -m pytest gwpy --markers``.
+"""
+
+MARKS = {
+    "cvmfs": "mark a test as requiring CVMFS",
+}
+
+
+def _register_marks(config):
+    """Register all marks for GWpy
+
+    This function is designed to be called from :mod:`gwpy.conftest`.
+    """
+    for name, doc in MARKS.items():
+        config.addinivalue_line(
+            "markers",
+            "{}: {}".format(name, doc),
+        )

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -122,6 +122,7 @@ def _gwosc_cvmfs(func):
     """Decorate ``func`` with all necessary CVMFS-related decorators
     """
     for dec in (
+        pytest.mark.cvmfs,
         pytest_skip_cvmfs_read_error,
         SKIP_CVMFS_GWOSC,
         SKIP_FRAMECPP,


### PR DESCRIPTION
This PR adds support for custom, registered pytest marks. The only mark added at the moment is `cvmfs`, which has been applied to all of those tests that attempt to use the GWOSC CVMFS repo.