### PR TITLE
Deprecate TemporaryFile context manager and tmpfile test fixture

### DIFF
--- a/gwpy/cli/tests/base.py
+++ b/gwpy/cli/tests/base.py
@@ -19,7 +19,6 @@
 """Unit tests for :mod:`gwpy.cli`
 """
 
-import os
 from argparse import ArgumentParser
 from unittest import mock
 
@@ -252,14 +251,14 @@ class _TestCliProduct(object):
         assert ax.get_ylabel() == params.get('ylabel', plotprod.get_ylabel())
 
     @utils.skip_missing_dependency('nds2')
-    def test_run(self, prod):
+    def test_run(self, tmp_path, prod):
         conn, _ = mock_nds2_connection()
-        with mock.patch('nds2.connection') as mocker, \
-                utils.TemporaryFilename(suffix='.png') as tmp:
+        tmp = tmp_path / "plot.png"
+        with mock.patch('nds2.connection') as mocker:
             mocker.return_value = conn
-            prod.args.out = tmp
+            prod.args.out = str(tmp)
             prod.run()
-            assert os.path.isfile(tmp)
+            assert tmp.is_file()
             assert prod.plot_num == 1
             assert not prod.has_more_plots()
 

--- a/gwpy/cli/tests/test_gwpy_plot.py
+++ b/gwpy/cli/tests/test_gwpy_plot.py
@@ -19,13 +19,11 @@
 """Tests for `gwpy-plot` command line module `gwpy.cli.gwpy_plot`
 """
 
-from pathlib import Path
 from unittest import mock
 
 import pytest
 
 from ...testing.utils import (
-    TemporaryFilename,
     skip_missing_dependency,
 )
 from .. import (
@@ -44,18 +42,19 @@ def test_gwpy_plot_help(mode):
 
 
 @skip_missing_dependency('nds2')
-def test_gwpy_plot_timeseries():
+def test_gwpy_plot_timeseries(tmp_path):
+    tmp = tmp_path / "plot.png"
     with mock.patch(
         'nds2.connection',
         return_value=mock_nds2_connection()[0],
-    ), TemporaryFilename(suffix=".png") as tmp:
+    ):
         args = [
             "timeseries",
             "--chan", "X1:TEST-CHANNEL",
             "--start", 0,
             "--nds2-server", "nds.test.gwpy",  # don't use datafind
-            "--out", tmp,
+            "--out", str(tmp),
         ]
         exitcode = gwpy_plot.main(args)
         assert not exitcode  # passed
-        assert Path(tmp).is_file()  # plot was created
+        assert tmp.is_file()  # plot was created

--- a/gwpy/detector/tests/test_channel.py
+++ b/gwpy/detector/tests/test_channel.py
@@ -468,73 +468,73 @@ class TestChannelList(object):
             utils.assert_segmentlist_equal(avail[self.NAMES[0]],
                                            [(0, 10), (20, 30)])
 
-    def test_read_write_omega_config(self):
+    def test_read_write_omega_config(self, tmp_path):
+        tmp = tmp_path / "config.ini"
         # write OMEGA_CONFIG to file and read it back
-        with utils.TemporaryFilename(suffix='.txt') as tmp:
-            with open(tmp, 'w') as f:
-                f.write(OMEGA_CONFIG)
-            cl = self.TEST_CLASS.read(tmp, format='omega-scan')
-            assert len(cl) == 2
-            assert cl[0].name == 'L1:GDS-CALIB_STRAIN'
-            assert cl[0].sample_rate == 4096 * units.Hertz
-            assert cl[0].frametype == 'L1_HOFT_C00'
-            assert cl[0].params == {
-                'channelName': 'L1:GDS-CALIB_STRAIN',
-                'frameType': 'L1_HOFT_C00',
-                'sampleFrequency': 4096,
-                'searchTimeRange': 64,
-                'searchFrequencyRange': (0, float('inf')),
-                'searchQRange': (4, 96),
-                'searchMaximumEnergyLoss': 0.2,
-                'whiteNoiseFalseRate': 1e-3,
-                'searchWindowDuration': 0.5,
-                'plotTimeRanges': (1, 4, 16),
-                'plotFrequencyRange': (),
-                'plotNormalizedEnergyRange': (0, 25.5),
-                'alwaysPlotFlag': 1,
-            }
-            assert cl[1].name == 'L1:PEM-CS_SEIS_LVEA_VERTEX_Z_DQ'
-            assert cl[1].frametype == 'L1_R'
+        with open(tmp, 'w') as f:
+            f.write(OMEGA_CONFIG)
+        cl = self.TEST_CLASS.read(tmp, format='omega-scan')
+        assert len(cl) == 2
+        assert cl[0].name == 'L1:GDS-CALIB_STRAIN'
+        assert cl[0].sample_rate == 4096 * units.Hertz
+        assert cl[0].frametype == 'L1_HOFT_C00'
+        assert cl[0].params == {
+            'channelName': 'L1:GDS-CALIB_STRAIN',
+            'frameType': 'L1_HOFT_C00',
+            'sampleFrequency': 4096,
+            'searchTimeRange': 64,
+            'searchFrequencyRange': (0, float('inf')),
+            'searchQRange': (4, 96),
+            'searchMaximumEnergyLoss': 0.2,
+            'whiteNoiseFalseRate': 1e-3,
+            'searchWindowDuration': 0.5,
+            'plotTimeRanges': (1, 4, 16),
+            'plotFrequencyRange': (),
+            'plotNormalizedEnergyRange': (0, 25.5),
+            'alwaysPlotFlag': 1,
+        }
+        assert cl[1].name == 'L1:PEM-CS_SEIS_LVEA_VERTEX_Z_DQ'
+        assert cl[1].frametype == 'L1_R'
 
-            # write omega config again using ChannelList.write and read it back
-            # and check that the two lists match
-            with open(tmp, 'w') as f:
-                cl.write(f, format='omega-scan')
-            cl2 = type(cl).read(tmp, format='omega-scan')
-            assert cl == cl2
+        # write omega config again using ChannelList.write and read it back
+        # and check that the two lists match
+        with open(tmp, 'w') as f:
+            cl.write(f, format='omega-scan')
+        cl2 = type(cl).read(tmp, format='omega-scan')
+        assert cl == cl2
 
-    def test_read_write_clf(self):
+    def test_read_write_clf(self, tmp_path):
+        tmp = tmp_path / "config.clf"
         # write clf to file and read it back
-        with utils.TemporaryFilename(suffix='.ini') as tmp:
-            with open(tmp, 'w') as f:
-                f.write(CLF)
-            cl = ChannelList.read(tmp)
-            assert len(cl) == 4
-            a = cl[0]
-            assert a.name == 'H1:GDS-CALIB_STRAIN'
-            assert a.sample_rate == 16384 * units.Hz
-            assert a.frametype == 'H1_HOFT_C00'
-            assert a.frequency_range[0] == 4. * units.Hz
-            assert a.frequency_range[1] == float('inf') * units.Hz
-            assert a.safe is False
-            assert a.params == {'qhigh': '150', 'safe': 'unsafe',
-                                'fidelity': 'clean'}
-            b = cl[1]
-            assert b.name == 'H1:ISI-GND_STS_HAM2_X_DQ'
-            assert b.frequency_range[0] == .1 * units.Hz
-            assert b.frequency_range[1] == 60. * units.Hz
-            c = cl[2]
-            assert c.name == 'H1:ISI-GND_STS_HAM2_Y_DQ'
-            assert c.sample_rate == 256 * units.Hz
-            assert c.safe is False
-            d = cl[3]
-            assert d.name == 'H1:ISI-GND_STS_HAM2_Z_DQ'
-            assert d.safe is True
-            assert d.params['fidelity'] == 'glitchy'
+        with open(tmp, 'w') as f:
+            f.write(CLF)
+        cl = ChannelList.read(tmp)
+        assert len(cl) == 4
+        a = cl[0]
+        assert a.name == 'H1:GDS-CALIB_STRAIN'
+        assert a.sample_rate == 16384 * units.Hz
+        assert a.frametype == 'H1_HOFT_C00'
+        assert a.frequency_range[0] == 4. * units.Hz
+        assert a.frequency_range[1] == float('inf') * units.Hz
+        assert a.safe is False
+        assert a.params == {'qhigh': '150', 'safe': 'unsafe',
+                            'fidelity': 'clean'}
+        b = cl[1]
+        assert b.name == 'H1:ISI-GND_STS_HAM2_X_DQ'
+        assert b.frequency_range[0] == .1 * units.Hz
+        assert b.frequency_range[1] == 60. * units.Hz
+        c = cl[2]
+        assert c.name == 'H1:ISI-GND_STS_HAM2_Y_DQ'
+        assert c.sample_rate == 256 * units.Hz
+        assert c.safe is False
+        d = cl[3]
+        assert d.name == 'H1:ISI-GND_STS_HAM2_Z_DQ'
+        assert d.safe is True
+        assert d.params['fidelity'] == 'glitchy'
 
-            # write omega config again using ChannelList.write and read it back
-            # and check that the two lists match
-            with open(tmp, 'w') as f:
-                cl.write(f)
-            cl2 = type(cl).read(tmp)
-            assert cl == cl2
+        # write clf again using ChannelList.write and read it back
+        # and check that the two lists match
+        with open(tmp, 'w') as f:
+            cl.write(f)
+        cl2 = type(cl).read(tmp)
+        assert cl == cl2

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -240,10 +240,10 @@ class TestFrequencySeries(_TestSeries):
 
     @staticmethod
     @pytest.fixture
-    def ligolw(tmpfile):
-        with open(tmpfile, 'w+') as fobj:
-            fobj.write(LIGO_LW_ARRAY)
-        return tmpfile
+    def ligolw(tmp_path):
+        tmp = tmp_path / "test.xml"
+        tmp.write_text(LIGO_LW_ARRAY)
+        return tmp
 
     @utils.skip_missing_dependency('lal')
     @utils.skip_missing_dependency('ligo.lw')

--- a/gwpy/io/tests/test_cache.py
+++ b/gwpy/io/tests/test_cache.py
@@ -67,48 +67,51 @@ def segments():
         "{0} {1[0]} {2} 0 0".format(CACHE[0], SEGMENTS[0], abs(SEGMENTS[0])),
         id="ffl"),
 ])
-def test_read_write_cache(cache, tmpfile, format, entry1):
+def test_read_write_cache(cache, tmp_path, format, entry1):
+    tmp = tmp_path / "test.lcf"
+
     # write cache using filename
-    io_cache.write_cache(cache, tmpfile, format=format)
+    io_cache.write_cache(cache, tmp, format=format)
 
     # check that first line is proper LAL format
-    with open(tmpfile, "r") as tmp:
-        assert tmp.readline().strip() == entry1
+    with tmp.open("r") as tmpf:
+        assert tmpf.readline().strip() == entry1
 
     # now read it back ans check we get the same answer
-    assert io_cache.read_cache(tmpfile) == cache
+    assert io_cache.read_cache(tmp) == cache
 
     # check read/write with a file object
-    with open(tmpfile, "w") as tmp:
-        io_cache.write_cache(cache, tmp, format=format)
-    with open(tmpfile, "r") as tmp:
-        assert io_cache.read_cache(tmp) == cache
+    with tmp.open("w") as tmpf:
+        io_cache.write_cache(cache, tmpf, format=format)
+    with tmp.open("r") as tmpf:
+        assert io_cache.read_cache(tmpf) == cache
 
     # check sieving and sorting works
     assert io_cache.read_cache(
-        tmpfile,
+        tmp,
         sort=lambda e: -io_cache.filename_metadata(e)[2][0],
         segment=Segment(0, 2),
     ) == cache[1::-1]
 
 
 @skip_missing_dependency('lal.utils')
-def test_write_cache_cacheentry(cache, tmpfile):
+def test_write_cache_cacheentry(cache, tmp_path):
     from lal.utils import CacheEntry
+    tmp = tmp_path / "test.lcf"
     lcache = list(map(CacheEntry.from_T050017, cache))
-    with open(tmpfile, 'w') as f:
-        io_cache.write_cache(lcache, f, format=None)
+    with tmp.open("w") as tmpf:
+        io_cache.write_cache(lcache, tmpf, format=None)
 
     # check first line looks like a LAL-format cache entry
-    with open(tmpfile, "r") as tmp:
-        assert tmp.readline().strip() == "A B {0[0]} {1} {2}".format(
+    with tmp.open("r") as tmpf:
+        assert tmpf.readline().strip() == "A B {0[0]} {1} {2}".format(
             SEGMENTS[0],
             abs(SEGMENTS[0]),
             CACHE[0],
         )
 
     # read from file name
-    assert io_cache.read_cache(tmpfile) == cache
+    assert io_cache.read_cache(tmp) == cache
 
 
 @pytest.mark.parametrize('input_, result', [

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -31,7 +31,6 @@ import gwdatafind
 
 from ...testing.utils import (
     TEST_GWF_FILE,
-    TemporaryFilename,
     skip_missing_dependency,
 )
 from .. import datafind as io_datafind
@@ -145,12 +144,12 @@ class TestFflConnection(object):
         conn._read_ffl_cache('X', 'test')
         mopen.assert_called_once()
 
-    def test_read_last_line(self, _):
-        with TemporaryFilename() as tmp:
-            with open(tmp, 'w') as fobj:
-                print('line1', file=fobj)
-                print('line2', file=fobj)
-            assert self.TEST_CLASS._read_last_line(tmp) == 'line2'
+    def test_read_last_line(self, _, tmp_path):
+        tmp = tmp_path / "tmp"
+        with tmp.open("w") as fobj:
+            print('line1', file=fobj)
+            print('line2', file=fobj)
+        assert self.TEST_CLASS._read_last_line(tmp) == 'line2'
 
     @mock.patch('gwpy.io.datafind.FflConnection._read_last_line',
                 return_value='X-TEST-0-1.gwf 0 1 0 0')

--- a/gwpy/io/tests/test_gwf.py
+++ b/gwpy/io/tests/test_gwf.py
@@ -19,12 +19,13 @@
 """Unit tests for :mod:`gwpy.io.gwf`
 """
 
-from urllib.parse import urljoin
-
 import pytest
 
-from ...testing.utils import (TEST_GWF_FILE, skip_missing_dependency,
-                              TemporaryFilename, assert_segmentlist_equal)
+from ...testing.utils import (
+    TEST_GWF_FILE,
+    assert_segmentlist_equal,
+    skip_missing_dependency,
+)
 from .. import gwf as io_gwf
 from ..cache import file_segment
 
@@ -43,16 +44,31 @@ def test_identify_gwf():
 
 
 @skip_missing_dependency('LDAStools.frameCPP')
-def test_open_gwf():
+def test_open_gwf_r(tmp_path):
     from LDAStools import frameCPP
     assert isinstance(io_gwf.open_gwf(TEST_GWF_FILE), frameCPP.IFrameFStream)
-    with TemporaryFilename() as tmp:
-        assert isinstance(io_gwf.open_gwf(tmp, mode='w'),
-                          frameCPP.OFrameFStream)
-        # check that we can use a file:// URL as well
-        url = urljoin('file:', tmp)
-        assert isinstance(io_gwf.open_gwf(url, mode='w'),
-                          frameCPP.OFrameFStream)
+
+
+@skip_missing_dependency('LDAStools.frameCPP')
+def test_open_gwf_w(tmp_path):
+    from LDAStools import frameCPP
+    tmp = tmp_path / "test.gwf"
+    assert isinstance(io_gwf.open_gwf(tmp, mode='w'), frameCPP.OFrameFStream)
+
+
+@skip_missing_dependency('LDAStools.frameCPP')
+def test_open_gwf_w_file_url(tmp_path):
+    from LDAStools import frameCPP
+    # check that we can use a file:// URL as well
+    tmp = tmp_path / "test.gwf"
+    assert isinstance(
+        io_gwf.open_gwf(tmp.as_uri(), mode='w'),
+        frameCPP.OFrameFStream,
+    )
+
+
+@skip_missing_dependency('LDAStools.frameCPP')
+def test_open_gwf_a_error():
     with pytest.raises(ValueError):
         io_gwf.open_gwf('test', mode='a')
 

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -23,7 +23,7 @@ import pytest
 
 from astropy.table import (Table, vstack)
 
-from ...testing.utils import (assert_table_equal, TemporaryFilename)
+from ...testing.utils import assert_table_equal
 from .. import (
     mp as io_mp,
 )
@@ -32,19 +32,17 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
 @pytest.fixture
-def tmp1():
-    with TemporaryFilename(suffix='.csv') as tmp:
-        with open(tmp, "w") as tmpf:
-            tmpf.write("a,b,c\n1,2,3\n4,5,6")
-        yield tmp
+def tmp1(tmp_path):
+    tmp = tmp_path / "tmp1.csv"
+    tmp.write_text("a,b,c\n1,2,3\n4,5,6")
+    yield str(tmp)
 
 
 @pytest.fixture
-def tmp2():
-    with TemporaryFilename(suffix='.csv') as tmp:
-        with open(tmp, "w") as tmpf:
-            tmpf.write("a,b,c\n7,8,9\n10,11,12")
-        yield tmp
+def tmp2(tmp_path):
+    tmp = tmp_path / "tmp2.csv"
+    tmp.write_text("a,b,c\n7,8,9\n10,11,12")
+    yield tmp
 
 
 def test_read_multi_single(tmp1):

--- a/gwpy/io/tests/test_utils.py
+++ b/gwpy/io/tests/test_utils.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import pytest
 
-from ...testing.utils import (TemporaryFilename, skip_missing_dependency)
+from ...testing.utils import skip_missing_dependency
 from .. import (
     cache as io_cache,
     utils as io_utils,
@@ -36,23 +36,24 @@ from .test_cache import cache  # noqa: F401
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
-def test_gopen():
+def test_gopen(tmp_path):
+    tmp = tmp_path / "test.tmp"
     # test simple use
-    with TemporaryFilename() as tmp:
-        with open(tmp, 'w') as f:
-            f.write('blah blah blah')
-        with io_utils.gopen(tmp) as f2:
-            assert f2.read() == 'blah blah blah'
+    with tmp.open('w') as f:
+        f.write('blah blah blah')
+    with io_utils.gopen(tmp) as f2:
+        assert f2.read() == 'blah blah blah'
 
-    # test gzip file (with and without extension)
-    for suffix in ('.txt.gz', ''):
-        with TemporaryFilename(suffix=suffix) as tmp:
-            text = b'blah blah blah'
-            with gzip.open(tmp, 'wb') as fobj:
-                fobj.write(text)
-            with io_utils.gopen(tmp, mode='rb') as fobj2:
-                assert isinstance(fobj2, gzip.GzipFile)
-                assert fobj2.read() == text
+
+@pytest.mark.parametrize("suffix", (".txt.gz", ""))
+def test_gopen_gzip(tmp_path, suffix):
+    tmp = tmp_path / "test{}".format(suffix)
+    text = b'blah blah blah'
+    with gzip.open(tmp, 'wb') as fobj:
+        fobj.write(text)
+    with io_utils.gopen(tmp, mode='rb') as fobj2:
+        assert isinstance(fobj2, gzip.GzipFile)
+        assert fobj2.read() == text
 
 
 def test_identify_factory():

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -19,8 +19,6 @@
 """Unit tests for :mod:`gwpy.plot`
 """
 
-import os.path
-
 import pytest
 
 import numpy
@@ -92,10 +90,10 @@ class TestPlot(FigureTestBase):
         utils.assert_array_equal(image.get_array(), array.value.T)
         plot.close()
 
-    def test_save(self, fig):
-        with utils.TemporaryFilename(suffix='.png') as tmp:
-            fig.save(tmp)
-            assert os.path.isfile(tmp)
+    def test_save(self, fig, tmp_path):
+        tmp = tmp_path / "plot.png"
+        fig.save(str(tmp))
+        assert tmp.is_file()
 
     def test_get_axes(self, fig):
         fig.add_subplot(2, 1, 1, projection='rectilinear')

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -508,20 +508,20 @@ class TestDataQualityFlag(object):
                 _read_write(autoidentify=True)
             _read_write(autoidentify=True, write_kw={'overwrite': True})
 
-    def test_read_write_hdf5(self, flag):
-        with utils.TemporaryFilename(suffix=".h5") as fp:
-            flag.write(fp, path="test")
-            f2 = self.TEST_CLASS.read(fp, path="test", format="hdf5")
-            utils.assert_flag_equal(f2, flag)
+    def test_read_write_hdf5(self, flag, tmp_path):
+        tmp = tmp_path / "test.h5"
+        flag.write(tmp, path="test")
+        f2 = self.TEST_CLASS.read(tmp, path="test", format="hdf5")
+        utils.assert_flag_equal(f2, flag)
 
-            # test direct access from dataset
-            with h5py.File(fp, "r") as h5f:
-                f2 = self.TEST_CLASS.read(h5f["test"])
-                utils.assert_flag_equal(f2, flag)
+        # test direct access from dataset
+        with h5py.File(tmp, "r") as h5f:
+            f2 = self.TEST_CLASS.read(h5f["test"])
+        utils.assert_flag_equal(f2, flag)
 
-            # test auto-discover of single dataset
-            f2 = self.TEST_CLASS.read(fp)
-            utils.assert_flag_equal(f2, flag)
+        # test auto-discover of single dataset
+        f2 = self.TEST_CLASS.read(tmp)
+        utils.assert_flag_equal(f2, flag)
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
     @pytest.mark.parametrize("ilwdchar_compat", [False, True])

--- a/gwpy/signal/tests/test_spectral_median_mean.py
+++ b/gwpy/signal/tests/test_spectral_median_mean.py
@@ -49,31 +49,23 @@ def test_median_mean(lal_func, pycbc_func):
     # first call goes to pycbc
     with pytest.deprecated_call() as record:
         fft_median_mean.median_mean(1, 2, 3)
-    try:
-        assert len(record) == 2  # once for pycbc, once for mm
-    except TypeError:  # pytest < 3.9.1
-        pass
-    else:
-        assert "pycbc_median_mean" in record[-1].message.args[0]
-        pycbc_func.assert_called_once_with(1, 2, 3, avg_method="median-mean")
+    assert len(record) == 2  # once for pycbc, once for mm
+    assert "pycbc_median_mean" in record[-1].message.args[0]
+    pycbc_func.assert_called_once_with(1, 2, 3, avg_method="median-mean")
 
     # second call goes to lal
     with pytest.deprecated_call() as record:
         fft_median_mean.median_mean(1, 2, 3)
-    try:
-        assert len(record) == 3  # once for pycbc, once for lal, once for mm
-    except TypeError:  # pytest < 3.9.1
-        pass
-    else:
-        assert "lal_median_mean" in record[-1].message.args[0]
-        lal_func.assert_called_once_with(
-            1,
-            2,
-            noverlap=3,
-            method='median-mean',
-            window=None,
-            plan=None,
-        )
+    assert len(record) == 3  # once for pycbc, once for lal, once for mm
+    assert "lal_median_mean" in record[-1].message.args[0]
+    lal_func.assert_called_once_with(
+        1,
+        2,
+        noverlap=3,
+        method='median-mean',
+        window=None,
+        plan=None,
+    )
 
     # third call errors
     with pytest.deprecated_call(), pytest.raises(KeyError):

--- a/gwpy/testing/fixtures.py
+++ b/gwpy/testing/fixtures.py
@@ -32,12 +32,14 @@ from matplotlib import rc_context
 
 from ..plot.tex import HAS_TEX
 from ..timeseries import TimeSeries
+from ..utils.decorators import deprecated_function
 from .utils import TemporaryFilename
 
 
 # -- I/O ---------------------------------------------------------------------
 
 @pytest.fixture
+@deprecated_function
 def tmpfile():
     """Return a temporary filename using `tempfile.mktemp`.
 

--- a/gwpy/timeseries/tests/test_io_gwf_framecpp.py
+++ b/gwpy/timeseries/tests/test_io_gwf_framecpp.py
@@ -24,10 +24,7 @@ import pytest
 import numpy
 
 from ...detector import Channel
-from ...testing.utils import (
-    assert_quantity_sub_equal,
-    TemporaryFilename,
-)
+from ...testing.utils import assert_quantity_sub_equal
 from ...timeseries import TimeSeries
 
 frameCPP = pytest.importorskip("LDAStools.frameCPP")  # noqa: F401
@@ -49,23 +46,23 @@ def int32ts():
     return ts
 
 
-def test_read_scaled_false(int32ts):
-    with TemporaryFilename() as tmpf:
-        int32ts.write(tmpf, format="gwf.framecpp", type="adc")
-        new = type(int32ts).read(tmpf, "test", type="adc", scaled=False)
+def test_read_scaled_false(int32ts, tmp_path):
+    tmp = tmp_path / "test.gwf"
+    int32ts.write(tmp, format="gwf.framecpp", type="adc")
+    new = type(int32ts).read(tmp, "test", type="adc", scaled=False)
     assert new.dtype == int32ts.dtype
     assert new.unit == "ct"
 
 
-def test_read_scaled_type_change(int32ts):
-    with TemporaryFilename() as tmpf:
-        int32ts.write(tmpf, format="gwf.framecpp", type="adc")
-        new = type(int32ts).read(tmpf, "test", type="adc")
+def test_read_scaled_type_change(int32ts, tmp_path):
+    tmp = tmp_path / "test.gwf"
+    int32ts.write(tmp, format="gwf.framecpp", type="adc")
+    new = type(int32ts).read(tmp, "test", type="adc")
     assert new.dtype == numpy.dtype("float64")
     assert_quantity_sub_equal(int32ts, new)
 
 
-def test_read_write_frvect_name():
+def test_read_write_frvect_name(tmp_path):
     """Test against regression of https://github.com/gwpy/gwpy/issues/1206
     """
     data = TimeSeries(
@@ -73,7 +70,7 @@ def test_read_write_frvect_name():
         channel="X1:TEST",
         name="test",
     )
-    with TemporaryFilename() as tmpf:
-        data.write(tmpf, format="gwf.framecpp", type="proc")
-        new = type(data).read(tmpf, "test")
+    tmp = tmp_path / "test.gwf"
+    data.write(tmp, format="gwf.framecpp", type="proc")
+    new = type(data).read(tmp, "test")
     assert_quantity_sub_equal(data, new, exclude=('channel',))

--- a/gwpy/timeseries/tests/test_io_gwf_lalframe.py
+++ b/gwpy/timeseries/tests/test_io_gwf_lalframe.py
@@ -31,7 +31,6 @@ from ...testing.utils import (
     assert_dict_equal,
     assert_quantity_sub_equal,
     skip_missing_dependency,
-    TemporaryFilename,
     TEST_GWF_FILE,
 )
 from ...timeseries import TimeSeries
@@ -85,10 +84,10 @@ def test_open_data_source_glue():
     return _test_open_data_source(cache)
 
 
-def test_open_data_source_cache():
-    with TemporaryFilename(".lcf") as cache:
-        write_cache([TEST_GWF_FILE], cache, format="lal")
-        return _test_open_data_source(cache)
+def test_open_data_source_cache(tmp_path):
+    tmp = tmp_path / "test.lcf"
+    write_cache([TEST_GWF_FILE], tmp, format="lal")
+    return _test_open_data_source(tmp)
 
 
 def test_open_data_source_error():
@@ -147,27 +146,27 @@ def test_read_deprecated_scaled():
         )
 
 
-def test_write():
+def test_write(tmp_path):
     # read the data first
     data = gwpy_lalframe.read(TEST_GWF_FILE, CHANNELS)
 
-    with TemporaryFilename() as tmp:
-        # write the data
-        gwpy_lalframe.write(
-            data,
-            tmp,
-        )
+    # write the data
+    tmp = tmp_path / "test.gwf"
+    gwpy_lalframe.write(
+        data,
+        tmp,
+    )
 
-        # read it back and check things
-        data2 = gwpy_lalframe.read(tmp, CHANNELS)
-        assert_dict_equal(data, data2, assert_quantity_sub_equal)
+    # read it back and check things
+    data2 = gwpy_lalframe.read(tmp, CHANNELS)
+    assert_dict_equal(data, data2, assert_quantity_sub_equal)
 
 
-def test_write_no_ifo():
+def test_write_no_ifo(tmp_path):
     # create timeseries with no IFO
     data = TimeSeries([1, 2, 3, 4, 5])
-    with TemporaryFilename() as tmp:
-        gwpy_lalframe.write(
-            {None: data},
-            tmp
-        )
+    tmp = tmp_path / "test.gwf"
+    gwpy_lalframe.write(
+        {None: data},
+        tmp
+    )


### PR DESCRIPTION
This PR deprecates the `gwpy.testing.utils.TemporaryFile` context manager function and the `gwpy.testing.fixtures.tmpfile` test fixture. These are basically no longer required now that we can rely properly on the [`tmp_path`](https://docs.pytest.org/en/stable/tmpdir.html?) fixture from pytest.