### PR TITLE
Drop support for python3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,6 @@ jobs:
           - Ubuntu
           - Windows
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
           - name: "Minimum"
-            python-version: "3.6"
+            python-version: "3.7"
             experimental: false
           - name: "Experimental"
             python-version: "3.9"

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -74,7 +74,6 @@ jobs:
           - macOS
           - Ubuntu
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ And that's it.
 
 ### Python compatibility
 
-**GWpy code must be compatible with Python >= 3.6.**
+**GWpy code must be compatible with Python >= 3.7.**
 
 ### Style
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,11 +46,11 @@ GWpy has the following strict requirements:
    ==================  ===========================
    Name                Constraints
    ==================  ===========================
-   |astropy|_          ``>=3.0.0``
+   |astropy|_          ``>=3.0.5``
    |dqsegdb2|_
    |gwdatafind|_
    |gwosc-mod|_        ``>=0.5.3``
-   |h5py|_             ``>=2.7.0``
+   |h5py|_             ``>=2.8.0``
    |ligo-segments|_    ``>=1.0.0``
    |ligotimegps|_      ``>=1.2.1``
    |matplotlib|_       ``>=3.1.0``

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,8 +32,6 @@ Pip
 
     python -m pip install gwpy
 
-Supported python versions: 3.6+.
-
 
 ============
 Requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ dev =
 	maya
 	pandas
 	psycopg2
-	pycbc >= 1.13.4 ; python_version >= '3' and sys_platform != 'win32'
+	pycbc >= 1.13.4 ; sys_platform != 'win32'
 	pymysql
 	pyRXP
 	python-ligo-lw >= 1.7.0 ; sys_platform != 'win32'

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,11 +39,11 @@ setup_requires =
 	setuptools_scm
 	wheel
 install_requires =
-	astropy >= 3.0.0
+	astropy >= 3.0.5
 	dqsegdb2
 	gwdatafind
 	gwosc >= 0.5.3
-	h5py >= 2.7.0
+	h5py >= 2.8.0
 	ligo-segments >= 1.0.0
 	ligotimegps >= 1.2.1
 	matplotlib >= 3.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ classifiers =
 	Operating System :: OS Independent
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
@@ -34,7 +33,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
 	setuptools >= 38.2.5
 	setuptools_scm


### PR DESCRIPTION
This PR removes support for Python 3.6.

As per NEP29 this version has already been dropped by a number of upstream packages as well as the conda-forge packaging group.