### PR TITLE
Check GET response status when querying zenodo API

### DIFF
--- a/gwpy/utils/sphinx/zenodo.py
+++ b/gwpy/utils/sphinx/zenodo.py
@@ -71,7 +71,9 @@ def format_citations(zid, url='https://zenodo.org/', hits=10, tag_prefix='v'):
            'q=conceptrecid:"{id}"&'
            'sort=-version&'
            'all_versions=True'.format(id=zid, url=url, hits=hits))
-    metadata = requests.get(url).json()
+    resp = requests.get(url)  # make the request
+    resp.raise_for_status()  # make sure it worked
+    metadata = resp.json()  # parse the response
 
     lines = []
     for i, hit in enumerate(metadata['hits']['hits']):


### PR DESCRIPTION
This PR improves the error handling in `gwpy.utils.sphinx.zenodo` (used in the documentation) by calling `Response.raise_for_status()`, which will raise an `HTTPError` on failure, rather than blindly continuing and attempting to parse the response as JSON, which results in a `JSONDecodeError`.

zenodo.org is [down](https://twitter.com/ZENODO_ORG/status/1449032779317006337)...