### PR TITLE
Use f-strings for string formatting in gwpy.detector

### DIFF
--- a/gwpy/detector/__init__.py
+++ b/gwpy/detector/__init__.py
@@ -51,7 +51,7 @@ def get_timezone(ifo):
     try:
         return TIMEZONE[ifo]
     except KeyError as exc:
-        exc.args = ('No time-zone information for %r detector' % ifo,)
+        exc.args = (f'No time-zone information for {ifo!r} detector',)
         raise
 
 

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -140,7 +140,7 @@ class Channel(object):
                 try:
                     setattr(self, key, val)
                 except AttributeError:
-                    setattr(self, '_%s' % key, val)
+                    setattr(self, f'_{key}', val)
 
     # -- properties -----------------------------
 
@@ -312,7 +312,7 @@ class Channel(object):
                 url = urlparse(href)
                 assert url.scheme in ('http', 'https', 'file')
             except (AttributeError, ValueError, AssertionError):
-                raise ValueError("Invalid URL %r" % href)
+                raise ValueError(f"Invalid URL {href!r}")
             self._url = href
 
     @property
@@ -393,7 +393,7 @@ class Channel(object):
         """Name of this channel as stored in the NDS database
         """
         if self.type not in [None, 'raw', 'reduced', 'online']:
-            return '%s,%s' % (self.name, self.type)
+            return f'{self.name},{self.type}'
         return self.name
 
     # -- classmethods ---------------------------
@@ -421,11 +421,13 @@ class Channel(object):
         """
         channellist = ChannelList.query(name, kerberos=kerberos)
         if not channellist:
-            raise ValueError("No channels found matching '%s'" % name)
+            raise ValueError(f"No channels found matching '{name}'")
         if len(channellist) > 1:
-            raise ValueError("%d channels found matching '%s', please refine "
-                             "search, or use `ChannelList.query` to return "
-                             "all results" % (len(channellist), name))
+            raise ValueError(
+                f"{len(channellist)} channels found matching '{name}', "
+                "please refine search, or use `ChannelList.query` to "
+                "return all results"
+            )
         return channellist[0]
 
     @classmethod
@@ -582,11 +584,11 @@ class Channel(object):
         return self.name
 
     def __repr__(self):
-        repr_ = '<Channel("%s"' % (str(self))
+        repr_ = f'<Channel("{self}"'
         if self.type:
-            repr_ += ' [%s]' % self.type
-        repr_ += ', %s' % self.sample_rate
-        return repr_ + ') at %s>' % hex(id(self))
+            repr_ += f' [{self.type}]'
+        repr_ += f', {self.sample_rate}'
+        return repr_ + f') at {hex(id(self))}>'
 
     def __eq__(self, other):
         for attr in ['name', 'sample_rate', 'unit', 'url', 'type', 'dtype']:
@@ -660,13 +662,13 @@ class ChannelList(list):
             if ',' not in namestr:
                 break
             for nds2type in io_nds2.Nds2ChannelType.nds2names() + ['']:
-                if nds2type and ',%s' % nds2type in namestr:
+                if nds2type and f',{nds2type}' in namestr:
                     try:
                         channel, ctype, namestr = namestr.split(',', 2)
                     except ValueError:
                         channel, ctype = namestr.split(',')
                         namestr = ''
-                    out.append('%s,%s' % (channel, ctype))
+                    out.append(f'{channel},{ctype}')
                     break
                 elif nds2type == '' and ',' in namestr:
                     channel, namestr = namestr.split(',', 1)
@@ -729,8 +731,8 @@ class ChannelList(list):
         else:
             flags = 0
         if exact_match:
-            name = name if name.startswith(r'\A') else r"\A%s" % name
-            name = name if name.endswith(r'\Z') else r"%s\Z" % name
+            name = name if name.startswith(r'\A') else fr"\A{name}"
+            name = name if name.endswith(r'\Z') else fr"{name}\Z"
         name_regexp = re.compile(name, flags=flags)
 
         matched = list(self)

--- a/gwpy/detector/io/cis.py
+++ b/gwpy/detector/io/cis.py
@@ -51,7 +51,7 @@ def query(name, kerberos=None):
     channel : `~gwpy.detector.Channel`
         Channel with all details as acquired from the CIS
     """
-    url = '%s/?q=%s' % (CIS_API_URL, name)
+    url = f"{CIS_API_URL}/?q={name}"
     more = True
     out = ChannelList()
     while more:

--- a/gwpy/detector/io/clf.py
+++ b/gwpy/detector/io/clf.py
@@ -118,7 +118,7 @@ def read_channel_list_file(*source):
             try:
                 match = CHANNEL_DEFINITION.match(channel).groupdict()
             except AttributeError as exc:
-                exc.args = ('Cannot parse %r as channel list entry' % channel,)
+                exc.args = (f"Cannot parse {channel!r} as channel list entry",)
                 raise
             # remove Nones from match
             match = dict((k, v) for k, v in match.items() if v is not None)
@@ -150,18 +150,17 @@ def write_channel_list_file(channels, fobj):
         for param, value in channel.params.items():
             out.set(group, param, value)
         if channel.sample_rate is not None:
-            entry = '%s %s' % (str(channel),
-                               str(channel.sample_rate.to('Hz').value))
+            entry = f"{channel} {channel.sample_rate.to('Hz').value}"
         else:
             entry = str(channel)
-        entry += ' %s' % channel.params.get('safe', 'safe')
-        entry += ' %s' % channel.params.get('fidelity', 'clean')
+        entry += f" {channel.params.get('safe', 'safe')}"
+        entry += f" {channel.params.get('fidelity', 'clean')}"
         try:
             clist = out.get(group, 'channels')
         except configparser.NoOptionError:
-            out.set(group, 'channels', '\n%s' % entry)
+            out.set(group, 'channels', f'\n{entry}')
         else:
-            out.set(group, 'channels', clist + '\n%s' % entry)
+            out.set(group, 'channels', clist + f'\n{entry}')
 
     out.write(fobj)
 

--- a/gwpy/detector/io/omega.py
+++ b/gwpy/detector/io/omega.py
@@ -67,7 +67,7 @@ def read_omega_scan_config(source):
             append(parse_omega_channel(source, section))
         else:
             raise RuntimeError(
-                "Failed to parse Omega config line: {!r}".format(line),
+                f"Failed to parse Omega config line: {line!r}",
             )
     return out
 
@@ -135,7 +135,7 @@ def write_omega_scan_config(channellist, fobj, header=True):
         # print header
         if channel.group != group:
             group = channel.group
-            print('\n[%s]' % group, file=fobj)
+            print(f'\n[{group}]', file=fobj)
         print("", file=fobj)
         print_omega_channel(channel, file=fobj)
 
@@ -166,16 +166,16 @@ def print_omega_channel(channel, file=sys.stdout):
     # write params
     for key in ['channelName', 'frameType']:
         if key not in params:
-            raise KeyError("No %r defined for %s" % (key, str(channel)))
+            raise KeyError(f"No {key!r} defined for {channel}")
     for key, value in params.items():
-        key = '%s:' % str(key)
+        key = f'{key}:'
         if isinstance(value, tuple):
-            value = '[%s]' % ' '.join(map(str, value))
+            value = f"[{' '.join(map(str, value))}]"
         elif isinstance(value, float) and value.is_integer():
             value = int(value)
         elif isinstance(value, str):
             value = repr(value)
-        print('  {0: <30}  {1}'.format(key, value), file=file)
+        print(f'  {key: <30}  {value}', file=file)
     print('}', file=file)
 
 

--- a/gwpy/detector/tests/test_channel.py
+++ b/gwpy/detector/tests/test_channel.py
@@ -177,7 +177,7 @@ class TestChannel(object):
         if type_ == 'RAISE':  # check invalid raises correct exception
             with pytest.raises(ValueError) as exc:
                 c = self.TEST_CLASS('', type=arg)
-            assert str(exc.value) == '%r is not a valid Nds2ChannelType' % arg
+            assert str(exc.value) == f'{arg!r} is not a valid Nds2ChannelType'
         else:
             c = self.TEST_CLASS('', type=arg)
             assert getattr(c, 'type') == type_
@@ -206,7 +206,7 @@ class TestChannel(object):
         if url is not None and not str(url).startswith(('http', 'file')):
             with pytest.raises(ValueError) as exc:
                 new = self.TEST_CLASS('test', url=url)
-            assert str(exc.value) == "Invalid URL %r" % url
+            assert str(exc.value) == f"Invalid URL {url!r}"
         else:
             new = self.TEST_CLASS('test', url=url)
             assert new.url == url
@@ -331,7 +331,7 @@ class TestChannel(object):
             results = []
 
         # mock response and test parsing
-        url = "https://cis.ligo.org/api/channel/?q={}".format(name)
+        url = f"https://cis.ligo.org/api/channel/?q={name}"
         with requests_mock.Mocker() as rmock:
             # mock the request to get the list of IdPs
             from ciecplib.utils import DEFAULT_IDPLIST_URL
@@ -352,7 +352,7 @@ class TestChannel(object):
             else:
                 with pytest.raises(ValueError) as exc:
                     self.TEST_CLASS.query(name, kerberos=True)
-                assert str(exc.value) == 'No channels found matching %r' % name
+                assert str(exc.value) == f'No channels found matching {name!r}'
 
     @pytest.mark.parametrize('name', ('X1:TEST-CHANNEL', 'Y1:TEST_CHANNEL'))
     @utils.skip_missing_dependency('nds2')

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -81,9 +81,9 @@ class GWpyFormat(Generic):
             else:
                 if cls.warn:
                     warnings.warn(
-                        '{0} Mathematical operations using this unit should '
-                        'work, but conversions to other units will '
-                        'not.'.format(str(exc).rstrip(' ')),
+                        f"{str(exc).rstrip(' ')} Mathematical operations "
+                        "using this unit should work, but conversions to "
+                        "other units will not.",
                         category=units.UnitsWarning)
                 try:  # return previously created unit
                     return UNRECOGNIZED_UNITS[name]


### PR DESCRIPTION
This PR updates the `gwpy.detector` module to use [f-strings](https://www.python.org/dev/peps/pep-0498/) for all string formatting, instead of a mix of `str.format` and `%`-formatting.