### PR TITLE
Don't check FrProcData's tRange when reading GWF

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -295,13 +295,9 @@ def read_frdata(frdata, epoch, start, end, scaled=True,
         ``[start, end)`` interval.
     """
     datastart = epoch + frdata.GetTimeOffset()
-    try:
-        trange = frdata.GetTRange()
-    except AttributeError:  # not proc channel
-        trange = 0.
 
     # check overlap with user-requested span
-    if (end and datastart >= end) or (trange and datastart + trange < start):
+    if end and datastart >= end:
         raise _Skip()
 
     # get scaling


### PR DESCRIPTION
This PR removes a check against the `tRange` attribute of an `FrProcData` structure when reading GWFs. According to [the frame spec](https://dcc.ligo.org/LIGO-T970130/public):

> tRange, fShift, fRange are redundant with the axis information in the data Vector in some cases. If a 
redundancy exists, the data must be identical to that in the FrVect for the earliest time and/or lowest frequency 
dimension (e.g. for a t-Series tRange = dx[0]*nx[0]). If a discrepancy exists then the FrVect values take 
precedence

This would resolve the issues reading BayesWave-produced files, see https://git.ligo.org/computing/helpdesk/-/issues/1579 (IGWN credentials required).