### PR TITLE
Use mamba to install things during CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,9 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: test
-        channels: conda-forge
+        miniforge-variant: Mambaforge
         python-version: ${{ matrix.python-version }}
+        use-mamba: true
         # this is needed for caching to work properly:
         use-only-tar-bz2: true
 
@@ -105,7 +106,7 @@ jobs:
         echo "-----------------"
         cat environment.txt
         echo "-----------------"
-        conda install --quiet --yes --name test --file environment.txt
+        mamba install --quiet --yes --name test --file environment.txt
 
     - name: Install extra dependencies (Linux)
       if: matrix.os == 'Ubuntu'

--- a/ci/parse-conda-requirements.py
+++ b/ci/parse-conda-requirements.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import tempfile
 from configparser import ConfigParser
-from distutils.spawn import find_executable
+from shutil import which
 
 import pkg_resources
 
@@ -26,7 +26,11 @@ except ImportError:
 else:
     coloredlogs.install(fmt=LOGGING_FORMAT, level=logging.INFO)
 
-CONDA = find_executable("conda") or os.environ.get("CONDA_EXE", "conda")
+CONDA = (
+    which("mamba")
+    or which("conda")
+    or os.environ.get("CONDA_EXE", "conda")
+)
 CONDA_PACKAGE_MAP = {
     "matplotlib": "matplotlib-base",
 }


### PR DESCRIPTION
This PR updates the CI scripts to use `mamba` to install things, rather than `conda` - it's faster most of the time, but I'm not sure how compatible the error handling is, and that sort of thing.