### PR TITLE
Use f-strings for string formatting in gwpy.cli

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -58,7 +58,7 @@ def timer(func):
     def timed_func(self, *args, **kwargs):  # pylint: disable=missing-docstring
         _start = time.time()
         out = func(self, *args, **kwargs)
-        self.log(2, '{0} took {1:.1f} sec'.format(name, time.time() - _start))
+        self.log(2, f'{name} took {time.time() - _start:.1f} sec')
         return out
 
     return timed_func
@@ -352,39 +352,39 @@ class CliProduct(object, metaclass=abc.ABCMeta):
 
     @classmethod
     def _arg_axis(cls, axis, parser, **defaults):
-        name = '{} axis'.format(axis.title())
-        group = parser.add_argument_group('{0} options'.format(name))
+        name = f'{axis.title()} axis'
+        group = parser.add_argument_group(f'{name} options')
 
         # label
-        group.add_argument('--{0}label'.format(axis),
+        group.add_argument(f'--{axis}label',
                            default=defaults.get('label'),
-                           dest='{0}label'.format(axis),
-                           help='{0} label'.format(name))
+                           dest=f'{axis}label',
+                           help=f'{name} label')
 
         # min and max
         for extrema in ('min', 'max'):
             opt = axis + extrema
-            group.add_argument('--{0}'.format(opt), type=float,
+            group.add_argument(f'--{opt}', type=float,
                                default=defaults.get(extrema), dest=opt,
-                               help='{0} value for {1}'.format(extrema, name))
+                               help=f'{extrema} value for {name}')
 
         # scale
         scaleg = group.add_mutually_exclusive_group()
-        scaleg.add_argument('--{0}scale'.format(axis), type=str,
+        scaleg.add_argument(f'--{axis}scale', type=str,
                             default=defaults.get('scale'),
-                            dest='{0}scale'.format(axis),
-                            help='scale for {0}'.format(name))
+                            dest=f'{axis}scale',
+                            help=f'scale for {name}')
         if defaults.get('scale') == 'log':
-            scaleg.add_argument('--nolog{0}'.format(axis),
+            scaleg.add_argument(f'--nolog{axis}',
                                 action='store_const',
-                                dest='{0}scale'.format(axis),
+                                dest=f'{axis}scale',
                                 const=None, default='log',
-                                help='use logarithmic {0}'.format(name))
+                                help=f'use logarithmic {name}')
         else:
-            scaleg.add_argument('--log{0}'.format(axis), action='store_const',
-                                dest='{0}scale'.format(axis),
+            scaleg.add_argument(f'--log{axis}', action='store_const',
+                                dest=f'{axis}scale',
                                 const='log', default=None,
-                                help='use logarithmic {0}'.format(name))
+                                help=f'use logarithmic {name}')
         return group
 
     def _finalize_arguments(self, args):
@@ -402,17 +402,18 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         """
         # validate number of data sets requested
         if len(self.chan_list) < self.MIN_CHANNELS:
-            raise ValueError('this product requires at least {0} '
-                             'channels'.format(self.MIN_CHANNELS))
+            raise ValueError(
+                f'this product requires at least {self.MIN_CHANNELS} channels'
+            )
         if self.n_datasets < self.MIN_DATASETS:
             raise ValueError(
-                '%d datasets are required for this plot but only %d are '
-                'supplied' % (self.MIN_DATASETS, self.n_datasets)
+                f'{self.MIN_DATASETS} are required for this plot but only '
+                f'{self.n_datasets} are supplied'
             )
         if self.n_datasets > self.MAX_DATASETS:
             raise ValueError(
-                'A maximum of %d datasets allowed for this plot but %d '
-                'specified' % (self.MAX_DATASETS, self.n_datasets)
+                f'A maximum of {self.MAX_DATASETS} datasets allowed for this '
+                f'plot but {self.n_datasets} specified'
             )
 
     # -- data transfer --------------------------
@@ -456,10 +457,12 @@ class CliProduct(object, metaclass=abc.ABCMeta):
                 self.timeseries.append(data)
 
         # report what we have if they asked for it
-        self.log(3, ('Channels: %s' % self.chan_list))
-        self.log(3, ('Start times: %s, duration %s' % (
-            self.start_list, self.duration)))
-        self.log(3, ('Number of time series: %d' % len(self.timeseries)))
+        self.log(3, f'Channels: {self.chan_list}')
+        self.log(
+            3,
+            f'Start times: {self.start_list}, duration {self.duration}',
+        )
+        self.log(3, f'Number of time series: {len(self.timeseries)}')
 
     @staticmethod
     def _filter_timeseries(data, highpass=None, lowpass=None, notch=None):
@@ -507,13 +510,13 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         notch = self.args.notch
         filt = ''
         if highpass and lowpass:
-            filt += "band pass (%.1f-%.1f)" % (highpass, lowpass)
+            filt += f"band pass ({highpass:.1f}-{lowpass:.1f})"
         elif highpass:
-            filt += "high pass (%.1f) " % highpass
+            filt += f"high pass ({highpass:.1f}) "
         elif lowpass:
-            filt += "low pass (%.1f) " % lowpass
+            filt += f"low pass ({lowpass:.1f}) "
         if notch:
-            filt += ', notch ({0})'.format(', '.join(map(str, notch)))
+            filt += f", notch ({', '.join(map(str, notch))})"
         return filt
 
     def get_suptitle(self):
@@ -546,16 +549,16 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         """Generic method to set properties for X/Y axis
         """
         def _get(param):
-            return getattr(self.ax, 'get_{0}{1}'.format(axis, param))()
+            return getattr(self.ax, f'get_{axis}{param}')()
 
         def _set(param, *args, **kwargs):
-            return getattr(self.ax, 'set_{0}{1}'.format(axis, param))(
+            return getattr(self.ax, f'set_{axis}{param}')(
                 *args, **kwargs)
 
-        scale = getattr(self.args, '{}scale'.format(axis))
-        label = getattr(self.args, '{}label'.format(axis))
-        min_ = getattr(self.args, '{}min'.format(axis))
-        max_ = getattr(self.args, '{}max'.format(axis))
+        scale = getattr(self.args, f'{axis}scale')
+        label = getattr(self.args, f'{axis}label')
+        min_ = getattr(self.args, f'{axis}min')
+        max_ = getattr(self.args, f'{axis}max')
 
         # parse limits
         if (
@@ -582,7 +585,7 @@ class CliProduct(object, metaclass=abc.ABCMeta):
 
         # set label
         if label is None:
-            label = getattr(self, 'get_{}label'.format(axis))()
+            label = getattr(self, f'get_{axis}label')()
         if label:
             if self.usetex:
                 label = label_to_latex(label)
@@ -592,10 +595,13 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         limits = _get('lim')
         scale = _get('scale')
         label = _get('label')
-        self.log(2, '{0}-axis parameters | scale: {1} | '
-                    'limits: {2[0]!s} - {2[1]!s}'.format(
-                        axis.upper(), scale, limits))
-        self.log(3, ('{0}-axis label: {1}'.format(axis.upper(), label)))
+        self.log(
+            2,
+            f'{axis.upper()}-axis parameters | '
+            f'scale: {scale} | '
+            f'limits: {limits[0]!s} - {limits[1]!s}'
+        )
+        self.log(3, (f'{axis.upper()}-axis label: {label}'))
 
     def set_xaxis_properties(self):
         """Set properties for X-axis
@@ -634,7 +640,7 @@ class CliProduct(object, metaclass=abc.ABCMeta):
             title_line = label_to_latex(title_line)
         if title_line:
             self.ax.set_title(title_line, fontsize=12)
-            self.log(3, ('Title is: %s' % title_line))
+            self.log(3, f'Title is: {title_line}')
 
     def set_suptitle(self, suptitle):
         """Set the super title for this plot.
@@ -644,7 +650,7 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         if self.usetex:
             suptitle = label_to_latex(suptitle)
         self.plot.suptitle(suptitle, fontsize=18)
-        self.log(3, ('Super title is: %s' % suptitle))
+        self.log(3, f'Super title is: {suptitle}')
 
     def set_grid(self, enable):
         """Set the grid parameters for this plot.
@@ -661,7 +667,7 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         """Save this product to the target `outfile`.
         """
         self.plot.savefig(outfile, edgecolor='white', bbox_inches='tight')
-        self.log(3, ('wrote %s' % outfile))
+        self.log(3, f'wrote {outfile}')
 
     def has_more_plots(self):
         """Determine whether this product has more plots to be created.
@@ -681,12 +687,12 @@ class CliProduct(object, metaclass=abc.ABCMeta):
     def run(self):
         """Make the plot.
         """
-        self.log(3, ('Verbosity level: %d' % self.verbose))
+        self.log(3, f'Verbosity level: {self.verbose}')
 
         self.log(3, 'Arguments:')
         argsd = vars(self.args)
         for key in sorted(argsd):
-            self.log(3, '{0:>15s} = {1}'.format(key, argsd[key]))
+            self.log(3, f'{key:>15s} = {argsd[key]}')
 
         # grab the data
         self.get_data()
@@ -852,42 +858,42 @@ class FFTMixin(object, metaclass=abc.ABCMeta):
     def _arg_faxis(cls, axis, parser, **defaults):
         defaults.setdefault('scale', 'log')
         axis = axis.lower()
-        name = '{0} axis'.format(axis.title())
-        group = parser.add_argument_group('{0} options'.format(name))
+        name = f'{axis.title()} axis'
+        group = parser.add_argument_group(f'{name} options')
 
         # label
-        group.add_argument('--{0}label'.format(axis),
+        group.add_argument(f'--{axis}label',
                            default=defaults.get('label'),
-                           dest='{0}label'.format(axis),
-                           help='{0} label'.format(name))
+                           dest=f'{axis}label',
+                           help=f'{name} label')
 
         # min and max
         for extrema in ('min', 'max'):
             meg = group.add_mutually_exclusive_group()
             for ax_ in (axis, 'f'):
                 meg.add_argument(
-                    '--{0}{1}'.format(ax_, extrema), type=float,
+                    f'--{ax_}{extrema}', type=float,
                     default=defaults.get(extrema),
-                    dest='{0}{1}'.format(axis, extrema),
-                    help='{0} value for {1}'.format(extrema, name))
+                    dest=f'{axis}{extrema}',
+                    help=f'{extrema} value for {name}')
 
         # scale
         scaleg = group.add_mutually_exclusive_group()
-        scaleg.add_argument('--{0}scale'.format(axis), type=str,
+        scaleg.add_argument(f'--{axis}scale', type=str,
                             default=defaults.get('scale'),
-                            dest='{0}scale'.format(axis),
-                            help='scale for {0}'.format(name))
+                            dest=f'{axis}scale',
+                            help=f'scale for {name}')
         for ax_ in (axis, 'f'):
             if defaults.get('scale') == 'log':
                 scaleg.add_argument(
-                    '--nolog{0}'.format(ax_), action='store_const',
-                    dest='{0}scale'.format(axis), const=None, default='log',
-                    help='use linear {0}'.format(name))
+                    f'--nolog{ax_}', action='store_const',
+                    dest=f'{axis}scale', const=None, default='log',
+                    help=f'use linear {name}')
             else:
                 scaleg.add_argument(
-                    '--log{0}'.format(ax_), action='store_const',
-                    dest='{0}scale'.format(axis), const='log', default=None,
-                    help='use logarithmic {0}'.format(name))
+                    f'--log{ax_}', action='store_const',
+                    dest=f'{axis}scale', const='log', default=None,
+                    help='use logarithmic {name}')
 
         return group
 
@@ -945,8 +951,7 @@ class TimeDomainProduct(CliProduct, metaclass=abc.ABCMeta):
             unit = trans.get_unit_name()
             utc = re.sub(r'\.0+', '',
                          Time(epoch, format='gps', scale='utc').iso)
-            return 'Time ({unit}) from {utc} ({gps})'.format(
-                unit=unit, gps=epoch, utc=utc)
+            return f'Time ({unit}) from {utc} ({epoch})'
         return ''
 
 

--- a/gwpy/cli/coherence.py
+++ b/gwpy/cli/coherence.py
@@ -68,7 +68,7 @@ class Coherence(Spectrum):
     def get_suptitle(self):
         """Start of default super title, first channel is appended to it
         """
-        return 'Coherence: {0}'.format(self.ref_chan)
+        return f'Coherence: {self.ref_chan}'
 
     def make_plot(self):
         """Generate the coherence plot from all time series
@@ -110,7 +110,7 @@ class Coherence(Spectrum):
 
                 label = name
                 if len(self.start_list) > 1:
-                    label += ', {0}'.format(series.epoch.gps)
+                    label += f', {series.epoch.gps}'
                 if self.usetex:
                     label = label_to_latex(label)
 

--- a/gwpy/cli/coherencegram.py
+++ b/gwpy/cli/coherencegram.py
@@ -64,11 +64,12 @@ class Coherencegram(Spectrogram):
     def get_suptitle(self):
         """Start of default super title, first channel is appended to it
         """
-        return "Coherence spectrogram: {0} vs {1}".format(*self.chan_list)
+        a, b = self.chan_list
+        return f"Coherence spectrogram: {a} vs {b}"
 
     def get_color_label(self):
         if self.args.norm:
-            return 'Normalized to {}'.format(self.args.norm)
+            return f'Normalized to {self.args.norm}'
         return 'Coherence'
 
     def get_stride(self):
@@ -84,7 +85,7 @@ class Coherencegram(Spectrogram):
         overlap = args.overlap  # fractional overlap
         stride = self.get_stride()
         self.log(2, "Calculating coherence spectrogram, "
-                    "secpfft: %s, overlap: %s" % (fftlength, overlap))
+                    f"secpfft: {fftlength}, overlap: {overlap}")
 
         if overlap is not None:  # overlap in seconds
             overlap *= fftlength

--- a/gwpy/cli/gwpy_plot.py
+++ b/gwpy/cli/gwpy_plot.py
@@ -46,7 +46,7 @@ PROG_START = time.time()    # verbose enough times major ops
 
 INTERACTIVE = hasattr(sys, 'ps1')
 
-EPILOG = """
+EPILOG = f"""
 Examples:
 
     $ gwpy-plot timeseries --chan H1:GDS-CALIB_STRAIN --start 1126259457
@@ -55,11 +55,9 @@ Examples:
 
     $ gwpy-plot coherencegram --chan H1:GDS-CALIB_STRAIN H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ --start 1126260017 --duration 600
 
-Written by {author}.
+Written by {__author__}.
 Report bugs to https://github.com/gwpy/gwpy/issues/.
-""".format(  # noqa: E501
-    author=__author__,
-)
+"""  # noqa: E501
 
 
 # -- init command line --------------------------------------------------------
@@ -132,11 +130,11 @@ def main(args=None):
     # parse the command line and create a product object
     args = parse_command_line(args=args)
     prod = PRODUCTS[args.mode](args)
-    prod.log(2, ('{0} created'.format(prod.action)))
+    prod.log(2, f'{prod.action} created')
 
     # log how long it took us to get here
     setup_time = time.time() - PROG_START
-    prod.log(2, 'Setup time %.1f sec' % setup_time)
+    prod.log(2, f'Setup time {setup_time:.1f} sec')
 
     # -- generate the plot
     prod.run()
@@ -153,7 +151,7 @@ def main(args=None):
         ax = plot.gca()  # noqa: F841
 
     run_time = time.time() - PROG_START
-    prod.log(1, 'Program run time: %.1f' % run_time)
+    prod.log(1, f'Program run time: {run_time:.1f}')
     if prod.got_error:
         return 2     # make sure when running batch they can test for error
 

--- a/gwpy/cli/qtransform.py
+++ b/gwpy/cli/qtransform.py
@@ -128,9 +128,7 @@ class Qtransform(Spectrogram):
         self.args.tres = search / xpix / 2
         self.log(
             3,
-            'Max time resolution (tres) set to {:.4f}'.format(
-                self.args.tres,
-            ),
+            f'Max time resolution (tres) set to {self.args.tres:.4f}',
         )
 
         args.start = [[int(gps - search/2)]]
@@ -162,14 +160,14 @@ class Qtransform(Spectrogram):
         return 'Normalized energy'
 
     def get_suptitle(self):
-        return 'Q-transform: {0}'.format(self.chan_list[0])
+        return f'Q-transform: {self.chan_list[0]}'
 
     def get_title(self):
         """Default title for plot
         """
         def fformat(x):  # float format
             if isinstance(x, (list, tuple)):
-                return '[{0}]'.format(', '.join(map(fformat, x)))
+                return f"[{', '.join(map(fformat, x))}]"
             if isinstance(x, Quantity):
                 x = x.value
             elif isinstance(x, str):
@@ -179,18 +177,17 @@ class Qtransform(Spectrogram):
                     'in a future release.',
                 )
                 x = float(x)
-            return '{0:.2f}'.format(x)
+            return f'{x:.2f}'
 
         bits = [('Q', fformat(self.result.q))]
-        bits.append(('tres', '{:.3g}'.format(self.qxfrm_args['tres'])))
+        bits.append(('tres', f"{self.qxfrm_args['tres']:.3g}"))
         if self.qxfrm_args.get('qrange'):
             bits.append(('q-range', fformat(self.qxfrm_args['qrange'])))
         if self.qxfrm_args['whiten'] is not None:
             bits.append(('whitened',))
         bits.extend([
             ('f-range', fformat(self.result.yspan)),
-            ('e-range', '[{:.3g}, {:.3g}]'.format(self.result.min(),
-                                                  self.result.max())),
+            ('e-range', f'[{self.result.min():.3g}, {self.result.max():.3g}]'),
         ])
         return ', '.join([': '.join(bit) for bit in bits])
 
@@ -235,9 +232,9 @@ class Qtransform(Spectrogram):
             self.qxfrm_args['search'] = int(len(proc_ts) * proc_ts.dt.value)
 
             self.log(3, 'Q-transform arguments:')
-            self.log(3, '{0:>15s} = {1}'.format('outseg', outseg))
-            for key in sorted(self.qxfrm_args):
-                self.log(3, '{0:>15s} = {1}'.format(key, self.qxfrm_args[key]))
+            self.log(3, f'         outseg = {outseg}')
+            for key, val in sorted(self.qxfrm_args.items()):
+                self.log(3, f'{key:>15s} = {val}')
 
             qtrans = proc_ts.q_transform(outseg=outseg, **self.qxfrm_args)
 
@@ -258,7 +255,10 @@ class Qtransform(Spectrogram):
     def save(self, outdir):  # pylint: disable=arguments-differ
         cname = re.sub('[-_:]', '_', self.timeseries[0].channel.name).replace(
             '_', '-', 1)
-        png = '{0}-{1}-{2}.png'.format(cname, float(self.args.gps),
-                                       self.args.plot[self.plot_num])
+        png = (
+            f'{cname}-'
+            f'{float(self.args.gps)}-'
+            f'{self.args.plot[self.plot_num]}.png'
+        )
         outfile = os.path.join(outdir, png)
         return super().save(outfile)

--- a/gwpy/cli/spectrogram.py
+++ b/gwpy/cli/spectrogram.py
@@ -57,22 +57,22 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
         return 'Frequency (Hz)'
 
     def get_title(self):
-        return 'fftlength={0}, overlap={1}'.format(self.args.secpfft,
-                                                   self.args.overlap)
+        return f'fftlength={self.args.secpfft}, overlap={self.args.overlap}'
 
     def get_suptitle(self):
-        return 'Spectrogram: {0}'.format(self.chan_list[0])
+        return f'Spectrogram: {self.chan_list[0]}'
 
     def get_color_label(self):
         """Text for colorbar label
         """
         if self.args.norm:
-            return 'Normalized to {}'.format(self.args.norm)
+            return f'Normalized to {self.args.norm}'
         if len(self.units) == 1 and self.usetex:
-            return r'ASD $\left({0}\right)$'.format(
-                self.units[0].to_string('latex').strip('$'))
-        elif len(self.units) == 1:
-            return 'ASD ({0})'.format(self.units[0].to_string('generic'))
+            u = self.units[0].to_string('latex').strip('$')
+            return fr'ASD $\left({u}\right)$'
+        if len(self.units) == 1:
+            u = self.units[0].to_string('generic')
+            return f'ASD ({u})'
         return super().get_color_label()
 
     def get_stride(self):
@@ -116,15 +116,20 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
                 window=args.window,
             )
             nfft = stride * (stride // (fftlength - overlap))
-            self.log(3, 'Spectrogram calc, stride: %s, fftlength: %s, '
-                        'overlap: %sf, #fft: %d' % (stride, fftlength,
-                                                    overlap, nfft))
+            self.log(
+                3,
+                f'Spectrogram calc, stride: {stride}, fftlength: {fftlength}, '
+                f'overlap: {overlap}, #fft: {nfft}'
+            )
         else:
             specgram = self.timeseries[0].spectrogram2(
                 fftlength=fftlength, overlap=overlap, window=args.window)
             nfft = specgram.shape[0]
-            self.log(3, 'HR-Spectrogram calc, fftlength: %s, overlap: %s, '
-                        '#fft: %d' % (fftlength, overlap, nfft))
+            self.log(
+                3,
+                f'HR-Spectrogram calc, fftlength: {fftlength}, '
+                f'overlap: {overlap}, #fft: {nfft}'
+            )
 
         return specgram ** (1/2.)   # ASD
 
@@ -138,9 +143,8 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
         inmin = self.timeseries[0].min().value
         if inmin == self.timeseries[0].max().value:
             if not self.got_error:
-                self.log(0, 'ERROR: Input has constant values [{:g}]. '
-                            'Spectrogram-like products cannot process '
-                            'them.'.format(inmin))
+                self.log(0, f'ERROR: Input has constant values [{inmin:g}]. '
+                            'Spectrogram-like products cannot process them.')
             self.got_error = True
         else:
             # create 'raw' spectrogram
@@ -198,7 +202,7 @@ class Spectrogram(FFTMixin, TimeDomainProduct, ImageProduct):
         if imin == 0 and args.color_scale == 'log':
             imin = specgram.value[specgram.value > 0].min()
 
-        self.log(3, ('Colorbar limits set to %f - %f' % (imin, imax)))
+        self.log(3, f'Colorbar limits set to {imin:f} - {imax:f}')
 
         try:
             image = self.ax.images[0]

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -62,22 +62,21 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
         """Text for y-axis label
         """
         if len(self.units) == 1:
-            return r'ASD $\left({0}\right)$'.format(
-                self.units[0].to_string('latex').strip('$'))
+            u = self.units[0].to_string('latex').strip('$')
+            return fr'ASD $\left({u}\right)$'
         return 'ASD'
 
     def get_suptitle(self):
         """Start of default super title, first channel is appended to it
         """
-        return 'Spectrum: {0}'.format(self.chan_list[0])
+        return f'Spectrum: {self.chan_list[0]}'
 
     def get_title(self):
         gps = self.start_list[0]
         utc = Time(gps, format='gps', scale='utc').iso
-        tstr = '{0} | {1} ({2})'.format(utc, gps, self.duration)
+        tstr = f'{utc} | {gps} ({self.duration})'
 
-        fftstr = 'fftlength={0}, overlap={1}'.format(self.args.secpfft,
-                                                     self.args.overlap)
+        fftstr = f'fftlength={self.args.secpfft}, overlap={self.args.overlap}'
 
         return ', '.join([tstr, fftstr])
 
@@ -89,8 +88,10 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
         fftlength = float(args.secpfft)
         overlap = args.overlap
         method = args.method
-        self.log(2, "Calculating spectrum secpfft: {0}, overlap: {1}".format(
-            fftlength, overlap))
+        self.log(
+            2,
+            f"Calculating spectrum secpfft: {fftlength}, overlap: {overlap}",
+        )
         overlap *= fftlength
 
         # create plot
@@ -106,10 +107,8 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
             warnings.warn(
                 'The number of legends specified must match the number of '
                 'time series (channels * start times). '
-                'There are {:d} series and {:d} legends'.format(
-                    len(self.timeseries),
-                    len(self.args.legend),
-                ),
+                f'There are {len(self.timeseries)} series '
+                f'and {len(self.args.legend)} legends'
             )
             nlegargs = 0  # don't use  themm
 
@@ -120,7 +119,7 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
             else:
                 label = series.channel.name
                 if len(self.start_list) > 1:
-                    label += ', {0}'.format(series.epoch.gps)
+                    label += f', {series.epoch.gps}'
 
             asd = series.asd(
                 fftlength=fftlength,

--- a/gwpy/cli/tests/test_coherence.py
+++ b/gwpy/cli/tests/test_coherence.py
@@ -36,5 +36,4 @@ class TestCliCoherence(_TestCliSpectrum):
         assert prod.ref_chan == prod.chan_list[0]
 
     def test_get_suptitle(self, prod):
-        assert prod.get_suptitle() == 'Coherence: {0}'.format(
-            prod.chan_list[0])
+        assert prod.get_suptitle() == f'Coherence: {prod.chan_list[0]}'

--- a/gwpy/cli/tests/test_coherencegram.py
+++ b/gwpy/cli/tests/test_coherencegram.py
@@ -36,8 +36,10 @@ class TestCliCoherencegram(_TestCliSpectrogram):
         assert prod.args.imax == 1.
 
     def test_get_suptitle(self, prod):
-        t = 'Coherence spectrogram: {0} vs {1}'.format(*prod.chan_list)
-        assert prod.get_suptitle() == t
+        assert prod.get_suptitle() == (
+            'Coherence spectrogram: '
+            f'{prod.chan_list[0]} vs {prod.chan_list[1]}'
+        )
 
     def test_init(self, prod):
         assert prod.chan_list == ['X1:TEST-CHANNEL', 'Y1:TEST-CHANNEL']

--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -55,19 +55,18 @@ class TestCliQtransform(_TestCliSpectrogram):
         _float_reg = r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?"
         title_reg = re.compile(
             r"\A"
-            r"q: {float}, "
-            r"tres: {float}, "
+            fr"q: {_float_reg}, "
+            fr"tres: {_float_reg}, "
             r"whitened, "
-            r"f-range: \[{float}, {float}\], "
-            r"e-range: \[{float}, {float}\]"
-            r"\Z".format(float=_float_reg),
+            fr"f-range: \[{_float_reg}, {_float_reg}\], "
+            fr"e-range: \[{_float_reg}, {_float_reg}\]"
+            r"\Z",
             re.I,
         )
         assert title_reg.match(dataprod.get_title())
 
     def test_get_suptitle(self, prod):
-        assert prod.get_suptitle() == 'Q-transform: {0}'.format(
-            prod.chan_list[0])
+        assert prod.get_suptitle() == f'Q-transform: {prod.chan_list[0]}'
 
     @skip_missing_dependency('nds2')
     def test_run(self, prod):

--- a/gwpy/cli/tests/test_spectrogram.py
+++ b/gwpy/cli/tests/test_spectrogram.py
@@ -39,10 +39,9 @@ class TestCliSpectrogram(_TestFFTMixin, _TestTimeDomainProduct,
 
     def test_get_title(self, prod):
         assert prod.get_title() == ', '.join([
-            'fftlength={0}'.format(prod.args.secpfft),
-            'overlap={0}'.format(prod.args.overlap),
+            f'fftlength={prod.args.secpfft}',
+            f'overlap={prod.args.overlap}',
         ])
 
     def test_get_suptitle(self, prod):
-        assert prod.get_suptitle() == 'Spectrogram: {0}'.format(
-            prod.chan_list[0])
+        assert prod.get_suptitle() == f'Spectrogram: {prod.chan_list[0]}'

--- a/gwpy/cli/tests/test_spectrum.py
+++ b/gwpy/cli/tests/test_spectrum.py
@@ -33,12 +33,11 @@ class TestCliSpectrum(_TestFrequencyDomainProduct):
         epoch = prod.start_list[0]
         utc = Time(epoch, format='gps', scale='utc').iso
         t = ', '.join([
-            '{0} | {1} ({2})'.format(utc, epoch, prod.duration),
-            'fftlength={0}'.format(prod.args.secpfft),
-            'overlap={0}'.format(prod.args.overlap),
+            f'{utc} | {epoch} ({prod.duration})',
+            f'fftlength={prod.args.secpfft}',
+            f'overlap={prod.args.overlap}',
         ])
         assert prod.get_title() == t
 
     def test_get_suptitle(self, prod):
-        assert prod.get_suptitle() == 'Spectrum: {0}'.format(
-            prod.chan_list[0])
+        assert prod.get_suptitle() == f'Spectrum: {prod.chan_list[0]}'

--- a/gwpy/cli/tests/test_timeseries.py
+++ b/gwpy/cli/tests/test_timeseries.py
@@ -29,10 +29,8 @@ class TestCliTimeSeries(_TestTimeDomainProduct):
 
     def test_get_title(self, prod):
         update_namespace(prod.args, highpass=10, lowpass=100)
-        t = 'Fs: (), duration: {0}, band pass (10.0-100.0)'.format(
-            prod.args.duration)
+        t = f'Fs: (), duration: {prod.args.duration}, band pass (10.0-100.0)'
         assert prod.get_title() == t
 
     def test_get_suptitle(self, prod):
-        assert prod.get_suptitle() == 'Time series: {0}'.format(
-            prod.chan_list[0])
+        assert prod.get_suptitle() == f'Time series: {prod.chan_list[0]}'

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -49,16 +49,16 @@ class TimeSeries(TimeDomainProduct):
     def get_suptitle(self):
         """Start of default super title, first channel is appended to it
         """
-        return 'Time series: {0}'.format(self.chan_list[0])
+        return f'Time series: {self.chan_list[0]}'
 
     def get_title(self):
         suffix = super().get_title()
         # limit significant digits for minute trends
         rates = {ts.sample_rate.round(3) for ts in self.timeseries}
-        fss = '({0})'.format('), ('.join(map(str, rates)))
+        fss = f"({'), ('.join(map(str, rates))})"
         return ', '.join([
-            'Fs: {0}'.format(fss),
-            'duration: {0}'.format(self.duration),
+            f'Fs: {fss}',
+            f'duration: {self.duration}',
             suffix,
         ])
 
@@ -77,10 +77,8 @@ class TimeSeries(TimeDomainProduct):
             warnings.warn(
                 'The number of legends specified must match the number of '
                 'time series (channels * start times). '
-                'There are {:d} series and {:d} legends'.format(
-                    len(self.timeseries),
-                    len(self.args.legend),
-                ),
+                f'There are {len(self.timeseries)} series '
+                f'and {len(self.args.legend)} legends'
             )
             nlegargs = 0    # don't use  them
 


### PR DESCRIPTION
This PR updates the `gwpy.cli` module to use [f-strings](https://www.python.org/dev/peps/pep-0498/) for all string formatting, instead of a mix of `str.format` and `%`-formatting.

I think f-strings are a nice, readable way to do most of this formatting, and normally result in shorter statements.