### PR TITLE
Simplify reading LIGO_LW documents

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,6 +224,7 @@ intersphinx_mapping = {
     'gwdatafind': ('https://gwdatafind.readthedocs.io/en/stable/', None),
     'gwosc': ('https://gwosc.readthedocs.io/en/stable/', None),
     'h5py': ('https://docs.h5py.org/en/latest/', None),
+    'ligo.skymap': ('https://lscsoft.docs.ligo.org/ligo.skymap/', None),
     'ligo-segments': ('https://lscsoft.docs.ligo.org/ligo-segments/', None),
     'ligolw': ('https://docs.ligo.org/kipp.cannon/python-ligo-lw/', None),
     'matplotlib': ('https://matplotlib.org/', None),

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -66,7 +66,7 @@ All of these will be installed using any of the above install methods.
 
 GWpy also depends on the following other packages for optional features:
 
-- :mod:`glue.ligolw`: to read/write :class:`~gwpy.table.EventTable` with
+- |python-ligo-lw| to read/write :class:`~gwpy.table.EventTable` with
   LIGO_LW XML format (see :ref:`gwpy-table-io-ligolw`)
 - |LDAStools.frameCPP|_: to read/write data in GWF format
 - |nds2|_: to provide remote data access for `TimeSeries`

--- a/docs/segments/io.rst
+++ b/docs/segments/io.rst
@@ -91,11 +91,7 @@ Extra attributes can be written to the tables via the ``attrs={}`` keyword, all 
    The |python-ligo-lw| library reads and writes files using an updated
    version of the ``LIGO_LW`` format compared to :mod:`glue.ligolw` used to.
    GWpy should support both format versions natively when _reading_, but
-   when _writing_ you may need to explicitly pass the
-   ``ilwdchar_compat=True`` keyword in order to write using the old
-   format::
-
-       >>> f.write('new-table.xml', ilwdchar_compat=True)
+   only supports writing using the updated format.
 
 
 `DataQualityDict`

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -384,12 +384,7 @@ preserving other tables, use *both* ``append=True`` and ``overwrite=True``:
    The |python-ligo-lw| library reads and writes files using an updated
    version of the ``LIGO_LW`` format compared to :mod:`glue.ligolw` used to.
    GWpy should support both format versions natively when _reading_, but
-   when _writing_ you may need to explicitly pass the
-   ``ilwdchar_compat=True`` keyword in order to write using the old
-   format::
-
-       >>> t.write('new-table.xml', format='ligolw', tablename='sngl_burst',
-       ...         ilwdchar_compat=True)
+   only supports writing using the updated format.
 
 
 .. _gwpy-table-io-ascii-cwb:

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -1279,16 +1280,14 @@ class DataQualityDict(OrderedDict):
 
         return out
 
-    def to_ligolw_tables(self, ilwdchar_compat=None, **attrs):
+    def to_ligolw_tables(self, ilwdchar_compat=False, **attrs):
         """Convert this `DataQualityDict` into a trio of LIGO_LW segment tables
 
         Parameters
         ----------
         ilwdchar_compat : `bool`, optional
             whether to write in the old format, compatible with
-            ILWD characters (`True`), or to use the new format (`False`);
-            the current default is `True` to maintain backwards
-            compatibility, but this will change for gwpy-1.0.0.
+            ILWD characters (`True`), or to use the new format (`False`)
 
         **attrs
             other attributes to add to all rows in all tables
@@ -1305,14 +1304,6 @@ class DataQualityDict(OrderedDict):
         segmenttable : :class:`~ligo.lw.lsctables.SegmentTable`
             the ``segment`` table
         """
-        if ilwdchar_compat is None:
-            warnings.warn("ilwdchar_compat currently defaults to `True`, "
-                          "but this will change to `False` in the future, to "
-                          "maintain compatibility in future releases, "
-                          "manually specify `ilwdchar_compat=True`",
-                          PendingDeprecationWarning)
-            ilwdchar_compat = True
-
         if ilwdchar_compat:
             from glue.ligolw import lsctables
         else:

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -1280,15 +1280,11 @@ class DataQualityDict(OrderedDict):
 
         return out
 
-    def to_ligolw_tables(self, ilwdchar_compat=False, **attrs):
+    def to_ligolw_tables(self, **attrs):
         """Convert this `DataQualityDict` into a trio of LIGO_LW segment tables
 
         Parameters
         ----------
-        ilwdchar_compat : `bool`, optional
-            whether to write in the old format, compatible with
-            ILWD characters (`True`), or to use the new format (`False`)
-
         **attrs
             other attributes to add to all rows in all tables
             (e.g. ``'process_id'``)
@@ -1304,10 +1300,7 @@ class DataQualityDict(OrderedDict):
         segmenttable : :class:`~ligo.lw.lsctables.SegmentTable`
             the ``segment`` table
         """
-        if ilwdchar_compat:
-            from glue.ligolw import lsctables
-        else:
-            from ligo.lw import lsctables
+        from ligo.lw import lsctables
         from ..io.ligolw import to_table_type as to_ligolw_table_type
 
         SegmentDefTable = lsctables.SegmentDefTable

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -103,7 +103,7 @@ def read_ligolw_flag(source, name=None, **kwargs):
 
 # -- write --------------------------------------------------------------------
 
-def write_ligolw(flags, target, attrs=None, ilwdchar_compat=False, **kwargs):
+def write_ligolw(flags, target, attrs=None, **kwargs):
     """Write this `DataQualityFlag` to the given LIGO_LW Document
 
     Parameters
@@ -129,8 +129,7 @@ def write_ligolw(flags, target, attrs=None, ilwdchar_compat=False, **kwargs):
         flags = DataQualityDict({flags.name: flags})
     return write_tables(
         target,
-        flags.to_ligolw_tables(ilwdchar_compat=ilwdchar_compat,
-                               **attrs or dict()),
+        flags.to_ligolw_tables(**attrs or dict()),
         **kwargs
     )
 

--- a/gwpy/segments/io/ligolw.py
+++ b/gwpy/segments/io/ligolw.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -102,7 +103,7 @@ def read_ligolw_flag(source, name=None, **kwargs):
 
 # -- write --------------------------------------------------------------------
 
-def write_ligolw(flags, target, attrs=None, ilwdchar_compat=None, **kwargs):
+def write_ligolw(flags, target, attrs=None, ilwdchar_compat=False, **kwargs):
     """Write this `DataQualityFlag` to the given LIGO_LW Document
 
     Parameters

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -36,7 +37,6 @@ from ...segments import (Segment, SegmentList,
                          DataQualityFlag, DataQualityDict)
 from ...testing import utils
 from ...testing.errors import pytest_skip_network_error
-from ...utils.misc import null_context
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -767,17 +767,11 @@ class TestDataQualityDict(object):
                 _read(on_missing='blah')
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    @pytest.mark.parametrize("ilwdchar_compat", [None, False, True])
+    @pytest.mark.parametrize("ilwdchar_compat", [False, True])
     def test_to_ligolw_tables(self, instance, ilwdchar_compat):
-        if ilwdchar_compat is None:
-            ctx = pytest.warns(PendingDeprecationWarning)
-        else:
-            ctx = null_context()
-        with ctx:
-            tables = instance.to_ligolw_tables(
-                ilwdchar_compat=ilwdchar_compat,
-            )
-
+        tables = instance.to_ligolw_tables(
+            ilwdchar_compat=ilwdchar_compat,
+        )
         if ilwdchar_compat is False:
             mod = "ligo.lw.lsctables"
         else:  # True or None

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -20,7 +20,6 @@
 """Tests for :mod:`gwpy.segments`
 """
 
-import importlib
 import re
 from io import BytesIO
 from unittest import mock
@@ -387,12 +386,8 @@ class TestDataQualityFlag(object):
             flag.pad(*PADDING, kwarg='test')
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    @pytest.mark.parametrize("lsctables", (
-        pytest.param("glue.ligolw.lsctables", id="glue.ligolw"),
-        pytest.param("ligo.lw.lsctables", id="python-ligo-lw"),
-    ))
-    def test_from_veto_def(self, lsctables):
-        VetoDef = importlib.import_module(lsctables).VetoDef
+    def test_from_veto_def(self):
+        from ligo.lw.lsctables import VetoDef
 
         def veto_def(ifo, name, version, **kwargs):
             vdef = VetoDef()
@@ -470,13 +465,14 @@ class TestDataQualityFlag(object):
         utils.assert_flag_equal(f2, flag)
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    @pytest.mark.parametrize("ilwdchar_compat", [False, True])
-    def test_read_write_ligolw(self, flag, ilwdchar_compat):
+    def test_read_write_ligolw(self, flag):
         utils.test_read_write(
-            flag, "ligolw", extension="xml",
+            flag,
+            "ligolw",
+            extension="xml",
             assert_equal=utils.assert_flag_equal,
             autoidentify=False,
-            read_kw={}, write_kw={"ilwdchar_compat": ilwdchar_compat},
+            read_kw={},
         )
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
@@ -487,7 +483,6 @@ class TestDataQualityFlag(object):
             tmp,
             format='ligolw',
             attrs={'process_id': 100},
-            ilwdchar_compat=False,
         )
         segdeftab = read_table(tmp, 'segment_definer')
         assert int(segdeftab[0].process_id) == 100
@@ -721,16 +716,16 @@ class TestDataQualityDict(object):
         _read_write(autoidentify=True, write_kw={'overwrite': True})
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    @pytest.mark.parametrize("ilwdchar_compat", [False, True])
-    def test_read_write_ligolw(self, instance, ilwdchar_compat):
+    def test_read_write_ligolw(self, instance):
         def _assert(a, b):
             return utils.assert_dict_equal(a, b, utils.assert_flag_equal)
         utils.test_read_write(
-            instance, "ligolw", extension="xml",
+            instance,
+            "ligolw",
+            extension="xml",
             assert_equal=_assert,
             autoidentify=False,
             read_kw={},
-            write_kw={"ilwdchar_compat": ilwdchar_compat},
         )
 
     def test_read_on_missing(self, instance):
@@ -767,17 +762,8 @@ class TestDataQualityDict(object):
                 _read(on_missing='blah')
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    @pytest.mark.parametrize("ilwdchar_compat", [False, True])
-    def test_to_ligolw_tables(self, instance, ilwdchar_compat):
-        tables = instance.to_ligolw_tables(
-            ilwdchar_compat=ilwdchar_compat,
-        )
-        if ilwdchar_compat is False:
-            mod = "ligo.lw.lsctables"
-        else:  # True or None
-            mod = "glue.ligolw.lsctables"
-        for tab in tables:
-            assert type(tab).__module__ == mod
+    def test_to_ligolw_tables(self, instance):
+        tables = instance.to_ligolw_tables()
         assert len(tables[0]) == len(instance)  # segdef
         assert len(tables[1]) == sum(len(x.known) for x in instance.values())
         assert len(tables[2]) == sum(len(x.active) for x in instance.values())

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -20,8 +20,6 @@
 """Read LIGO_LW documents into :class:`~ligo.lw.table.Table` objects.
 """
 
-import importlib
-
 import numpy
 
 try:
@@ -30,16 +28,9 @@ except ImportError:
     LIGOLW_TABLES = set()
 else:
     LIGOLW_TABLES = set(_TableByName.values())
-try:
-    from glue.ligolw.lsctables import TableByName as _TableByName
-    LIGOLW_TABLES.update(_TableByName.values())
-except ImportError:
-    pass
 
 from ...io import registry
 from ...io.ligolw import (
-    LigolwElementError,
-    ilwdchar_compat,
     is_ligolw,
     patch_ligotimegps,
     read_table as read_ligolw_table,
@@ -70,28 +61,8 @@ else:
     NUMPY_TYPE_MAP[LIGOTimeGPS] = numpy.float_
 
 
-def _get_ilwdchar_types(library):
-    """Yields all ``ilwdchar`` type objects from the given LIGO_LW library
-    """
-    for modname in ("ilwd", "_ilwd"):
-        try:
-            mod = importlib.import_module(f"{library}.{modname}")
-        except ImportError:
-            continue
-        yield getattr(mod, "ilwdchar")
-
-
-ILWDCHAR_TYPES = tuple(
-    typ
-    for lib in ("glue.ligolw", "ligo.lw")
-    for typ in _get_ilwdchar_types(lib)
-)
-NUMPY_TYPE_MAP[ILWDCHAR_TYPES] = numpy.int_
-
-
 # -- utilities ----------------------------------------------------------------
 
-@ilwdchar_compat
 def _get_property_columns(tabletype, columns):
     """Returns list of GPS columns required to read gpsproperties for a table
 
@@ -112,7 +83,6 @@ def _get_property_columns(tabletype, columns):
     return extracols
 
 
-@ilwdchar_compat
 def _get_property_type(tabletype, column):
     """Returns the type of values in the given property
 
@@ -248,26 +218,12 @@ def to_astropy_column(llwcol, cls, copy=False, dtype=None,
             try:
                 dtype = NUMPY_TYPE_MAP[dtype]
             except KeyError:
-                # try subclass matches (mainly for ilwdchar)
-                for key in NUMPY_TYPE_MAP:
-                    if issubclass(dtype, key):
-                        dtype = NUMPY_TYPE_MAP[key]
-                        break
-                else:  # no subclass matches, raise
-                    raise TypeError("no mapping from object type %r to numpy "
-                                    "type" % dtype)
-    try:
-        return cls(data=llwcol, copy=copy, dtype=dtype, **kwargs)
-    except TypeError:
-        # numpy tries to cast ilwdchar to int via long, which breaks
-        if dtype is numpy.int_ and isinstance(llwcol[0], ILWDCHAR_TYPES):
-            return cls(data=map(dtype, llwcol),
-                       copy=False, dtype=dtype, **kwargs)
-        # any other error, raise
-        raise
+                raise TypeError(
+                    f"no mapping from object type '{dtype}' to numpy type",
+                )
+    return cls(data=llwcol, copy=copy, dtype=dtype, **kwargs)
 
 
-@ilwdchar_compat
 def _get_column_dtype(llwcol):
     """Get the data type of a LIGO_LW `Column`
 
@@ -300,7 +256,6 @@ def _get_column_dtype(llwcol):
             return _get_pytype(llwtype)
 
 
-@ilwdchar_compat
 def _get_pytype(llwtype):
     """Returns a dtype-compatible type for the given LIGO_LW type string
     """
@@ -311,7 +266,6 @@ def _get_pytype(llwtype):
         return ToPyType[llwtype]
 
 
-@ilwdchar_compat
 def table_to_ligolw(table, tablename):
     """Convert a `astropy.table.Table` to a :class:`ligo.lw.table.Table`
     """
@@ -426,33 +380,18 @@ def read_table(source, tablename=None, **kwargs):
 
 # -- write --------------------------------------------------------------------
 
-def write_table(table, target, tablename=None, ilwdchar_compat=False,
-                **kwargs):
+def write_table(table, target, tablename=None, **kwargs):
     """Write a `~astropy.table.Table` to file in LIGO_LW XML format
-
-    This method will attempt to write in the new `ligo.lw` format
-    (if ``ilwdchar_compat`` is ``None`` or ``False``),
-    but will fall back to the older `glue.ligolw` (in that order) if that
-    fails (if ``ilwdchar_compat`` is ``None`` or ``True``).
     """
     if tablename is None:  # try and get tablename from metadata
         tablename = table.meta.get('tablename', None)
     if tablename is None:  # panic
         raise ValueError("please pass ``tablename=`` to specify the target "
                          "LIGO_LW Table Name")
-    try:
-        llwtable = table_to_ligolw(
-            table,
-            tablename,
-            ilwdchar_compat=ilwdchar_compat,
-        )
-    except LigolwElementError as exc:
-        if ilwdchar_compat is not None:
-            raise
-        try:
-            llwtable = table_to_ligolw(table, tablename, ilwdchar_compat=True)
-        except Exception:
-            raise exc
+    llwtable = table_to_ligolw(
+        table,
+        tablename,
+    )
     return write_ligolw_tables(target, [llwtable], **kwargs)
 
 

--- a/gwpy/table/io/ligolw.py
+++ b/gwpy/table/io/ligolw.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2021)
 #
 # This file is part of GWpy.
 #
@@ -425,7 +426,7 @@ def read_table(source, tablename=None, **kwargs):
 
 # -- write --------------------------------------------------------------------
 
-def write_table(table, target, tablename=None, ilwdchar_compat=None,
+def write_table(table, target, tablename=None, ilwdchar_compat=False,
                 **kwargs):
     """Write a `~astropy.table.Table` to file in LIGO_LW XML format
 
@@ -443,7 +444,7 @@ def write_table(table, target, tablename=None, ilwdchar_compat=None,
         llwtable = table_to_ligolw(
             table,
             tablename,
-            ilwdchar_compat=ilwdchar_compat or False,
+            ilwdchar_compat=ilwdchar_compat,
         )
     except LigolwElementError as exc:
         if ilwdchar_compat is not None:

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -141,7 +141,7 @@ class TestTable(object):
         table = self.create(
             100, ['peak_time', 'peak_time_ns', 'snr', 'central_freq'],
             ['i4', 'i4', 'f4', 'f4'])
-        tmp = tmp_path / "table.{}".format(ext)
+        tmp = tmp_path / f"table.{ext}"
 
         def _read(*args, **kwargs):
             kwargs.setdefault('format', 'ligolw')
@@ -165,8 +165,10 @@ class TestTable(object):
         # check numpy type casting works
         from ligo.lw.lsctables import LIGOTimeGPS as LigolwGPS
         t3 = _read(columns=['peak'])
+        assert len(t3) == 100
         assert isinstance(t3['peak'][0], LigolwGPS)
         t3 = _read(columns=['peak'], use_numpy_dtypes=True)
+        assert len(t3) == 100
         assert t3['peak'].dtype == dtype('float64')
         utils.assert_array_equal(
             t3['peak'], table['peak_time'] + table['peak_time_ns'] * 1e-9)
@@ -213,63 +215,6 @@ class TestTable(object):
                                   'one sngl_burst table')
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    def test_read_write_ligolw_ilwdchar_compat(self, tmp_path):
-        from glue.ligolw.ilwd import get_ilwdchar_class
-        from glue.ligolw.lsctables import SnglBurstTable
-
-        eid_type = get_ilwdchar_class("sngl_burst", "event_id")
-
-        table = self.create(
-            100,
-            ["peak", "snr", "central_freq", "event_id"],
-            ["f8", "f4", "f4", "i8"],
-        )
-
-        # write table with ilwdchar_compat=True
-        tmp = tmp_path / "tmp.xml"
-        table.write(
-            tmp,
-            format="ligolw",
-            tablename="sngl_burst",
-            ilwdchar_compat=True,
-        )
-
-        # read raw ligolw and check type is correct
-        llw = io_ligolw.read_table(
-            tmp,
-            tablename="sngl_burst",
-            ilwdchar_compat=True,
-        )
-        assert type(llw.getColumnByName("event_id")[0]) is eid_type
-
-        # reset IDs to 0
-        SnglBurstTable.reset_next_id()
-
-        # read without explicit use of ilwdchar_compat
-        t2 = self.TABLE.read(tmp, columns=table.colnames)
-        assert type(t2[0]["event_id"]) is eid_type
-
-        # read again with explicit use of ilwdchar_compat
-        SnglBurstTable.reset_next_id()
-        utils.assert_table_equal(
-            self.TABLE.read(
-                tmp,
-                columns=table.colnames,
-                ilwdchar_compat=True,
-            ),
-            t2,
-        )
-
-        # and check that ilwdchar_compat=True, use_numpy_dtypes=True works
-        SnglBurstTable.reset_next_id()
-        utils.assert_table_equal(
-            self.TABLE.read(tmp, columns=table.colnames,
-                            ilwdchar_compat=True, use_numpy_dtypes=True),
-            table,
-            almost_equal=True,
-        )
-
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
     def test_read_write_ligolw_property_columns(self, tmp_path):
         table = self.create(100, ['peak', 'snr', 'central_freq'],
                             ['f8', 'f4', 'f4'])
@@ -297,8 +242,7 @@ class TestTable(object):
         utils.assert_table_equal(t2, table, almost_equal=True)
 
     @utils.skip_missing_dependency('ligo.lw.lsctables')
-    @pytest.mark.parametrize('ilwdchar_compat', (False, True))
-    def test_read_ligolw_get_as_exclude(self, tmp_path, ilwdchar_compat):
+    def test_read_ligolw_get_as_exclude(self, tmp_path):
         table = self.TABLE(
             rows=[
                 ("H1", 0.0, 4, 0),
@@ -314,7 +258,6 @@ class TestTable(object):
             tmp,
             format="ligolw",
             tablename="time_slide",
-            ilwdchar_compat=ilwdchar_compat,
         )
 
         # read it back and assert that we the `instrument` table is
@@ -322,7 +265,6 @@ class TestTable(object):
         t2 = table.read(
             tmp,
             tablename="time_slide",
-            use_numpy_dtypes=ilwdchar_compat,
         )
         t2.sort("instrument")
         utils.assert_table_equal(t2, table)


### PR DESCRIPTION
This PR simplifies reading LIGO_LW-format XML documents by replacing the annoying `ilwdchar_compat` system where documents are parsed twice, with a content handler-based system where `ilwdchar` types are swapped with the relevant `int`-like types on-the-fly automatically as documents are being parsed.

This allows to simplify everything else about reading LIGO_LW documents.