### PR TITLE
Fix deprecationwarning from scipy 1.8.0

### DIFF
--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -27,7 +27,10 @@ import numpy
 from numpy import fft as npfft
 
 from scipy import signal
-from scipy.signal.ltisys import LinearTimeInvariant
+try:
+    from scipy.signal import LinearTimeInvariant
+except ImportError:  # scipy < 1.8.0
+    from scipy.signal.ltisys import LinearTimeInvariant
 
 from astropy.units import (Unit, Quantity)
 


### PR DESCRIPTION
This PR fixes a `DeprecationWarning` when importing `LinearTimeInvariant` with scipy 1.8.0a0.