### PR TITLE
Allow irregular non-contiguous time series to be appended

### DIFF
--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -771,7 +771,11 @@ class Series(Array):
 
         # check metadata (do not do this if trying to join to unevenly sampled
         # discontiguous series')
-        if not (gap == 'ignore' and (not hasattr(self, 'dx') or not hasattr(other, 'dx'))):
+        if not (
+            gap == 'ignore' and (
+                not hasattr(self, 'dx') or not hasattr(other, 'dx')
+            )
+        ):
             self.is_compatible(other)
 
         # make copy if needed

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -316,7 +316,7 @@ class TestSeries(_TestArray):
         z = numpy.zeros((1,) + array.shape[1:])
         utils.assert_array_equal(
             ts4.value, numpy.concatenate((array.value, z, a3.value)))
-            
+
         # gap='ignore' with irregular data
         ts4 = array.copy()
         xindex1 = ts4.xindex.copy()

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -319,13 +319,13 @@ class TestSeries(_TestArray):
 
         # gap='ignore' with irregular data
         ts4 = array.copy()
-        xindex1 = ts4.xindex.copy()
-        xindex1[int(len(ts4) // 2):] += 1 * ts4.xunit
-        ts4.xindex = xindex1.copy()
+        xindex1 = ts4.xindex.value.copy()
+        xindex1[int(len(ts4) // 2):] += 1.0
+        ts4.xindex = xindex1.copy() * ts4.xunit
         a3 = self.create(x0=ts4.xindex[-1] + 1)
-        xindex2 = a3.xindex.copy()
-        xindex2[int(len(ts4) // 2):] += 1 * a3.xunit
-        a3.xindex = xindex2.copy()
+        xindex2 = a3.xindex.value.copy()
+        xindex2[int(len(a3) // 2):] += 1.0
+        a3.xindex = xindex2.copy() * a3.xunit
         ts4.append(a3, gap='ignore')
         with pytest.raises(AttributeError):
             ts4.dx
@@ -334,7 +334,7 @@ class TestSeries(_TestArray):
             ts4.value, numpy.concatenate((array.value, a3.value)))
         utils.assert_array_equal(
             ts4.xindex.value, numpy.concatenate(
-                (xindex1.value, xindex2.value)
+                (xindex1, xindex2)
             )
         )
 

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -316,6 +316,16 @@ class TestSeries(_TestArray):
         z = numpy.zeros((1,) + array.shape[1:])
         utils.assert_array_equal(
             ts4.value, numpy.concatenate((array.value, z, a3.value)))
+            
+        # gap='ignore' with irregular data
+        ts4 = array.copy()
+        ts4.xindex[int(len(ts4) // 2):] += 1  # make irregular
+        a3 = self.create(x0=ts4.xindex[-1] + 1)  # make discontinguous
+        ts4.xindex[int(len(a3) // 2):] += 1  # make irregular
+        ts4.append(a3, gap='ignore')
+        with pytest.raises(AttributeError):
+            ts4.dx
+        assert not ts4.xindex.is_regular()
 
     def test_prepend(self, array):
         """Test the `Series.prepend` method

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -319,13 +319,24 @@ class TestSeries(_TestArray):
             
         # gap='ignore' with irregular data
         ts4 = array.copy()
-        ts4.xindex[int(len(ts4) // 2):] += 1  # make irregular
-        a3 = self.create(x0=ts4.xindex[-1] + 1)  # make discontinguous
-        ts4.xindex[int(len(a3) // 2):] += 1  # make irregular
+        xindex1 = ts4.xindex.copy()
+        xindex1[int(len(ts4) // 2):] += 1
+        ts4.xindex = xindex1.copy()
+        a3 = self.create(x0=ts4.xindex[-1] + 1)
+        xindex2 = a3.xindex.copy()
+        xindex2[int(len(ts4) // 2):] += 1
+        a3.xindex = xindex2.copy()
         ts4.append(a3, gap='ignore')
         with pytest.raises(AttributeError):
             ts4.dx
         assert not ts4.xindex.is_regular()
+        utils.assert_array_equal(
+            ts4.value, numpy.concatenate((array.value, a3.value)))
+        utils.assert_array_equal(
+            ts4.xindex.value, numpy.concatenate(
+                (xindex1.value, xindex2.value)
+            )
+        )
 
     def test_prepend(self, array):
         """Test the `Series.prepend` method

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -320,11 +320,11 @@ class TestSeries(_TestArray):
         # gap='ignore' with irregular data
         ts4 = array.copy()
         xindex1 = ts4.xindex.copy()
-        xindex1[int(len(ts4) // 2):] += 1
+        xindex1[int(len(ts4) // 2):] += 1 * ts4.xunit
         ts4.xindex = xindex1.copy()
         a3 = self.create(x0=ts4.xindex[-1] + 1)
         xindex2 = a3.xindex.copy()
-        xindex2[int(len(ts4) // 2):] += 1
+        xindex2[int(len(ts4) // 2):] += 1 * a3.xunit
         a3.xindex = xindex2.copy()
         ts4.append(a3, gap='ignore')
         with pytest.raises(AttributeError):

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -322,7 +322,7 @@ class TestSeries(_TestArray):
         xindex1 = ts4.xindex.value.copy()
         xindex1[int(len(ts4) // 2):] += 1.0
         ts4.xindex = xindex1.copy() * ts4.xunit
-        a3 = self.create(x0=ts4.xindex[-1] + 1)
+        a3 = self.create(x0=(ts4.xindex[-1] + 1 * ts4.xunit))
         xindex2 = a3.xindex.value.copy()
         xindex2[int(len(a3) // 2):] += 1.0
         a3.xindex = xindex2.copy() * a3.xunit


### PR DESCRIPTION
In a follow-up to https://github.com/gwpy/gwpy/pull/1428, this PR edits the `Series.append()` method to allow irregular non-consecutive time series to be appended/joined. For example, currently the following will fail:

```python
from gwpy.timeseries import TimeSeries, TimeSeriesList
ts1 = TimeSeries([1, 2, 3, 4], times=[0, 4, 5, 7])
ts2 = TimeSeries([5, 6, 7, 8, 9], times=[10, 11, 12, 15, 16])
l = TimeSeriesList()
l.append(ts1)
l.append(ts2)
newd = l.join(gap="ignore")
```

With this PR it will work.