### PR TITLE
Improve auto-detection of time-like columns in tables

### DIFF
--- a/gwpy/table/table.py
+++ b/gwpy/table/table.py
@@ -163,7 +163,7 @@ class EventTable(Table):
         """
         tcols = [
             "time",  # standard
-            "tc",  # GWOSC catalogues
+            "gps",  # GWOSC catalogues
             "peakGPS",  # gravityspy
         ]
         for col in tcols:


### PR DESCRIPTION
This PR introduces a refactoring of the internal method `EventTable._get_time_column` in an attempt to simplify the logic. This method is used mainly in plotting to try and automatically detect that a column represents 'time' and to use a GPS-scaled axis for it.