### PR TITLE
Refactor `Series.is_compatible`

### DIFF
--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -104,8 +104,11 @@ class TestSpectralVariance(_TestArray2D):
         assert array.y0 == self.bins[0]
         assert array.dy == self.bins[1] - self.bins[0]
 
-    def test_is_compatible(self, array):
-        return super(_TestArray2D, self).test_is_compatible(array)
+    def test_is_compatible_yindex(self, array):
+        return NotImplemented
+
+    def test_is_compatible_error_yindex(self, array):
+        return NotImplemented
 
     def test_plot(self, array):
         with rc_context(rc={'text.usetex': False}):

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -147,7 +147,7 @@ class TestStateTimeSeries(_TestTimeSeriesBase):
     def test_override_unit(self):
         return NotImplemented
 
-    def test_is_compatible(self):
+    def test_is_compatible_error_unit(self):
         return NotImplemented
 
     def test_to_from_pycbc(self):

--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -302,22 +302,9 @@ class Array2D(Series):
 
     # -- Array2D methods ------------------------
 
-    def is_compatible(self, other):
-        """Check whether this array and ``other`` have compatible metadata
-        """
-        super().is_compatible(other)
-        # check y-axis metadata
-        if isinstance(other, type(self)):
-            try:
-                if not self.dy == other.dy:
-                    raise ValueError("%s sample sizes do not match: "
-                                     "%s vs %s." % (type(self).__name__,
-                                                    self.dy, other.dy))
-            except AttributeError:
-                raise ValueError("Series with irregular y-indexes cannot "
-                                 "be compatible")
-
-        return True
+    def _is_compatible_gwpy(self, other):
+        self._compare_index(other, "y")
+        return super()._is_compatible_gwpy(other)
 
     def value_at(self, x, y):
         """Return the value of this `Series` at the given `(x, y)` coordinates

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -193,17 +193,22 @@ class TestArray2D(_TestSeries):
             exclude=['epoch'],
         )
 
-    def test_is_compatible(self, array):
-        super().test_is_compatible(array)
+    def test_is_compatible_yindex(self):
+        """Check that irregular arrays are compatible if their yindexes match
+        """
+        y = numpy.logspace(0, 2, num=self.data.shape[1])
+        a = self.create(yindex=y)
+        b = self.create(yindex=y)
+        assert a.is_compatible(b)
 
-        a2 = self.create(dy=2)
-        with pytest.raises(ValueError):
-            array.is_compatible(a2)
-
-        y = numpy.logspace(0, 2, num=self.data.shape[0])
-        a2 = self.create(yindex=y)
-        with pytest.raises(ValueError):
-            array.is_compatible(a2)
+    def test_is_compatible_error_yindex(self, array):
+        """Check that `Array2D.is_compatible` errors with mismatching indexes
+        """
+        y = numpy.logspace(0, 2, num=self.data.shape[1])
+        other = self.create(yindex=y)
+        with pytest.raises(ValueError) as exc:
+            array.is_compatible(other)
+        assert "indexes do not match" in str(exc.value)
 
     def test_value_at(self, array):
         assert array.value_at(2, 3) == self.data[2][3] * array.unit

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -196,21 +196,41 @@ class TestSeries(_TestArray):
     def test_is_compatible(self, array):
         """Test the `Series.is_compatible` method
         """
-        a2 = self.create(name='TEST CASE 2')
-        assert array.is_compatible(a2)
+        other = self.create(name='TEST CASE 2')
+        assert array.is_compatible(other)
 
-        a3 = self.create(dx=2)
-        with pytest.raises(ValueError):
-            array.is_compatible(a3)
+    def test_is_compatible_error_dx(self, array):
+        """Check that `Series.is_compatible` errors with mismatching ``dx``
+        """
+        other = self.create(dx=2)
+        with pytest.raises(ValueError) as exc:
+            array.is_compatible(other)
+        assert "sample sizes do not match" in str(exc.value)
 
-        a4 = self.create(unit='m')
-        with pytest.raises(ValueError):
-            array.is_compatible(a4)
+    def test_is_compatible_error_unit(self, array):
+        """Check that `Series.is_compatible` errors with mismatching ``unit``
+        """
+        other = self.create(unit='m')
+        with pytest.raises(ValueError) as exc:
+            array.is_compatible(other)
+        assert "units do not match" in str(exc.value)
 
+    def test_is_compatible_xindex(self):
+        """Check that irregular arrays are compatible if their xindexes match
+        """
         x = numpy.logspace(0, 2, num=self.data.shape[0])
-        a5 = self.create(xindex=x)
-        with pytest.raises(ValueError):
-            array.is_compatible(a5)
+        a = self.create(xindex=x)
+        b = self.create(xindex=x)
+        assert a.is_compatible(b)
+
+    def test_is_compatible_error_xindex(self, array):
+        """Check that `Series.is_compatible` errors with mismatching indexes
+        """
+        x = numpy.logspace(0, 2, num=self.data.shape[0])
+        other = self.create(xindex=x)
+        with pytest.raises(ValueError) as exc:
+            array.is_compatible(other)
+        assert "indexes do not match" in str(exc.value)
 
     def test_is_contiguous(self, array):
         a2 = self.create(x0=array.xspan[1])


### PR DESCRIPTION
This PR refactors the `Series.is_compatible` method by separating internal logic into two functions, and then improve the tests. This also adds one small improvement that irregular `Series` can now be compatible if their X-index arrays match identically.