### PR TITLE
Fix bug in Nds2ChannelType.find

### DIFF
--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -139,13 +139,22 @@ class _Nds2Enum(enum.IntFlag):
     def find(cls, name):
         """Returns the NDS2 type corresponding to the given name
         """
+        name = str(name)
+        # if given a number, use it
+        if name.isdigit():
+            return cls(int(name))
+        # otherwise we might have been given a registered name
         try:
-            return cls(name)
-        except ValueError as exc:
-            try:
-                return cls[str(name).replace('-', '').upper()]
-            except KeyError:
-                raise exc
+            return cls[name.upper()]
+        except KeyError:
+            # otherwise otherwise check the NDS2 names
+            for item in cls:
+                if name.lower() == item.nds2name.lower():
+                    return item
+        # bail out
+        raise ValueError(
+            "{!r} is not a valid {}".format(name, cls.__name__),
+        )
 
 
 Nds2ChannelType = _Nds2Enum(

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -62,11 +62,20 @@ class TestNds2ChannelType(_TestNds2Enum):
         _raw_names = sorted(v[1] for v in io_nds2._NDS2_CHANNEL_TYPE.values())
         assert sorted(self.TEST_CLASS.nds2names()) == _raw_names
 
-    @pytest.mark.parametrize('input_', ['m-trend', 'MTREND'])
-    def test_find(self, input_):
+    @pytest.mark.parametrize(('input_', 'expected'), (
+        (TEST_CLASS.MTREND.value, TEST_CLASS.MTREND),
+        (TEST_CLASS.MTREND.name, TEST_CLASS.MTREND),
+        (TEST_CLASS.MTREND.nds2name, TEST_CLASS.MTREND),
+        ('mtrend', TEST_CLASS.MTREND),
+        ('rds', TEST_CLASS.RDS),
+        ('RDS', TEST_CLASS.RDS),
+        ('reduced', TEST_CLASS.RDS),
+        ('REDUCED', TEST_CLASS.RDS),
+    ))
+    def test_find(self, input_, expected):
         """Test :meth:`gwpy.io.nds2.Nds2ChannelType.find`
         """
-        assert self.TEST_CLASS.find(input_) == self.TEST_CLASS.MTREND
+        assert self.TEST_CLASS.find(input_) == expected
 
 
 class TestNds2DataType(_TestNds2Enum, _TestNumpyTypeEnum):


### PR DESCRIPTION
This PR fixes a bug in Nds2ChannelType.find whereby valid NDS2 channel type strings (e.g. `'reduced'`) weren't being recognised because they didn't match the enum attribute name (e.g. `'RDS'`). See https://git.ligo.org/nds/nds2-client/-/issues/118 for a short discussion of this naming choice in the NDS2 client.

This closes #1297 with the caveat that the correct NDS2 name for the channel is `'L1:DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01,reduced'` (and not `'L1:DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01,rds'`). 

Closes #1298.