### PR TITLE
Fix reading ASCII files that contain a header that is five words long

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -283,13 +283,10 @@ def is_cache(cache):
     """
     if isinstance(cache, (str, os.PathLike) + FILE_LIKE):
         try:
-            return bool(len(read_cache(cache)))
-        except (
-            OSError,  # failed to read file
-            TypeError,  # failed to parse a line as a cache entry
-            UnicodeDecodeError,  # failed to decode file
-            ValueError,  # failed to parse a line as a cache entry
-        ):
+            return bool(len(read_cache(cache, coltype=float)))
+        except Exception:
+            # if parsing the file as a cache fails for _any reason_
+            # presume it isn't a cache file
             return False
     if HAS_CACHE and isinstance(cache, Cache):
         return True


### PR DESCRIPTION
This PR fixes #1473 by simplifying the `gwpy.io.cache.is_cache` method in two ways

- use `float` as the GPS column type, which has more predictable error reporting (`ValueError`) and no stderr output
- catch all exceptions from `read_cache` and return `False`