### PR TITLE
Fix bugs in LAL unit conversion

### DIFF
--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -378,10 +378,11 @@ class FrequencySeries(Series):
 
         # map unit
         try:
-            unit = to_lal_unit(self.unit)
+            unit, scale = to_lal_unit(self.unit)
         except ValueError as exc:
             warnings.warn(f"{exc}, defaulting to lal.DimensionlessUnit")
             unit = lal.DimensionlessUnit
+            scale = 1
 
         # convert epoch
         epoch = lal.LIGOTimeGPS(0 if self.epoch is None else self.epoch.gps)
@@ -390,7 +391,7 @@ class FrequencySeries(Series):
         create = find_typed_function(self.dtype, 'Create', 'FrequencySeries')
         lalfs = create(self.name, epoch, self.f0.value, self.df.value,
                        unit, self.shape[0])
-        lalfs.data.data = self.value
+        lalfs.data.data = self.value * scale
 
         return lalfs
 

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -692,11 +692,7 @@ class TimeSeriesBase(Series):
         """Generate a new TimeSeries from a LAL TimeSeries of any type.
         """
         from ..utils.lal import from_lal_unit
-        try:
-            unit = from_lal_unit(lalts.sampleUnits)
-        except (TypeError, ValueError) as exc:
-            warnings.warn("%s, defaulting to 'dimensionless'" % str(exc))
-            unit = None
+        unit = from_lal_unit(lalts.sampleUnits)
         channel = Channel(lalts.name, sample_rate=1/lalts.deltaT, unit=unit,
                           dtype=lalts.data.data.dtype)
         out = cls(lalts.data.data, channel=channel, t0=lalts.epoch,

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -156,6 +156,18 @@ class TestStateTimeSeries(_TestTimeSeriesBase):
     def test_to_from_lal(self):
         return NotImplemented
 
+    def test_to_from_lal_no_copy(self):
+        return NotImplemented
+
+    def test_to_from_lal_pow10_units(self):
+        return NotImplemented
+
+    def test_to_from_lal_scaled_units(self):
+        return NotImplemented
+
+    def test_to_from_lal_unrecognised_units(self):
+        return NotImplemented
+
 
 # -- StateTimeSeriesDict ------------------------------------------------------
 
@@ -310,6 +322,9 @@ class TestStateVector(_TestTimeSeriesBase):
             array.resample(array.sample_rate * .75)
         with pytest.raises(ValueError):
             array.resample(array.sample_rate * 1.5)
+
+    def test_to_from_lal_scaled_units(self):
+        return NotImplemented
 
     # -- data access ----------------------------
 

--- a/gwpy/utils/lal.py
+++ b/gwpy/utils/lal.py
@@ -159,13 +159,7 @@ LAL_UNIT_INDEX = [  # the order corresponds to how LAL stores compound units
 
 
 def to_lal_unit(aunit):
-    """Convert the input unit into a `LALUnit`
-
-    For example::
-
-       >>> u = to_lal_unit('m**2 / kg ** 4')
-       >>> print(u)
-       m^2 kg^-4
+    """Convert the input unit into a `lal.Unit` and a scaling factor.
 
     Parameters
     ----------
@@ -174,35 +168,70 @@ def to_lal_unit(aunit):
 
     Returns
     -------
-    unit : `LALUnit`
-        the LALUnit representation of the input
+    unit : `lal.Unit`
+        the LAL representation of the base unit.
+
+    scale : `float`
+        the linear scaling factor that should be applied to any associated
+        data, see _Notes_ below.
+
+    Notes
+    -----
+    Astropy supports 'scaled' units of the form ``<N> <u>``
+    ere ``<N>`` is a `float` and ``<u>`` the base `astropy.units.Unit`,
+    e.g. ``'123 m'``, e.g:
+
+    >>> from astropy.units import Quantity
+    >>> x = Quantity(4, '123m')
+    >>> print(x)
+    4.0 123 m
+    >>> print(x.decompose())
+    492.0 m
+
+    LAL doesn't support scaled units in this way, so this function simply
+    returns the scaling factor of the unit so that it may be applied
+    manually to any associated data.
+
+    Examples
+    --------
+    >>> print(to_lal_unit('m**2 / kg ** 4'))
+    (m^2 kg^-4, 1.0)
+    >>> print(to_lal_unit('123 m'))
+    (m, 123.0)
 
     Raises
     ------
     ValueError
         if LAL doesn't understand the base units for the input
     """
+    # format incoming unit
     if isinstance(aunit, str):
         aunit = units.Unit(aunit)
     aunit = aunit.decompose()
-    lunit = lal.Unit()
+
+    # handle scaled units
+    pow10 = numpy.log10(aunit.scale)
+    if pow10 and pow10.is_integer():
+        lunit = lal.Unit(f"10^{int(pow10)}")
+        scale = 1
+    else:
+        lunit = lal.Unit()
+        scale = aunit.scale
+
+    # decompose unit into LAL base units
     for base, power in zip(aunit.bases, aunit.powers):
         try:  # try this base
             i = LAL_UNIT_INDEX.index(base)
-        except IndexError:  # otherwise loop through the equivalent bases
-            for eqbase in base.find_equivalent_units():
-                try:
-                    i = LAL_UNIT_INDEX.index(base)
-                except IndexError:
-                    continue
-                break
-            # if we didn't find anything, raise an exception
-            else:
-                raise ValueError("LAL has no unit corresponding to %r" % base)
+        except ValueError as exc:
+            exc.args = (
+                f"LAL has no unit corresponding to '{base}'",
+            )
+            raise
         frac = Fraction(power)
         lunit.unitNumerator[i] = frac.numerator
         lunit.unitDenominatorMinusOne[i] = frac.denominator - 1
-    return lunit
+
+    return lunit, scale
 
 
 def from_lal_unit(lunit):

--- a/gwpy/utils/tests/test_lal.py
+++ b/gwpy/utils/tests/test_lal.py
@@ -59,23 +59,29 @@ def test_find_typed_function():
             module=lalframe) is lalframe.FrStreamReadREAL4TimeSeries
 
 
-def test_to_lal_unit():
-    assert utils_lal.to_lal_unit('m') == lal.MeterUnit
-    assert utils_lal.to_lal_unit('Farad') == lal.Unit(
-        'm^-2 kg^-1 s^4 A^2')
+@pytest.mark.parametrize(("in_", "out"), (
+    ("m", "m"),
+    ("Farad", "m^-2 kg^-1 s^4 A^2"),
+    ("m**(1/2)", "m^1/2"),
+    ("km", "10^3 m"),
+))
+def test_to_lal_unit(in_, out):
+    assert utils_lal.to_lal_unit(in_) == lal.Unit(out)
+
+
+def test_to_lal_unit_error():
     with pytest.raises(ValueError):
         utils_lal.to_lal_unit('rad/s')
 
 
-def test_from_lal_unit():
-    try:
-        lalms = lal.MeterUnit / lal.SecondUnit
-    except TypeError as exc:  # pragma: no-cover
-        # see https://git.ligo.org/lscsoft/lalsuite/issues/65
-        pytest.skip(str(exc))
-    assert utils_lal.from_lal_unit(lalms) == units.Unit('m/s')
-    assert utils_lal.from_lal_unit(lal.StrainUnit) == (
-        units.Unit('strain'))
+@pytest.mark.parametrize(("in_", "out"), (
+    ("m s^-1", "m/s"),
+    ("strain", "strain"),
+    ("m^1/2", "m**(1/2.)"),
+    ("10^3 m", "km"),
+))
+def test_from_lal_unit(in_, out):
+    assert utils_lal.from_lal_unit(lal.Unit(in_)) == units.Unit(out)
 
 
 def test_to_lal_ligotimegps():

--- a/gwpy/utils/tests/test_lal.py
+++ b/gwpy/utils/tests/test_lal.py
@@ -59,19 +59,21 @@ def test_find_typed_function():
             module=lalframe) is lalframe.FrStreamReadREAL4TimeSeries
 
 
-@pytest.mark.parametrize(("in_", "out"), (
-    ("m", "m"),
-    ("Farad", "m^-2 kg^-1 s^4 A^2"),
-    ("m**(1/2)", "m^1/2"),
-    ("km", "10^3 m"),
+@pytest.mark.parametrize(("in_", "out", "scale"), (
+    ("m", "m", 1),
+    ("Farad", "m^-2 kg^-1 s^4 A^2", 1),
+    ("m**(1/2)", "m^1/2", 1),
+    ("km", "10^3 m", 1),
+    ("123 m", "m", 123),
 ))
-def test_to_lal_unit(in_, out):
-    assert utils_lal.to_lal_unit(in_) == lal.Unit(out)
+def test_to_lal_unit(in_, out, scale):
+    assert utils_lal.to_lal_unit(in_) == (lal.Unit(out), scale)
 
 
 def test_to_lal_unit_error():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         utils_lal.to_lal_unit('rad/s')
+    assert str(exc.value) == "LAL has no unit corresponding to 'rad'"
 
 
 @pytest.mark.parametrize(("in_", "out"), (


### PR DESCRIPTION
This PR fixes #1478 by implementing changes proposed by @jolien-creighton to improve the LAL to/from unit conversions.
This has required an API change in the `gwpy.utils.lal.to_lal_unit` function, but I believe this to be sparingly used out of GWpy, so shouldn't be heavily disruptive.