### PR TITLE
Fix pathlib compatibility in file I/O

### DIFF
--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -72,7 +72,11 @@ from collections import OrderedDict
 from numpy import inf
 
 from ...io import registry
-from ...io.utils import (FILE_LIKE, file_list, identify_factory)
+from ...io.utils import (
+    file_list,
+    identify_factory,
+    with_open,
+)
 from .. import (Channel, ChannelList)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -134,13 +138,10 @@ def read_channel_list_file(*source):
     return out
 
 
+@with_open(mode="w", pos=1)
 def write_channel_list_file(channels, fobj):
     """Write a `~gwpy.detector.ChannelList` to a INI-format channel list file
     """
-    if not isinstance(fobj, FILE_LIKE):
-        with open(fobj, "w") as fobj:
-            return write_channel_list_file(channels, fobj)
-
     out = configparser.ConfigParser(dict_type=OrderedDict)
     for channel in channels:
         group = channel.group

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -20,6 +20,7 @@
 """
 
 import gzip
+import os
 import tempfile
 from urllib.parse import urlparse
 
@@ -176,8 +177,11 @@ def file_path(fobj):
     Examples
     --------
     >>> from gwpy.io.utils import file_path
+    >>> import pathlib
     >>> file_path("test.txt")
     'test.txt'
+    >>> file_path(pathlib.Path('dir') / 'test.txt')
+    'dir/test.txt'
     >>> file_path(open("test.txt", "r"))
     'test.txt'
     >>> file_path("file:///home/user/test.txt")
@@ -187,6 +191,8 @@ def file_path(fobj):
         return urlparse(fobj).path
     if isinstance(fobj, str):
         return fobj
+    if isinstance(fobj, os.PathLike):
+        return str(fobj)
     if (isinstance(fobj, FILE_LIKE) and hasattr(fobj, "name")):
         return fobj.name
     try:

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -67,14 +67,14 @@ def identify_factory(*extensions):
 def gopen(name, *args, **kwargs):
     """Open a file handling optional gzipping
 
-    If ``name`` endswith ``'.gz'``, or if the GZIP file signature is
+    If ``name`` ends with ``'.gz'``, or if the GZIP file signature is
     found at the beginning of the file, the file will be opened with
     `gzip.open`, otherwise a regular file will be returned from `open`.
 
     Parameters
     ----------
-    name : `str`
-        path (name) of file to open.
+    name : `str`, `pathlib.Path`
+        path or name of file to open.
 
     *args, **kwargs
         other arguments to pass to either `open` for regular files, or
@@ -86,7 +86,7 @@ def gopen(name, *args, **kwargs):
         the open file object
     """
     # filename declares gzip
-    if name.endswith('.gz'):
+    if str(name).endswith('.gz'):
         return gzip.open(name, *args, **kwargs)
 
     # open regular file

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -189,9 +189,7 @@ def file_path(fobj):
     """
     if isinstance(fobj, str) and fobj.startswith("file:"):
         return urlparse(fobj).path
-    if isinstance(fobj, str):
-        return fobj
-    if isinstance(fobj, os.PathLike):
+    if isinstance(fobj, (str, os.PathLike)):
         return str(fobj)
     if (isinstance(fobj, FILE_LIKE) and hasattr(fobj, "name")):
         return fobj.name

--- a/gwpy/segments/io/json.py
+++ b/gwpy/segments/io/json.py
@@ -22,7 +22,10 @@
 import json
 
 from ...io import registry
-from ...io.utils import identify_factory
+from ...io.utils import (
+    identify_factory,
+    with_open,
+)
 from .. import DataQualityFlag
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -30,19 +33,11 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 # -- read ---------------------------------------------------------------------
 
+@with_open
 def read_json_flag(fobj):
     """Read a `DataQualityFlag` from a segments-web.ligo.org JSON file
     """
-    # read from filename
-    if isinstance(fobj, str):
-        with open(fobj, 'r') as fobj2:
-            return read_json_flag(fobj2)
-
-    # read from open file
-    txt = fobj.read()
-    if isinstance(txt, bytes):
-        txt = txt.decode('utf-8')
-    data = json.loads(txt)
+    data = json.load(fobj)
 
     # format flag
     name = '{ifo}:{name}:{version}'.format(**data)
@@ -63,6 +58,7 @@ def read_json_flag(fobj):
 
 # -- write --------------------------------------------------------------------
 
+@with_open(mode="w", pos=1)
 def write_json_flag(flag, fobj, **kwargs):
     """Write a `DataQualityFlag` to a JSON file
 
@@ -82,11 +78,6 @@ def write_json_flag(flag, fobj, **kwargs):
     json.dump
         for details on acceptable keyword arguments
     """
-    # write to filename
-    if isinstance(fobj, str):
-        with open(fobj, 'w') as fobj2:
-            return write_json_flag(flag, fobj2, **kwargs)
-
     # build json packet
     data = {}
     data['ifo'] = flag.ifo

--- a/gwpy/segments/io/segwizard.py
+++ b/gwpy/segments/io/segwizard.py
@@ -23,7 +23,10 @@ import re
 
 from .. import (Segment, SegmentList)
 from ...io import registry
-from ...io.utils import identify_factory
+from ...io.utils import (
+    identify_factory,
+    with_open,
+)
 from ...time import LIGOTimeGPS
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -43,6 +46,7 @@ FOUR_COL_REGEX = re.compile(
 
 # -- read ---------------------------------------------------------------------
 
+@with_open
 def from_segwizard(source, gpstype=LIGOTimeGPS, strict=True):
     """Read segments from a segwizard format file into a `SegmentList`
 
@@ -68,11 +72,6 @@ def from_segwizard(source, gpstype=LIGOTimeGPS, strict=True):
     This method is adapted from original code written by Kipp Cannon and
     distributed under GPLv3.
     """
-    # read file path
-    if isinstance(source, str):
-        with open(source, 'r') as fobj:
-            return from_segwizard(fobj, gpstype=gpstype, strict=strict)
-
     # read file object
     out = SegmentList()
     fmt_pat = None
@@ -115,7 +114,7 @@ def _format_segment(tokens, strict=True, gpstype=LIGOTimeGPS):
 
 # -- write --------------------------------------------------------------------
 
-# pylint: disable=inconsistent-return-statements
+@with_open(mode="w", pos=1)
 def to_segwizard(segs, target, header=True, coltype=LIGOTimeGPS):
     """Write the given `SegmentList` to a file in SegWizard format.
 
@@ -138,11 +137,6 @@ def to_segwizard(segs, target, header=True, coltype=LIGOTimeGPS):
     This method is adapted from original code written by Kipp Cannon and
     distributed under GPLv3.
     """
-    # write file path
-    if isinstance(target, str):
-        with open(target, 'w') as fobj:
-            return to_segwizard(segs, fobj, header=header, coltype=coltype)
-
     # write file object
     if header:
         print('# seg\tstart\tstop\tduration', file=target)

--- a/gwpy/timeseries/io/gwf/framel.py
+++ b/gwpy/timeseries/io/gwf/framel.py
@@ -25,7 +25,10 @@ import warnings
 
 import framel
 
-from ....io.utils import file_list
+from ....io.utils import (
+    file_list,
+    file_path,
+)
 from ....segments import Segment
 from ... import TimeSeries
 
@@ -142,7 +145,7 @@ def write(
             series.crop(start=start, end=end),
             type,
         ))
-    return framel.frputvect(outfile, channellist)
+    return framel.frputvect(file_path(outfile), channellist)
 
 
 def _channel_data_to_write(timeseries, type_):

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -225,4 +225,4 @@ def write(
         add_(frame, lalseries)
 
     # write frame
-    lalframe.FrameWrite(frame, outfile)
+    lalframe.FrameWrite(frame, file_path(outfile))


### PR DESCRIPTION
This PR fixes up a number of functions to enable reading from `pathlib.Path` objects as well as `file` and `str`. This probably supersedes #1360.