### PR TITLE
Remove deprecated GWF I/O options

### DIFF
--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -182,15 +182,6 @@ To read multiple channels from one or more GWF files (rather than opening and cl
 
    >>> data = TimeSeriesDict.read('HLV-HW100916-968654552-1.gwf', ['H1:LDAS-STRAIN', 'L1:LDAS-STRAIN'])
 
-In this case the ``resample`` and ``dtype`` keywords can be given as a single value used for all data channels, or a `dict` mapping an argument for each data channel name:
-
-.. code-block:: python
-
-   >>> data = TimeSeriesDict.read('HLV-HW100916-968654552-1.gwf', ['H1:LDAS-STRAIN', 'L1:LDAS-STRAIN'],
-   ...                            resample={'H1:LDAS-STRAIN': 2048})
-
-The above example will resample only the ``'H1:LDAS-STRAIN'`` `TimeSeries` and will not modify that for ``'L1:LDAS-STRAIN'``.
-
 .. note::
 
    A mix of `TimeSeries` and `StateVector` objects can be read by using only `TimeSeriesDict` class, and casting the returned data to a `StateVector` using :meth:`~TimeSeries.view`.

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -368,10 +368,10 @@ class TimeSeriesBase(Series):
             prefix for the progress meter
 
         type : `int`, optional
-            NDS2 channel type integer
+            NDS2 channel type integer or string name to match
 
         dtype : `type`, `numpy.dtype`, `str`, optional
-            identifier for desired output data type
+            NDS2 data type to match
         """
         return cls.DictClass.fetch(
             [channel], start, end, host=host, port=port, verbose=verbose,
@@ -1068,11 +1068,10 @@ class TimeSeriesBaseDict(OrderedDict):
             access if necessary to retrieve the data
 
         type : `int`, `str`, optional
-            NDS2 channel type integer or string name.
+            NDS2 channel type integer or string name to match.
 
         dtype : `numpy.dtype`, `str`, `type`, or `dict`
-            numeric data type for returned data, e.g. `numpy.float`, or
-            `dict` of (`channel`, `dtype`) pairs
+            NDS2 data type to match
 
         Returns
         -------
@@ -1298,10 +1297,6 @@ class TimeSeriesBaseDict(OrderedDict):
         scaled : `bool`, optional
             apply slope and bias calibration to ADC data, for non-ADC data
             this option has no effect.
-
-        dtype : `numpy.dtype`, `str`, `type`, or `dict`
-            numeric data type for returned data, e.g. `numpy.float`, or
-            `dict` of (`channel`, `dtype`) pairs
 
         nproc : `int`, optional, default: `1`
             number of parallel processes to use, serial process by

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -490,7 +490,7 @@ class TimeSeriesBase(Series):
 
     @classmethod
     def find(cls, channel, start, end, frametype=None, pad=None,
-             scaled=None, dtype=None, nproc=1, verbose=False, **readargs):
+             scaled=None, nproc=1, verbose=False, **readargs):
         """Find and read data from frames for a channel
 
         Parameters
@@ -518,10 +518,6 @@ class TimeSeriesBase(Series):
             value with which to fill gaps in the source data,
             by default gaps will result in a `ValueError`.
 
-        dtype : `numpy.dtype`, `str`, `type`, or `dict`
-            numeric data type for returned data, e.g. `numpy.float`, or
-            `dict` of (`channel`, `dtype`) pairs
-
         allow_tape : `bool`, optional, default: `True`
             allow reading from frame files on (slow) magnetic tape
 
@@ -539,7 +535,6 @@ class TimeSeriesBase(Series):
             verbose=verbose,
             pad=pad,
             scaled=scaled,
-            dtype=dtype,
             nproc=nproc,
             **readargs
         )[str(channel)]
@@ -572,10 +567,6 @@ class TimeSeriesBase(Series):
         scaled : `bool`, optional
             apply slope and bias calibration to ADC data, for non-ADC data
             this option has no effect
-
-        dtype : `numpy.dtype`, `str`, `type`, or `dict`
-            numeric data type for returned data, e.g. `numpy.float`, or
-            `dict` of (`channel`, `dtype`) pairs
 
         nproc : `int`, optional, default: `1`
             number of parallel processes to use, serial process by
@@ -1164,7 +1155,7 @@ class TimeSeriesBaseDict(OrderedDict):
 
     @classmethod
     def find(cls, channels, start, end, frametype=None,
-             frametype_match=None, pad=None, scaled=None, dtype=None, nproc=1,
+             frametype_match=None, pad=None, scaled=None, nproc=1,
              verbose=False, allow_tape=True, observatory=None, **readargs):
         """Find and read data from frames for a number of channels.
 
@@ -1195,10 +1186,6 @@ class TimeSeriesBaseDict(OrderedDict):
         scaled : `bool`, optional
             apply slope and bias calibration to ADC data, for non-ADC data
             this option has no effect.
-
-        dtype : `numpy.dtype`, `str`, `type`, or `dict`
-            numeric data type for returned data, e.g. `numpy.float`, or
-            `dict` of (`channel`, `dtype`) pairs
 
         nproc : `int`, optional, default: `1`
             number of parallel processes to use, serial process by
@@ -1272,7 +1259,7 @@ class TimeSeriesBaseDict(OrderedDict):
             # read data
             readargs.setdefault('format', 'gwf')
             new = cls.read(cache, names, start=start, end=end, pad=pad,
-                           scaled=scaled, dtype=dtype, nproc=nproc,
+                           scaled=scaled, nproc=nproc,
                            verbose=verbose, **readargs)
             # map back to user-given channel name and append
             out.append(type(new)((key, new[chan]) for
@@ -1339,7 +1326,7 @@ class TimeSeriesBaseDict(OrderedDict):
         """
         # separate non-None nds2-only keywords here
         nds_kw = {}
-        for key in ('host', 'port', 'connection'):
+        for key in ('host', 'port', 'connection', 'type', 'dtype'):
             val = kwargs.pop(key, None)
             if val is not None:
                 nds_kw[key] = val
@@ -1350,7 +1337,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 gprint("Attempting to access data from frames...")
             try:
                 return cls.find(channels, start, end, pad=pad, scaled=scaled,
-                                dtype=dtype, verbose=verbose,
+                                verbose=verbose,
                                 allow_tape=allow_tape or False,
                                 **kwargs)
             except (ImportError, RuntimeError, ValueError) as exc:

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2022)
 #
 # This file is part of GWpy.
 #
@@ -32,7 +33,6 @@ on a system.
 """
 
 import importlib
-import warnings
 
 import numpy
 
@@ -178,7 +178,6 @@ def register_gwf_api(library):
     # -- read -----------------------------------
 
     def read_timeseriesdict(source, channels, start=None, end=None,
-                            dtype=None, resample=None,
                             gap=None, pad=None, nproc=1,
                             series_class=TimeSeries, **kwargs):
         """Read the data for a list of channels from a GWF data source
@@ -222,20 +221,6 @@ def register_gwf_api(library):
         if end:
             end = to_gps(end)
 
-        # parse output format kwargs -- DEPRECATED
-        if resample is not None:
-            warnings.warn('the resample keyword for is deprecated, instead '
-                          'you should manually resample after reading',
-                          DeprecationWarning)
-        if not isinstance(resample, dict):
-            resample = dict((c, resample) for c in channels)
-        if dtype is not None:
-            warnings.warn('the dtype keyword for is deprecated, instead '
-                          'you should manually call astype() after reading',
-                          DeprecationWarning)
-        if not isinstance(dtype, dict):
-            dtype = dict((c, dtype) for c in channels)
-
         # format gap handling
         if gap is None and pad is not None:
             gap = 'pad'
@@ -273,18 +258,6 @@ def register_gwf_api(library):
                                 series_class=series_class, **kwargs),
                        gap=gap, pad=pad, copy=False)
 
-        # apply resampling and dtype-casting -- DEPRECATED
-        for name in out:
-            if (
-                resample.get(name)
-                and resample[name] != out[name].sample_rate.value
-            ):
-                out[name] = out[name].resample(resample[name])
-            if (
-                dtype.get(name) is not None
-                and numpy.dtype(dtype[name]) != out[name].dtype
-            ):
-                out[name] = out[name].astype(dtype[name])
         return out
 
     def read_timeseries(source, channel, *args, **kwargs):

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -238,31 +238,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
                                         exclude=['channel'])
 
     @pytest.mark.parametrize('api', GWF_APIS)
-    def test_read_write_gwf_deprecated_kwargs(self, tmp_path, api):
-        fmt = "gwf" if api is None else "gwf." + api
-        array = self.create(name='TEST')
-        tmp = tmp_path / "test.gwf"
-        array.write(tmp, format=fmt)
-
-        # test dtype - DEPRECATED
-        with pytest.deprecated_call():
-            t = self.TEST_CLASS.read(
-                tmp,
-                array.name,
-                format=fmt,
-                dtype='float32',
-            )
-        assert t.dtype is numpy.dtype('float32')
-        with pytest.deprecated_call():
-            t = self.TEST_CLASS.read(
-                tmp,
-                array.name,
-                format=fmt,
-                dtype={array.name: 'float64'},
-            )
-        assert t.dtype is numpy.dtype('float64')
-
-    @pytest.mark.parametrize('api', GWF_APIS)
     def test_read_write_gwf_gps_errors(self, tmp_path, api):
         fmt = "gwf" if api is None else "gwf." + api
         array = self.create(name='TEST')


### PR DESCRIPTION
This PR removes the `resample` and `dtype` options for reading GWF files, these have been deprecated since v0.11.0,
see 84672af3c4d3c285b758736eda4487fbe40fa1a0.