### PR TITLE
Default to ilwdchar_compat=False throughout

### DIFF
--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -1279,16 +1280,14 @@ class DataQualityDict(OrderedDict):
 
         return out
 
-    def to_ligolw_tables(self, ilwdchar_compat=None, **attrs):
+    def to_ligolw_tables(self, ilwdchar_compat=False, **attrs):
         """Convert this `DataQualityDict` into a trio of LIGO_LW segment tables
 
         Parameters
         ----------
         ilwdchar_compat : `bool`, optional
             whether to write in the old format, compatible with
-            ILWD characters (`True`), or to use the new format (`False`);
-            the current default is `True` to maintain backwards
-            compatibility, but this will change for gwpy-1.0.0.
+            ILWD characters (`True`), or to use the new format (`False`)
 
         **attrs
             other attributes to add to all rows in all tables
@@ -1305,14 +1304,6 @@ class DataQualityDict(OrderedDict):
         segmenttable : :class:`~ligo.lw.lsctables.SegmentTable`
             the ``segment`` table
         """
-        if ilwdchar_compat is None:
-            warnings.warn("ilwdchar_compat currently defaults to `True`, "
-                          "but this will change to `False` in the future, to "
-                          "maintain compatibility in future releases, "
-                          "manually specify `ilwdchar_compat=True`",
-                          PendingDeprecationWarning)
-            ilwdchar_compat = True
-
         if ilwdchar_compat:
             from glue.ligolw import lsctables
         else:

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -102,7 +103,7 @@ def read_ligolw_flag(source, name=None, **kwargs):
 
 # -- write --------------------------------------------------------------------
 
-def write_ligolw(flags, target, attrs=None, ilwdchar_compat=None, **kwargs):
+def write_ligolw(flags, target, attrs=None, ilwdchar_compat=False, **kwargs):
     """Write this `DataQualityFlag` to the given LIGO_LW Document
 
     Parameters

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -36,7 +37,6 @@ from ...segments import (Segment, SegmentList,
                          DataQualityFlag, DataQualityDict)
 from ...testing import utils
 from ...testing.errors import pytest_skip_network_error
-from ...utils.misc import null_context
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -767,17 +767,11 @@ class TestDataQualityDict(object):
                 _read(on_missing='blah')
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    @pytest.mark.parametrize("ilwdchar_compat", [None, False, True])
+    @pytest.mark.parametrize("ilwdchar_compat", [False, True])
     def test_to_ligolw_tables(self, instance, ilwdchar_compat):
-        if ilwdchar_compat is None:
-            ctx = pytest.warns(PendingDeprecationWarning)
-        else:
-            ctx = null_context()
-        with ctx:
-            tables = instance.to_ligolw_tables(
-                ilwdchar_compat=ilwdchar_compat,
-            )
-
+        tables = instance.to_ligolw_tables(
+            ilwdchar_compat=ilwdchar_compat,
+        )
         if ilwdchar_compat is False:
             mod = "ligo.lw.lsctables"
         else:  # True or None

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -425,7 +426,7 @@ def read_table(source, tablename=None, **kwargs):
 
 # -- write --------------------------------------------------------------------
 
-def write_table(table, target, tablename=None, ilwdchar_compat=None,
+def write_table(table, target, tablename=None, ilwdchar_compat=False,
                 **kwargs):
     """Write a `~astropy.table.Table` to file in LIGO_LW XML format
 
@@ -443,7 +444,7 @@ def write_table(table, target, tablename=None, ilwdchar_compat=None,
         llwtable = table_to_ligolw(
             table,
             tablename,
-            ilwdchar_compat=ilwdchar_compat or False,
+            ilwdchar_compat=ilwdchar_compat,
         )
     except LigolwElementError as exc:
         if ilwdchar_compat is not None:


### PR DESCRIPTION
This PR removes all defaults of `ilwdchar_compat=None`, which existed to warn the user to manually set `True` if they need ilwdchar compatilibity.

I want to remove all ilwdchar compatibility in the codebase in favour of a simpler mechanism, so this is the first step.