### PR TITLE
Update 'LOSC' references to 'GWOSC'

### DIFF
--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -234,7 +234,7 @@ GWpy allows storing data in HDF5 format files, using a custom specification for 
 
 .. warning::
 
-   To read GWOSC (LOSC) data from HDF5, please see
+   To read GWOSC data from HDF5, please see
    :ref:`gwpy-timeseries-io-hdf5-gwosc`.
 
 Reading
@@ -302,19 +302,22 @@ with `format='hdf5'`.
 Reading
 -------
 
-GWpy can read data from GWOSC (LOSC) HDF5 files using the `format='hdf5.losc'`
+GWpy can read data from GWOSC HDF5 files using the `format='hdf5.gwosc'`
 keyword:
 
 .. code-block:: python
 
-   >>> data = TimeSeries.read('H-H1_GWOSC_16KHZ_R1-1187056280-4096.hdf5',
-   ...                        format='hdf5.losc')
+   >>> data = TimeSeries.read(
+   ...     "H-H1_GWOSC_16KHZ_R1-1187056280-4096.hdf5",
+   ...     format="hdf5.gwosc",
+   ... )
 
-By default, `TimeSeries.read` will return the contents of the
-``/strain/Strain`` dataset, while `StateVector.read` will return those of
-``/quality/simple``.
+By default, :meth:`TimeSeries.read` will return the contents of the
+``/strain/Strain`` dataset, while :meth:`StateVector.read` will return those
+of ``/quality/simple``.
 
-As with regular HDF5, the ``start`` and ``end`` keyword arguments can be used to downselect data to a specific ``[start, end)`` time segment when reading.
+As with regular HDF5, the ``start`` and ``end`` keyword arguments can be used
+to downselect data to a specific ``[start, end)`` time segment when reading.
 
 
 .. _gwpy-timeseries-io-wav:

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -538,7 +538,7 @@ class DataQualityFlag(object):
             timeout for download (seconds)
 
         host : `str`, optional
-            URL of LOSC host, default: ``'losc.ligo.org'``
+            URL of GWOSC host, default: ``'https://gw-openscience.org'``
 
         Returns
         -------

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -472,11 +472,21 @@ class TimeSeriesBase(Series):
         -----
         `StateVector` data are not available in ``txt.gz`` format.
         """
-        from .io.losc import fetch_losc_data
-        return fetch_losc_data(ifo, start, end, sample_rate=sample_rate,
-                               tag=tag, version=version, format=format,
-                               verbose=verbose, cache=cache,
-                               host=host, cls=cls, **kwargs)
+        from .io.losc import fetch_gwosc_data
+        return fetch_gwosc_data(
+            ifo,
+            start,
+            end,
+            sample_rate=sample_rate,
+            tag=tag,
+            version=version,
+            format=format,
+            verbose=verbose,
+            cache=cache,
+            host=host,
+            cls=cls,
+            **kwargs,
+        )
 
     @classmethod
     def find(cls, channel, start, end, frametype=None, pad=None,

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -401,7 +401,7 @@ class TimeSeriesBase(Series):
 
         sample_rate : `float`, optional,
             the sample rate of desired data; most data are stored
-            by LOSC at 4096 Hz, however there may be event-related
+            by GWOSC at 4096 Hz, however there may be event-related
             data releases with a 16384 Hz rate, default: `4096`
 
         tag : `str`, optional
@@ -419,7 +419,7 @@ class TimeSeriesBase(Series):
             - ``'gwf'`` - requires |LDAStools.frameCPP|_
 
         host : `str`, optional
-            HTTP host name of LOSC server to access
+            HTTP host name of GWOSC server to access
 
         verbose : `bool`, optional, default: `False`
             print verbose output while fetching data
@@ -465,7 +465,7 @@ class TimeSeriesBase(Series):
                                epoch=1126259446.0))
 
         For the `StateVector`, the naming of the bits will be
-        ``format``-dependent, because they are recorded differently by LOSC
+        ``format``-dependent, because they are recorded differently by GWOSC
         in different formats.
 
         Notes

--- a/gwpy/timeseries/tests/test_io_losc.py
+++ b/gwpy/timeseries/tests/test_io_losc.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2021)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwpy.timeseries.io.losc`
+"""
+
+import pytest
+
+from astropy.utils.data import download_file
+
+from gwosc.locate import get_event_urls
+
+from ...utils.env import bool_env
+from .. import (
+    StateVector,
+    TimeSeries,
+)
+
+GWPY_CACHE = bool_env("GWPY_CACHE", False)
+
+
+@pytest.fixture(scope="module")
+def gw150914_hdf5():
+    url, = get_event_urls(
+        "GW150914",
+        version=3,
+        detector="L1",
+        duration=32,
+        sample_rate=4096,
+        format="hdf5",
+    )
+    return download_file(url, cache=GWPY_CACHE)
+
+
+def test_read_hdf5_gwosc(gw150914_hdf5):
+    data = TimeSeries.read(
+        gw150914_hdf5,
+        format="hdf5.gwosc",
+    )
+    assert data.span == (1126259447, 1126259479)
+    assert data.name == "Strain"
+    assert data.max().value == pytest.approx(-4.60035111e-20)
+
+
+def test_read_hdf5_gwosc_state(gw150914_hdf5):
+    state = StateVector.read(
+        gw150914_hdf5,
+        format="hdf5.gwosc",
+    )
+    assert state.name == "Data quality"
+    assert state.max().value == 127
+
+
+def test_read_hdf5_losc_deprecated(gw150914_hdf5):
+    with pytest.warns(DeprecationWarning):
+        data = TimeSeries.read(
+            gw150914_hdf5,
+            format="hdf5.losc",
+        )
+    assert data.max().value == pytest.approx(-4.60035111e-20)
+
+
+def test_read_hdf5_losc_state_deprecated(gw150914_hdf5):
+    with pytest.warns(DeprecationWarning):
+        state = StateVector.read(
+            gw150914_hdf5,
+            format="hdf5.losc",
+        )
+    assert state.name == "Data quality"
+    assert state.max().value == 127

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -520,19 +520,17 @@ class TestTimeSeries(_TestTimeSeriesBase):
         )
         assert ts.sample_rate == 16384 * units.Hz
 
-        # make sure errors happen
-        with pytest.raises(ValueError) as exc:
+    @pytest_skip_network_error
+    def test_fetch_open_data_error(self):
+        """Test that TimeSeries.fetch_open_data raises errors it receives
+        from the `gwosc` module.
+        """
+        with pytest.raises(ValueError):
             self.TEST_CLASS.fetch_open_data(
                 GWOSC_GW150914_IFO,
                 0,
                 1,
-                format=format,
             )
-        assert str(exc.value) == (
-            "Cannot find a LOSC dataset for {} covering [0, 1)".format(
-                GWOSC_GW150914_IFO,
-            )
-        )
 
     @utils.skip_missing_dependency('nds2')
     @pytest.mark.parametrize('protocol', (1, 2))

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1068,7 +1068,7 @@ class TimeSeries(TimeSeriesBase):
         >>> notches = [filter_design.notch(f, 4096.) for f in (60, 120, 180)]
         >>> zpk = filter_design.concatenate_zpks(bp, *notches)
 
-        And then can download some data from LOSC to apply it using
+        And then can download some data from GWOSC to apply it using
         `TimeSeries.filter`:
 
         >>> from gwpy.timeseries import TimeSeries
@@ -1427,7 +1427,7 @@ class TimeSeries(TimeSeriesBase):
         --------
         Demodulation is useful when trying to examine steady sinusoidal
         signals we know to be contained within data. For instance,
-        we can download some data from LOSC to look at trends of the
+        we can download some data from GWOSC to look at trends of the
         amplitude and phase of LIGO Livingston's calibration line at 331.3 Hz:
 
         >>> from gwpy.timeseries import TimeSeries


### PR DESCRIPTION
This PR updates references to LOSC to use 'GWOSC', which is the newer name. This includes renaming the `hdf5.losc` I/O format to `hdf5.gwosc`, but the old name is retaining in a deprecated manner (with tests added to check the deprecation warning is emitted).