### PR TITLE
Fix physical_type str formatting for astropy 4.3+

### DIFF
--- a/gwpy/plot/units.py
+++ b/gwpy/plot/units.py
@@ -34,6 +34,6 @@ class LatexInlineDimensional(LatexInline):
         u = '[{0}]'.format(super().to_string(unit))
 
         if unit.physical_type not in {None, 'unknown', 'dimensionless'}:
-            ptype = cls._latex_escape(unit.physical_type.title())
-            return '{0} {1}'.format(ptype, u)
+            ptype = str(unit.physical_type).split('/', 1)[0].title()
+            return '{0} {1}'.format(cls._latex_escape(ptype), u)
         return u


### PR DESCRIPTION
This PR addresses a warning emitted by Astropy 4.3+ relating to formatting of `<unit>.physical_type`, which used to just be a `str`, but is now a structured object that complains about using `str` methods.