### PR TITLE
Allowing cropping of irregular Series

### DIFF
--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -978,19 +978,37 @@ class Series(Array):
                  % type(self).__name__)
             end = None
 
+        # check if series is irregular
+        try:
+            _ = self.dx
+            irregular = False
+        except AttributeError:
+            irregular = True
+
         # find start index
         if start is None:
             idx0 = None
         else:
-            idx0 = int((xtype(start) - x0) // self.dx.value)
+            if not irregular:
+                idx0 = int((xtype(start) - x0) // self.dx.value)
+            else:
+                idx0 = numpy.searchsorted(self.xindex.value, xtype(start), side="left")
 
         # find end index
         if end is None:
             idx1 = None
         else:
-            idx1 = int((xtype(end) - x0) // self.dx.value)
-            if idx1 >= self.size:
-                idx1 = None
+            if not irregular:
+                idx1 = int((xtype(end) - x0) // self.dx.value)
+                if idx1 >= self.size:
+                    idx1 = None
+            else:
+                if xtype(end) >= self.xindex.value[-1]:
+                    idx1 = None
+                else:
+                    idx1 = (
+                        numpy.searchsorted(self.xindex.value, xtype(end), side="left") - 1
+                    )
 
         # crop
         if copy:


### PR DESCRIPTION
I would like to be able to crop irregular TimeSeries objects, but because the `dx` attribute is not defined for these it doesn't work. This PR makes a change to the `crop` method of the `Series` object, so that cropping can be performed on irregularly sampled series.