### PR TITLE
Remove equivalence between custom strain unit and 'dimensionless_unscaled'

### DIFF
--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -177,7 +177,7 @@ units.def_unit(['NONE', 'undef'], namespace=_ns,
                doc='No unit has been defined for these data')
 
 # other dimenionless units
-units.def_unit('strain', represents=units.Unit(''), namespace=_ns)
+units.def_unit('strain', namespace=_ns)
 units.def_unit('coherence', namespace=_ns)
 
 # alias for 'second' but with prefices


### PR DESCRIPTION
This PR improves the handling of the 'strain' unit by removing the equivalence with astropy's dimensionless_unscaled. This means that it won't be silently dropped during unit operations.

Before:

```python
>>> import gwpy.detector  # register the 'strain' unit
>>> from astropy import units
>>> units.Unit('strain') * units.Unit('second')
Unit("s")
```

After:

```python
>>> import gwpy.detector
>>> from astropy import units
>>> units.Unit('strain') * units.Unit('second')
Unit("s strain")
```