### PR TITLE
Automatically cancel redundant CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ on:
       - master
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   conda:
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -23,6 +23,10 @@ on:
       - master
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   minmax-dependencies:
     name: ${{ matrix.name }} (Python ${{ matrix.python-version }})

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -23,6 +23,10 @@ on:
       - master
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tarball:
     name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,10 @@ on:
       - master
       - release/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   flake8:
     name: Flake8


### PR DESCRIPTION
This PR reconfigures the Github Actions workflows to automatically cancel redundant workflows when a new commit is pushed to the matching reference, in an attempt to be a good citizen and speed up time-to-completion at the PR level.