### PR TITLE
Fix datafind trend discovery

### DIFF
--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -361,7 +361,7 @@ def _parse_ifos_and_trends(chans):
     for name in chans:
         chan = Channel(name)
         try:
-            found.add((chan.ifo[0], chan.trend))
+            found.add((chan.ifo[0], chan.type))
         except TypeError:  # chan.ifo is None
             raise ValueError("Cannot parse interferometer prefix from channel "
                              "name %r, cannot proceed with find()" % str(chan))
@@ -504,8 +504,8 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     # create set() of GWF channel names, and dict map back to user names
     #    this allows users to use nds-style names in this query, e.g.
     #    'X1:TEST.mean,m-trend', and still get results
-    chans = {Channel(c).name: c for c in channels}
-    names = set(chans.keys())
+    channels = {c: Channel(c).name for c in channels}
+    names = {val: key for key, val in channels.items()}
 
     # format GPS time(s)
     if isinstance(gpstime, (list, tuple)):
@@ -525,7 +525,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     match = defaultdict(list)
     searched = set()
 
-    for ifo, trend in _parse_ifos_and_trends(chans):
+    for ifo, trend in _parse_ifos_and_trends(channels):
         # find all types (prioritising trends if we need to)
         types = find_types(
             ifo,
@@ -568,12 +568,12 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
                         found += 1
 
                         # record the match using the user-given channel name
-                        match[chans[n]].append((ftype, path, gaps))
+                        match[names[n]].append((ftype, path, gaps))
 
                         # if only matching once, don't search other types
                         # for this channel
                         if not return_all:
-                            names.remove(n)
+                            names.pop(n)
 
                         if found == nchan:  # all channels have been found
                             break

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -351,15 +351,18 @@ def test_find_best_frametype(connection):
     reason='No LIGO datafind server configured on this host',
 )
 @pytest.mark.parametrize('channel, expected', [
-    ('H1:GDS-CALIB_STRAIN', ['H1_HOFT_C00', 'H1_ER_C00_L1']),
-    ('L1:IMC-ODC_CHANNEL_OUT_DQ', ['L1_R']),
-    ('H1:ISI-GND_STS_ITMY_X_BLRMS_30M_100M.mean,s-trend', ['H1_T']),
-    ('H1:ISI-GND_STS_ITMY_X_BLRMS_30M_100M.mean,m-trend', ['H1_M'])
+    ('H1:GDS-CALIB_STRAIN', {'H1_HOFT_C00', 'H1_ER_C00_L1'}),
+    ('L1:IMC-PWR_IN_OUT_DQ', {'L1_R'}),
+    ('H1:ISI-GND_STS_ITMY_X_BLRMS_30M_100M.mean,s-trend', {'H1_T'}),
+    ('H1:ISI-GND_STS_ITMY_X_BLRMS_30M_100M.mean,m-trend', {'H1_M'}),
 ])
 def test_find_best_frametype_ligo(channel, expected):
     try:
         ft = io_datafind.find_best_frametype(
-            channel, 1143504017, 1143504017+100)
+            channel,
+            1262276680,  # GW200105 -4s
+            1262276688,  # GW200105 +4s
+        )
     except ValueError as exc:  # pragma: no-cover
         if str(exc).lower().startswith('cannot locate'):
             pytest.skip(str(exc))


### PR DESCRIPTION
This PR fixes an apparently critical problem with `gwpy.io.datafind.find_frametype` that _may_ have been introduced by #1376 where trend requests weren't properly parsed, so the wrong trend type may have been selected.

This was flagged by the `test_find_best_frametype_ligo` test function, but that only runs during the cron nightly build at Caltech, which isn't part of the github CI.