### PR TITLE
Deprecate gwpy.utils.shell.which

### DIFF
--- a/gwpy/io/kerberos.py
+++ b/gwpy/io/kerberos.py
@@ -31,8 +31,6 @@ import subprocess
 import sys
 from collections import OrderedDict
 
-from ..utils.shell import which
-
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
 __all__ = ['kinit']
@@ -49,12 +47,18 @@ class KerberosError(RuntimeError):
     pass
 
 
-def kinit(username=None, password=None, realm=None, exe=None, keytab=None,
-          krb5ccname=None, verbose=None):
-    """Initialise a kerberos (krb5) ticket.
+def kinit(
+        username=None,
+        password=None,
+        realm=None,
+        exe="kinit",
+        keytab=None,
+        krb5ccname=None,
+        verbose=None,
+):
+    """Initialise a kerberos ticket using the ``kinit`` command-line tool.
 
-    This allows authenticated connections to, amongst others, NDS2
-    services.
+    This allows authenticated connections to, amongst others, NDS2 services.
 
     Parameters
     ----------
@@ -103,10 +107,6 @@ def kinit(username=None, password=None, realm=None, exe=None, keytab=None,
     >>> kinit(keytab='~/.kerberos/ligo.org.keytab', verbose=True)
     Kerberos ticket generated for albert.einstein@LIGO.ORG
     """
-    # get kinit path
-    if exe is None:
-        exe = which('kinit')
-
     # get keytab
     if keytab is None:
         keytab = os.environ.get('KRB5_KTNAME', None)

--- a/gwpy/io/tests/test_kerberos.py
+++ b/gwpy/io/tests/test_kerberos.py
@@ -80,11 +80,10 @@ def test_parse_keytab(check_output):
 
 
 @mock.patch('sys.stdout.isatty', return_value=True)
-@mock.patch('gwpy.io.kerberos.which', return_value='/bin/kinit')
 @mock.patch('gwpy.io.kerberos.input', return_value='rainer.weiss')
 @mock.patch('getpass.getpass', return_value='test')
 @mock.patch('subprocess.Popen')
-def test_kinit_up(popen, getpass, input_, which, _, capsys):
+def test_kinit_up(popen, getpass, input_, _, capsys):
     """Test `gwpy.io.kerberos.kinit` with username and password given
     """
     proc = popen.return_value
@@ -92,7 +91,6 @@ def test_kinit_up(popen, getpass, input_, which, _, capsys):
 
     # basic call should prompt for username and password
     io_kerberos.kinit()
-    which.assert_called_with('kinit')
     input_.assert_called_with(
         "Please provide username for the LIGO.ORG kerberos realm: ",
     )
@@ -100,7 +98,7 @@ def test_kinit_up(popen, getpass, input_, which, _, capsys):
         prompt="Password for rainer.weiss@LIGO.ORG: ",
     )
     popen.assert_called_with(
-        ['/bin/kinit', 'rainer.weiss@LIGO.ORG'],
+        ['kinit', 'rainer.weiss@LIGO.ORG'],
         stdin=-1,
         stdout=-1,
         env=None,

--- a/gwpy/plot/tests/test_tex.py
+++ b/gwpy/plot/tests/test_tex.py
@@ -26,18 +26,28 @@ import pytest
 from .. import tex as plot_tex
 
 
-def which_patcher(error=False):
-    def which_(arg):
-        if error:
-            raise ValueError
-        return arg
-    return which_
+def _which(arg):
+    """Fake which to force pdflatex to being not found
+    """
+    if arg == "pdflatex":
+        return None
+    return arg
 
 
-@pytest.mark.parametrize('error', (False, True))
-def test_has_tex(error):
-    with mock.patch('gwpy.plot.tex.which', side_effect=which_patcher(error)):
-        assert plot_tex.has_tex() is not error
+@mock.patch("gwpy.plot.tex.which", return_value="path")
+def test_has_tex_true(_):
+    """Test that `gwpy.plot.tex.has_tex` returns `True` when
+    all of the necessary executables are found
+    """
+    assert plot_tex.has_tex()
+
+
+@mock.patch("gwpy.plot.tex.which", _which)
+def test_has_tex_false():
+    """Test that `gwpy.plot.tex.has_tex` returns `False` when
+    any one of the necessary executables is missing.
+    """
+    assert not plot_tex.has_tex()
 
 
 @pytest.mark.parametrize('in_, out', [

--- a/gwpy/plot/tex.py
+++ b/gwpy/plot/tex.py
@@ -20,8 +20,7 @@
 """
 
 import re
-
-from ..utils.shell import which
+from shutil import which
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -44,9 +43,7 @@ def has_tex():
         `False`
     """
     for exe in ('latex', 'pdflatex', 'dvipng'):
-        try:
-            which(exe)
-        except (ValueError, KeyError):
+        if which(exe) is None:
             return False
     return True
 

--- a/gwpy/utils/shell.py
+++ b/gwpy/utils/shell.py
@@ -28,6 +28,12 @@ from .decorators import deprecated_function
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
+@deprecated_function(
+    message=(
+        "gwpy.utils.shell.which is deprecated in favour of shutil.which from "
+        "the Python standard library, and will be removed in a future release"
+    ),
+)
 def which(program):
     """Find full path of executable program
 

--- a/gwpy/utils/tests/test_shell.py
+++ b/gwpy/utils/tests/test_shell.py
@@ -71,6 +71,7 @@ def test_shell_call_error_warn():
 
 
 def test_which():
-    assert shell.which('python') == find_executable('python')
-    with pytest.raises(ValueError):
+    with pytest.warns(DeprecationWarning):
+        assert shell.which('python') == find_executable('python')
+    with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
         shell.which('gwpy-no-executable')


### PR DESCRIPTION
~~This PR modifies `gwpy.utils.shell.which` to use `shutil.which` instead of `distutils.spawn.find_executable`, which doesn't work as well on windows.~~

This PR deprecates the `gwpy.utils.shell.which` function, people should use use `shutil.which` directly.