### PR TITLE
Fix path to versions.json for documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ html_theme_options = {
     "color_primary": "blue-grey",
     "color_accent": "deep-orange",
     "version_dropdown": True,
-    "version_json": "versions.json",
+    "version_json": "../versions.json",
 }
 html_favicon = str(Path(STATIC_DIRNAME) / "favicon.png")
 html_logo = str(Path(STATIC_DIRNAME) / "favicon.png")


### PR DESCRIPTION
This PR fixes the documentation configuration reference to the `versions.json` file that allows for dynamic linking across versions. The production docs at CIT will be built with the `versions.json` in the `/docs/` directory which is one up from the base of the build for any particular version.