### PR TITLE
Remove deprecated Axes.legend kwargs

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018-2020)
+# Copyright (C) Cardiff University (2018-2022)
 #
 # This file is part of GWpy.
 #
@@ -19,7 +19,6 @@
 """Extension of `~matplotlib.axes.Axes` for gwpy
 """
 
-import warnings
 from functools import wraps
 from math import log
 from numbers import Number
@@ -525,30 +524,10 @@ class Axes(_Axes):
     # -- overloaded auxiliary methods -----------
 
     def legend(self, *args, **kwargs):
-        # handle deprecated keywords
-        linewidth = kwargs.pop("linewidth", None)
-        if linewidth:
-            warnings.warn(
-                "the linewidth keyword to gwpy.plot.Axes.legend has been "
-                "deprecated and will be removed in a future release; "
-                "please update your code to use a custom legend handler, "
-                "e.g. gwpy.plot.legend.HandlerLine2D.",
-                DeprecationWarning,
-            )
-        alpha = kwargs.pop("alpha", None)
-        if alpha:
-            kwargs.setdefault("framealpha", alpha)
-            warnings.warn(
-                "the alpha keyword to gwpy.plot.Axes.legend has been "
-                "deprecated and will be removed in a future release; "
-                "use framealpha instead.",
-                DeprecationWarning,
-            )
-
-        # build custom handler
+        # build custom handler to render thick lines by default
         handler_map = kwargs.setdefault("handler_map", dict())
         if isinstance(handler_map, dict):
-            handler_map.setdefault(Line2D, HandlerLine2D(linewidth or 6))
+            handler_map.setdefault(Line2D, HandlerLine2D(6))
 
         # create legend
         return super().legend(*args, **kwargs)

--- a/gwpy/plot/legend.py
+++ b/gwpy/plot/legend.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2019-2020)
+# Copyright (C) Cardiff University (2019-2022)
 #
 # This file is part of GWpy.
 #
@@ -25,7 +25,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
 class HandlerLine2D(legend_handler.HandlerLine2D):
-    """Custom Line2D legend handler that draws lines with linewidth 8
+    """Custom Line2D legend handler that draws lines with custom linewidth
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ class HandlerLine2D(legend_handler.HandlerLine2D):
     def create_artists(self, *args, **kwargs):
         artists = super().create_artists(
             *args,
-            **kwargs
+            **kwargs,
         )
         artists[0].set_linewidth(self._linewidth)
         return artists

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018-2020)
+# Copyright (C) Cardiff University (2018-2022)
 #
 # This file is part of GWpy.
 #
@@ -251,18 +251,6 @@ class TestAxes(AxesTestBase):
         leg = ax.legend(handler_map=None)
         for line in leg.get_lines():
             assert line.get_linewidth() == rcParams["lines.linewidth"]
-
-    def test_legend_deprecated_linewidth(self, ax):
-        ax.plot(numpy.arange(5), label='test')
-        with pytest.deprecated_call():
-            leg = ax.legend(linewidth=4)
-        assert leg.get_lines()[0].get_linewidth() == 4.
-
-    def test_legend_deprecated_alpha(self, ax):
-        ax.plot(numpy.arange(5), label='test')
-        with pytest.deprecated_call():
-            leg = ax.legend(alpha=.1)
-        assert leg.get_frame().get_alpha() == .1
 
     def test_plot_mmm(self, ax):
         mean_ = Series(numpy.random.random(10))


### PR DESCRIPTION
This PR removes the two deprecated `gwpy.plot.Axes.legend` keyword arguments which have been deprecated since v1.0.0,
see 78675976382aec23450aeccd0c784f5496a0c6af.