### PR TITLE
Improve GravitySpyTable tests

### DIFF
--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -16,8 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for `gwpy.table`
+"""Unit tests for `gwpy.table.gravityspy`
 """
+
+from unittest import mock
+from urllib.error import HTTPError
+
+import pytest
 
 from ...testing import utils
 from ...testing.errors import pytest_skip_network_error
@@ -26,34 +32,56 @@ from .test_table import TestEventTable as _TestEventTable
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-JSON_RESPONSE = {
-    "url4": [u"https://panoptes-uploads.zooniverse.org/production/"
-             "subject_location/08895951-ea30-4cf7-9374-135a335afe0e.png"],
-    "peak_frequency": [84.4759674072266],
-    "links_subjects": [5740011.0],
-    "ml_label": [u"Scratchy"],
-    "searchedID": [u"8FHTgA8MEu"],
-    "snr": [8.96664047241211],
-    "gravityspy_id": [u"8FHTgA8MEu"],
-    "searchedzooID": [5740011.0],
-    "ifo": [u"H1"],
-    "url3": [u"https://panoptes-uploads.zooniverse.org/production/"
-             "subject_location/415dde44-3109-434c-b3ad-b722a879c159.png"],
-    "url2": [u"https://panoptes-uploads.zooniverse.org/production/"
-             "subject_location/09ebb6f4-e839-466f-80a1-64d79ac4d934.png"],
-    "url1": [u"https://panoptes-uploads.zooniverse.org/production/"
-             "subject_location/5e89d817-583c-4646-8e6c-9391bb99ad41.png"],
-}
+TEST_ID = "8FHTgA8MEu"
+TEST_IFO = "H1"
 
 
 class TestGravitySpyTable(_TestEventTable):
     TABLE = GravitySpyTable
 
-    @pytest_skip_network_error
-    def test_search(self):
-        table = self.TABLE.search(
-            gravityspy_id="8FHTgA8MEu",
+    @classmethod
+    def search(cls):
+        return cls.TABLE.search(
+            gravityspy_id=TEST_ID,
             howmany=1,
             remote_timeout=60,
         )
-        utils.assert_table_equal(table, self.TABLE(JSON_RESPONSE))
+
+    @pytest_skip_network_error
+    def test_search(self):
+        """Test `GravitySpyTable.search`
+        """
+        # run the search
+        table = self.search()
+
+        # validate the result
+        assert len(table) == 1
+        t = table[0]
+        assert t["gravityspy_id"] == TEST_ID
+        assert t["ifo"] == TEST_IFO
+        assert t["ml_label"] == "Scratchy"
+
+    @mock.patch(
+        "gwpy.table.gravityspy.get_readable_fileobj",
+        side_effect=HTTPError(None, 500, "test", None, None),
+    )
+    def test_search_error(self, _):
+        """Test `GravitySpyTable.search` error handling
+        """
+        with pytest.raises(HTTPError) as exc:
+            self.TABLE.search(gravityspy_id="abcde")
+        assert str(exc.value) == (
+            "HTTP Error 500: test, confirm the gravityspy_id is valid"
+        )
+
+    @utils.skip_missing_dependency("pandas")
+    @pytest_skip_network_error
+    def test_download(self, tmp_path):
+        """Test `GravitySpyTable.download`
+        """
+        table = self.search()
+        table.download(download_path=tmp_path, ifos=TEST_IFO)
+        assert (
+            tmp_path
+            / "{}_{}_spectrogram_0.5.png".format(TEST_IFO, TEST_ID)
+        ).is_file()


### PR DESCRIPTION
This PR improves (IMO) the tests of the `GravitySpyTable`, adding a new test for `GravitySpyTable.download()` and simplifying the result assertion for `GravitySpyTable.search()` to be less hardcoded.