### PR TITLE
Use f-strings for string formatting in gwpy.frequencyseries

### DIFF
--- a/gwpy/frequencyseries/_fdcommon.py
+++ b/gwpy/frequencyseries/_fdcommon.py
@@ -43,8 +43,10 @@ def fdfilter(data, *filt, **kwargs):
     analog = kwargs.pop('analog', False)
     fs = kwargs.pop('sample_rate', None)
     if kwargs:
-        raise TypeError("filter() got an unexpected keyword argument '%s'"
-                        % list(kwargs.keys())[0])
+        raise TypeError(
+            "filter() got an unexpected keyword argument "
+            f"'{list(kwargs).pop()}'"
+        )
 
     # parse filter
     if fs is None:

--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -379,8 +379,8 @@ class FrequencySeries(Series):
         # map unit
         try:
             unit = to_lal_unit(self.unit)
-        except ValueError as e:
-            warnings.warn("%s, defaulting to lal.DimensionlessUnit" % str(e))
+        except ValueError as exc:
+            warnings.warn(f"{exc}, defaulting to lal.DimensionlessUnit")
             unit = lal.DimensionlessUnit
 
         # convert epoch

--- a/gwpy/frequencyseries/hist.py
+++ b/gwpy/frequencyseries/hist.py
@@ -145,7 +145,8 @@ class SpectralVariance(Array2D):
     @property
     def T(self):
         raise NotImplementedError(
-            "transposing a {0} is not supported".format(type(self).__name__))
+            f"transposing a {type(self).__name__} is not supported",
+        )
 
     # -- i/O ------------------------------------
 
@@ -308,7 +309,7 @@ class SpectralVariance(Array2D):
                 out[i, :] /= out[i, :].sum()
 
         # return SpectralVariance
-        name = '%s variance' % spectrogram.name
+        name = f"{spectrogram.name} variance"
         new = cls(out, qbins, epoch=spectrogram.epoch, name=name,
                   channel=spectrogram.channel, f0=spectrogram.f0,
                   df=spectrogram.df)
@@ -340,14 +341,16 @@ class SpectralVariance(Array2D):
             val = self.bins[minindex]
             out[i] = val
 
-        name = '%s %s%% percentile' % (self.name, percentile)
+        name = f"{self.name} {percentile}% percentile"
         return FrequencySeries(out, epoch=self.epoch, channel=self.channel,
                                frequencies=self.bins[:-1], name=name)
 
     def plot(self, xscale='log', method='pcolormesh', **kwargs):
         if method == 'imshow':
-            raise TypeError("plotting a {0} with {1}() is not "
-                            "supported".format(type(self).__name__, method))
+            raise TypeError(
+                f"plotting a {type(self).__name__} with {method}() is not "
+                "supported"
+            )
         bins = self.bins.value
         if (
             numpy.all(bins > 0)


### PR DESCRIPTION
This PR updates the `gwpy.frequencyseries` module to use [f-strings](https://www.python.org/dev/peps/pep-0498/) for all string formatting, instead of a mix of `str.format` and `%`-formatting.