### PR TITLE
Update minimum astropy requirement to 4.0

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,7 +46,7 @@ GWpy has the following strict requirements:
    ==================  ===========================
    Name                Constraints
    ==================  ===========================
-   |astropy|_          ``>=3.0.5``
+   |astropy|_          ``>=4.0``
    |dqsegdb2|_
    |gwdatafind|_
    |gwosc-mod|_        ``>=0.5.3``
@@ -54,7 +54,7 @@ GWpy has the following strict requirements:
    |ligo-segments|_    ``>=1.0.0``
    |ligotimegps|_      ``>=1.2.1``
    |matplotlib|_       ``>=3.1.0``
-   |numpy|_            ``>=1.12.0``
+   |numpy|_            ``>=1.16.0``
    |dateutil|_
    |scipy|_            ``>=1.2.0``
    |tqdm|_             ``>=4.10.0``

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ setup_requires =
 	setuptools_scm
 	wheel
 install_requires =
-	astropy >= 3.0.5
+	astropy >= 4.0
 	dqsegdb2
 	gwdatafind
 	gwosc >= 0.5.3
@@ -47,7 +47,7 @@ install_requires =
 	ligo-segments >= 1.0.0
 	ligotimegps >= 1.2.1
 	matplotlib >= 3.3.0
-	numpy >= 1.15.0
+	numpy >= 1.16
 	python-dateutil
 	scipy >= 1.2.0
 	tqdm >= 4.10.0


### PR DESCRIPTION
This PR bumps the minimum requirement on Astropy to `>= 4.0`, principally to resolve warnings from erfa relating to leap seconds for 2022. This also updates numpy since astropy will require at least 1.16 anyway.