### PR TITLE
Fix compatibility with matplotlib-3.5.0

### DIFF
--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -144,7 +144,7 @@ class TestSpectrogram(_TestArray2D):
         with rc_context(rc={'text.usetex': False}):
             plot = array.plot(method=method)
             ax = plot.gca()
-            assert ax.lines == []
+            assert len(ax.lines) == 0
             if method == 'imshow':
                 assert len(ax.images) == 1
             else:

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -280,7 +280,7 @@ class TestStateVector(_TestTimeSeriesBase):
         with rc_context(rc={'text.usetex': False}):
             plot = array.plot()
             # make sure there were no lines drawn
-            assert plot.gca().lines == []
+            assert len(plot.gca().lines) == 0
             # assert one collection for each of known and active segmentlists
             assert len(plot.gca().collections) == len(array.bits) * 2
             plot.save(BytesIO(), format='png')


### PR DESCRIPTION
This PR fixes a couple of instances of `assert ax.lines == []`, which doesn't work any more as of matplotlib-3.5.0b1. This is easy fixed by comparing only the lengths of the objects, which is independently defined for the `ArtistList` object.