### PR TITLE
Use uproot4 for writing ROOT files as well

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -95,9 +95,6 @@
 .. |uproot| replace:: `uproot`
 .. _uproot: https://uproot.readthedocs.io/
 
-.. |uproot3| replace:: `uproot3`
-.. _uproot3: https://github.com/scikit-hep/uproot3
-
 .. -- Other references --------------------------
 
 .. |GWOSCl| replace:: The Gravitational-Wave Open Science Centre (GWOSC)

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -441,12 +441,6 @@ ROOT
 
 **Additional dependencies:** |uproot|_
 
-.. note::
-
-   |uproot|_ version 4 (at time of writing) cannot handle writing ROOT files,
-   so if wish to use this version to read files, you may need to also install
-   |uproot3|_ as well.
-
 Reading
 -------
 

--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -75,33 +75,11 @@ def table_from_root(source, treename=None, **kwargs):
             return Table(trees[treename].arrays(namedecode="utf-8"), **kwargs)
 
 
-def _import_uproot_that_can_write_root_files():
-    """uproot v4 can't handle writing files (ATOW),
-    so try it and fall back to uproot3
-    """
-    import uproot
-    try:
-        uproot.newtree
-    except AttributeError:
-        try:
-            import uproot3 as uproot
-        except ModuleNotFoundError as exc:  # pragma: no cover
-            exc.msg = (
-                "you have uproot {} installed, which does not support writing "
-                "ROOT files (yet), please install uproot3 "
-                "(see https://pypi.org/project/uproot3/)".format(
-                    uproot.__version__,
-                )
-            )
-            raise
-    return uproot
-
-
 def table_to_root(table, filename, treename="tree",
                   overwrite=False, append=False, **kwargs):
     """Write a Table to a ROOT file
     """
-    uproot = _import_uproot_that_can_write_root_files()
+    import uproot
 
     createkw = {k: kwargs.pop(k) for k in {"compression", } if k in kwargs}
     create_func = uproot.recreate if overwrite else uproot.create
@@ -111,11 +89,14 @@ def table_to_root(table, filename, treename="tree",
             "uproot currently doesn't support appending to existing files",
         )
 
-    tree = uproot.newtree(dict(table.dtype.descr), **kwargs)
 
     with create_func(filename, **createkw) as outf:
-        outf[treename] = tree
-        outf[treename].extend(dict(table.columns))
+        tree = outf.mktree(
+            treename,
+            dict(table.dtype.descr),
+            **kwargs,
+        )
+        tree.extend(dict(table.columns))
 
 
 # register I/O

--- a/gwpy/table/io/root.py
+++ b/gwpy/table/io/root.py
@@ -75,20 +75,30 @@ def table_from_root(source, treename=None, **kwargs):
             return Table(trees[treename].arrays(namedecode="utf-8"), **kwargs)
 
 
-def table_to_root(table, filename, treename="tree",
-                  overwrite=False, append=False, **kwargs):
+def table_to_root(
+        table,
+        filename,
+        treename="tree",
+        overwrite=False,
+        append=False,
+        **kwargs,
+):
     """Write a Table to a ROOT file
     """
     import uproot
 
-    createkw = {k: kwargs.pop(k) for k in {"compression", } if k in kwargs}
-    create_func = uproot.recreate if overwrite else uproot.create
-
-    if append is True:
-        raise NotImplementedError(
-            "uproot currently doesn't support appending to existing files",
-        )
-
+    createkw = {
+        k: kwargs.pop(k) for k in {
+            "initial_directory_bytes",
+            "uuid_function",
+        } if k in kwargs
+    }
+    if append:
+        create_func = uproot.update
+    elif overwrite:
+        create_func = uproot.recreate
+    else:
+        create_func = uproot.create
 
     with create_func(filename, **createkw) as outf:
         tree = outf.mktree(

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -44,7 +44,6 @@ from ...timeseries import (TimeSeries, TimeSeriesDict)
 from .. import (Table, EventTable, filters)
 from ..filter import filter_table
 from ..io.hacr import HACR_COLUMNS
-from ..io.root import _import_uproot_that_can_write_root_files
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -52,17 +51,6 @@ TEST_DATA_DIR = os.path.join(os.path.split(__file__)[0], 'data')
 TEST_XML_FILE = os.path.join(
     TEST_DATA_DIR, 'H1-LDAS_STRAIN-968654552-10.xml.gz')
 TEST_OMEGA_FILE = os.path.join(TEST_DATA_DIR, 'omega.txt')
-
-try:
-    uproot = _import_uproot_that_can_write_root_files()
-except ImportError:
-    HAVE_UPROOT_RW = False
-else:
-    HAVE_UPROOT_RW = True
-SKIP_UPROOT_RW = pytest.mark.skipif(
-    not HAVE_UPROOT_RW,
-    reason="uproot>4 doesn't support r/w and no uproot3",
-)
 
 
 # -- mocks --------------------------------------------------------------------
@@ -327,7 +315,7 @@ class TestTable(object):
         t2.sort("instrument")
         utils.assert_table_equal(t2, table)
 
-    @SKIP_UPROOT_RW
+    @utils.skip_missing_dependency('uproot')
     def test_read_write_root(self, table, tmp_path):
         tmp = tmp_path / "table.root"
 
@@ -355,7 +343,7 @@ class TestTable(object):
             ),
         )
 
-    @SKIP_UPROOT_RW
+    @utils.skip_missing_dependency('uproot')
     def test_write_root_overwrite(self, table, tmp_path):
         tmp = tmp_path / "table.root"
         table.write(tmp)
@@ -367,19 +355,19 @@ class TestTable(object):
         # assert works with overwrite=True
         table.write(tmp, overwrite=True)
 
-    @SKIP_UPROOT_RW
-    def test_read_root_multiple_trees(self, table, tmp_path):
+    @utils.skip_missing_dependency('uproot')
+    def test_read_root_multiple_trees(self, tmp_path):
+        uproot = pytest.importorskip("uproot")
         tmp = tmp_path / "table.root"
         with uproot.create(tmp) as root:
-            root["a"] = uproot.newtree({"branch": "int32"})
-            root["a"].extend({"branch": asarray([1, 2, 3, 4, 5])})
-            root["b"] = uproot.newtree()
+            a = root.mktree("a", {"branch": "int32"})
+            a.extend({"branch": asarray([1, 2, 3, 4, 5])})
+            root.mktree("b", {"branch": "int32"})
         with pytest.raises(ValueError) as exc:
             self.TABLE.read(tmp)
         assert str(exc.value).startswith('Multiple trees found')
         self.TABLE.read(tmp, treename="a")
 
-    @SKIP_UPROOT_RW
     def test_read_write_root_append(self, table, tmp_path):
         tmp = tmp_path / "table.root"
         # append hasn't been implemented in uproot 3 yet

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -368,11 +368,31 @@ class TestTable(object):
         assert str(exc.value).startswith('Multiple trees found')
         self.TABLE.read(tmp, treename="a")
 
+    @utils.skip_missing_dependency('uproot')
     def test_read_write_root_append(self, table, tmp_path):
         tmp = tmp_path / "table.root"
-        # append hasn't been implemented in uproot 3 yet
-        with pytest.raises(NotImplementedError):
-            table.write(tmp, treename="test2", append=True)
+        # write one tree
+        table.write(tmp, treename="a")
+        # write a second tree
+        table.write(tmp, treename="b", append=True)
+        # check that we can read both trees
+        self.TABLE.read(tmp, treename="a")
+        self.TABLE.read(tmp, treename="b")
+
+    @utils.skip_missing_dependency('uproot')
+    def test_read_write_root_append_overwrite(self, table, tmp_path):
+        tmp = tmp_path / "table.root"
+        # write one tree
+        table.write(tmp, treename="a")
+        # write a second tree
+        table.write(tmp, treename="b", append=True)
+        # overwrite the first tree
+        t2 = table[:50]
+        t2.write(tmp, treename="a", overwrite=True, append=True)
+        # check that we can read the original 'b' tree and the new
+        # 'a' tree
+        utils.assert_table_equal(table, self.TABLE.read(tmp, treename="b"))
+        utils.assert_table_equal(t2, self.TABLE.read(tmp, treename="a"))
 
     @utils.skip_missing_dependency('LDAStools.frameCPP')
     def test_read_write_gwf(self, tmp_path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,8 +90,7 @@ dev =
 	python-ligo-lw >= 1.7.0 ; sys_platform != 'win32'
 	regex != 2021.8.27
 	sqlalchemy
-	uproot >= 3.11
-	uproot3
+	uproot >= 4.1.0
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda =

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,7 @@ dev =
 	python-ligo-lw >= 1.7.0 ; sys_platform != 'win32'
 	regex != 2021.8.27
 	sqlalchemy
-	uproot >= 4.1.0
+	uproot >= 4.1.5
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda =


### PR DESCRIPTION
This PR updates the ROOT I/O interface to use `uproot` (v4) for writing ROOT files, rather than relying up uproot3.

Depends on #1441.