### PR TITLE
Update gwpy.io to support Astropy 5 class-based registries

### DIFF
--- a/gwpy/io/registry.py
+++ b/gwpy/io/registry.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -26,12 +27,18 @@ import sys
 from functools import wraps
 
 from astropy.io.registry import (  # noqa: F401
-    _get_valid_format as get_format,
     get_reader,
     register_identifier as astropy_register_identifier,
     register_reader,
     register_writer,
 )
+try:
+    from astropy.io.registry.compat import default_registry
+except ModuleNotFoundError:  # astropy < 5
+    from astropy.io.registry import _get_valid_format as get_format
+else:
+    get_format = default_registry._get_valid_format
+
 from astropy.utils.data import get_readable_fileobj
 
 from .utils import (file_list, FILE_LIKE)

--- a/gwpy/table/io/fetch.py
+++ b/gwpy/table/io/fetch.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -23,6 +24,15 @@ import re
 
 from astropy.io import registry as io_registry
 from astropy.table import Table
+
+# NOTE: this block should be replaced with a custom UnifedInputRegistry
+#       once we can require astropy >= 5
+try:
+    from astropy.io.registry.compat import default_registry
+except ModuleNotFoundError:  # astropy < 5
+    from astropy.io.registry import _is_best_match
+else:
+    _is_best_match = default_registry._is_best_match
 
 _FETCHERS = {}
 
@@ -78,11 +88,11 @@ def get_fetcher(data_format, data_class):
     # this is a copy of astropy.io.regsitry.get_reader
     fetchers = [(fmt, cls) for fmt, cls in _FETCHERS if fmt == data_format]
     for fetch_fmt, fetch_cls in fetchers:
-        if io_registry._is_best_match(data_class, fetch_cls, fetchers):
+        if _is_best_match(data_class, fetch_cls, fetchers):
             return _FETCHERS[(fetch_fmt, fetch_cls)][0]
     else:
         formats = [fmt for fmt, cls in _FETCHERS if
-                   io_registry._is_best_match(fmt, cls, fetchers)]
+                   _is_best_match(fmt, cls, fetchers)]
         formatstr = '\n'.join(sorted(formats))
         raise io_registry.IORegistryError(
             "No fetcher definer for format '{0}' and class '{1}'.\n"

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -790,6 +790,14 @@ class TimeSeriesBase(Series):
             out.name = '{0!s} {1!s} {2!s}'.format(oname, op_, vname)
         return out
 
+    # Quantity overrides __eq__ and __ne__ in a way that doesn't work for us,
+    # so we just undo that
+    def __eq__(self, other):
+        return numpy.ndarray.__eq__(self, other)
+
+    def __ne__(self, other):
+        return numpy.ndarray.__ne__(self, other)
+
 
 # -- TimeSeriesBaseDict -------------------------------------------------------
 

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -788,26 +789,6 @@ class TimeSeriesBase(Series):
             vname = value.name if isinstance(value, type(self)) else value
             out.name = '{0!s} {1!s} {2!s}'.format(oname, op_, vname)
         return out
-
-    def __array_wrap__(self, obj, context=None):
-        # if output type is boolean, return a `StateTimeSeries`
-        if obj.dtype == numpy.dtype(bool):
-            from .statevector import StateTimeSeries
-            ufunc = context[0]
-            value = context[1][-1]
-            try:
-                op_ = _UFUNC_STRING[ufunc.__name__]
-            except KeyError:
-                op_ = ufunc.__name__
-            result = obj.view(StateTimeSeries)
-            result.override_unit('')
-            oname = obj.name if isinstance(obj, type(self)) else obj
-            vname = value.name if isinstance(value, type(self)) else value
-            result.name = '{0!s} {1!s} {2!s}'.format(oname, op_, vname)
-        # otherwise, return a regular TimeSeries
-        else:
-            result = super().__array_wrap__(obj, context=context)
-        return result
 
 
 # -- TimeSeriesBaseDict -------------------------------------------------------

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -201,9 +202,6 @@ class StateTimeSeries(TimeSeriesBase):
         if out.ndim:
             return out.view(bool)
         return out
-
-    def __array_wrap__(self, obj, context=None):
-        return super().__array_wrap__(obj, context=context).view(bool)
 
     def diff(self, n=1, axis=-1):
         slice1 = (slice(1, None),)


### PR DESCRIPTION
This PR fixes #1432 by updating the use of a private function from `astropy.io.registry`. This is still a hack, but is the easiest thing to do while attempting to support the old registry format and the new class-based system at the same time.