### PR TITLE
Use f-strings for string formatting in gwpy.io

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -64,7 +64,7 @@ def _preformat_entry(entry):
 
 def _format_entry_lal(entry):
     path, obs, tag, seg = _preformat_entry(entry)
-    return "{} {} {} {} {}".format(obs, tag, seg[0], abs(seg), path)
+    return f"{obs} {tag} {seg[0]} {abs(seg)} {path}"
 
 
 def _parse_entry_lal(line, gpstype=LIGOTimeGPS):
@@ -77,7 +77,7 @@ def _parse_entry_lal(line, gpstype=LIGOTimeGPS):
 
 def _format_entry_ffl(entry):
     path, obs, tag, seg = _preformat_entry(entry)
-    return "{} {} {} 0 0".format(path, seg[0], abs(seg))
+    return f"{path} {seg[0]} {abs(seg)} 0 0"
 
 
 def _parse_entry_ffl(line, gpstype=LIGOTimeGPS):
@@ -121,8 +121,9 @@ class _CacheEntry(namedtuple(
                 return _parse_entry_lal(parts, gpstype=gpstype)
             except ValueError:
                 pass
-            exc.args = ("Cannot identify format for cache entry {!r}".format(
-                line.strip()),)
+            exc.args = (
+                f"Cannot identify format for cache entry {line.strip()!r}",
+            )
             raise
 
 
@@ -256,14 +257,14 @@ def write_cache(cache, fobj, format=None):
     elif format.lower() == "ffl":
         formatter = _format_entry_ffl
     else:
-        raise ValueError("Unrecognised cache format {!r}".format(format))
+        raise ValueError(f"Unrecognised cache format {format!r}")
 
     # write file
     for line in map(formatter, cache):
         try:
             print(line, file=fobj)
         except TypeError:  # bytes-mode
-            fobj.write("{}\n".format(line).encode("utf-8"))
+            fobj.write(f"{line}\n".encode("utf-8"))
 
 
 def is_cache(cache):
@@ -368,8 +369,9 @@ def filename_metadata(filename):
     try:
         obs, desc, start, dur = name.split('-')
     except ValueError as exc:
-        exc.args = ('Failed to parse {!r} as LIGO-T050017-compatible '
-                    'filename'.format(name),)
+        exc.args = (
+            f'Failed to parse {name!r} as a LIGO-T050017-compatible filename',
+        )
         raise
     start = float(start)
     dur = dur.rsplit('.', 1)[0]

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -99,7 +99,7 @@ class FflConnection(object):
 
     @classmethod
     def _is_ffl_file(cls, path):
-        return path.endswith('.{0}'.format(cls._EXTENSION))
+        return path.endswith(f".{cls._EXTENSION}")
 
     def _find_paths(self):
         _is_ffl = self._is_ffl_file
@@ -220,7 +220,7 @@ class FflConnection(object):
             return urls
 
         # handle missing data
-        msg = 'Missing segments: \n{0}'.format('\n'.join(map(str, missing)))
+        msg = "Missing segments: \n" + "\n".join(map(str, missing))
         if on_gaps == 'warn':
             warnings.warn(msg)
             return urls
@@ -363,8 +363,10 @@ def _parse_ifos_and_trends(chans):
         try:
             found.add((chan.ifo[0], chan.type))
         except TypeError:  # chan.ifo is None
-            raise ValueError("Cannot parse interferometer prefix from channel "
-                             "name %r, cannot proceed with find()" % str(chan))
+            raise ValueError(
+                "Cannot parse interferometer prefix from channel name "
+                f"'{chan}', cannot proceed with find()",
+            )
     return found
 
 
@@ -400,8 +402,8 @@ def _error_missing_channels(required, found, gpstime, allow_tape):
     # failure
     msg = "Cannot locate the following channel(s) in any known frametype"
     if gpstime:
-        msg += " at GPS=%d" % gpstime
-    msg += ":\n    {}".format('\n    '.join(missing))
+        msg += f" at GPS={gpstime}"
+    msg += ":\n    " + "\n    ".join(missing)
     if not allow_tape:
         msg += ("\n[files on tape have not been checked, use "
                 "allow_tape=True for a complete search]")
@@ -579,10 +581,7 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
                             break
             except RuntimeError as exc:  # failed to open file (probably)
                 warnings.warn(
-                    "failed to read channels for type {!r}: {}:".format(
-                        ftype,
-                        str(exc),
-                    ),
+                    f"failed to read channels for type {ftype!r}: {exc}:",
                 )
                 continue
 
@@ -730,12 +729,12 @@ def find_latest(observatory, frametype, gpstime=None, allow_tape=False,
             path = connection.find_latest(observatory, frametype,
                                           on_missing='ignore')[-1]
     except (IndexError, RuntimeError):
-        raise RuntimeError(
-            "no files found for {}-{}".format(observatory, frametype))
+        raise RuntimeError(f"no files found for {observatory}-{frametype}")
 
     path = file_path(path)
     if not allow_tape and on_tape(path):
-        raise IOError("Latest frame file for {}-{} is on tape "
-                      "(pass allow_tape=True to force): "
-                      "{}".format(observatory, frametype, path))
+        raise IOError(
+            f"Latest frame file for {observatory}-{frametype} is on tape "
+            f"(pass allow_tape=True to force): {path}",
+        )
     return path

--- a/gwpy/io/gwf.py
+++ b/gwpy/io/gwf.py
@@ -470,8 +470,9 @@ def get_channel_type(channel, framefile):
     for name, type_ in _iter_channels(framefile):
         if channel == name:
             return type_
-    raise ValueError("%s not found in table-of-contents for %s"
-                     % (channel, framefile))
+    raise ValueError(
+        f"'{channel}' not found in table-of-contents for {framefile}",
+    )
 
 
 def channel_in_frame(channel, framefile):
@@ -559,7 +560,7 @@ def _iter_channels(framefile):
     toc = framefile.GetTOC()
     for typename in ('Sim', 'Proc', 'ADC'):
         typen = typename.lower()
-        for name in getattr(toc, 'Get{0}'.format(typename))():
+        for name in getattr(toc, f"Get{typename}")():
             yield name, typen
 
 
@@ -604,7 +605,7 @@ def _gwf_channel_segments(path, channel, warn=True):
     nano = toc.GetGTimeN()
     dur = toc.GetDt()
 
-    readers = [getattr(stream, 'ReadFr{0}Data'.format(type_.title())) for
+    readers = [getattr(stream, f"ReadFr{type_.title()}Data") for
                type_ in ("proc", "sim", "adc")]
 
     # for each segment, try and read the data for this channel
@@ -621,8 +622,7 @@ def _gwf_channel_segments(path, channel, warn=True):
         else:  # none of the readers worked for this channel, warn
             if warn:
                 warnings.warn(
-                    "{0!r} not found in frame {1} of {2}".format(
-                        channel, i, path),
+                    f"'{channel}' not found in frame {i} of {path}",
                 )
 
 

--- a/gwpy/io/hdf5.py
+++ b/gwpy/io/hdf5.py
@@ -121,7 +121,7 @@ def with_write_hdf5(func):
             append = kwargs.get('append', False)
             overwrite = kwargs.get('overwrite', False)
             if os.path.exists(fobj) and not (overwrite or append):
-                raise IOError("File exists: %s" % fobj)
+                raise IOError(f"File exists: {fobj}")
             with h5py.File(fobj, 'a' if append else 'w') as h5f:
                 return func(obj, h5f, *args, **kwargs)
         return func(obj, fobj, *args, **kwargs)
@@ -162,6 +162,8 @@ def create_dataset(parent, path, overwrite=False, **kwargs):
         return parent.create_dataset(path, **kwargs)
     except RuntimeError as exc:
         if str(exc) == 'Unable to create link (Name already exists)':
-            exc.args = ('{0}: {1!r}, pass overwrite=True '
-                        'to ignore existing datasets'.format(str(exc), path),)
+            exc.args = (
+                f"{exc}: '{path}', pass overwrite=True to ignore "
+                f"existing datasets",
+            )
         raise

--- a/gwpy/io/kerberos.py
+++ b/gwpy/io/kerberos.py
@@ -146,12 +146,13 @@ def kinit(
         realm = 'LIGO.ORG'
     if username is None:
         verbose = True
-        username = input("Please provide username for the {} kerberos "
-                         "realm: ".format(realm))
-    identity = '{}@{}'.format(username, realm)
+        username = input(
+            f"Please provide username for the {realm} kerberos realm: ",
+        )
+    identity = f"{username}@{realm}"
     if not keytab and password is None:
         verbose = True
-        password = getpass.getpass(prompt="Password for {}: ".format(identity))
+        password = getpass.getpass(prompt=f"Password for {identity}: ")
 
     # format kinit command
     if keytab:
@@ -173,7 +174,7 @@ def kinit(
     if retcode:
         raise subprocess.CalledProcessError(kget.returncode, ' '.join(cmd))
     if verbose:
-        print("Kerberos ticket generated for {}".format(identity))
+        print(f"Kerberos ticket generated for {identity}")
 
 
 def parse_keytab(keytab):
@@ -203,7 +204,7 @@ def parse_keytab(keytab):
     except OSError:
         raise KerberosError("Failed to locate klist, cannot read keytab")
     except subprocess.CalledProcessError:
-        raise KerberosError("Cannot read keytab {!r}".format(keytab))
+        raise KerberosError(f"Cannot read keytab '{keytab}'")
     principals = []
     for line in out.splitlines():
         if isinstance(line, bytes):

--- a/gwpy/io/ligolw.py
+++ b/gwpy/io/ligolw.py
@@ -67,7 +67,7 @@ _compat_errors = {
     r"invalid Column \'event_id'",
     r"invalid type \'ilwd:char\'"
 }
-LIGO_LW_COMPAT_ERROR = re.compile("({})".format("|".join(_compat_errors)))
+LIGO_LW_COMPAT_ERROR = re.compile(f"({'|'.join(_compat_errors)})")
 
 
 # -- import hackery to support ligo.lw and glue.ligolw concurrently -----------
@@ -410,11 +410,12 @@ def read_table(source, tablename=None, columns=None, contenthandler=None,
         if not tables:
             raise ValueError("No tables found in LIGO_LW document(s)")
         if len(tables) > 1:
-            tlist = "'{}'".format("', '".join(tables))
-            raise ValueError("Multiple tables found in LIGO_LW document(s), "
-                             "please specify the table to read via the "
-                             "``tablename=`` keyword argument. The following "
-                             "tables were found: {}".format(tlist))
+            raise ValueError(
+                "Multiple tables found in LIGO_LW document(s), please specify "
+                "the table to read via the ``tablename=`` keyword argument. "
+                "The following tables were found: "
+                "'{}'".format("', '".join(tables)),
+            )
         tableclass = lsctables.TableByName[table.Table.TableName(tables[0])]
 
     # extract table
@@ -574,7 +575,7 @@ def write_tables(target, tables, append=False, overwrite=False, **kwargs):
         and isinstance(target, (str, os.PathLike))
         and os.path.exists(target)
     ):
-        raise IOError("File exists: {}".format(target))
+        raise IOError(f"File exists: {target}")
     else:  # or create a new document
         xmldoc = Document()
 
@@ -717,8 +718,9 @@ def _to_ilwd(value, tablename, colname):
     from ligo.lw._ilwd import ilwdchar as IlwdChar
 
     if isinstance(value, IlwdChar) and value.column_name != colname:
-        raise ValueError("ilwdchar '{0!s}' doesn't match column "
-                         "{1!r}".format(value, colname))
+        raise ValueError(
+            f"ilwdchar '{value!s}' doesn't match column {colname!r}",
+        )
     if isinstance(value, IlwdChar):
         return value
     if isinstance(value, Integral):

--- a/gwpy/io/mp.py
+++ b/gwpy/io/mp.py
@@ -70,9 +70,7 @@ def read_multi(flatten, cls, source, *args, **kwargs):
 
     # raise IndexError early when reading from empty cache
     if not files:
-        raise IndexError(
-            "cannot read {} from empty source list".format(cls.__name__),
-        )
+        raise IndexError(f"cannot read {cls.__name__} from empty source list")
 
     # determine input format (so we don't have to do it multiple times)
     if kwargs.get('format', None) is None:
@@ -83,7 +81,7 @@ def read_multi(flatten, cls, source, *args, **kwargs):
 
     # format verbosity
     if verbose is True:
-        verbose = 'Reading ({})'.format(kwargs['format'])
+        verbose = f"Reading ({format})"
 
     # bundle inputs
     inputs = [(f, cls, nproc, args, kwargs) for f in files]
@@ -95,7 +93,7 @@ def read_multi(flatten, cls, source, *args, **kwargs):
     # raise exceptions (from multiprocessing, single process raises inline)
     for fobj, exc in output:
         if isinstance(exc, Exception):
-            exc.args = ('Failed to read %s: %s' % (fobj, str(exc)),)
+            exc.args = (f"Failed to read {fobj}: {exc}",)
             raise exc
 
     # return combined object

--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -130,7 +130,7 @@ class _Nds2Enum(enum.IntFlag):
         """DEPRECATED: see ``.nds2names()``
         """
         warnings.warn(
-            "{0}.names has been renamed {0}.nds2names".format(cls.__name__),
+            f"{cls.__name__}.names has been renamed {cls.__name__}.nds2names",
             DeprecationWarning,
         )
         return cls.nds2names()
@@ -153,7 +153,7 @@ class _Nds2Enum(enum.IntFlag):
                     return item
         # bail out
         raise ValueError(
-            "{!r} is not a valid {}".format(name, cls.__name__),
+            f"'{name}' is not a valid {cls.__name__}",
         )
 
 
@@ -195,8 +195,10 @@ def _get_nds2_name(channel):
     if hasattr(channel, 'ndsname'):  # gwpy.detector.Channel
         return channel.ndsname
     if hasattr(channel, 'channel_type'):  # nds2.channel
-        return '%s,%s' % (channel.name,
-                          channel.channel_type_to_string(channel.channel_type))
+        return ",".join((
+            channel.name,
+            channel.channel_type_to_string(channel.channel_type),
+        ))
     return str(channel)
 
 
@@ -280,7 +282,7 @@ def host_resolution_order(ifo, env='NDSSERVER', epoch='now',
             # hosts already defined (either by NDSSERVER or similar)
             # we should warn the user
             if not hosts:
-                warnings.warn('No default host found for ifo %r' % ifo)
+                warnings.warn(f"No default host found for ifo '{ifo}'")
         else:
             if (host, port) not in hosts:
                 hosts.append((host, port))
@@ -339,8 +341,7 @@ def auth_connect(host, port=None):
     except RuntimeError as exc:
         if 'Request SASL authentication' not in str(exc):
             raise
-    warnings.warn('Error authenticating against {0}:{1}'.format(host, port),
-                  NDSWarning)
+    warnings.warn(f"Error authenticating against {host}:{port}", NDSWarning)
     kinit()
     return connect(host, port)
 
@@ -524,8 +525,7 @@ def _find_channel(connection, name, ctype, dtype, sample_rate, unique=False):
 
     # if not unique result, panic
     if len(found) != 1:
-        raise ValueError("unique NDS2 channel match not found for %r"
-                         % name)
+        raise ValueError(f"unique NDS2 channel match not found for '{name}'")
 
     return found
 
@@ -548,7 +548,7 @@ def _strip_ctype(name, ctype, protocol=2):
                 Nds2ChannelType.STREND.value,
                 Nds2ChannelType.MTREND.value
         ):
-            name += ',{0}'.format(ctypestr)
+            name += f',{ctypestr}'
     return name, ctype
 
 

--- a/gwpy/io/tests/test_cache.py
+++ b/gwpy/io/tests/test_cache.py
@@ -38,8 +38,8 @@ SEGMENTS = SegmentList(map(Segment, [
     (1, 2),
     (4, 5),
 ]))
-CACHE = [os.path.join('tmp', 'A-B-%d-%d.tmp' % (seg[0], seg[1] - seg[0])) for
-         seg in SEGMENTS]
+CACHE = [os.path.join("tmp", f"A-B-{seg[0]}-{seg[1]-seg[0]}.tmp")
+         for seg in SEGMENTS]
 
 
 # -- fixtures -----------------------------------------------------------------
@@ -60,11 +60,11 @@ def segments():
     (None, CACHE[0]),
     pytest.param(
         "lal",
-        "A B {0[0]} {1} {2}".format(SEGMENTS[0], abs(SEGMENTS[0]), CACHE[0]),
+        f"A B {SEGMENTS[0][0]} {abs(SEGMENTS[0])} {CACHE[0]}",
         id="lal"),
     pytest.param(
         "ffl",
-        "{0} {1[0]} {2} 0 0".format(CACHE[0], SEGMENTS[0], abs(SEGMENTS[0])),
+        f"{CACHE[0]} {SEGMENTS[0][0]} {abs(SEGMENTS[0])} 0 0",
         id="ffl"),
 ])
 def test_read_write_cache(cache, tmp_path, format, entry1):
@@ -104,10 +104,8 @@ def test_write_cache_cacheentry(cache, tmp_path):
 
     # check first line looks like a LAL-format cache entry
     with tmp.open("r") as tmpf:
-        assert tmpf.readline().strip() == "A B {0[0]} {1} {2}".format(
-            SEGMENTS[0],
-            abs(SEGMENTS[0]),
-            CACHE[0],
+        assert tmpf.readline().strip() == (
+            f"A B {SEGMENTS[0][0]} {abs(SEGMENTS[0])} {CACHE[0]}"
         )
 
     # read from file name
@@ -228,8 +226,9 @@ def test_file_segment():
     # test errors
     with pytest.raises(ValueError) as exc:
         io_cache.file_segment('blah')
-    assert str(exc.value) == ('Failed to parse \'blah\' as '
-                              'LIGO-T050017-compatible filename')
+    assert str(exc.value) == (
+        "Failed to parse 'blah' as a LIGO-T050017-compatible filename"
+    )
 
 
 def test_flatten(cache):

--- a/gwpy/io/tests/test_gwf.py
+++ b/gwpy/io/tests/test_gwf.py
@@ -111,8 +111,8 @@ def test_get_channel_type():
     with pytest.raises(ValueError) as exc:
         io_gwf.get_channel_type('X1:NOT-IN_FRAME', TEST_GWF_FILE)
     assert str(exc.value) == (
-        'X1:NOT-IN_FRAME not found in table-of-contents for {gwf}'.format(
-            gwf=TEST_GWF_FILE))
+        f"'X1:NOT-IN_FRAME' not found in table-of-contents for {TEST_GWF_FILE}"
+    )
 
 
 @skip_missing_dependency('LDAStools.frameCPP')

--- a/gwpy/io/tests/test_ligolw.py
+++ b/gwpy/io/tests/test_ligolw.py
@@ -50,7 +50,7 @@ parametrize_ilwdchar_compat = pytest.mark.parametrize("ilwdchar_compat", [
     params=[
         pytest.param(
             lib,
-            marks=skip_missing_dependency("{}.lsctables".format(lib)))
+            marks=skip_missing_dependency(f"{lib}.lsctables"))
         for lib in LIGOLW_LIBS
     ],
 )

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -45,8 +45,8 @@ class _TestNds2Enum(object):
         """
         with pytest.raises(ValueError) as exc:
             self.TEST_CLASS.find('blah')
-        assert str(exc.value) == "'blah' is not a valid {}".format(
-            self.TEST_CLASS.__name__,
+        assert str(exc.value) == (
+            f"'blah' is not a valid {self.TEST_CLASS.__name__}"
         )
 
 

--- a/gwpy/io/tests/test_utils.py
+++ b/gwpy/io/tests/test_utils.py
@@ -47,7 +47,7 @@ def test_gopen(tmp_path):
 
 @pytest.mark.parametrize("suffix", (".txt.gz", ""))
 def test_gopen_gzip(tmp_path, suffix):
-    tmp = tmp_path / "test{}".format(suffix)
+    tmp = tmp_path / f"test{suffix}"
     text = b'blah blah blah'
     with gzip.open(tmp, 'wb') as fobj:
         fobj.write(text)

--- a/gwpy/io/utils.py
+++ b/gwpy/io/utils.py
@@ -197,8 +197,8 @@ def file_list(flist):
         return [file_path(flist)]
     except ValueError as exc:
         exc.args = (
-            "Could not parse input {!r} as one or more "
-            "file-like objects".format(flist),
+            f"Could not parse input {flist!r} as "
+            "one or more file-like objects",
         )
         raise
 
@@ -246,4 +246,4 @@ def file_path(fobj):
     try:
         return fobj.path
     except AttributeError:
-        raise ValueError("Cannot parse file name for {!r}".format(fobj))
+        raise ValueError(f"Cannot parse file name for {fobj!r}")


### PR DESCRIPTION
This PR updates the `gwpy.io` module to use [f-strings](https://www.python.org/dev/peps/pep-0498/) for all string formatting, instead of a mix of `str.format` and `%`-formatting.