### PR TITLE
Run full test suite on Python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,10 @@ jobs:
           - Ubuntu
           - Windows
         python-version:
-          - 3.7
-          - 3.8
-          - 3.9
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
     runs-on: ${{ matrix.os }}-latest
 
     # this is needed for conda environments to activate automatically

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -43,7 +43,7 @@ jobs:
             python-version: "3.7"
             experimental: false
           - name: "Experimental"
-            python-version: "3.9"
+            python-version: "3.x"
             experimental: true
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a Python 3.10 matrix entry for the full end-to-end CI test job.