### PR TITLE
Fix reading a contiguous series of files with LALFrame

### DIFF
--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -147,6 +147,7 @@ def read(source, channels, start=None, end=None, series_class=TimeSeries,
     start = max(epoch, lalutils.to_lal_ligotimegps(start))
     if end is None:
         end = epoch + streamdur
+    end = min(epoch + streamdur, lalutils.to_lal_ligotimegps(end))
     duration = float(end - start)
 
     # read data


### PR DESCRIPTION
This PR fixes #1486 by fixing an issue with how the LALFrame API (`gwpy.timeseries.io.gwf.lalframe`) pins the 'end' time of a read request. This effectively now matches the behaviour of the framecpp and framel APIs.