### PR TITLE
Migrate pytest configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,14 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "gwpy/_version.py"
+
+[tool.pytest.ini_options]
+addopts = "-r a"
+filterwarnings = [
+	# https://github.com/gwastro/pycbc/pull/3701
+	"ignore:`np.int` is a deprecated alias::pycbc..*",
+	# https://git.ligo.org/lscsoft/glue/-/merge_requests/69
+	"ignore:PY_SSIZE_T_CLEAN will be required",
+	# https://github.com/pyreadline/pyreadline/issues/65
+	"ignore:Using or importing the ABCs::pyreadline",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,6 +133,3 @@ exclude =
 per-file-ignores =
 	__init__.py:F401,
 	examples/**.py:E402
-
-[tool:pytest]
-addopts = -r a --color=yes


### PR DESCRIPTION
This PR migrates the pytest configuration from `setup.cfg` to `pyproject.toml`, and then adds a few warnings that aren't our problem.

This is extracted from #1331 to get it through quickly so that it can be used elsewhere.