### PR TITLE
Catch KeyError when filtering errors from parse-conda-requirements.py

### DIFF
--- a/ci/parse-conda-requirements.py
+++ b/ci/parse-conda-requirements.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     # conda search failed, which means one or more packages are missing
     if pfind.returncode:
         LOGGER.warning(
-            "conda install failed, attempting to filter out messages",
+            "conda install failed, attempting to filter out missing packages",
         )
         if isinstance(out, bytes):
             out = out.decode('utf-8')
@@ -137,7 +137,7 @@ if __name__ == "__main__":
         try:
             missing = [pkg.split('[', 1)[0].lower() for
                        pkg in json.loads(out)['packages']]
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, KeyError):
             # run it all again so that it fails out in the open
             LOGGER.critical("filtering failed...")
             cmd.remove("--json")


### PR DESCRIPTION
This PR improves the error handling in the `parse-conda-requirements.py` script. When an UnsatisfiableError is raised by `conda install` there won't be a `'packages'` key in the JSON output, so we need to catch `KeyError` then run it again to expose the underlying problem. See build errors in #1366 for an example of why this is needed.