### PR TITLE
Avoid regex 2021.8.27, it's broken

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,7 @@ dev =
 	pymysql
 	pyRXP
 	python-ligo-lw >= 1.7.0 ; sys_platform != 'win32'
+	regex != 2021.8.27
 	sqlalchemy
 	uproot >= 3.11
 	uproot3


### PR DESCRIPTION
This PR patches `setup.cfg` to workaround a segmentation fault caused by the latest version of `regex`, see https://bitbucket.org/mrabarnett/mrab-regex/issues/421 for details.