### PR TITLE
Pin the experimental dependencies check to Python 3.9

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -43,7 +43,7 @@ jobs:
             python-version: "3.6"
             experimental: false
           - name: "Experimental"
-            python-version: "3.x"
+            python-version: "3.9"
             experimental: true
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
The experimental dependencies check has been failing for a while because the check is running on Python 3.10 which doesn't have any lalsuite wheels yet. For now we need to pin back to Python 3.9. This may expose #1432.