### PR TITLE
Remove unnecessary import protection for python < 3

### DIFF
--- a/gwpy/plot/tests/test_log.py
+++ b/gwpy/plot/tests/test_log.py
@@ -19,10 +19,7 @@
 """Tests for `gwpy.plot.log`
 """
 
-try:
-    from unittest import mock
-except ImportError:  # python < 3
-    import mock
+from unittest import mock
 
 import pytest
 


### PR DESCRIPTION
This PR removes a lingering `ImportError` catch relating to `unittest.mock`; we don't support python < 3 any more.