### PR TITLE
Use pytest-xdist to parallellise the test suite during CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
       run: conda list --name test
 
     - name: Run test suite
-      run: python -m pytest -ra --color yes --cov gwpy --cov-report=xml --junitxml=pytest.xml gwpy/ examples/
+      run: python -m pytest -ra --color yes --cov gwpy --cov-report=xml --junitxml=pytest.xml --numprocesses=auto gwpy/ examples/
 
     - name: Coverage report
       run: python -m coverage report --show-missing

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ test =
 	pytest >= 3.9.1
 	pytest-cov >= 2.4.0
 	pytest-socket
+	pytest-xdist
 	requests-mock
 # sphinx documentation
 docs =


### PR DESCRIPTION
This PR modifies the CI to use `pytest-xdist` to parallelise the test suite, which might speed things up.