### PR TITLE
Add missing import of warnings module

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -19,6 +19,7 @@
 """Extension of `~matplotlib.axes.Axes` for gwpy
 """
 
+import warnings
 from functools import wraps
 from math import log
 from numbers import Number


### PR DESCRIPTION
This PR fixes an issue shown up by the linter caused by merging PRs #1470 and #1483 without rebasing.