### PR TITLE
Remove ldas-tools-framecpp from conda extra in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,6 @@ dev =
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda =
-	ldas-tools-framecpp ; sys_platform != 'win32'
 	python-framel >= 8.40.1
 	python-ldas-tools-framecpp ; sys_platform != 'win32'
 	python-nds2-client


### PR DESCRIPTION
This PR removes a redundant entry from the `dev` extra spec in `setup.cfg`; this should have been removed as part of #1396.