### PR TITLE
Improve gwpy.cli example handling in docs

### DIFF
--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -67,4 +67,14 @@ the image and allow interactive manipulations, (zoom, pan, etc).
 Examples
 ========
 
-.. include:: /cli/examples/examples.rst
+.. examples.rst index is dynamically generated
+.. include:: examples/examples.rst
+
+.. add a hidden toctree to stop sphinx complaining
+.. that the examples RST files aren't included in a toctree
+.. when they clearly are
+.. toctree::
+   :hidden:
+   :glob:
+
+   examples/*


### PR DESCRIPTION
This PR improves the handling/rendering of the `gwpy.cli` examples as part of the documentation. I think the changes basically boil down to:

- only run the example if it has changed or the output doesn't exist yet
- resolve a couple of sphinx warnings