### PR TITLE
Dynamically generate NDS2 enums

### DIFF
--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -265,7 +265,7 @@ class Channel(object):
         if type_ is None:
             self._type = None
         else:
-            self._type = io_nds2.Nds2ChannelType.find(type_).name
+            self._type = io_nds2.Nds2ChannelType.find(type_).nds2name
 
     @property
     def ndstype(self):
@@ -659,7 +659,7 @@ class ChannelList(list):
             namestr = namestr.strip('\' \n')
             if ',' not in namestr:
                 break
-            for nds2type in io_nds2.Nds2ChannelType.names() + ['']:
+            for nds2type in io_nds2.Nds2ChannelType.nds2names() + ['']:
                 if nds2type and ',%s' % nds2type in namestr:
                     try:
                         channel, ctype, namestr = namestr.split(',', 2)

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -55,12 +55,12 @@ class TestNds2ChannelType(_TestNds2Enum):
     """
     TEST_CLASS = io_nds2.Nds2ChannelType
 
-    def test_name(self):
-        assert self.TEST_CLASS.MTREND.name == 'm-trend'
+    def test_nds2name(self):
+        assert self.TEST_CLASS.MTREND.nds2name == 'm-trend'
 
-    def test_names(self):
-        assert sorted(self.TEST_CLASS.names()) == sorted(
-            io_nds2.NDS2_TYPE_NAME.values())
+    def test_nds2names(self):
+        _raw_names = sorted(v[1] for v in io_nds2._NDS2_CHANNEL_TYPE.values())
+        assert sorted(self.TEST_CLASS.nds2names()) == _raw_names
 
     @pytest.mark.parametrize('input_', ['m-trend', 'MTREND'])
     def test_find(self, input_):


### PR DESCRIPTION
This PR refactors the Enum generation in `gwpy.io.nds2` to dynamically generate the `Nds2ChannelType` and `Nds2DataType` enums if possible using the `nds2.channel` object itself. This should mean that the enums are always an accurate reflection of the underlying NDS2 interface, if present.

This does present a minor breaking change in that the enums no longer overload the `name` property, instead providing a `nds2name` property instead.