### PR TITLE
Address python 3.10 deprecation warning

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1243,7 +1243,7 @@ class DataQualityDict(OrderedDict):
         outq = Queue()
         for i in range(len(flags)):
             t = _QueryDQSegDBThread(inq, outq, qsegs, **kwargs)
-            t.setDaemon(True)
+            t.daemon = True
             t.start()
         for i, flag in enumerate(flags):
             inq.put((i, flag))


### PR DESCRIPTION
This PR addresses a `DeprecationWarning` emitted by Python 3.10, see https://docs.python.org/3/whatsnew/3.10.html#deprecated.