### PR TITLE
Improve usage of pathlib.Path objects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -418,11 +418,9 @@ def write_citing_rst(app):
     """
     logger = logging.getLogger('zenodo')
     citing = SPHINX_DIR / "citing.rst"
-    with citing.with_suffix(".rst.in").open("r") as fobj:
-        content = fobj.read()
+    content = citing.with_suffix(".rst.in").read_text()
     content += '\n' + zenodo.format_citations(597016)
-    with citing.open("w") as f:
-        f.write(content)
+    citing.write_text(content)
     logger.info('[zenodo] wrote {0}'.format(citing))
 
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -79,8 +79,7 @@ def example_context():
 @pytest.mark.parametrize('script', EXAMPLES)
 def test_example(script):
     with cwd(script.parent):
-        with script.open('r') as example:
-            raw = example.read()
+        raw = script.read_text()
         code = compile(raw, str(script), "exec")
         try:
             exec(code, globals())


### PR DESCRIPTION
This PR replaces any calls to `pathlib.Path.open()` with simpler calls to `pathlib.Path.read_text` as appropriate. It's just cleaner.