### PR TITLE
Remove usage of tag keyword in calls to TimeSeries.fetch_open_data

### DIFF
--- a/docs/plot/colorbars.rst
+++ b/docs/plot/colorbars.rst
@@ -47,7 +47,7 @@ specifying, ``norm='log'``:
    :include-source:
 
    from gwpy.timeseries import TimeSeries
-   data = TimeSeries.fetch_open_data('L1', 1187008866, 1187008898, tag='C00')
+   data = TimeSeries.fetch_open_data('L1', 1187008866, 1187008898)
    specgram = data.spectrogram2(fftlength=.5, overlap=.25,
                                 window='hann') ** (1/2.)
    plot = specgram.plot(yscale='log', ylim=(30, 1400))

--- a/examples/frequencyseries/percentiles.py
+++ b/examples/frequencyseries/percentiles.py
@@ -39,7 +39,7 @@ __currentmodule__ = 'gwpy.timeseries'
 # First, as always, we get the data using :meth:`TimeSeries.fetch_open_data`:
 
 from gwpy.timeseries import TimeSeries
-hoft = TimeSeries.fetch_open_data('H1', 1187007040, 1187009088, tag='C00')
+hoft = TimeSeries.fetch_open_data('H1', 1187007040, 1187009088)
 
 # Next we calculate a :class:`~gwpy.spectrogram.Spectrogram` by calculating
 # a number of ASDs, using the :meth:`~gwpy.timeseries.TimeSeries.spectrogram2`

--- a/examples/miscellaneous/range-spectrogram.py
+++ b/examples/miscellaneous/range-spectrogram.py
@@ -33,7 +33,7 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 # around the GW170817 BNS merger:
 
 from gwpy.timeseries import TimeSeries
-l1 = TimeSeries.fetch_open_data('L1', 1187006834, 1187010930, tag='C02')
+l1 = TimeSeries.fetch_open_data('L1', 1187006834, 1187010930)
 
 # Then, we can calculate a `Spectrogram` of the inspiral range
 # amplitude spectrum:

--- a/examples/miscellaneous/range-timeseries.py
+++ b/examples/miscellaneous/range-timeseries.py
@@ -35,8 +35,8 @@ __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 # around the GW170817 BNS merger:
 
 from gwpy.timeseries import TimeSeries
-h1 = TimeSeries.fetch_open_data('H1', 1187006834, 1187010930, tag='C02')
-l1 = TimeSeries.fetch_open_data('L1', 1187006834, 1187010930, tag='C02')
+h1 = TimeSeries.fetch_open_data('H1', 1187006834, 1187010930)
+l1 = TimeSeries.fetch_open_data('L1', 1187006834, 1187010930)
 
 # Then, we can measure the inspiral range directly:
 

--- a/examples/signal/qscan.py
+++ b/examples/signal/qscan.py
@@ -41,7 +41,7 @@ __currentmodule__ = 'gwpy.timeseries'
 from gwosc import datasets
 from gwpy.timeseries import TimeSeries
 gps = datasets.event_gps('GW170817')
-data = TimeSeries.fetch_open_data('L1', gps-34, gps+34, tag='C00')
+data = TimeSeries.fetch_open_data('L1', gps-34, gps+34)
 
 # We can Q-transform these data and scan over time-frequency planes to
 # find the one with the most significant tile near the time of merger:

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -468,25 +468,6 @@ class TimeSeriesBase(Series):
         ``format``-dependent, because they are recorded differently by LOSC
         in different formats.
 
-        For events published in O2 and later, LOSC typically provides
-        multiple data sets containing the original (``'C00'``) and cleaned
-        (``'CLN'``) data.
-        To select both data sets and plot a comparison, for example:
-
-        >>> orig = TimeSeries.fetch_open_data('H1', 1187008870, 1187008896,
-        ...                                   tag='C00')
-        >>> cln = TimeSeries.fetch_open_data('H1', 1187008870, 1187008896,
-        ...                                  tag='CLN')
-        >>> origasd = orig.asd(fftlength=4, overlap=2)
-        >>> clnasd = cln.asd(fftlength=4, overlap=2)
-        >>> plot = origasd.plot(label='Un-cleaned')
-        >>> ax = plot.gca()
-        >>> ax.plot(clnasd, label='Cleaned')
-        >>> ax.set_xlim(10, 1400)
-        >>> ax.set_ylim(1e-24, 1e-20)
-        >>> ax.legend()
-        >>> plot.show()
-
         Notes
         -----
         `StateVector` data are not available in ``txt.gz`` format.


### PR DESCRIPTION
This PR removes all usage of the deprecated `tag` keyword in calls to `TimeSeries.fetch_open_data` - this should resolve a bunch of `DeprecationWarning`s emitted when building the documentation.