### PR TITLE
Execute the examples as part of the test suite in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
       run: conda list --name test
 
     - name: Run test suite
-      run: python -m pytest -ra --color yes --cov gwpy --pyargs gwpy --cov-report=xml --junitxml=pytest.xml
+      run: python -m pytest -ra --color yes --cov gwpy --cov-report=xml --junitxml=pytest.xml gwpy/ examples/
 
     - name: Coverage report
       run: python -m coverage report --show-missing


### PR DESCRIPTION
This PR adds an argument to `pytest` to execute the examples as part of the full `build-and-test` suite run. This used to happen, but I think got lost during the transition to github actions.