### PR TITLE
Handle default ADC slope of 0. in new frameCPP versions

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -312,6 +312,10 @@ def read_frdata(frdata, epoch, start, end, scaled=True,
         slope = None
         bias = None
     else:
+        # workaround https://git.ligo.org/ldastools/LDAS_Tools/-/issues/114
+        # by forcing the default slope to 1.
+        if bias == slope == 0.:
+            slope = 1.
         null_scaling = slope == 1. and bias == 0.
 
     out = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,9 +92,9 @@ dev =
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda =
-	ldas-tools-framecpp != 2.7.1
+	ldas-tools-framecpp ; sys_platform != 'win32'
 	python-framel >= 8.40.1
-	python-ldas-tools-framecpp != 2.6.10 ; sys_platform != 'win32'
+	python-ldas-tools-framecpp ; sys_platform != 'win32'
 	python-nds2-client
 
 # -- packaging --------------


### PR DESCRIPTION
This PR fixes a failing test when running with the latest versions of `ldas-tools-framecpp`, in which `FrAdcData` structures are created with a `DEFAULT_SLOPE` of `0.`, with no way to change the slope from the Python bindings. This means that if you write a GWF from Python that contains ADC channels, the slope you read back is _always_ `0.`. The patch here is to replace a default of `0.` with `1.` if the bias is also at its default (`0.`).

See https://git.ligo.org/ldastools/LDAS_Tools/-/issues/114