### PR TITLE
Remove deprecated Plot methods

### DIFF
--- a/docs/table/plot.rst
+++ b/docs/table/plot.rst
@@ -27,7 +27,7 @@ x-axis, y-axis, and optionally colouring:
    >>> ax.set_epoch(968654552)
    >>> ax.set_yscale('log')
    >>> ax.set_ylabel('Frequency [Hz]')
-   >>> plot.add_colorbar(clim=[1, 10], cmap='YlGnBu', log=True, label='Signal-to-noise ratio (SNR)')
+   >>> ax.colorbar(clim=[1, 10], cmap='YlGnBu', norm='log', label='Signal-to-noise ratio (SNR)')
 
 .. _gwpy-table-plot-tiles:
 
@@ -48,7 +48,6 @@ These tiles can be plotted in a similar manner to simple triggers.
    >>> ax.set_epoch(968654552)
    >>> ax.set_yscale('log')
    >>> ax.set_ylabel('Frequency [Hz]')
-   >>> plot.add_colorbar(clim=[1, 10], cmap='YlGnBu', log=True, label='Signal-to-noise ratio (SNR)')
-
+   >>> ax.colorbar(clim=[1, 10], cmap='YlGnBu', norm='log', label='Signal-to-noise ratio (SNR)')
 
 These code snippets are part of the example :ref:`gwpy-example-table-tiles`.

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2022)
 #
 # This file is part of GWpy.
 #
@@ -21,7 +22,6 @@
 
 import itertools
 import importlib
-import warnings
 from collections.abc import (KeysView, ValuesView)
 from itertools import zip_longest
 
@@ -426,15 +426,6 @@ class Plot(figure.Figure):
                 map_.set_cmap(cmap)
 
         return cbar
-
-    def add_colorbar(self, *args, **kwargs):
-        """DEPRECATED, use `Plot.colorbar` instead
-        """
-        warnings.warn(
-            "{0}.add_colorbar was renamed {0}.colorbar, this warnings will "
-            "result in an error in the future".format(type(self).__name__),
-            DeprecationWarning)
-        return self.colorbar(*args, **kwargs)
 
     # -- extra methods --------------------------
 

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -523,14 +523,6 @@ class Plot(figure.Figure):
 
         return segax
 
-    def add_state_segments(self, *args, **kwargs):
-        """DEPRECATED: use :meth:`Plot.add_segments_bar`
-        """
-        warnings.warn('add_state_segments() was renamed add_segments_bar(), '
-                      'this warning will result in an error in the future',
-                      DeprecationWarning)
-        return self.add_segments_bar(*args, **kwargs)
-
 
 # -- utilities ----------------------------------------------------------------
 

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -135,9 +135,3 @@ class TestPlot(FigureTestBase):
         # check errors
         with pytest.raises(ValueError):
             fig.add_segments_bar(segs, location='left')
-
-    def test_add_state_segments(self, fig):
-        fig.add_subplot(xscale='auto-gps')
-        segs = SegmentList([Segment(10, 110), Segment(150, 400)])
-        with pytest.deprecated_call():
-            fig.add_state_segments(segs)

--- a/gwpy/plot/tests/test_plot.py
+++ b/gwpy/plot/tests/test_plot.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018-2020)
+# Copyright (C) Cardiff University (2018-2022)
 #
 # This file is part of GWpy.
 #
@@ -108,14 +108,6 @@ class TestPlot(FigureTestBase):
         cbar = fig.colorbar(vmin=2, vmax=4, fraction=0.)
         assert cbar.mappable is image
         assert cbar.mappable.get_clim() == (2., 4.)
-
-    def test_add_colorbar(self, fig):
-        ax = fig.gca()
-        array = Array2D(numpy.random.random((10, 10)), dx=.1, dy=.2)
-        image = ax.imshow(array)
-        with pytest.deprecated_call():
-            cbar = fig.add_colorbar(vmin=2, vmax=4, fraction=0.)
-        assert cbar.mappable is image
 
     def test_add_segments_bar(self, fig):
         ax = fig.add_subplot(xscale='auto-gps', epoch=150)


### PR DESCRIPTION
This PR removes two methods of the `gwpy.plot.Plot` class that have been deprecated essentially forever (since e270362e6e4bec91eb9c0e5688900e6be1af8f4c).