### PR TITLE
Fail tests on any warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,8 @@ filterwarnings = [
   # ignore warnings from distutils.version
   "ignore:distutils Version::matplotlib",
   "ignore:distutils Version::distutils",  # actually setuptools._distutils
+  # https://git.ligo.org/gwinc/inspiral-range/-/issues/12
+  "ignore:Please use `p_roots`::inspiral_range..*",
 ]
 xfail_strict = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,8 @@ precision = 1
 [tool.pytest.ini_options]
 addopts = "-r a"
 filterwarnings = [
+  # fail tests on any warnings
+  "error",
   # https://github.com/gwastro/pycbc/pull/3701
   "ignore:`np.int` is a deprecated alias::pycbc..*",
   # https://git.ligo.org/lscsoft/glue/-/merge_requests/69


### PR DESCRIPTION
This PR modifies the pytest configuration to fail a test on any warnings, forcing us to stay on top of upstream dependency changes, etc.

This will likely need to stay open in 'Draft' form for a while until all of the different warnings are addressed.

This closes #1331 which should be split up into separate PRs that fix specific warnings.

Depends #1484.