### PR TITLE
Update default branch references from master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,28 +36,27 @@ contributing guide.
 
 ## Development model
 
-Contributions to GWpy are made via pull requests from GitHub users' forks of the main [gwpy repositories](https://github.com/gwpy/gwpy), following the [GitHub flow](https://guides.github.com/introduction/flow/) workflow.
-The basic idea is to use the `master` branch of your fork as a way of updating your fork with other people's changes that have been merged into the main repo, and then  working on a dedicated _feature branch_ for each piece of work:
+Contributions to GWpy are made via pull requests from GitHub users' forks of
+the main [gwpy repositories](https://github.com/gwpy/gwpy), following the
+[GitHub flow](https://guides.github.com/introduction/flow/) workflow.
+The basic idea is that all changes are proposed using a dedicated _feature_
+branch:
 
-- create the fork (if needed) by clicking _Fork_ in the upper-right corner of <https://github.com/gwpy/gwpy/> - this only needs to be done once, ever
-- clone the fork (replace `<username>` with your GitHub username):
+- create the fork (if needed) by clicking _Fork_ in the upper-right corner of
+  <https://github.com/gwpy/gwpy/> - this only needs to be done once, ever
+
+- clone the main repo, calling it `upstream` in the git configuration:
 
   ```bash
-  git clone https://github.com/<username>/gwpy.git gwpy-fork
-  cd gwpy-fork
+  git clone https://github.com/gwpy/gwpy.git gwpy --origin upstream
+  cd gwpy
   ```
-  
-- link the fork to the upstream 'main' repo:
+
+- add your fork as the `origin` remote (replace `<username>` with your
+  GitHub username):
 
   ```bash
-  git remote add upstream https://github.com/gwpy/gwpy.git
-  ```
-  
-- pull changes from the upstream 'main' repo onto your fork's master branch to pick up other people's changes, then push to your remote to update your fork on github.com
-
-  ```bash
-  git pull --rebase upstream master
-  git push
+  git remote add origin git@github.com:<username>/gwpy.git
   ```
 
 - create a new branch on which to work
@@ -65,18 +64,37 @@ The basic idea is to use the `master` branch of your fork as a way of updating y
   ```bash
   git checkout -b my-new-branch
   ```
-  
+
 - make commits to that branch
+
 - push changes to your remote on github.com
 
   ```bash
   git push -u origin my-new-branch
   ```
 
-- open a merge request on github.com
-- when the request is merged, you should 'delete the source branch' (there's a button), to keep your fork clean
+- open a merge request on github.com, this will trigger a code review by one
+  of the GWpy maintainers, who may suggest modifications to your proposed
+  changes
 
-And that's it.
+- to update your feature branch with the latest changes from the `main` branch
+  of the `upstream` repository:
+
+  ```bash
+  git pull --rebase upstream main
+  ```
+
+  This `rebase` will pull in new changes from the `upstream/main` branch, but will
+  restage your commits on top of the newest upstream changes.
+  This changes the 'history' of your branch, which means you will need to `force`
+  git to push your changes to github.com:
+
+  ```bash
+  git push origin my-new-branch --force
+  ```
+
+- finally, if your Pull Request is merged, you should 'delete the source branch'
+  (there's a button), to keep your fork clean
 
 ## Coding guidelines
 
@@ -94,7 +112,7 @@ the [`flake8`](http://flake8.pycqa.org) linter, which checks the style of code
 in the repo. You can run this locally before committing changes via:
 
 ```bash
-python -m flake8
+python3 -m flake8
 ```
 
 ### Testing
@@ -107,5 +125,5 @@ all new or modified lines.
 You can run the test suite locally from the root of the repository via:
 
 ```bash
-python -m pytest gwpy/
+python3 -m pytest gwpy/
 ```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ step.
 
 # Development status
 
-[![Build status](https://github.com/gwpy/gwpy/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/gwpy/gwpy/actions/workflows/build.yml)
-[![Coverage status](https://codecov.io/gh/gwpy/gwpy/branch/master/graph/badge.svg)](https://codecov.io/gh/gwpy/gwpy)
+[![Build status](https://github.com/gwpy/gwpy/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/gwpy/gwpy/actions?query=branch%3Amain)
+[![Coverage status](https://codecov.io/gh/gwpy/gwpy/branch/main/graph/badge.svg)](https://codecov.io/gh/gwpy/gwpy)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2cf14445b3e070133745/maintainability)](https://codeclimate.com/github/gwpy/gwpy/maintainability)
 
 # Installation
@@ -45,4 +45,4 @@ python -c "import gwpy; print(gwpy.__version__)"
 
 # License
 
-GWpy is released under the GNU General Public License v3.0 or later, see [here](https://choosealicense.com/licenses/gpl-3.0/) for a description of this license, or see the [LICENSE](https://github.com/gwpy/gwpy/blob/master/LICENSE) file for the full text.
+GWpy is released under the GNU General Public License v3.0 or later, see [here](https://choosealicense.com/licenses/gpl-3.0/) for a description of this license, or see the [LICENSE](https://github.com/gwpy/gwpy/blob/main/LICENSE) file for the full text.

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -36,7 +36,7 @@ Step-by-step
 
    .. code-block:: bash
 
-      git push -u origin master
+      git push -u origin main
 
    for major/minor releases, or
 
@@ -67,8 +67,8 @@ Step-by-step
 
       # push maintenance branch
       git push --signed=if-asked origin release/X.Y.x
-      # push master branch
-      git push --signed=if-asked origin master
+      # push main branch
+      git push --signed=if-asked origin main
       # push new tag
       git push --signed=if-asked origin vX.Y.Z
 

--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -124,7 +124,7 @@ To read data from a GWF file, pass the input file path (or paths) and the name o
 
 .. note::
 
-   The ``HLV-HW100916-968654552-1.gwf`` file is included with the GWpy source under `/gwpy/testing/data/ <https://github.com/gwpy/gwpy/tree/master/gwpy/testing/data>`_.
+   The ``HLV-HW100916-968654552-1.gwf`` file is included with the GWpy source under `/gwpy/testing/data/ <https://github.com/gwpy/gwpy/tree/main/gwpy/testing/data>`_.
 
 Reading a `StateVector` uses the same syntax:
 


### PR DESCRIPTION
This PR updates the few references to the old default branch (`master`) to `main`. I included a more generic update to the contributing guide as I noticed that it was out-of-date relative to my recommended workflow.