### PR TITLE
Update CI to run on main branch and run some jobs nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,12 @@ name: Build and test
 on:
   push:
     branches:
+      - main
       - master
       - release/**
   pull_request:
     branches:
+      - main
       - master
       - release/**
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -24,6 +24,8 @@ on:
       - main
       - master
       - release/**
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   minmax-dependencies:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,10 +16,12 @@ name: Dependencies
 on:
   push:
     branches:
+      - main
       - master
       - release/**
   pull_request:
     branches:
+      - main
       - master
       - release/**
 

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -16,10 +16,12 @@ name: Distribution
 on:
   push:
     branches:
+      - main
       - master
       - release/**
   pull_request:
     branches:
+      - main
       - master
       - release/**
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,12 @@ name: Lint
 on:
   push:
     branches:
+      - main
       - master
       - release/**
   pull_request:
     branches:
+      - main
       - master
       - release/**
 


### PR DESCRIPTION
This PR makes two small changes to the Github Actions CI

- run all jobs on the `main` branch - this just means that if we rename `master` to `main` we don't have to update the CI again
- run the `Dependencies` workflow on a cron schedule every night - this should allow us to catch breaking changes in dependencies as early as possible, rather than 'whenever the next person submits a PR'