### PR TITLE
Handle cases in EventTable.cluster() where table is empty or clustered multiple times

### DIFF
--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -779,14 +779,23 @@ class EventTable(Table):
         if window <= 0.0:
             raise ValueError('Window must be a positive value')
 
+        # If no rows, no need to cluster
+        if len(self) == 0:
+            return self.copy()
+
         # Generate index and rank vectors that are ordered
         orderidx = numpy.argsort(self[index])
         col = self[index][orderidx]
         param = self[rank][orderidx]
 
         # Find all points where the index vector changes by less than window
-        # and divide the resulting array into clusters of adjacent points
         clusterpoints = numpy.where(numpy.diff(col) <= window)[0]
+
+        # If no such cluster points, no need to cluster
+        if len(clusterpoints) == 0:
+            return self.copy()
+
+        # Divide points into clusters of adjacent points
         sublists = numpy.split(clusterpoints,
                                numpy.where(numpy.diff(clusterpoints) > 1)[0]+1)
 

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -558,6 +558,15 @@ class TestEventTable(TestTable):
             clustertable.cluster('time', 'amplitude', 0)
         assert str(exc.value) == 'Window must be a positive value'
 
+    def test_cluster_multiple(self, clustertable):
+        # check that after clustering a table, clustering the table a
+        # second time with the same parameters returns the same result
+        t_clustered = clustertable.cluster('time', 'amplitude', 0.6)
+        utils.assert_table_equal(
+            t_clustered,
+            t_clustered.cluster('time', 'amplitude', 0.6),
+        )
+
     # -- test I/O -------------------------------
 
     def test_read_write_hdf5(self, table, tmp_path):

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -116,6 +116,11 @@ class TestTable(object):
 
     @classmethod
     @pytest.fixture()
+    def emptytable(cls):
+        return cls.create(0, ['time', 'snr', 'frequency'])
+
+    @classmethod
+    @pytest.fixture()
     def clustertable(cls):
         return cls.TABLE(data=[[11, 1, 1, 10, 1, 1, 9],
                                [0.0, 1.9, 1.95, 2.0, 2.05, 2.1, 4.0]],
@@ -566,6 +571,11 @@ class TestEventTable(TestTable):
             t_clustered,
             t_clustered.cluster('time', 'amplitude', 0.6),
         )
+
+    def test_cluster_empty(self, emptytable):
+        # check that clustering an empty table is a no-op
+        t = emptytable.cluster('time', 'amplitude', 0.6)
+        utils.assert_table_equal(t, emptytable)
 
     # -- test I/O -------------------------------
 


### PR DESCRIPTION
This PR handles a few edge cases more gracefully when calling `EventTable.cluster()`:

1. The table is empty.
2. The table is already clustered.

In both cases, the error encountered looks like:

```
>>> table.cluster('time', 'snr', 0.1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/patrick.godwin/workspace/projects/gwpy/gwpy/table/table.py", line 782, in cluster
    padded_sublists = [numpy.append(s, numpy.array([s[-1]+1]))
  File "/home/patrick.godwin/workspace/projects/gwpy/gwpy/table/table.py", line 782, in <listcomp>
    padded_sublists = [numpy.append(s, numpy.array([s[-1]+1]))
IndexError: index -1 is out of bounds for axis 0 with size 0
```

In both cases, the original table is now returned as a result. I have also added a test which checks that running `table.cluster()` with the same parameters twice returns the same table.