### PR TITLE
Refactor TimeSeries.coherence to use scipy.signal.coherence

### DIFF
--- a/gwpy/signal/spectral/__init__.py
+++ b/gwpy/signal/spectral/__init__.py
@@ -30,6 +30,7 @@ from ...utils.decorators import deprecated_function
 from ._registry import (get_method, register_method)
 from ._scipy import (
     bartlett,
+    coherence,
     csd,
     median,
     rayleigh,

--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -169,3 +169,46 @@ def csd(timeseries, other, segmentlength, noverlap=None, **kwargs):
         timeseries, segmentlength, noverlap=noverlap,
         name=str(timeseries.name)+'---'+str(other.name),
         sdfunc=scipy.signal.csd, **kwargs)
+
+
+def coherence(timeseries, other, segmentlength, noverlap=None, **kwargs):
+    """Calculate the coherence between two `TimeSeries` using Welch's method
+
+    Parameters
+    ----------
+    timeseries : `~gwpy.timeseries.TimeSeries`
+        time-series of data
+
+    other : `~gwpy.timeseries.TimeSeries`
+        time-series of data
+
+    segmentlength : `int`
+        number of samples in single average.
+
+    noverlap : `int`
+        number of samples to overlap between segments, defaults to 50%.
+
+    **kwargs
+        other keyword arguments are passed to :meth:`scipy.signal.coherence`
+
+    Returns
+    -------
+    spectrum : `~gwpy.frequencyseries.FrequencySeries`
+        average power `FrequencySeries`
+
+    See also
+    --------
+    scipy.signal.coherence
+    """
+    # calculate CSD
+    kwargs.setdefault('y', other.value)
+    out = _spectral_density(
+        timeseries,
+        segmentlength,
+        noverlap=noverlap,
+        name="Coherence between {} and {}".format(timeseries.name, other.name),
+        sdfunc=scipy.signal.coherence,
+        **kwargs,
+    )
+    out.override_unit("coherence")
+    return out

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1157,42 +1157,17 @@ class TimeSeries(TimeSeriesBase):
 
         See also
         --------
-        matplotlib.mlab.cohere
+        scipy.signal.coherence
             for details of the coherence calculator
         """
-        from matplotlib import mlab
-        from ..frequencyseries import FrequencySeries
-        # check sampling rates
-        if self.sample_rate.to('Hertz') != other.sample_rate.to('Hertz'):
-            sampling = min(self.sample_rate.value, other.sample_rate.value)
-            # resample higher rate series
-            if self.sample_rate.value == sampling:
-                other = other.resample(sampling)
-                self_ = self
-            else:
-                self_ = self.resample(sampling)
-        else:
-            sampling = self.sample_rate.value
-            self_ = self
-        # check fft lengths
-        if overlap is None:
-            overlap = 0
-        else:
-            overlap = int((overlap * self_.sample_rate).decompose().value)
-        if fftlength is None:
-            fftlength = int(self_.size/2. + overlap/2.)
-        else:
-            fftlength = int((fftlength * self_.sample_rate).decompose().value)
-        if window is not None:
-            kwargs['window'] = signal.get_window(window, fftlength)
-        coh, freqs = mlab.cohere(self_.value, other.value, NFFT=fftlength,
-                                 Fs=sampling, noverlap=overlap, **kwargs)
-        out = coh.view(FrequencySeries)
-        out.xindex = freqs
-        out.epoch = self.epoch
-        out.name = 'Coherence between %s and %s' % (self.name, other.name)
-        out.unit = 'coherence'
-        return out
+        return spectral.psd(
+            (self, other),
+            spectral.coherence,
+            fftlength=fftlength,
+            overlap=overlap,
+            window=window,
+            **kwargs
+        )
 
     def auto_coherence(self, dt, fftlength=None, overlap=None,
                        window='hann', **kwargs):


### PR DESCRIPTION
This PR closes #1328 by reimplementing `TimeSeries.coherence` to call out to `scipy.signal.coherence` rather than `mlab.cohere`.