### PR TITLE
Update compatibility with matplotlib 3.5.0

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -650,12 +650,12 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         """Set the grid parameters for this plot.
         """
         if enable:
-            self.ax.grid(b=True, which='major',
+            self.ax.grid(True, which='major',
                          color='k', linestyle='solid')
-            self.ax.grid(b=True, which='minor',
+            self.ax.grid(True, which='minor',
                          color='0.06', linestyle='dotted')
         else:
-            self.ax.grid(b=False)
+            self.ax.grid(False)
 
     def save(self, outfile):
         """Save this product to the target `outfile`.

--- a/gwpy/plot/legend.py
+++ b/gwpy/plot/legend.py
@@ -45,9 +45,9 @@ class HandlerLine2D(legend_handler.HandlerLine2D):
         self._linewidth = linewidth
 
     def create_artists(self, *args, **kwargs):
-        line, marker = super().create_artists(
+        artists = super().create_artists(
             *args,
             **kwargs
         )
-        line.set_linewidth(self._linewidth)
-        return line, marker
+        artists[0].set_linewidth(self._linewidth)
+        return artists

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -519,7 +519,7 @@ class Plot(figure.Figure):
 
         # plot segments
         segax.plot(segments, **plotargs)
-        segax.grid(b=False, which='both', axis='y')
+        segax.grid(False, which='both', axis='y')
         segax.autoscale(axis='y', tight=True)
 
         return segax

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -482,7 +482,6 @@ class Plot(figure.Figure):
         # set options for new axes
         axes_kw = {
             'pad': pad,
-            'add_to_figure': True,
             'sharex': ax if sharex is True else sharex or None,
             'axes_class': get_projection_class('segments'),
         }

--- a/gwpy/plot/tests/test_log.py
+++ b/gwpy/plot/tests/test_log.py
@@ -24,7 +24,6 @@ from unittest import mock
 import pytest
 
 from matplotlib import (
-    __version__ as mpl_version,
     rc_context,
 )
 
@@ -55,7 +54,7 @@ class TestLogFormatter(object):
             1,
             None,
             r'$\mathdefault{10^{0}}$',
-            r'$\mathdefault{10^{0}}$' if mpl_version > "3.2.1" else "$10^{0}$",
+            r'$\mathdefault{10^{0}}$',
             id="fmt=None",
         ),
         pytest.param(


### PR DESCRIPTION
This PR addresses a number of `DeprecationWarning`s from matplotlib 3.5.0.