### PR TITLE
Simplify from_lal series conversions

### DIFF
--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -28,8 +28,6 @@ from astropy import units
 from astropy.io import registry as io_registry
 
 from ..types import Series
-from ..detector import Channel
-
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org"
 
@@ -349,16 +347,24 @@ class FrequencySeries(Series):
         """Generate a new `FrequencySeries` from a LAL `FrequencySeries`
         of any type.
         """
+        # convert units
         from ..utils.lal import from_lal_unit
         try:
             unit = from_lal_unit(lalfs.sampleUnits)
         except TypeError:
             unit = None
-        channel = Channel(lalfs.name, unit=unit,
-                          dtype=lalfs.data.data.dtype)
-        return cls(lalfs.data.data, channel=channel, f0=lalfs.f0,
-                   df=lalfs.deltaF, epoch=float(lalfs.epoch),
-                   dtype=lalfs.data.data.dtype, copy=copy)
+
+        # create a new series
+        return cls(
+            lalfs.data.data,
+            name=lalfs.name or None,
+            unit=unit,
+            f0=lalfs.f0,
+            df=lalfs.deltaF,
+            epoch=lalfs.epoch,
+            channel=None,
+            copy=copy,
+        )
 
     def to_lal(self):
         """Convert this `FrequencySeries` into a LAL FrequencySeries.

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -189,8 +189,7 @@ class TestFrequencySeries(_TestSeries):
         # check that to + from returns the same array
         lalts = array.to_lal()
         a2 = type(array).from_lal(lalts)
-        utils.assert_quantity_sub_equal(array, a2, exclude=['name', 'channel'])
-        assert a2.name == array.name
+        utils.assert_quantity_sub_equal(array, a2, exclude=['channel'])
 
         # test copy=False
         a2 = type(array).from_lal(lalts, copy=False)
@@ -202,7 +201,7 @@ class TestFrequencySeries(_TestSeries):
             lalts = array.to_lal()
         assert lalts.sampleUnits == lal.DimensionlessUnit
         a2 = self.TEST_CLASS.from_lal(lalts)
-        assert a2.unit is units.dimensionless_unscaled
+        assert a2.unit == units.dimensionless_unscaled
 
     @utils.skip_missing_dependency('lal')
     @utils.skip_missing_dependency('pycbc')

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -691,12 +691,22 @@ class TimeSeriesBase(Series):
     def from_lal(cls, lalts, copy=True):
         """Generate a new TimeSeries from a LAL TimeSeries of any type.
         """
+        # convert the units
         from ..utils.lal import from_lal_unit
         unit = from_lal_unit(lalts.sampleUnits)
-        channel = Channel(lalts.name, sample_rate=1/lalts.deltaT, unit=unit,
-                          dtype=lalts.data.data.dtype)
-        out = cls(lalts.data.data, channel=channel, t0=lalts.epoch,
-                  dt=lalts.deltaT, unit=unit, name=lalts.name, copy=False)
+
+        # create new series
+        out = cls(
+            lalts.data.data,
+            name=lalts.name or None,
+            unit=unit,
+            t0=lalts.epoch,
+            dt=lalts.deltaT,
+            channel=None,
+            copy=False,
+        )
+
+        # return a copy, or the new series
         if copy:
             return out.copy()
         return out

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -176,8 +176,7 @@ class TestTimeSeriesBase(_TestSeries):
         # check that to + from returns the same array
         lalts = array.to_lal()
         a2 = type(array).from_lal(lalts)
-        utils.assert_quantity_sub_equal(array, a2, exclude=['name', 'channel'])
-        assert a2.name == ''
+        utils.assert_quantity_sub_equal(array, a2, exclude=['channel'])
 
     @utils.skip_missing_dependency("lal")
     @pytest.mark.parametrize("copy", (False, True))

--- a/gwpy/timeseries/tests/test_io_gwf_lalframe.py
+++ b/gwpy/timeseries/tests/test_io_gwf_lalframe.py
@@ -125,7 +125,6 @@ def test_read(start, end):
         # check basic parameters
         assert ts.sample_rate.value == 16384
         assert ts.name == name
-        assert ts.channel.name == name
 
         # check data span is what we asked for
         assert ts.xspan == (start, end)


### PR DESCRIPTION
This PR fixes #1475 by simplifying the `{TimeSeries.FrequencySeries}.from_lal` conversion method. The LAL series object doesn't hold enough information to properly seed a `Channel` object, and supports more data types than supported by NDS2, so the solution is to just not create a Channel object in the first place.

Depends #1479.