### PR TITLE
Use f-strings for string formatting in gwpy.plot

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -181,8 +181,7 @@ class Axes(_Axes):
                 unit = trans.get_unit_name()
                 iso = Time(epoch, format='gps', scale='utc').iso
                 utc = iso.rstrip('0').rstrip('.')
-                ax.set_label_text('Time [{0!s}] from {1!s} UTC ({2!r})'.format(
-                    unit, utc, epoch))
+                ax.set_label_text(f"Time [{unit}] from {utc} UTC ({epoch!r})")
 
         try:
             super().draw(*args, **kwargs)
@@ -538,7 +537,7 @@ class Axes(_Axes):
                 return ((x-w/2., y-h/2.), (x-w/2., y+h/2.),
                         (x+w/2., y+h/2.), (x+w/2., y-h/2.))
         else:
-            raise ValueError("Unrecognised tile anchor {!r}".format(anchor))
+            raise ValueError(f"Unrecognised tile anchor '{anchor}'")
 
         # build collection
         cmap = kwargs.pop('cmap', rcParams['image.cmap'])

--- a/gwpy/plot/colors.py
+++ b/gwpy/plot/colors.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017-2020)
+# Copyright (C) Louisiana State University (2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -52,7 +53,7 @@ GW_OBSERVATORY_COLORS = {_GWO_PREFIX[n]: GWPY_COLORS[n] for n in GWPY_COLORS}
 
 # set named colour upstream in matplotlib, so users can specify as
 # e.g. plot(..., color='gwpy:ligo-hanford')
-color_map.update({'gwpy:{}'.format(n): c for n, c in GWPY_COLORS.items()})
+color_map.update({f"gwpy:{name}": col for name, col in GWPY_COLORS.items()})
 
 
 # -- colour utilities ---------------------------------------------------------
@@ -91,7 +92,7 @@ def format_norm(kwargs, current=None):
     elif norm == 'log':
         norm = colors.LogNorm()
     elif not isinstance(norm, colors.Normalize):
-        raise ValueError("unrecognised value for norm {!r}".format(norm))
+        raise ValueError(f"unrecognised value for norm '{norm}'")
 
     for attr, value in (('vmin', clim[0]), ('vmax', clim[1]), ('clip', clip)):
         if value is not None:

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -68,9 +69,9 @@ def _truncate(f, n):
 
     From https://stackoverflow.com/a/783927/1307974 (CC-BY-SA)
     """
-    s = "{}".format(f)
+    s = str(f)
     if "e" in s or "E" in s:
-        return "{0:.{1}f}".format(f, n)
+        return f"{f:.{n}f}"
     i, p, d = s.partition(".")
     return ".".join([i, (d+"0"*n)[:n]])
 
@@ -137,13 +138,13 @@ class GPSMixin(object):
         # decompose and check that it's actually a time unit
         dec = unit.decompose()
         if dec.bases != [units.second]:
-            raise ValueError("Cannot set GPS unit to %s" % unit)
+            raise ValueError(f"cannot set GPS unit to '{unit}'")
         # check equivalent units
         for other in TIME_UNITS:
             if other.decompose().scale == dec.scale:
                 self._unit = other
                 return
-        raise ValueError("Unrecognised unit: %s" % unit)
+        raise ValueError("unrecognised unit '{unit}'")
 
     unit = property(fget=get_unit, fset=set_unit,
                     doc=get_unit.__doc__)
@@ -156,7 +157,7 @@ class GPSMixin(object):
         if not self.unit:
             return None
         name = sorted(self.unit.names, key=len)[-1]
-        return '%ss' % name  # pluralise
+        return name + "s"  # pluralise
 
     def get_scale(self):
         """The scale (in seconds) of the current GPS unit.
@@ -399,7 +400,7 @@ class GPSScale(GPSMixin, LinearScale):
         super().__init__(unit=unit, epoch=epoch)
         self.axis = axis
         # set tight scaling on parent axes
-        getattr(axis.axes, 'set_{0}margin'.format(axis.axis_name))(0)
+        getattr(axis.axes, f"set_{axis.axis_name}margin")(0)
 
     def set_default_locators_and_formatters(self, axis):
         axis.set_major_locator(GPSAutoLocator())
@@ -410,10 +411,9 @@ class GPSScale(GPSMixin, LinearScale):
     @staticmethod
     def _lim(axis):
         # if autoscaling and datalim is set, use it
-        autoscale_on_var = "get_autoscale{}_on".format(axis.axis_name)
         dlim = tuple(axis.get_data_interval())
         if (
-                getattr(axis.axes, autoscale_on_var)()
+                getattr(axis.axes, f"get_autoscale{axis.axis_name}_on")()
                 and not numpy.isinf(dlim).any()
         ):
             return dlim
@@ -482,8 +482,7 @@ def _gps_scale_factory(unit):
     class FixedGPSScale(GPSScale):
         """`GPSScale` for a specific GPS time unit
         """
-        name = str('{0}s'.format(unit.long_names[0] if unit.long_names else
-                                 unit.names[0]))
+        name = (unit.long_names or unit.names)[0] + "s"
 
         def __init__(self, axis, epoch=None):
             """

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -144,7 +144,7 @@ class GPSMixin(object):
             if other.decompose().scale == dec.scale:
                 self._unit = other
                 return
-        raise ValueError("unrecognised unit '{unit}'")
+        raise ValueError(f"unrecognised unit '{unit}'")
 
     unit = property(fget=get_unit, fset=set_unit,
                     doc=get_unit.__doc__)

--- a/gwpy/plot/log.py
+++ b/gwpy/plot/log.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -32,8 +33,8 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 def _math(s):
     if rcParams["text.usetex"]:
-        return "${}$".format(s)
-    return r"$\mathdefault{%s}$" % s
+        return f"${s}$"
+    return fr"$\mathdefault{{{s}}}$"
 
 
 def _render_simple(values, ndec=2, thresh=100001):
@@ -62,7 +63,7 @@ class LogFormatter(mticker.LogFormatterMathtext):
         self.set_locs(values)
 
         # remove floating-point precision errors
-        values2 = numpy.asanyarray([float("%.12g" % x) for x in values])
+        values2 = numpy.asanyarray([float(f"{x:.12g}") for x in values])
 
         # if can render using just "%s" do it
         if _render_simple(values2):
@@ -126,7 +127,7 @@ class LogFormatter(mticker.LogFormatterMathtext):
 
         # enable custom format
         if fmt:
-            return _math("{}{}".format(sign, fmt % x))
+            return _math(sign + fmt % x)
 
         return super().__call__(x, pos=pos)
 

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -78,8 +78,10 @@ def get_backend_mod(name=None):
     """
     if name is None:
         name = get_backend()
-    backend_name = (name[9:] if name.startswith("module://") else
-                    "matplotlib.backends.backend_{}".format(name.lower()))
+    backend_name = (
+        name[9:] if name.startswith("module://")
+        else f"matplotlib.backends.backend_{name.lower()}"
+    )
     return importlib.import_module(backend_name)
 
 
@@ -164,9 +166,10 @@ class Plot(figure.Figure):
         nrows, ncols = geometry
         if axes_groups and nrows * ncols != len(axes_groups):
             # mismatching data and geometry
-            raise ValueError("cannot group data into {0} axes with a "
-                             "{1}x{2} grid".format(len(axes_groups), nrows,
-                                                   ncols))
+            raise ValueError(
+                f"cannot group data into {len(axes_groups)} with "
+                f"a {nrows}x{ncols} grid"
+            )
 
         # create grid spec
         gs = GridSpec(nrows, ncols)
@@ -179,8 +182,10 @@ class Plot(figure.Figure):
         for axis in ('x', 'y'):
             unit = _common_axis_unit(flatdata, axis=axis)
             if unit:
-                axes_kw.setdefault('{}label'.format(axis),
-                                   unit.to_string('latex_inline_dimensional'))
+                axes_kw.setdefault(
+                    f"{axis}label",
+                    unit.to_string('latex_inline_dimensional'),
+                )
 
         # create axes for each group and draw each data object
         for group, (row, col) in zip_longest(
@@ -222,11 +227,14 @@ class Plot(figure.Figure):
         # -- only if the user hasn't customised the subplot params
         figsize = kwargs.get('figsize') or rcParams['figure.figsize']
         subplotpars = get_subplot_params(figsize)
-        use_subplotpars = 'subplotpars' not in kwargs and all([
-            rcParams['figure.subplot.%s' % pos]
-            == MPL_RCPARAMS['figure.subplot.%s' % pos]
-            for pos in ('left', 'bottom', 'right', 'top')
-        ])
+        use_subplotpars = (
+            'subplotpars' not in kwargs
+            and all([
+                rcParams[f"figure.subplot.{pos}"]
+                == MPL_RCPARAMS[f"figure.subplot.{pos}"]
+                for pos in ('left', 'bottom', 'right', 'top')
+            ])
+        )
         if use_subplotpars:
             kwargs['subplotpars'] = subplotpars
 
@@ -602,7 +610,7 @@ def _group_axes_data(inputs, separate=None, flat=False):
 
 def _common_axis_unit(data, axis='x'):
     units = set()
-    uname = '{}unit'.format(axis)
+    uname = f"{axis}unit"
     for x in data:
         units.add(getattr(x, uname, None))
     if len(units) == 1:

--- a/gwpy/plot/segments.py
+++ b/gwpy/plot/segments.py
@@ -88,8 +88,10 @@ class SegmentAxes(Axes):
             return self.plot_segmentlistdict
         if isinstance(obj, ligo.segments.segmentlist):
             return self.plot_segmentlist
-        raise TypeError("no known {0}.plot_xxx method for {1}".format(
-            type(self).__name__, type(obj).__name__))
+        raise TypeError(
+            f"no known {type(self).__name__}.plot_xxx method "
+            f"for {type(obj).__name__}",
+        )
 
     def plot(self, *args, **kwargs):
         """Plot data onto these axes

--- a/gwpy/plot/tests/test_rc.py
+++ b/gwpy/plot/tests/test_rc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018-2020)
+# Copyright (C) Cardiff University (2018-2021)
 #
 # This file is part of GWpy.
 #
@@ -26,8 +26,10 @@ from matplotlib import rcParams
 from .. import rc as plot_rc
 
 
-DEFAULT_LRTB = [rcParams['figure.subplot.{0}'.format(x)] for
-                x in ('left', 'right', 'bottom', 'top')]
+DEFAULT_LRTB = [
+    rcParams[f"figure.subplot.{x}"]
+    for x in ('left', 'right', 'bottom', 'top')
+]
 
 
 @pytest.mark.parametrize('figsize, lrbt', [

--- a/gwpy/plot/tex.py
+++ b/gwpy/plot/tex.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -53,8 +54,9 @@ HAS_TEX = has_tex()
 # -- tex formatting -----------------------------------------------------------
 
 LATEX_CONTROL_CHARS = ["%", "\\", "_", "~", "&", "#"]
-re_latex_control = re.compile(r'(?<!\\)[%s](?!.*{)'
-                              % ''.join(LATEX_CONTROL_CHARS))
+re_latex_control = re.compile(
+    rf"(?<!\\)[{''.join(LATEX_CONTROL_CHARS)}](?!.*{{)",
+)
 
 
 def float_to_latex(x, format="%.2g"):  # pylint: disable=redefined-builtin
@@ -100,8 +102,8 @@ def float_to_latex(x, format="%.2g"):  # pylint: disable=redefined-builtin
     if exponent.startswith('-0'):
         exponent = '-' + exponent[2:]
     if float(mantissa) == 1.0:
-        return r"10^{%s}" % exponent
-    return r"%s\!\!\times\!\!10^{%s}" % (mantissa, exponent)
+        return fr"10^{{{exponent}}}"
+    return fr"{mantissa}\!\!\times\!\!10^{{{exponent}}}"
 
 
 def label_to_latex(text):
@@ -144,7 +146,7 @@ def label_to_latex(text):
         a, b = m.span()
         char = m.group()[0]
         out.append(text[x:a])
-        out.append(r'\%s' % char)
+        out.append(fr"\{char}")
         x = b
     if not x:  # no match
         return text

--- a/gwpy/plot/units.py
+++ b/gwpy/plot/units.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -31,9 +32,9 @@ class LatexInlineDimensional(LatexInline):
 
     @classmethod
     def to_string(cls, unit):
-        u = '[{0}]'.format(super().to_string(unit))
+        u = f"[{super().to_string(unit)}]"
 
         if unit.physical_type not in {None, 'unknown', 'dimensionless'}:
             ptype = str(unit.physical_type).split('/', 1)[0].title()
-            return '{0} {1}'.format(cls._latex_escape(ptype), u)
+            return f"{cls._latex_escape(ptype)} {u}"
         return u


### PR DESCRIPTION
This PR updates the `gwpy.plot` module to use [f-strings](https://www.python.org/dev/peps/pep-0498/) for all string formatting, instead of a mix of `str.format` and `%`-formatting.