### PR TITLE
Add a method to compute the transfer function between two TimeSeries objects

### DIFF
--- a/examples/frequencyseries/transfer_function.py
+++ b/examples/frequencyseries/transfer_function.py
@@ -50,15 +50,9 @@ data = TimeSeriesDict.get([gndchannel, hpichannel], start, end, verbose=True)
 gnd = data[gndchannel]
 hpi = data[hpichannel]
 
-# Next, we can call the :meth:`~TimeSeries.average_fft` method to calculate
-# an averages, complex-valued FFT for each `TimeSeries`:
-gndfft = gnd.average_fft(100, 50, window='hamming')
-hpifft = hpi.average_fft(100, 50, window='hamming')
-
-# Finally, we can divide one by the other to get the transfer function
-# (up to the lower Nyquist)
-size = min(gndfft.size, hpifft.size)
-tf = hpifft[:size] / gndfft[:size]
+# The transfer function between time series is easily computed with the
+# :meth:`~TimeSeries.transfer_function` method:
+tf = gnd.transfer_function(hpi, 100, 50)
 
 # The `~gwpy.plot.BodePlot` knows how to separate a complex-valued
 # `~gwpy.frequencyseries.FrequencySeries` into magnitude and phase:

--- a/gwpy/cli/__init__.py
+++ b/gwpy/cli/__init__.py
@@ -30,6 +30,7 @@ from .spectrogram import Spectrogram
 from .coherence import Coherence
 from .coherencegram import Coherencegram
 from .qtransform import Qtransform
+from .transferfunction import TransferFunction
 
 __author__ = 'Joseph Areeda <joseph.areeda@ligo.org>'
 
@@ -40,4 +41,5 @@ PRODUCTS = _od((x.action, x) for x in (
     Coherence,
     Coherencegram,
     Qtransform,
+    TransferFunction,
 ))

--- a/gwpy/cli/tests/test_transferfunction.py
+++ b/gwpy/cli/tests/test_transferfunction.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Evan Goetz (2021)
 #
 # This file is part of GWpy.
 #

--- a/gwpy/cli/tests/test_transferfunction.py
+++ b/gwpy/cli/tests/test_transferfunction.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright (C) Evan Goetz (2021)
 #
 # This file is part of GWpy.
 #
@@ -21,6 +22,8 @@
 from ... import cli
 from .base import _TestCliProduct
 from .test_spectrum import TestCliSpectrum as _TestCliSpectrum
+
+__author__ = 'Evan Goetz <evan.goetz@ligo.org>'
 
 
 class TestCliTransferFunction(_TestCliSpectrum):

--- a/gwpy/cli/tests/test_transferfunction.py
+++ b/gwpy/cli/tests/test_transferfunction.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Evan Goetz (2021)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for :mod:`gwpy.cli.transferfunction`
+"""
+
+from ... import cli
+from .base import _TestCliProduct
+from .test_spectrum import TestCliSpectrum as _TestCliSpectrum
+
+
+class TestCliTransferFunction(_TestCliSpectrum):
+    TEST_CLASS = cli.TransferFunction
+    ACTION = 'transferfunction'
+    TEST_ARGS = _TestCliProduct.TEST_ARGS + [
+        '--chan', 'Y1:TEST-CHANNEL', '--secpfft', '0.25',
+    ]
+
+    def test_init(self, prod):
+        assert prod.chan_list == ['X1:TEST-CHANNEL', 'Y1:TEST-CHANNEL']
+        assert prod.ref_chan == prod.chan_list[0]
+
+    def test_get_suptitle(self, prod):
+        assert prod.get_suptitle() == 'Transfer function: {0}'.format(
+            prod.chan_list[0])

--- a/gwpy/cli/transferfunction.py
+++ b/gwpy/cli/transferfunction.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Evan Goetz (2021)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Transfer function plots
+"""
+
+from collections import OrderedDict
+
+from ..plot import Plot
+from ..plot.tex import label_to_latex
+from .spectrum import Spectrum
+
+__author__ = 'Evan Goetz <evan.goetz@ligo.org>'
+
+
+class TransferFunction(Spectrum):
+    """Plot transfer function between a reference time series and one
+    or more other time series
+    """
+    action = 'transferfunction'
+
+    MIN_DATASETS = 2
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ref_chan = self.args.ref or self.chan_list[0]
+        # deal with channel type appendages
+        if ',' in self.ref_chan:
+            self.ref_chan = self.ref_chan.split(',')[0]
+
+    @classmethod
+    def arg_channels(cls, parser):
+        group = super().arg_channels(parser)
+        group.add_argument('--ref', help='Reference channel against which '
+                                         'others will be compared')
+        return group
+
+    def _finalize_arguments(self, args):
+        if args.yscale is None:
+            args.yscale = 'linear'
+        if args.yscale == 'linear':
+            if not args.ymin:
+                args.ymin = 0
+            if not args.ymax:
+                args.ymax = 1.05
+        return super()._finalize_arguments(args)
+
+    def get_ylabel(self):
+        """Text for y-axis label
+        """
+        return 'Transfer function'
+
+    def get_suptitle(self):
+        """Start of default super title, first channel is appended to it
+        """
+        return 'Transfer function: {0}'.format(self.ref_chan)
+
+    def make_plot(self):
+        """Generate the coherence plot from all time series
+        """
+        args = self.args
+
+        fftlength = float(args.secpfft)
+        overlap = args.overlap
+        self.log(2, "Calculating spectrum secpfft: %s, overlap: %s" %
+                 (fftlength, overlap))
+        if overlap is not None:
+            overlap *= fftlength
+
+        self.log(3, 'Reference channel: ' + self.ref_chan)
+
+        # group data by segment
+        groups = OrderedDict()
+        for series in self.timeseries:
+            seg = series.span
+            try:
+                groups[seg][series.channel.name] = series
+            except KeyError:
+                groups[seg] = OrderedDict()
+                groups[seg][series.channel.name] = series
+
+        # -- plot
+
+        plot = Plot(figsize=self.figsize, dpi=self.dpi)
+        ax = plot.gca()
+        self.spectra = []
+
+        # calculate transfer function
+        for seg in groups:
+            refts = groups[seg].pop(self.ref_chan)
+            for name in groups[seg]:
+                series = groups[seg][name]
+                tf = series.transferfunction(refts, fftlength=fftlength,
+                                             overlap=overlap,
+                                             window=args.window)
+
+                label = name
+                if len(self.start_list) > 1:
+                    label += ', {0}'.format(series.epoch.gps)
+                if self.usetex:
+                    label = label_to_latex(label)
+
+                ax.plot(tf, label=label)
+                self.spectra.append(tf)
+
+        if args.xscale == 'log' and not args.xmin:
+            args.xmin = 1/fftlength
+
+        return plot
+
+    def set_legend(self):
+        """Create a legend for this product
+        """
+        leg = super().set_legend()
+        if leg is not None:
+            leg.set_title('Transfer function with:')
+        return leg

--- a/gwpy/cli/transferfunction.py
+++ b/gwpy/cli/transferfunction.py
@@ -105,9 +105,9 @@ class TransferFunction(Spectrum):
             refts = groups[seg].pop(self.ref_chan)
             for name in groups[seg]:
                 series = groups[seg][name]
-                tf = series.transferfunction(refts, fftlength=fftlength,
-                                             overlap=overlap,
-                                             window=args.window)
+                tf = series.transfer_function(refts, fftlength=fftlength,
+                                              overlap=overlap,
+                                              window=args.window)
 
                 label = name
                 if len(self.start_list) > 1:

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1407,6 +1407,14 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert (array == array).name == '{0} == {0}'.format(array.name)
 
     @pytest_skip_network_error
+    def test_transferfunction(self):
+        tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
+        tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
+        tf = tsh.transferfunction(tsl, fftlength=1.0, overlap=0.5)
+        assert tf.df == 1 * units.Hz
+        assert tf.frequencies[abs(tf).argmax()] == 516 * units.Hz
+
+    @pytest_skip_network_error
     def test_coherence(self):
         tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
         tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1407,10 +1407,10 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert (array == array).name == '{0} == {0}'.format(array.name)
 
     @pytest_skip_network_error
-    def test_transferfunction(self):
+    def test_transfer_function(self):
         tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
         tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-        tf = tsh.transferfunction(tsl, fftlength=1.0, overlap=0.5)
+        tf = tsh.transfer_function(tsl, fftlength=1.0, overlap=0.5)
         assert tf.df == 1 * units.Hz
         assert tf.frequencies[abs(tf).argmax()] == 516 * units.Hz
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1114,6 +1114,55 @@ class TimeSeries(TimeSeriesBase):
         new._unit = self.unit
         return new
 
+    def transferfunction(self, other, fftlength=None, overlap=None,
+                         window='hann', **kwargs):
+        """Calculate the transfer function between this `TimeSeries`
+        and another. This transfer function is the 'A-channel', serving
+        as the reference (denominator) while the other time series is
+        the test (numerator)
+
+        Parameters
+        ----------
+        other : `TimeSeries`
+            `TimeSeries` signal to calculate the transfer function with
+
+        fftlength : `float`, optional
+            number of seconds in single FFT, defaults to a single FFT
+            covering the full duration
+
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs, defaults to the
+            recommended overlap for the given window (if given), or 0
+
+        window : `str`, `numpy.ndarray`, optional
+            window function to apply to timeseries prior to FFT,
+            see :func:`scipy.signal.get_window` for details on acceptable
+            formats
+
+        **kwargs
+            any other keyword arguments accepted by
+            :func:`matplotlib.mlab.csd` or :func:`matplotlib.mlab.psd`
+            except ``NFFT``, ``window``, and ``noverlap`` which are
+            superceded by the above keyword arguments
+
+        Returns
+        -------
+        transferfunction : `~gwpy.frequencyseries.FrequencySeries`
+            the transfer function `FrequencySeries` of this `TimeSeries`
+            with the other
+
+        Notes
+        -----
+        If `self` and `other` have difference
+        :attr:`TimeSeries.sample_rate` values, the higher sampled
+        `TimeSeries` will be down-sampled to match the lower.
+        """
+        csd = other.csd(self, fftlength=fftlength, overlap=overlap,
+                        window=window, **kwargs)
+        psd = self.psd(fftlength=fftlength, overlap=overlap, window=window,
+                       **kwargs)
+        return csd / psd
+
     def coherence(self, other, fftlength=None, overlap=None,
                   window='hann', **kwargs):
         """Calculate the frequency-coherence between this `TimeSeries`

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1114,12 +1114,13 @@ class TimeSeries(TimeSeriesBase):
         new._unit = self.unit
         return new
 
-    def transferfunction(self, other, fftlength=None, overlap=None,
-                         window='hann', **kwargs):
-        """Calculate the transfer function between this `TimeSeries`
-        and another. This transfer function is the 'A-channel', serving
-        as the reference (denominator) while the other time series is
-        the test (numerator)
+    def transfer_function(self, other, fftlength=None, overlap=None,
+                          window='hann', **kwargs):
+        """Calculate the transfer function between this `TimeSeries` and
+        another.
+
+        This `TimeSeries` is the 'A-channel', serving as the reference
+        (denominator) while the other time series is the test (numerator)
 
         Parameters
         ----------
@@ -1141,13 +1142,11 @@ class TimeSeries(TimeSeriesBase):
 
         **kwargs
             any other keyword arguments accepted by
-            :func:`matplotlib.mlab.csd` or :func:`matplotlib.mlab.psd`
-            except ``NFFT``, ``window``, and ``noverlap`` which are
-            superceded by the above keyword arguments
+            :meth:`TimeSeries.csd` or :meth:`TimeSeries.psd`
 
         Returns
         -------
-        transferfunction : `~gwpy.frequencyseries.FrequencySeries`
+        transfer_function : `~gwpy.frequencyseries.FrequencySeries`
             the transfer function `FrequencySeries` of this `TimeSeries`
             with the other
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1160,7 +1160,13 @@ class TimeSeries(TimeSeriesBase):
                         window=window, **kwargs)
         psd = self.psd(fftlength=fftlength, overlap=overlap, window=window,
                        **kwargs)
-        return csd / psd
+
+        # Take the minimum of the frequencyseries csd and psd because the
+        # sample rate of different channels might yield different length
+        # objects
+        size = min(csd.size, psd.size)
+
+        return csd[:size] / psd[:size]
 
     def coherence(self, other, fftlength=None, overlap=None,
                   window='hann', **kwargs):


### PR DESCRIPTION
Added a TimeSeries method to compute the transfer function between two TimeSeries objects; added command line functions to carry this out as well, as I thought that may be useful for, e.g., LDVW

This method follows the standard procedure to compute the unknown transfer function between two time series using the cross spectral density and power spectral density estimators. This is what DTT does [see, page 20](https://dcc.ligo.org/DocDB/0026/T990013/002/Diagnostics_Test_Software_DCC_T990013_v2.pdf)

This functionality was mentioned in #321, though perhaps not initially what Andy had in mind as he mentions ASD2, etc., and code snippet suggested by [me](https://github.com/gwpy/gwpy/issues/321#issuecomment-566669307)