### PR TITLE
ligolw: add to the list of ilwd compat errors

### DIFF
--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -62,6 +62,9 @@ LIGO_LW_MODULE_REGEX = re.compile(r"\Aligo.lw")
 # with the new library
 _compat_errors = {
     r"invalid Column \'process_id\'",
+    r"invalid Column \'coinc_event_id'",
+    r"invalid Column \'coinc_def_id'",
+    r"invalid Column \'event_id'",
     r"invalid type \'ilwd:char\'"
 }
 LIGO_LW_COMPAT_ERROR = re.compile("({})".format("|".join(_compat_errors)))


### PR DESCRIPTION
gwpy fails to read ld style coinc files, specifically tables coinc_inspiral and coinc_event. These fail with errors:

ligo.lw.ligolw.ElementError: line 1972: invalid Column 'coinc_event_id' for Table 'coinc_inspiral'

and

ligo.lw.ligolw.ElementError: line 43: invalid Column 'coinc_def_id' for Table 'coinc_event'

The reading works if I explicitly pass the flag ilwdchar_compat=True. This change will allow reading without having to pass the flag.