### PR TITLE
Use 'dev' as the version for development documentation builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ copyright = ' and '.join((
     '2013, 2017-2021 Cardiff University',
     '2013-2017 Lousiana State University',
 ))
-version = GWPY_VERSION.split('.dev', 1)[0]
+version = "dev" if ".dev" in GWPY_VERSION else GWPY_VERSION
 release = GWPY_VERSION
 
 # extension modules


### PR DESCRIPTION
This PR modifies the sphinx configuration to just use `dev` as the version number when building outside of tags. This is needed since the tags aren't always synchronised to the development branch (since we use a `release/X.Y.z` branch for bug-fix releases). E.g. the current dev docs say `2.0.1` because the 2.0.2-2.0.4 tags aren't on `master`.