### PR TITLE
Handle CVMFS failures more gracefully

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -275,8 +275,12 @@ def is_cache(cache):
     if isinstance(cache, (str,) + FILE_LIKE):
         try:
             return bool(len(read_cache(cache)))
-        except (TypeError, ValueError, UnicodeDecodeError, ImportError):
-            # failed to parse cache
+        except (
+            OSError,  # failed to read file
+            TypeError,  # failed to parse a line as a cache entry
+            UnicodeDecodeError,  # failed to decode file
+            ValueError,  # failed to parse a line as a cache entry
+        ):
             return False
     if HAS_CACHE and isinstance(cache, Cache):
         return True

--- a/gwpy/testing/errors.py
+++ b/gwpy/testing/errors.py
@@ -70,3 +70,24 @@ def pytest_skip_network_error(func):
             pytest.skip(str(exc))
 
     return wrapper
+
+
+def pytest_skip_cvmfs_read_error(func):
+    """Execute `func` but skip if a CVMFS file fails to open
+
+    This is most likely indicative of a broken CVMFS mount, which is not
+    GWpy's problem.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except RuntimeError as exc:  # pragma: no cover
+            # if function failed to read a CVMFS file, skip
+            msg = str(exc)
+            if msg.startswith("Unable to open file: /cvmfs"):
+                pytest.skip(msg)
+            # otherwise raise the original error
+            raise
+
+    return wrapper

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -39,7 +39,10 @@ from ...signal.window import planck
 from ...table import EventTable
 from ...spectrogram import Spectrogram
 from ...testing import (mocks, utils)
-from ...testing.errors import pytest_skip_network_error
+from ...testing.errors import (
+    pytest_skip_cvmfs_read_error,
+    pytest_skip_network_error,
+)
 from ...time import LIGOTimeGPS
 from ...utils.misc import null_context
 from .. import (TimeSeries, TimeSeriesDict, TimeSeriesList, StateTimeSeries)
@@ -570,6 +573,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             assert 'no data received' in str(exc.value)
 
     @SKIP_CVMFS_GWOSC
+    @pytest_skip_cvmfs_read_error
     @SKIP_FRAMECPP
     @mock.patch.dict(
         "os.environ",
@@ -601,6 +605,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             )
 
     @SKIP_CVMFS_GWOSC
+    @pytest_skip_cvmfs_read_error
     @SKIP_FRAMECPP
     @mock.patch.dict(
         "os.environ",

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -118,6 +118,18 @@ GWOSC_GW150914_DQ_BITS = {
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+def _gwosc_cvmfs(func):
+    """Decorate ``func`` with all necessary CVMFS-related decorators
+    """
+    for dec in (
+        pytest_skip_cvmfs_read_error,
+        SKIP_CVMFS_GWOSC,
+        SKIP_FRAMECPP,
+    ):
+        func = dec(func)
+    return func
+
+
 class TestTimeSeries(_TestTimeSeriesBase):
     TEST_CLASS = TimeSeries
 
@@ -572,9 +584,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
                 self.TEST_CLASS.fetch('L1:TEST', 0, 1, host='nds.gwpy')
             assert 'no data received' in str(exc.value)
 
-    @SKIP_CVMFS_GWOSC
-    @pytest_skip_cvmfs_read_error
-    @SKIP_FRAMECPP
+    @_gwosc_cvmfs
     @mock.patch.dict(
         "os.environ",
         {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
@@ -604,9 +614,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
                 observatory='X',
             )
 
-    @SKIP_CVMFS_GWOSC
-    @pytest_skip_cvmfs_read_error
-    @SKIP_FRAMECPP
+    @_gwosc_cvmfs
     @mock.patch.dict(
         "os.environ",
         {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
@@ -622,7 +630,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             exclude=['name', 'channel', 'unit'],
         )
 
-    @SKIP_CVMFS_GWOSC
+    @_gwosc_cvmfs
     @mock.patch.dict(
         # force 'import nds2' to fail so that we are actually testing
         # the gwdatafind API or nothing


### PR DESCRIPTION
This PR adds some error-handling to skip over CVMFS-related failures in the test suite.

There's currently an issue with gwosc.osgstorage.org that is failing the tests, but since this isn't really a GWpy issue we should skip those failures.