### PR TITLE
Add basic Python 3.10 builds in CI

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -74,11 +74,11 @@ jobs:
           - macOS
           - Ubuntu
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
-          - 3.10
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -78,6 +78,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+          - 3.10
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 	Topic :: Scientific/Engineering :: Astronomy
 	Topic :: Scientific/Engineering :: Physics
 


### PR DESCRIPTION
This PR adds Python 3.10 to the list of versions to build in CI.