### PR TITLE
Remove deprecated colorbar behaviour

### DIFF
--- a/gwpy/plot/colorbar.py
+++ b/gwpy/plot/colorbar.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2017-2020)
+# Copyright (C) Louisiana State University (2017)
+#               Cardiff University (2017-2022)
 #
 # This file is part of GWpy.
 #
@@ -18,8 +19,6 @@
 
 """Utilities for generating colour bars for figures
 """
-
-import warnings
 
 from matplotlib.axes import SubplotBase
 from matplotlib.colors import LogNorm
@@ -60,24 +59,10 @@ def process_colorbar_kwargs(figure, mappable=None, ax=None, use_axesgrid=True,
     # -- create axes for colorbar (if required)
 
     cax = kwargs.pop('cax', None)
-    if cax is None:
-        # show warning about pending change
-        #     current default is to shrink the axes a wee bit,
-        #     which will change to no shrinking before 1.0
-        if kwargs.get('fraction') is None:
-            warnings.warn("`fraction` was not specified. Currently the "
-                          "default is `0.15`, matching the previous release "
-                          "behaviour, however, this will change to `0.0` in "
-                          "an upcoming release. To keep the current default, "
-                          "manually specify `fraction=0.15`",
-                          PendingDeprecationWarning)
-            kwargs['fraction'] = 0.15
-
-        # create axes if requesting not to resize the parent
-        if use_axesgrid:
-            cax, kwargs = make_axes_axesgrid(ax, **kwargs)
-    else:
-        kwargs.pop('fraction', None)  # don't need this if already have axes
+    if cax is not None:  # cax was given, we don't need fraction
+        kwargs.pop("fraction", None)
+    elif use_axesgrid:
+        cax, kwargs = make_axes_axesgrid(ax, **kwargs)
 
     # pack kwargs
     kwargs.update(ax=ax, cax=cax)

--- a/gwpy/plot/colorbar.py
+++ b/gwpy/plot/colorbar.py
@@ -34,8 +34,55 @@ LOC_CODES = Legend.codes
 
 # -- custom colorbar generation -----------------------------------------------
 
-def process_colorbar_kwargs(figure, mappable=None, ax=None, use_axesgrid=True,
-                            **kwargs):
+def process_colorbar_kwargs(
+    figure,
+    mappable=None,
+    ax=None,
+    cax=None,
+    use_axesgrid=True,
+    **kwargs,
+):
+    """Internal function to configure the keyword arguments for colorbars.
+
+    The main purpose of this function is to replace the default matplotlib
+    behaviour (resizing the 'parent' axes to make space for the colorbar
+    axes) with our default or creating a new axes alongside the parent
+    axes without resizing.
+
+    Parameters
+    ----------
+    figure : `matplotlib.figure.Figure`
+        The figure on which to draw the new colorbar axes.
+
+    mappable : matplotlib data collection
+        Collection against which to map the colouring, default will
+        be the last added mappable artist (collection or image)
+
+    ax : `matplotlib.axes.Axes`
+        The `Axes` against which to anchor the colorbar Axes.
+
+    cax : `matplotlib.axes.Axes`
+        The `Axes` on which to draw the colorbar.
+
+    use_axesgrid : `boolean`
+        If `True`, use `mpl_toolkits.axes_grid1` to generate the colorbar
+        Axes without resizing the parent Axes.
+        If `False`, use the default Matplotlib behaviour.
+        Only used if `cax=None` is given.
+
+    **kwargs
+        Other keyword arguments to pass to
+        :meth:`matplotlib.figure.Figure.colorbar`
+
+    Returns
+    -------
+    mappable
+        The Collection against which to map the colouring.
+
+    kwargs
+        A dict of keyword arguments to pass to
+        :meth:`matplotlib.figure.Figure.colorbar`.
+    """
     # get mappable and axes objects
     if mappable is None and ax is None:
         mappable = find_mappable(*figure.axes)
@@ -58,11 +105,11 @@ def process_colorbar_kwargs(figure, mappable=None, ax=None, use_axesgrid=True,
 
     # -- create axes for colorbar (if required)
 
-    cax = kwargs.pop('cax', None)
     if cax is not None:  # cax was given, we don't need fraction
         kwargs.pop("fraction", None)
-    elif use_axesgrid:
+    elif use_axesgrid:  # use axesgrid to generate Axes
         cax, kwargs = make_axes_axesgrid(ax, **kwargs)
+    # else: let matplotlib generate the Axes using its own default
 
     # pack kwargs
     kwargs.update(ax=ax, cax=cax)

--- a/gwpy/plot/colorbar.py
+++ b/gwpy/plot/colorbar.py
@@ -48,15 +48,6 @@ def process_colorbar_kwargs(figure, mappable=None, ax=None, use_axesgrid=True,
     # -- format mappable
 
     # parse normalisation
-    log = kwargs.pop('log', None)
-    if log is not None:
-        warnings.warn('the `log` keyword to Plot.colorbar is deprecated, '
-                      'please pass `norm=\'log\'` in the future to '
-                      'request a logarithimic normalisation',
-                      DeprecationWarning)
-    if log:
-        kwargs.setdefault('norm', 'log')
-
     norm, kwargs = format_norm(kwargs, mappable.norm)
     mappable.set_norm(norm)
     mappable.set_cmap(kwargs.pop('cmap', mappable.get_cmap()))

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -328,12 +328,22 @@ class Plot(figure.Figure):
 
     # -- colour bars ----------------------------
 
-    def colorbar(self, mappable=None, cax=None, ax=None, fraction=0.,
-                 emit=True, **kwargs):
-        """Add a colorbar to the current `Plot`
+    def colorbar(
+        self,
+        mappable=None,
+        cax=None,
+        ax=None,
+        fraction=0.,
+        use_axesgrid=True,
+        emit=True,
+        **kwargs,
+    ):
+        """Add a colorbar to the current `Plot`.
 
-        A colorbar must be associated with an `Axes` on this `Plot`,
-        and an existing mappable element (e.g. an image).
+        This method differs from the default
+        :meth:`matplotlib.figure.Figure.colorbar` in that it doesn't
+        resize the parent `Axes` to accommodate the colorbar, but rather
+        draws a new Axes alongside it.
 
         Parameters
         ----------
@@ -347,8 +357,16 @@ class Plot(figure.Figure):
             Axes relative to which to position colorbar
 
         fraction : `float`, optional
-            Fraction of original axes to use for colorbar, give `fraction=0`
-            to not resize the original axes at all.
+            Fraction of original axes to use for colorbar.
+            The default (``fraction=0``) is to not resize the
+            original axes at all.
+
+        use_axesgrid : `bool`
+            Use :mod:`mpl_toolkits.axes_grid1` to generate the
+            colorbar axes (default: `True`).
+            This takes precedence over the ``use_gridspec``
+            keyword argument from the upstream
+            :meth:`~matplotlib.figure.Figure.colorbar` method.
 
         emit : `bool`, optional
             If `True` update all mappables on `Axes` to match the same
@@ -362,6 +380,11 @@ class Plot(figure.Figure):
         -------
         cbar : `~matplotlib.colorbar.Colorbar`
             the newly added `Colorbar`
+
+        Notes
+        -----
+        To revert to the default matplotlib behaviour, pass
+        ``use_axesgrid=False, fraction=0.15``.
 
         See also
         --------

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -262,9 +262,9 @@ class TestAxes(AxesTestBase):
             ax.tile(x, y, w, h, anchor='blah')
 
     @pytest.mark.parametrize('cb_kw', [
-        {'use_axesgrid': True, 'fraction': 0.},
-        {'use_axesgrid': True, 'fraction': 0.15},
-        {'use_axesgrid': False},
+        {},  # our default
+        {'use_axesgrid': True, 'fraction': 0.15},  # match matplotlib behaviour
+        {'use_axesgrid': False, 'fraction': 0.15},  # matplotlib default
     ])
     def test_colorbar(self, ax, cb_kw):
         array = Array2D(numpy.random.random((10, 10)), dx=.1, dy=.2)

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -269,11 +269,7 @@ class TestAxes(AxesTestBase):
     def test_colorbar(self, ax, cb_kw):
         array = Array2D(numpy.random.random((10, 10)), dx=.1, dy=.2)
         mesh = ax.pcolormesh(array)
-        if not cb_kw['use_axesgrid'] and 'fraction' not in cb_kw:
-            with pytest.warns(PendingDeprecationWarning):
-                cbar = ax.colorbar(vmin=2, vmax=4, **cb_kw)
-        else:
-            cbar = ax.colorbar(vmin=2, vmax=4, **cb_kw)
+        cbar = ax.colorbar(vmin=2, vmax=4, **cb_kw)
         assert cbar.mappable is mesh
         assert cbar.mappable.get_clim() == (2., 4.)
 


### PR DESCRIPTION
This PR finalises two deprecations of the colorbar functionality:

- remove the `log` keyword that has been deprecated for years
- implement the change to the default `fraction`, now is 0.0 which means 'don't shrink the parent axes'