### PR TITLE
Refactor GravitySpyTable

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -100,6 +100,9 @@
 
 .. -- Other references --------------------------
 
+.. |GravitySpy| replace:: Gravity Spy
+.. _GravitySpy: https://gravityspy.org
+
 .. |GWOSCl| replace:: The Gravitational-Wave Open Science Centre (GWOSC)
 .. _GWOSCl: https://www.gw-openscience.org/
 

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -162,6 +162,62 @@ using the ``selection`` keyword:
 
 .. _gwpy-table-io-formats:
 
+***************************
+Accessing GravitySpy events
+***************************
+
+|GravitySpy|_ is a citizen-science project that enables the public to
+characterize and classify glitches in IGWN detector data.
+The :class:`GravitySpyTable` subclass of :class:`EventTable` provides
+methods to query GravitySpy for various tables of classified events.
+
+=====================
+Full database queries
+=====================
+
+The :meth:`GravitySpyTable.fetch` method (inherited directly from
+`EventTable <EventTable.fetch>`) enables querying the Gravity Spy database
+directly:
+
+.. code-block:: python
+
+   >>> from gwpy.table import GravitySpyTable
+   >>> blips = GravitySpyTable.fetch(
+   ...     "gravityspy",
+   ...     "glitches",
+   ...     selection="Label=Blip",
+   ... )
+
+.. warning::
+
+   Login credentials are required to support this query.
+   IGWN members with LIGO.ORG credentials can find the required
+   credentials at https://secrets.ligo.org/secrets/144/.
+
+===================
+Similarity searches
+===================
+
+The :meth:`GravitySpyTable.search` method enables performing a
+`Similarity Search <https://gravityspytools.ciera.northwestern.edu/search/>`__
+given the ID of a Gravity Spy event:
+
+.. code-block:: python
+
+   >>> from gwpy.table import GravitySpyTable
+   >>> similar = GravitySpyTable.search("8FHTgA8MEu", howmany=5)
+   >>> print(similar)
+   ifo  peak_frequency  links_subjects ml_label searchedID ...
+   --- ---------------- -------------- -------- ---------- ...
+    H1 84.4759674072266      5740011.0 Scratchy 8FHTgA8MEu ...
+    L1   128.8896484375     20892636.0 Scratchy 8FHTgA8MEu ...
+    L1 73.4049224853516     20892632.0 Scratchy 8FHTgA8MEu ...
+    L1 75.5168914794922     20892526.0 Scratchy 8FHTgA8MEu ...
+    L1 144.991333007812      8644242.0 Scratchy 8FHTgA8MEu ...
+
+This has download 5 similarly *Scratchy* glitches from the LIGO-Hanford
+(`'H1'`) and LIGO-Livingston (`'L1'`) observatories.
+
 *********************
 Built-in file formats
 *********************

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -54,6 +54,7 @@ class TestGravitySpyTable(_TestEventTable):
         table = self.TABLE.search(
             gravityspy_id="8FHTgA8MEu",
             howmany=1,
-            remote_timeout=60,
+            ifos="H1L1",
+            timeout=60,
         )
         utils.assert_table_equal(table, self.TABLE(JSON_RESPONSE))

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -16,45 +17,90 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for `gwpy.table`
+"""Unit tests for `gwpy.table.gravityspy`
 """
 
-from ...testing import utils
+import pytest
+
+import requests
+
 from ...testing.errors import pytest_skip_network_error
-from .. import GravitySpyTable
+from .. import (
+    gravityspy as table_gravityspy,
+    GravitySpyTable,
+)
 from .test_table import TestEventTable as _TestEventTable
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-JSON_RESPONSE = {
-    "url4": [u"https://panoptes-uploads.zooniverse.org/production/"
-             "subject_location/08895951-ea30-4cf7-9374-135a335afe0e.png"],
-    "peak_frequency": [84.4759674072266],
-    "links_subjects": [5740011.0],
-    "ml_label": [u"Scratchy"],
-    "searchedID": [u"8FHTgA8MEu"],
-    "snr": [8.96664047241211],
-    "gravityspy_id": [u"8FHTgA8MEu"],
-    "searchedzooID": [5740011.0],
-    "ifo": [u"H1"],
-    "url3": [u"https://panoptes-uploads.zooniverse.org/production/"
-             "subject_location/415dde44-3109-434c-b3ad-b722a879c159.png"],
-    "url2": [u"https://panoptes-uploads.zooniverse.org/production/"
-             "subject_location/09ebb6f4-e839-466f-80a1-64d79ac4d934.png"],
-    "url1": [u"https://panoptes-uploads.zooniverse.org/production/"
-             "subject_location/5e89d817-583c-4646-8e6c-9391bb99ad41.png"],
-}
+TEST_ID = "8FHTgA8MEu"
+TEST_IFO = "H1"
 
 
 class TestGravitySpyTable(_TestEventTable):
     TABLE = GravitySpyTable
 
-    @pytest_skip_network_error
-    def test_search(self):
-        table = self.TABLE.search(
-            gravityspy_id="8FHTgA8MEu",
+    @classmethod
+    def search(cls):
+        return cls.TABLE.search(
+            gravityspy_id=TEST_ID,
             howmany=1,
             ifos="H1L1",
             timeout=60,
         )
-        utils.assert_table_equal(table, self.TABLE(JSON_RESPONSE))
+
+    @pytest_skip_network_error
+    def test_search(self):
+        """Test `GravitySpyTable.search`
+        """
+        # run the search
+        table = self.search()
+
+        # validate the result
+        assert len(table) == 1
+        t = table[0]
+        assert t["gravityspy_id"] == TEST_ID
+        assert t["ifo"] == TEST_IFO
+        assert t["ml_label"] == "Scratchy"
+
+    def test_search_error(self):
+        """Test `GravitySpyTable.search` error handling
+
+        Mainly to make sure that an HTTP Error is raised instead
+        of a JSONDecodeError.
+        """
+        requests_mock = pytest.importorskip("requests_mock")
+        with requests_mock.Mocker() as rmock, \
+             pytest.raises(requests.HTTPError) as exc:
+            rmock.get(
+                "{}{}{}/?{}".format(
+                    table_gravityspy.DEFAULT_HOST,
+                    table_gravityspy.SEARCH_PATH,
+                    table_gravityspy.SIMILARITY_SEARCH_PATH,
+                    "&".join((
+                        "howmany=10",
+                        "imageid=abcde",
+                        "era=event_time+BETWEEN+1126400000+AND+1584057618",
+                        "ifo=%27H1%27%2C+%27L1%27",
+                        "database=similarity_index_o3",
+                    )),
+                ),
+                text="<!DOCTYPE html><html></html>",
+                status_code=200,
+                headers={
+                    "Content-Type": "text/html; charset=utf-8",
+                },
+            )
+            self.TABLE.search(gravityspy_id="abcde")
+        assert str(exc.value).endswith("please check the request parameters")
+
+    @pytest_skip_network_error
+    def test_download(self, tmp_path):
+        """Test `GravitySpyTable.download`
+        """
+        table = self.search()
+        table.download(download_path=tmp_path)
+        assert (
+            tmp_path
+            / "{}_{}_spectrogram_0.5.png".format(TEST_IFO, TEST_ID)
+        ).is_file()

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
 	matplotlib >= 3.3.0
 	numpy >= 1.16
 	python-dateutil
+	requests
 	scipy >= 1.2.0
 	tqdm >= 4.10.0
 include_package_data = true
@@ -70,7 +71,6 @@ test =
 # sphinx documentation
 docs =
 	numpydoc >= 0.8.0
-	requests
 	sphinx >= 4.0.0
 	sphinx-automodapi
 	sphinx-material >= 0.0.32
@@ -82,7 +82,6 @@ dev =
 	lalsuite ; sys_platform != 'win32'
 	lscsoft-glue ; sys_platform != 'win32'
 	maya
-	pandas
 	psycopg2
 	pycbc >= 1.13.4 ; sys_platform != 'win32'
 	pymysql


### PR DESCRIPTION
This PR refactors the `GravitySpyTable` code to simplify the methods and remove the requirement on Pandas. This has been replaced by a requirement on `requests`, which is fine since `gwosc` already requires `requests`, and `gwpy` requires `gwosc`.

cc @scottcoughlin2014