### PR TITLE
Avoid regex 2022.3.15 in requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,23 +35,23 @@ classifiers =
 packages = find:
 python_requires = >=3.7
 setup_requires =
-	setuptools >= 38.2.5
+	setuptools >=38.2.5
 	setuptools_scm
 	wheel
 install_requires =
-	astropy >= 4.0
+	astropy >=4.0
 	dqsegdb2
 	gwdatafind
-	gwosc >= 0.5.3
-	h5py >= 2.8.0
-	ligo-segments >= 1.0.0
-	ligotimegps >= 1.2.1
-	matplotlib >= 3.3.0
-	numpy >= 1.16
+	gwosc >=0.5.3
+	h5py >=2.8.0
+	ligo-segments >=1.0.0
+	ligotimegps >=1.2.1
+	matplotlib >=3.3.0
+	numpy >=1.16
 	python-dateutil
 	requests
-	scipy >= 1.2.0
-	tqdm >= 4.10.0
+	scipy >=1.2.0
+	tqdm >=4.10.0
 include_package_data = true
 
 [options.entry_points]
@@ -62,9 +62,9 @@ console_scripts =
 # test suite
 test =
 	beautifulsoup4
-	freezegun >= 0.3.12
-	pytest >= 3.9.1
-	pytest-cov >= 2.4.0
+	freezegun >=0.3.12
+	pytest >=3.9.1
+	pytest-cov >=2.4.0
 	pytest-socket
 	pytest-xdist
 	requests-mock
@@ -73,11 +73,11 @@ astro =
 	inspiral-range
 # sphinx documentation
 docs =
-	numpydoc >= 0.8.0
-	sphinx >= 4.0.0
+	numpydoc >=0.8.0
+	sphinx >=4.0.0
 	sphinx-automodapi
-	sphinx-material >= 0.0.32
-	sphinx-panels >= 0.6.0
+	sphinx-material >=0.0.32
+	sphinx-panels >=0.6.0
 	sphinxcontrib-programoutput
 # development environments
 dev =
@@ -86,17 +86,17 @@ dev =
 	lscsoft-glue ; sys_platform != 'win32'
 	maya
 	psycopg2
-	pycbc >= 1.13.4 ; sys_platform != 'win32'
+	pycbc >=1.13.4 ; sys_platform != 'win32'
 	pymysql
 	pyRXP
-	python-ligo-lw >= 1.7.0 ; sys_platform != 'win32'
-	regex != 2021.8.27
+	python-ligo-lw >=1.7.0 ; sys_platform != 'win32'
+	regex !=2021.8.27
 	sqlalchemy
-	uproot >= 4.1.5
+	uproot >=4.1.5
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda =
-	python-framel >= 8.40.1
+	python-framel >=8.40.1
 	python-ldas-tools-framecpp ; sys_platform != 'win32'
 	python-nds2-client
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,7 @@ dev =
 	pymysql
 	pyRXP
 	python-ligo-lw >=1.7.0 ; sys_platform != 'win32'
-	regex !=2021.8.27
+	regex !=2021.8.27, !=2022.3.15
 	sqlalchemy
 	uproot >=4.1.5
 # conda packages for development


### PR DESCRIPTION
This MR patches `setup.cfg` to avoid `regex` 2022.3.15, see https://github.com/scrapinghub/dateparser/issues/1045.