### PR TITLE
Split up functionality of TimeSeries.gate()

### DIFF
--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1806,7 +1806,7 @@ class TimeSeries(TimeSeriesBase):
         return out * numpy.sqrt(2 * in_.dt.decompose().value)
 
     def find_gates(self, tzero=1.0, whiten=True,
-             threshold=50., cluster_window=0.5, **whiten_kwargs):
+                   threshold=50., cluster_window=0.5, **whiten_kwargs):
         """Identify points that should be gates using a provided threshold
         and clustered within a provided time window.
 
@@ -1929,9 +1929,10 @@ class TimeSeries(TimeSeriesBase):
         TimeSeries.whiten
             for the whitening filter used to identify gating points
         """
-        deadtime = self.find_gates(tzero=tzero, 
-             whiten=whiten, threshold=threshold, 
-             cluster_window=cluster_window, **whiten_kwargs)
+        deadtime = self.find_gates(tzero=tzero, whiten=whiten,
+                                   threshold=threshold,
+                                   cluster_window=cluster_window,
+                                   **whiten_kwargs)
         return self.mask(deadtime=deadtime, const=0, tpad=tpad)
 
     def convolve(self, fir, window='hanning'):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1933,7 +1933,7 @@ class TimeSeries(TimeSeriesBase):
         TimeSeries.whiten
             for the whitening filter used to identify gating points
         """
-        deadtime = self.find_gates(self, tzero=tzero, 
+        deadtime = self.find_gates(tzero=tzero, 
              whiten=whiten, threshold=threshold, 
              cluster_window=cluster_window, **whiten_kwargs)
         return self.mask(deadtime=deadtime, const=0, tpad=tpad)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1848,7 +1848,7 @@ class TimeSeries(TimeSeriesBase):
         data = self.whiten(**whiten_kwargs) if whiten else self
         window_samples = cluster_window * sample
         gates = signal.find_peaks(abs(data.value), height=threshold,
-                           distance=window_samples)[0]
+                                  distance=window_samples)[0]
         # represent gates as time segments
         return SegmentList([Segment(
             self.t0.value + (k / sample) - tzero,
@@ -1929,9 +1929,9 @@ class TimeSeries(TimeSeriesBase):
             for the whitening filter used to identify gating points
         """
         gates = self.find_gates(tzero=tzero, whiten=whiten,
-                                   threshold=threshold,
-                                   cluster_window=cluster_window,
-                                   **whiten_kwargs)
+                                threshold=threshold,
+                                cluster_window=cluster_window,
+                                **whiten_kwargs)
         return self.mask(deadtime=gates, const=0, tpad=tpad)
 
     def convolve(self, fir, window='hanning'):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1805,7 +1805,7 @@ class TimeSeries(TimeSeriesBase):
         out = in_.convolve(tdw, window=window)
         return out * numpy.sqrt(2 * in_.dt.decompose().value)
 
-    def find_gates(self, tzero=1.0, tpad=0.5, whiten=True,
+    def find_gates(self, tzero=1.0, whiten=True,
              threshold=50., cluster_window=0.5, **whiten_kwargs):
         """Identify points that should be gates using a provided threshold
         and clustered within a provided time window.
@@ -1933,7 +1933,7 @@ class TimeSeries(TimeSeriesBase):
         TimeSeries.whiten
             for the whitening filter used to identify gating points
         """
-        deadtime = self.find_gates(self, tzero=tzero, tpad=tpad, 
+        deadtime = self.find_gates(self, tzero=tzero, 
              whiten=whiten, threshold=threshold, 
              cluster_window=cluster_window, **whiten_kwargs)
         return self.mask(deadtime=deadtime, const=0, tpad=tpad)

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1805,6 +1805,61 @@ class TimeSeries(TimeSeriesBase):
         out = in_.convolve(tdw, window=window)
         return out * numpy.sqrt(2 * in_.dt.decompose().value)
 
+    def find_gates(self, tzero=1.0, tpad=0.5, whiten=True,
+             threshold=50., cluster_window=0.5, **whiten_kwargs):
+        """Identify points that should be gates using a provided threshold
+        and clustered within a provided time window.
+
+        Parameters
+        ----------
+        tzero : `int`, optional
+            half-width time duration (seconds) in which the timeseries is
+            set to zero
+
+        tpad : `int`, optional
+            half-width time duration (seconds) in which the Planck window
+            is tapered
+
+        whiten : `bool`, optional
+            if True, data will be whitened before gating points are discovered,
+            use of this option is highly recommended
+
+        threshold : `float`, optional
+            amplitude threshold, if the data exceeds this value a gating window
+            will be placed
+
+        cluster_window : `float`, optional
+            time duration (seconds) over which gating points will be clustered
+
+        **whiten_kwargs
+            other keyword arguments that will be passed to the
+            `TimeSeries.whiten` method if it is being used when discovering
+            gating points
+
+        Returns
+        -------
+        out : `~gwpy.segments.SegmentList`
+            a list of segments that should be gated based on the
+            provided parameters
+        See also
+        --------
+        TimeSeries.gate
+            for a method that applies the identified gates
+        """
+        from scipy.signal import find_peaks
+        # Find points to gate based on a threshold
+        sample = self.sample_rate.to('Hz').value
+        data = self.whiten(**whiten_kwargs) if whiten else self
+        window_samples = cluster_window * sample
+        gates = find_peaks(abs(data.value), height=threshold,
+                           distance=window_samples)[0]
+        # represent gates as time segments
+        deadtime = SegmentList([Segment(
+            self.t0.value + (k / sample) - tzero,
+            self.t0.value + (k / sample) + tzero,
+        ) for k in gates]).coalesce()
+        return deadtime
+
     def gate(self, tzero=1.0, tpad=0.5, whiten=True,
              threshold=50., cluster_window=0.5, **whiten_kwargs):
         """Removes high amplitude peaks from data using inverse Planck window.
@@ -1873,22 +1928,14 @@ class TimeSeries(TimeSeriesBase):
         --------
         TimeSeries.mask
             for the method that masks out unwanted data
+        TimeSeries.find_gates
+            for the method that identifies gating points
         TimeSeries.whiten
             for the whitening filter used to identify gating points
         """
-        from scipy.signal import find_peaks
-        # Find points to gate based on a threshold
-        sample = self.sample_rate.to('Hz').value
-        data = self.whiten(**whiten_kwargs) if whiten else self
-        window_samples = cluster_window * sample
-        gates = find_peaks(abs(data.value), height=threshold,
-                           distance=window_samples)[0]
-        # represent gates as time segments
-        deadtime = SegmentList([Segment(
-            self.t0.value + (k / sample) - tzero,
-            self.t0.value + (k / sample) + tzero,
-        ) for k in gates]).coalesce()
-        # return the self-gated timeseries
+        deadtime = self.find_gates(self, tzero=tzero, tpad=tpad, 
+             whiten=whiten, threshold=threshold, 
+             cluster_window=cluster_window, **whiten_kwargs)
         return self.mask(deadtime=deadtime, const=0, tpad=tpad)
 
     def convolve(self, fir, window='hanning'):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1816,10 +1816,6 @@ class TimeSeries(TimeSeriesBase):
             half-width time duration (seconds) in which the timeseries is
             set to zero
 
-        tpad : `int`, optional
-            half-width time duration (seconds) in which the Planck window
-            is tapered
-
         whiten : `bool`, optional
             if True, data will be whitened before gating points are discovered,
             use of this option is highly recommended


### PR DESCRIPTION
This PR splits `TimeSeries.gate()` into two functions:
* `TimeSeries.find_gates()` - find peaks in whitened timeseries and returns the segments to gate
* `TimeSeries.gate()` - now only calls `TimeSeries.find_gates()` and `TimeSeries.mask()` to find and apply gates

The motivation for this change is that it would be helpful to be able to record the segments that were gated. Users hoping to do this can now use `TimeSeries.find_gates()` and `TimeSeries.mask()` separately. 

Since this PR is only reorganizing code, the result of `TimeSeries.gate()` remains unchanged.