### PR TITLE
Fix detection of dev builds in docs index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 
 .. title:: GWpy docs
 
-.. ifconfig:: '+' in release
+.. ifconfig:: 'dev' in release
 
    .. warning::
 


### PR DESCRIPTION
This PR fixes the `ifconfig` 'dev' build warning on the documentation index; this was broken when we moved to setuptools_scm.