### PR TITLE
Pin dev builds to astropy <5.1a0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,8 @@ docs =
 	sphinxcontrib-programoutput
 # development environments
 dev =
+	; https://github.com/gwpy/gwpy/issues/1496
+	astropy <5.1a0 ; sys_platform != 'win32'
 	ciecplib
 	lalsuite ; sys_platform != 'win32'
 	lscsoft-glue ; sys_platform != 'win32'


### PR DESCRIPTION
This PR fixes #1496 by pinning the `dev` extra to `astropy <5.1a0`. This should be reverted once a fix for gwastro/pycbc#4019 is distributed.