### PR TITLE
Migrate GWDataFind interface to new UI

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -48,7 +48,7 @@ GWpy has the following strict requirements:
    ==================  ===========================
    |astropy|_          ``>=4.0``
    |dqsegdb2|_
-   |gwdatafind|_
+   |gwdatafind|_       ``>=1.1.0``
    |gwosc-mod|_        ``>=0.5.3``
    |h5py|_             ``>=2.8.0``
    |ligo-segments|_    ``>=1.0.0``

--- a/docs/timeseries/datafind.rst
+++ b/docs/timeseries/datafind.rst
@@ -50,8 +50,9 @@ How it works
 Without any customisation, :meth:`TimeSeries.get` will attempt to locate
 data 'by any means necessary'; in practice that is
 
-- if the ``GWDATAFIND_SERVER`` environment variable points to a
-  server URL, use |gwdatafind|_ to identify which data set includes
+- if the ``GWDATAFIND_SERVER`` environment variable (or legacy
+  ``LIGO_DATAFIND_SERVER`` variable) points to a server URL,
+  use |gwdatafind|_ to identify which data set includes
   the channel(s) requested, then locate the files for that data set,
   and then read them,
 - if that doesn't work (for any reason), loop through the NDS2 servers

--- a/docs/timeseries/datafind.rst
+++ b/docs/timeseries/datafind.rst
@@ -50,7 +50,7 @@ How it works
 Without any customisation, :meth:`TimeSeries.get` will attempt to locate
 data 'by any means necessary'; in practice that is
 
-- if the ``LIGO_DATAFIND_SERVER`` environment variable points to a
+- if the ``GWDATAFIND_SERVER`` environment variable points to a
   server URL, use |gwdatafind|_ to identify which data set includes
   the channel(s) requested, then locate the files for that data set,
   and then read them,

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -53,6 +53,8 @@ from .utils import file_path
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+SINGLE_IFO_OBSERVATORY = re.compile("^[A-Z][0-9]$")
+
 # special-case frame types
 LIGO_SECOND_TREND_TYPE = re.compile(r'\A(.*_)?T\Z')  # T or *_T
 LIGO_MINUTE_TREND_TYPE = re.compile(r'\A(.*_)?M\Z')  # M or *_M
@@ -536,7 +538,8 @@ def find_latest(
     --------
     gwdatafind.find_latest
     """
-    observatory = observatory[0]
+    if SINGLE_IFO_OBSERVATORY.match(observatory):
+        observatory = observatory[0]
     try:
         if gpstime is not None:
             gpstime = int(to_gps(gpstime))

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -25,8 +25,9 @@ The functions in this module are highly reliant on having local access to
 files (either directly, or via NFS, or CVMFS).
 
 Data discovery using the DataFind service requires the `gwdatafind` Python
-package, and either the ``LIGO_DATAFIND_SERVER`` environment variable to be
-set, or the ``host`` keyword must be passed to :func:`find_urls` and friends.
+package (a dependency of ``gwpy``), and either the ``GW_DATAFIND_SERVER``
+(or legacy ``LIGO_DATAFIND_SERVER``) environment variable to be set,
+or the ``host`` keyword must be passed to :func:`find_urls` and friends.
 
 Data discovery using the Virgo FFL system requires the ``FFLPATH`` environment
 variable to point to the directory containing FFL files, **or** the

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -40,6 +40,7 @@ import re
 import warnings
 from collections import defaultdict
 from functools import wraps
+from unittest import mock
 
 import gwdatafind
 
@@ -163,11 +164,11 @@ def _select_gwdatafind_mod(func):
     @wraps(func)
     def wrapped(*args, **kwargs):
         # replace the 'gwdatafind' module in the function namespace
-        # with the right one
-        func.__globals__["gwdatafind"] = _gwdatafind_module(**kwargs)
+        # with the API we need for this call
+        with mock.patch.dict(func.__globals__):
+            func.__globals__["gwdatafind"] = _gwdatafind_module(**kwargs)
+            return func(*args, **kwargs)
 
-        # run the function
-        return func(*args, **kwargs)
     return wrapped
 
 

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -40,15 +40,14 @@ import re
 import warnings
 from collections import defaultdict
 from functools import wraps
-from http.client import HTTPException
 
-from ligo.segments import (
-    segment as LigoSegment,
-    segmentlist as LigoSegmentList,
-)
+import gwdatafind
+
+from ligo.segments import segment as LigoSegment
 
 from ..time import to_gps
-from .cache import (cache_segments, read_cache_entry, _iter_cache)
+from . import ffldatafind
+from .cache import cache_segments
 from .gwf import (num_channels, iter_channel_names)
 from .utils import file_path
 
@@ -72,204 +71,6 @@ LOW_PRIORITY_TYPE = re.compile("({})".format("|".join((
 
 
 # -- utilities ----------------------------------------------------------------
-
-class FflConnection(object):
-    """API for Virgo FFL queries that mimics `gwdatafind.http.HTTPConnection`
-    """
-    _EXTENSION = 'ffl'
-    _SITE_REGEX = re.compile(r'\A(\w+)-')
-
-    def __init__(self, ffldir=None):
-        self.ffldir = ffldir or self._get_ffl_dir()
-        self.paths = {}
-        self.cache = {}
-        self._find_paths()
-
-    # -- utilities ------------------------------
-
-    @staticmethod
-    def _get_ffl_dir():
-        if 'FFLPATH' in os.environ:
-            return os.environ['FFLPATH']
-        if 'VIRGODATA' in os.environ:
-            return os.path.join(os.environ['VIRGODATA'], 'ffl')
-        raise KeyError("failed to parse FFTPATH from environment, please set "
-                       "FFLPATH to point to the directory containing FFL "
-                       "files")
-
-    @classmethod
-    def _is_ffl_file(cls, path):
-        return path.endswith(f".{cls._EXTENSION}")
-
-    def _find_paths(self):
-        _is_ffl = self._is_ffl_file
-
-        # reset
-        paths = self.paths = {}
-
-        # scan directory tree
-        for root, _, files in os.walk(self.ffldir):
-            for name in filter(_is_ffl, files):
-                path = os.path.join(root, name)
-                try:
-                    site, tag = self._get_site_tag(path)
-                except (OSError, IOError, AttributeError):
-                    # OSError: file is empty (or cannot be read at all)
-                    # IOError: as above on python2
-                    # AttributeError: last entry didn't match _SITE_REGEX
-                    continue
-                paths[(site, tag)] = path
-
-    # -- readers --------------------------------
-
-    def _read_ffl_cache(self, site, tag):
-        key = (site, tag)
-        path = self.ffl_path(site, tag)
-
-        # use cached result if already read, and file not modified since
-        try:
-            mtime = self.cache[key][0]
-        except KeyError:
-            mtime = 0
-        newm = os.path.getmtime(path)
-        if newm > mtime:  # read FFL file
-            def _update_metadata(entry):
-                return type(entry)(site, tag, entry.segment, entry.path)
-            with open(path, 'r') as fobj:
-                cache = list(map(
-                    _update_metadata,
-                    _iter_cache(fobj, gpstype=float),
-                ))
-            self.cache[key] = newm, cache
-        return self.cache[key][-1]
-
-    @staticmethod
-    def _read_last_line(path):
-        with open(path, 'rb') as fobj:
-            # read last line of file only
-            fobj.seek(-2, os.SEEK_END)
-            while fobj.read(1) != b"\n":
-                fobj.seek(-2, os.SEEK_CUR)
-            line = fobj.readline().rstrip()
-            if isinstance(line, bytes):
-                return line.decode('utf-8')
-            return line
-
-    def _get_site_tag(self, path):
-        # tag is just name of file minus extension
-        tag = os.path.splitext(os.path.basename(path))[0]
-
-        # need to read first file from FFL to get site (IFO)
-        last = self._read_last_line(path).split()[0]
-        site = self._SITE_REGEX.match(os.path.basename(last)).groups()[0]
-
-        return site, tag
-
-    # -- UI -------------------------------------
-
-    def ffl_path(self, site, frametype):
-        """Returns the path of the FFL file for the given site and frametype
-
-        Examples
-        --------
-        >>> from gwpy.io.datafind import FflConnection
-        >>> conn = FflConnection()
-        >>> print(conn.ffl_path('V', 'V1Online'))
-        /virgoData/ffl/V1Online.ffl
-        """
-        try:
-            return self.paths[(site, frametype)]
-        except KeyError:
-            self._find_paths()
-            return self.paths[(site, frametype)]
-
-    def find_types(self, site=None, match=r'^(?!lastfile|spectro|\.).*'):
-        """Return the list of known data types.
-
-        This is just the basename of each FFL file found in the
-        FFL directory (minus the ``.ffl`` extension)
-        """
-        self._find_paths()
-        types = [tag for (site_, tag) in self.paths if site in (None, site_)]
-        if match is not None:
-            match = re.compile(match)
-            return list(filter(match.search, types))
-        return types
-
-    def find_urls(self, site, frametype, gpsstart, gpsend,
-                  match=None, on_gaps='warn'):
-        """Find all files of the given type in the [start, end) GPS interval.
-        """
-        span = LigoSegment(gpsstart, gpsend)
-        cache = [
-            e for e in self._read_ffl_cache(site, frametype) if (
-                e.observatory == site
-                and e.description == frametype
-                and e.segment.intersects(span)
-            )
-        ]
-        urls = [e.path for e in cache]
-        missing = LigoSegmentList([span]) - cache_segments(cache)
-
-        if match:
-            match = re.compile(match)
-            urls = list(filter(match.search, urls))
-
-        # no missing data or don't care, return
-        if on_gaps == 'ignore' or not missing:
-            return urls
-
-        # handle missing data
-        msg = "Missing segments: \n" + "\n".join(map(str, missing))
-        if on_gaps == 'warn':
-            warnings.warn(msg)
-            return urls
-        raise RuntimeError(msg)
-
-    def find_latest(self, site, frametype, on_missing='warn'):
-        """Return the most recent file of a given type.
-        """
-        try:
-            urls = [self.cache[(site, frametype)][-1].path]
-        except KeyError:
-            try:
-                path = self.ffl_path(site, frametype)
-                urls = [
-                    read_cache_entry(self._read_last_line(path), gpstype=float)
-                ]
-            except (KeyError, OSError):
-                urls = []
-        if urls or on_missing == 'ignore':
-            return urls
-
-        # handle no files
-        msg = 'No files found'
-        if on_missing == 'warn':
-            warnings.warn(msg)
-            return urls
-        raise RuntimeError(msg)
-
-
-def reconnect(connection):
-    """Open a new datafind connection based on an existing connection
-
-    This is required because of https://git.ligo.org/lscsoft/glue/issues/1
-
-    Parameters
-    ----------
-    connection : :class:`~gwdatafind.http.HTTPConnection` or `FflConnection`
-        a connection object (doesn't need to be open)
-
-    Returns
-    -------
-    newconn : :class:`~gwdatafind.http.HTTPConnection` or `FflConnection`
-        the new open connection to the same `host:port` server
-    """
-    if isinstance(connection, FflConnection):
-        return type(connection)(connection.ffldir)
-    kw = {'context': connection._context} if connection.port != 80 else {}
-    return connection.__class__(connection.host, port=connection.port, **kw)
-
 
 def _type_priority(ifo, ftype, trend=None):
     """Prioritise the given GWF type based on its name or trend status.
@@ -316,40 +117,48 @@ def on_tape(*files):
         otherwise `False`
     """
     for path in files:
+        stat = os.stat(path)
         try:
-            if os.stat(path).st_blocks == 0:
+            if stat.st_blocks == 0:
                 return True
         except AttributeError:  # windows doesn't have st_blocks
             return False
     return False
 
 
-def _choose_connection(**datafind_kw):
-    if os.getenv('LIGO_DATAFIND_SERVER') or datafind_kw.get('host'):
-        from gwdatafind import connect
-        return connect(**datafind_kw)
+def _gwdatafind_module(**datafind_kw):
+    """Return the appropriate GWDataFind-like API based on the environment
+
+    This allows switching to the hacky `gwpy.io.ffldatafind` replacement
+    module to enable a GWDataFind-like interface for direct FFL data
+    discovery at Virgo.
+    """
+    if (
+        os.getenv('GWDATAFIND_SERVER')
+        or os.getenv('LIGO_DATAFIND_SERVER')
+        or datafind_kw.get('host')
+    ):
+        return gwdatafind
     if os.getenv('VIRGODATA'):
-        return FflConnection()
+        return ffldatafind
     raise RuntimeError("unknown datafind configuration, cannot discover data")
 
 
-def with_connection(func):
-    """Decorate a function to open a new datafind connection if required
+def _select_gwdatafind_mod(func):
+    """Decorate a function to see the right ``gwdatafind`` API.
 
-    This method will inspect the ``connection`` keyword, and if `None`
-    (or missing), will use the ``host`` and ``port`` keywords to open
-    a new connection and pass it as ``connection=<new>`` to ``func``.
+    This exists only to allow on-the-fly replacing of the actual `gwdatafind`
+    with :mod:`gwpy.io.ffldatafind` if it looks like we are trying to find
+    data from FFL files.
     """
     @wraps(func)
     def wrapped(*args, **kwargs):
-        if kwargs.get('connection') is None:
-            kwargs['connection'] = _choose_connection(host=kwargs.get('host'),
-                                                      port=kwargs.get('port'))
-        try:
-            return func(*args, **kwargs)
-        except HTTPException:
-            kwargs['connection'] = reconnect(kwargs['connection'])
-            return func(*args, **kwargs)
+        # replace the 'gwdatafind' module in the function namespace
+        # with the right one
+        func.__globals__["gwdatafind"] = _gwdatafind_module(**kwargs)
+
+        # run the function
+        return func(*args, **kwargs)
     return wrapped
 
 
@@ -370,7 +179,7 @@ def _parse_ifos_and_trends(chans):
     return found
 
 
-def _find_gaps(ifo, frametype, segment, on_gaps, connection):
+def _find_gaps(ifo, frametype, segment, on_gaps):
     """Discover gaps in a datafind/ffl archive for the given ifo/type
 
     Returns
@@ -385,7 +194,6 @@ def _find_gaps(ifo, frametype, segment, on_gaps, connection):
         frametype,
         *segment,
         on_gaps=on_gaps,
-        connection=connection,
     )
     csegs = cache_segments(cache)
     return max(0, abs(segment) - abs(csegs))
@@ -425,10 +233,10 @@ def _rank_types(match):
 
 # -- user methods -------------------------------------------------------------
 
-@with_connection
+@_select_gwdatafind_mod
 def find_frametype(channel, gpstime=None, frametype_match=None,
                    host=None, port=None, return_all=False, allow_tape=False,
-                   connection=None, on_gaps='error'):
+                   on_gaps='error'):
     """Find the frametype(s) that hold data for a given channel
 
     Parameters
@@ -533,7 +341,6 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
             ifo,
             match=frametype_match,
             trend=trend,
-            connection=connection,
         )
 
         # loop over types testing each in turn
@@ -551,14 +358,13 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
                     ftype,
                     gpstime=gpstime,
                     allow_tape=allow_tape,
-                    connection=connection,
                     on_missing='ignore',
                 )
             except (RuntimeError, IOError, IndexError):  # something went wrong
                 continue
 
             # check for gaps in the record for this type
-            gaps = _find_gaps(ifo, ftype, gpssegment, on_gaps, connection)
+            gaps = _find_gaps(ifo, ftype, gpssegment, on_gaps)
 
             # search the TOC for one frame file and match any channels
             found = 0
@@ -610,10 +416,10 @@ def find_frametype(channel, gpstime=None, frametype_match=None,
     return output[str(channel)]
 
 
-@with_connection
+@_select_gwdatafind_mod
 def find_best_frametype(channel, start, end,
                         frametype_match=None, allow_tape=True,
-                        connection=None, host=None, port=None):
+                        host=None, port=None):
     """Intelligently select the best frametype from which to read this channel
 
     Parameters
@@ -663,13 +469,12 @@ def find_best_frametype(channel, start, end,
         return find_frametype(channel, gpstime=(start, end),
                               frametype_match=frametype_match,
                               allow_tape=allow_tape, on_gaps='error',
-                              connection=connection, host=host, port=port)
+                              host=host, port=port)
     except RuntimeError:  # gaps (or something else went wrong)
         ftout = find_frametype(channel, gpstime=(start, end),
                                frametype_match=frametype_match,
                                return_all=True, allow_tape=allow_tape,
-                               on_gaps='ignore', connection=connection,
-                               host=host, port=port)
+                               on_gaps='ignore', host=host, port=port)
         try:
             if isinstance(ftout, dict):
                 return {key: ftout[key][0] for key in ftout}
@@ -678,56 +483,69 @@ def find_best_frametype(channel, start, end,
             raise ValueError("Cannot find any valid frametypes for channel(s)")
 
 
-@with_connection
-def find_types(observatory, match=None, trend=None,
-               connection=None, **connection_kw):
+@_select_gwdatafind_mod
+def find_types(observatory, match=None, trend=None, **kwargs):
     """Find the available data types for a given observatory.
 
     See also
     --------
-    gwdatafind.http.HTTPConnection.find_types
-    FflConnection.find_types
-        for details on the underlying method(s)
+    gwdatafind.find_types
     """
-    return sorted(connection.find_types(observatory, match=match),
-                  key=lambda x: _type_priority(observatory, x, trend=trend))
+    return sorted(
+        gwdatafind.find_types(observatory, match=match, **kwargs),
+        key=lambda x: _type_priority(observatory, x, trend=trend),
+    )
 
 
-@with_connection
-def find_urls(observatory, frametype, start, end, on_gaps='error',
-              connection=None, **connection_kw):
+@_select_gwdatafind_mod
+def find_urls(observatory, frametype, start, end, on_gaps='error', **kwargs):
     """Find the URLs of files of a given data type in a GPS interval.
 
     See also
     --------
-    gwdatafind.http.HTTPConnection.find_urls
-    FflConnection.find_urls
-        for details on the underlying method(s)
+    gwdatafind.find_urls
     """
-    return connection.find_urls(observatory, frametype, start, end,
-                                on_gaps=on_gaps)
+    return gwdatafind.find_urls(
+        observatory,
+        frametype,
+        start,
+        end,
+        on_gaps=on_gaps,
+        **kwargs,
+    )
 
 
-@with_connection
-def find_latest(observatory, frametype, gpstime=None, allow_tape=False,
-                connection=None, **connection_kw):
+@_select_gwdatafind_mod
+def find_latest(
+    observatory,
+    frametype,
+    gpstime=None,
+    allow_tape=False,
+    **kwargs,
+):
     """Find the path of the latest file of a given data type.
 
     See also
     --------
-    gwdatafind.http.HTTPConnection.find_latest
-    FflConnection.find_latest
-        for details on the underlying method(s)
+    gwdatafind.find_latest
     """
     observatory = observatory[0]
     try:
         if gpstime is not None:
             gpstime = int(to_gps(gpstime))
-            path = find_urls(observatory, frametype, gpstime, gpstime+1,
-                             on_gaps='ignore', connection=connection)[-1]
+            path = find_urls(
+                observatory,
+                frametype,
+                gpstime,
+                gpstime+1,
+                on_gaps='ignore',
+            )[-1]
         else:
-            path = connection.find_latest(observatory, frametype,
-                                          on_missing='ignore')[-1]
+            path = gwdatafind.find_latest(
+                observatory,
+                frametype,
+                on_missing='ignore',
+            )[-1]
     except (IndexError, RuntimeError):
         raise RuntimeError(f"no files found for {observatory}-{frametype}")
 

--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -133,15 +133,22 @@ def _gwdatafind_module(**datafind_kw):
     module to enable a GWDataFind-like interface for direct FFL data
     discovery at Virgo.
     """
+    # GWDataFind
     if (
         os.getenv('GWDATAFIND_SERVER')
         or os.getenv('LIGO_DATAFIND_SERVER')
         or datafind_kw.get('host')
     ):
         return gwdatafind
-    if os.getenv('VIRGODATA'):
-        return ffldatafind
-    raise RuntimeError("unknown datafind configuration, cannot discover data")
+
+    # FFL
+    try:
+        ffldatafind._get_ffl_basedir()
+    except KeyError:  # failed to discover FFL directories
+        raise RuntimeError(
+            "unknown datafind configuration, cannot discover data",
+        )
+    return ffldatafind
 
 
 def _select_gwdatafind_mod(func):

--- a/gwpy/io/ffldatafind.py
+++ b/gwpy/io/ffldatafind.py
@@ -162,6 +162,20 @@ def _read_ffl(site, tag, basedir=None):
 
 def find_types(site=None, match=_DEFAULT_TYPE_MATCH):
     """Return the list of known data types.
+
+    Parameters
+    ----------
+    site : `str`, optional
+        Observatory ID (e.g. ``'A'`)) to retrict types, if `None` (default)
+        is given, all types are returned.
+
+    match : `str`, optional
+        Regular expression to use to restrict types.
+
+    Returns
+    -------
+    types : `list` of `str`
+        The list of data types matching the criteria.
     """
     ffls = _find_ffls()
     types = [tag for (site_, tag) in ffls if site in (None, site_)]
@@ -181,6 +195,34 @@ def find_urls(
 ):
     """Return the list of all files of the given type in the [start, end)
     GPS interval.
+
+    Parameters
+    ----------
+    site : `str`
+        Observatory ID to search for.
+
+    tag : `str`
+        Data type tag to search for.
+
+    gpsstart : `int`
+        GPS start time of query.
+
+    gpsend : `int`
+        GPS end time of query.
+
+    match : `str`, optional
+        Regular expression to use to retrict returned data URLs.
+
+    on_gaps : `str`, optional
+        What to do if the full GPS interval is not covered, one of
+        ``'warn'`` (emit a `UserWarning`, default),
+        ``'ignore'`` (do nothing),
+        anything else (raise a `RuntimeError`).
+
+    Returns
+    -------
+    urls : `list` of `str`
+        A list of URLs representing discovered data.
     """
     if match:
         match = re.compile(match)
@@ -213,6 +255,26 @@ def find_urls(
 
 def find_latest(site, tag, on_missing="warn"):
     """Return the most recent file of a given type.
+
+    Parameters
+    ----------
+    site : `str`
+        Observatory ID to search for.
+
+    tag : `str`
+        Data type tag to search for.
+
+    on_missing : `str`, optional
+        What to do if a URL is not found for the given site and tag, one of
+        ``'warn'`` (emit a `UserWarning`, default),
+        ``'ignore'`` (do nothing),
+        anything else (raise a `RuntimeError`).
+
+    Returns
+    -------
+    urls : `list` of `str`
+        A list (typically of one item) of URLs representing the latest data
+        for a specific site and tag.
     """
     try:
         fflfile = _ffl_path(site, tag)

--- a/gwpy/io/ffldatafind.py
+++ b/gwpy/io/ffldatafind.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2022)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""GWDataFind UI for FFL cache files.
+
+This module is used to replace the proper GWDataFind interface
+on-the-fly when FFL data access is inferred.
+As such this module is required to emulate those functions
+from `gwdatafind` used in :mod:`gwpy.io.datafind`.
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+import os
+import re
+from warnings import warn
+from functools import lru_cache
+
+from ligo.segments import (
+    segment,
+    segmentlist,
+)
+
+from .cache import (
+    _iter_cache,
+    cache_segments,
+    read_cache_entry,
+)
+
+_SITE_REGEX = re.compile(r"\A(\w+)-")
+_DEFAULT_TYPE_MATCH = re.compile(r"^(?!lastfile|spectro|\.).*")
+
+
+# -- generic utilities ------
+
+def _read_last_line(path, bufsize=2, encoding="utf-8"):
+    """Read the last line of a file.
+    """
+    with open(path, "rb") as fobj:
+        # go to end of file
+        fobj.seek(-bufsize, os.SEEK_END)
+
+        # rewind until we hit a line break
+        while fobj.read(1) != b"\n":
+            try:
+                fobj.seek(-bufsize, os.SEEK_CUR)
+            except OSError:
+                # if we've rewound to the start of the file, just stop
+                if fobj.tell() < bufsize:
+                    fobj.seek(0)
+                    break
+                # otherwise this is a different error
+                raise
+
+        # read the current line
+        return fobj.readline().rstrip().decode(encoding)
+
+
+# -- ffl utilities ----------
+
+def _get_ffl_basedir():
+    """Return the base directory in which to find FFL files
+
+    Raises
+    ------
+    KeyError
+        If neither the ``FFLPATH`` or ``VIRGODATA`` environment variables
+        are set.
+    """
+    if 'FFLPATH' in os.environ:
+        return os.environ['FFLPATH']
+    if 'VIRGODATA' in os.environ:
+        return os.path.join(os.environ['VIRGODATA'], 'ffl')
+    raise KeyError(
+        "failed to parse FFLPATH from environment, please set "
+        "FFLPATH to point to the directory containing FFL files",
+    )
+
+
+def _is_ffl_file(path):
+    """Return `True` if this file looks (naively) like an FFL file.
+    """
+    return str(path).endswith(".ffl")
+
+
+def _get_site_tag(path):
+    """Return the ``(site, tag)`` for a given FFL file.
+    """
+    # tag is just name of file minus extension
+    tag = os.path.splitext(os.path.basename(path))[0]
+
+    # need to read first file from FFL to get site (IFO)
+    last = _read_last_line(path).split()[0]
+    site = _SITE_REGEX.match(os.path.basename(last)).groups()[0]
+
+    return site, tag
+
+
+def _find_ffl_files(basedir=None):
+    """Find all FFL files under a given base directory.
+    """
+    for root, _, files in os.walk(basedir or _get_ffl_basedir()):
+        for name in filter(_is_ffl_file, files):
+            yield os.path.join(root, name)
+
+
+@lru_cache()
+def _find_ffls(basedir=None):
+    """Find all readable FFL files.
+    """
+    ffls = {}
+    for path in _find_ffl_files(basedir=basedir):
+        try:
+            ffls[_get_site_tag(path)] = path
+        except (
+            OSError,  # file is empty (or cannot be read at all)
+            AttributeError,  # last entry didn't match _SITE_REGEX
+        ):
+            continue
+    return ffls
+
+
+def _ffl_path(site, tag, basedir=None):
+    """Return the path of the FFL file for a given site and tag.
+    """
+    try:
+        return _find_ffls(basedir=basedir)[(site, tag)]
+    except KeyError:
+        raise ValueError(
+            f"no FFL file found for ('{site}', '{tag}')",
+        )
+
+
+@lru_cache()
+def _read_ffl(site, tag, basedir=None):
+    """Read an FFL file as a list of `CacheEntry` objects
+    """
+    ffl = _ffl_path(site, tag, basedir=basedir)
+    with open(ffl, "r") as fobj:
+        return [
+            type(entry)(site, tag, entry.segment, entry.path)
+            for entry in _iter_cache(fobj, gpstype=float)
+        ]
+
+
+# -- ui ---------------------
+
+def find_types(site=None, match=_DEFAULT_TYPE_MATCH):
+    """Return the list of known data types.
+    """
+    ffls = _find_ffls()
+    types = [tag for (site_, tag) in ffls if site in (None, site_)]
+    if match is not None:
+        match = re.compile(match)
+        return list(filter(match.search, types))
+    return types
+
+
+def find_urls(
+    site,
+    tag,
+    gpsstart,
+    gpsend,
+    match=None,
+    on_gaps="warn",
+):
+    """Return the list of all files of the given type in the [start, end)
+    GPS interval.
+    """
+    if match:
+        match = re.compile(match)
+
+    span = segment(gpsstart, gpsend)
+
+    cache = [
+        e for e in _read_ffl(site, tag) if (
+            e.observatory == site
+            and e.description == tag
+            and e.segment.intersects(span)
+            and (match.search(e.path) if match else True)
+        )
+    ]
+
+    urls = [e.path for e in cache]
+    missing = segmentlist([span]) - cache_segments(cache)
+
+    # no missing data or don't care, return
+    if on_gaps == 'ignore' or not missing:
+        return urls
+
+    # handle missing data
+    msg = "Missing segments: \n" + "\n".join(map(str, missing))
+    if on_gaps == 'warn':
+        warn(msg)
+        return urls
+    raise RuntimeError(msg)
+
+
+def find_latest(site, tag, on_missing="warn"):
+    """Return the most recent file of a given type.
+    """
+    try:
+        fflfile = _ffl_path(site, tag)
+    except ValueError:  # no readable FFL file
+        urls = []
+    else:
+        urls = [read_cache_entry(_read_last_line(fflfile), gpstype=float)]
+
+    if urls or on_missing == 'ignore':
+        return urls
+
+    # handle no files
+    msg = 'No files found'
+    if on_missing == 'warn':
+        warn(msg)
+        return urls
+    raise RuntimeError(msg)

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -41,7 +41,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 GWDATAFIND_PATH = "gwpy.io.datafind.gwdatafind"
 MOCK_ENV = {
     'VIRGODATA': 'tmp',
-    'LIGO_DATAFIND_SERVER': 'test:80',
+    'GWDATAFIND_SERVER': 'test:80',
 }
 
 

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -20,14 +20,9 @@
 """
 
 import os
-from http.client import (HTTPConnection, HTTPException)
-from io import BytesIO
-from itertools import cycle
 from unittest import mock
 
 import pytest
-
-import gwdatafind
 
 from ...testing.utils import (
     TEST_GWF_FILE,
@@ -37,236 +32,46 @@ from .. import datafind as io_datafind
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-# -- mock the environment -----------------------------------------------------
-
+GWDATAFIND_PATH = "gwpy.io.datafind.gwdatafind"
 MOCK_ENV = {
     'VIRGODATA': 'tmp',
     'LIGO_DATAFIND_SERVER': 'test:80',
 }
 
-_mock_env = mock.patch.dict("os.environ", MOCK_ENV)
 
+def _mock_gwdatafind(func):
+    @mock.patch.dict("os.environ", MOCK_ENV)
+    @mock.patch(
+        f"{GWDATAFIND_PATH}.find_types",
+        mock.MagicMock(
+            return_value=[os.path.basename(TEST_GWF_FILE).split("-")[1]],
+        )
+    )
+    @mock.patch(
+        f"{GWDATAFIND_PATH}.find_urls",
+        mock.MagicMock(return_value=[TEST_GWF_FILE]),
+    )
+    @mock.patch(
+        f"{GWDATAFIND_PATH}.find_latest",
+        mock.MagicMock(return_value=[TEST_GWF_FILE]),
+    )
+    @mock.patch(
+        'gwpy.io.datafind.iter_channel_names',
+        mock.MagicMock(return_value=['L1:LDAS-STRAIN', 'H1:LDAS-STRAIN']),
+    )
+    @mock.patch(
+        'gwpy.io.datafind.num_channels',
+        mock.MagicMock(return_value=1),
+    )
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
 
-# -- utilities ----------------------------------------------------------------
-
-def mock_connection(framefile=TEST_GWF_FILE):
-    # create mock up of connection object
-    conn = mock.create_autospec(gwdatafind.http.HTTPConnection)
-    conn.find_types.return_value = [os.path.basename(framefile).split('-')[1]]
-    conn.find_latest.return_value = [framefile]
-    conn.find_urls.return_value = [framefile]
-    conn.host = 'mockhost'
-    conn.port = 80
-    return conn
-
-
-@pytest.fixture()
-def connection():
-    return mock_connection(TEST_GWF_FILE)
-
-
-_mock_connection = mock.patch(
-    "gwdatafind.connect",
-    mock.MagicMock(return_value=mock_connection(TEST_GWF_FILE)),
-)
-
-_mock_iter_channel_names = mock.patch(
-    'gwpy.io.datafind.iter_channel_names',
-    mock.MagicMock(return_value=['L1:LDAS-STRAIN', 'H1:LDAS-STRAIN']),
-)
-
-_mock_num_channels = mock.patch(
-    'gwpy.io.datafind.num_channels',
-    mock.MagicMock(return_value=1),
-)
-
-# -- FFL tests ----------------------------------------------------------------
-
-FFL_WALK = [
-    (os.curdir, [], ['test.ffl', 'test2.ffl']),
-]
-
-
-@mock.patch.dict("os.environ", MOCK_ENV)
-@mock.patch('os.walk', return_value=FFL_WALK)
-class TestFflConnection(object):
-    TEST_CLASS = io_datafind.FflConnection
-
-    @mock.patch('gwpy.io.datafind.FflConnection._read_last_line',
-                return_value='X-TEST-0-1.gwf 0 1 0 0')
-    def test_init(self, mwalk, mreadlast):
-        conn = self.TEST_CLASS()
-        assert conn.paths == {
-            ('X', 'test'): os.path.join(os.curdir, 'test.ffl'),
-            ('X', 'test2'): os.path.join(os.curdir, 'test2.ffl'),
-        }
-
-    def test_get_ffl_dir(self, _):
-        with mock.patch.dict(os.environ, {'FFLPATH': 'somepath'}):
-            assert self.TEST_CLASS._get_ffl_dir() == 'somepath'
-        with mock.patch.dict(os.environ, {'VIRGODATA': 'somepath'}):
-            assert self.TEST_CLASS._get_ffl_dir() == (
-                os.path.join('somepath', 'ffl'))
-        with mock.patch.dict(os.environ), pytest.raises(KeyError):
-            os.environ.pop('FFLPATH')
-            os.environ.pop('VIRGODATA')
-            self.TEST_CLASS._get_ffl_dir()
-
-    def test_is_ffl_file(self, _):
-        assert self.TEST_CLASS._is_ffl_file('test.ffl')
-        assert not self.TEST_CLASS._is_ffl_file('test.ffl2')
-
-    @mock.patch('gwpy.io.datafind.FflConnection._read_last_line',
-                side_effect=[OSError(), 'X-TEST-0-1.gwf 0 1 0 0'])
-    def test_find_paths(self, mwalk, mreadlast):
-        conn = self.TEST_CLASS()  # find_paths() called by __init__()
-        assert conn.paths == {
-            ('X', 'test2'): os.path.join(os.curdir, 'test2.ffl'),
-        }
-
-    @mock.patch("builtins.open", return_value=BytesIO(b"""
-/path/to/X-TEST-0-1.gwf 0 1 0 0
-/path/to/X-TEST-1-1.gwf 1 1 0 0
-""".lstrip()))
-    @mock.patch('os.path.getmtime', return_value=1)
-    @mock.patch('gwpy.io.datafind.FflConnection._read_last_line',
-                return_value='X-TEST-0-1.gwf 0 1 0 0')
-    def test_read_ffl_cache(self, mwalk, mreadlast, mgetmtime, mopen):
-        conn = self.TEST_CLASS()
-        cache = list(conn._read_ffl_cache('X', 'test'))
-        assert [c.path for c in cache] == [
-            '/path/to/X-TEST-0-1.gwf',
-            '/path/to/X-TEST-1-1.gwf'
-        ]
-        mopen.assert_called_once()
-
-        # check that calling the same again is a no-op
-        conn._read_ffl_cache('X', 'test')
-        mopen.assert_called_once()
-
-    def test_read_last_line(self, _, tmp_path):
-        tmp = tmp_path / "tmp"
-        with tmp.open("w") as fobj:
-            print('line1', file=fobj)
-            print('line2', file=fobj)
-        assert self.TEST_CLASS._read_last_line(tmp) == 'line2'
-
-    @mock.patch('gwpy.io.datafind.FflConnection._read_last_line',
-                return_value='X-TEST-0-1.gwf 0 1 0 0')
-    def test_ffl_path(self, mwalk, mreadlast):
-        conn = self.TEST_CLASS()
-        assert conn.ffl_path('X', 'test') == os.path.join(
-            os.curdir, 'test.ffl')
-        conn.paths = {}
-        assert conn.ffl_path('X', 'test') == os.path.join(
-            os.curdir, 'test.ffl')
-
-    @mock.patch('gwpy.io.datafind.FflConnection._get_site_tag',
-                side_effect=cycle([('X', 'test'), ('Y', 'test2')]))
-    def test_find_types(self, mwalk, msitetag):
-
-        conn = self.TEST_CLASS()
-        assert sorted(conn.find_types(match=None)) == ['test', 'test2']
-        assert conn.find_types('X') == ['test']
-        assert conn.find_types(match='test2') == ['test2']
-
-    @mock.patch("builtins.open", return_value=BytesIO(b"""
-/path/to/X-TEST-0-1.gwf 0 1 0 0
-/path/to/X-TEST-1-1.gwf 1 1 0 0
-/path/to/X-TEST-2-1.gwf 2 1 0 0
-""".lstrip()))
-    @mock.patch('os.path.getmtime', return_value=1)
-    @mock.patch('gwpy.io.datafind.FflConnection._get_site_tag',
-                side_effect=cycle([('X', 'test'), ('Y', 'test2')]))
-    def test_find_urls(self, mwalk, msitetag, getmtime, mopen):
-        conn = self.TEST_CLASS()
-        assert conn.find_urls('X', 'test', 0, 2) == [
-            '/path/to/X-TEST-0-1.gwf',
-            '/path/to/X-TEST-1-1.gwf',
-        ]
-        assert conn.find_urls('X', 'test', 0, 2, match='TEST-0') == [
-            '/path/to/X-TEST-0-1.gwf',
-        ]
-
-        # check exceptions or warnings get raised as designed
-        with pytest.raises(RuntimeError):
-            conn.find_urls('X', 'test', 10, 20, on_gaps='raise')
-        with pytest.warns(UserWarning) as rec:
-            conn.find_urls('X', 'test', 10, 20, on_gaps='warn')
-            conn.find_urls('X', 'test', 10, 20, on_gaps='ignore')
-        assert len(rec) == 1
-
-    @mock.patch('gwpy.io.datafind.FflConnection._read_last_line',
-                return_value='/path/to/file.gwf 0 1 0 0')
-    @mock.patch('gwpy.io.datafind.FflConnection._get_site_tag',
-                side_effect=cycle([('X', 'test'), ('Y', 'test2')]))
-    def test_find_latest(self, mwalk, msitetag, mreadlast):
-        conn = self.TEST_CLASS()
-        assert conn.find_latest('X', 'test') == ['/path/to/file.gwf']
-        mreadlast.assert_called_once()
-        assert conn.find_latest('X', 'test') == ['/path/to/file.gwf']
-        mreadlast.assert_called_once()  # doesn't call again
-
-        # check exceptions or warnings get raised as designed
-        with pytest.raises(RuntimeError):
-            conn.find_latest('Z', 'test3', on_missing='raise')
-        with pytest.warns(UserWarning) as rec:
-            conn.find_latest('Z', 'test3', on_missing='warn')
-            conn.find_latest('Z', 'test3', on_missing='ignore')
-        assert len(rec) == 1
+    return wrapper
 
 
 # -- tests --------------------------------------------------------------------
 
-@mock.patch.dict("os.environ", MOCK_ENV)
-@mock.patch("gwdatafind.connect", return_value="connection")
-def test_with_connection(connect):
-    # mock out the function, and wrap it
-    func = mock.MagicMock()
-    wrapped_func = io_datafind.with_connection(func)
-
-    # call it
-    wrapped_func(1, host="host")
-
-    # check that connect() was called once
-    connect.assert_called_once_with(host="host", port=None)
-    # and that the function was called once with that connection
-    func.assert_called_once_with(1, connection="connection", host="host")
-
-
-@mock.patch.dict("os.environ", MOCK_ENV)
-@mock.patch("gwdatafind.ui.connect", return_value="connection")
-@mock.patch("gwpy.io.datafind.reconnect", lambda x: x)
-def test_with_connection_reconnect(connect):
-    func = mock.MagicMock()
-    # https://stackoverflow.com/questions/22204660/python-mock-wrapsf-problems
-    func.__name__ = "func"
-    func.side_effect = [HTTPException, "return"]
-    wrapped_func = io_datafind.with_connection(func)
-
-    assert wrapped_func(1, host="host") == "return"
-    assert func.call_count == 2
-
-
-@mock.patch.dict("os.environ", MOCK_ENV)
-def test_reconnect():
-    a = HTTPConnection('127.0.0.1')
-    b = io_datafind.reconnect(a)
-    assert b is not a
-    assert b.host == a.host
-    assert b.port == a.port
-
-    with mock.patch('os.walk', return_value=[]):
-        a = io_datafind.FflConnection()
-        b = io_datafind.reconnect(a)
-        assert b is not a
-        assert b.ffldir == a.ffldir
-
-
-@_mock_connection
-@_mock_env
-@_mock_iter_channel_names
-@_mock_num_channels
+@_mock_gwdatafind
 def test_find_frametype():
     # simple test
     assert io_datafind.find_frametype(
@@ -275,10 +80,7 @@ def test_find_frametype():
     ) == 'HW100916'
 
 
-@_mock_connection
-@_mock_env
-@_mock_iter_channel_names
-@_mock_num_channels
+@_mock_gwdatafind
 def test_find_frametype_return_all():
     assert io_datafind.find_frametype(
         'L1:LDAS-STRAIN',
@@ -286,10 +88,7 @@ def test_find_frametype_return_all():
     ) == ['HW100916']
 
 
-@_mock_connection
-@_mock_env
-@_mock_iter_channel_names
-@_mock_num_channels
+@_mock_gwdatafind
 def test_find_frametype_multiple():
     # test multiple channels
     assert io_datafind.find_frametype(
@@ -298,10 +97,7 @@ def test_find_frametype_multiple():
     ) == {'H1:LDAS-STRAIN': 'HW100916'}
 
 
-@_mock_connection
-@_mock_env
-@_mock_iter_channel_names
-@_mock_num_channels
+@_mock_gwdatafind
 def test_find_frametype_errors():
     # test missing channel raises sensible error
     with pytest.raises(ValueError) as exc:
@@ -332,11 +128,8 @@ def test_find_frametype_errors():
         assert '[files on tape have not been checked' in str(exc.value)
 
 
-@_mock_connection
-@_mock_env
-@_mock_iter_channel_names
-@_mock_num_channels
-def test_find_best_frametype(connection):
+@_mock_gwdatafind
+def test_find_best_frametype():
     assert io_datafind.find_best_frametype(
         'L1:LDAS-STRAIN',
         968654552,
@@ -344,10 +137,15 @@ def test_find_best_frametype(connection):
     ) == 'HW100916'
 
 
+# -- utilities --------------
+
 @skip_missing_dependency('LDAStools.frameCPP')
 @pytest.mark.skipif(
-    'LIGO_DATAFIND_SERVER' not in os.environ,
-    reason='No LIGO datafind server configured on this host',
+    (
+        "GWDATAFIND_SERVER" not in os.environ
+        or "LIGO_DATAFIND_SERVER" not in os.environ
+    ),
+    reason='No GWDataFind server configured on this host',
 )
 @pytest.mark.parametrize('channel, expected', [
     ('H1:GDS-CALIB_STRAIN', {'H1_HOFT_C00', 'H1_ER_C00_L1'}),
@@ -373,27 +171,39 @@ def test_find_best_frametype_ligo(channel, expected):
     assert ft in expected
 
 
-def test_find_types(connection):
+@mock.patch.dict("os.environ", MOCK_ENV)
+def test_find_types():
+    """Check that `find_types` works with default arguments.
+    """
     types = ["a", "b", "c"]
-    connection.find_types.return_value = types
-    assert io_datafind.find_types(
-        "X",
-        connection=connection,
-    ) == types
+    with mock.patch(f"{GWDATAFIND_PATH}.find_types", return_value=types):
+        assert io_datafind.find_types(
+            "X",
+        ) == sorted(types)
 
 
-def test_find_types_priority(connection):
+@mock.patch.dict("os.environ", MOCK_ENV)
+def test_find_types_priority():
+    """Check that `find_types` prioritises trends properly.
+    """
     types = ["L1_R", "L1_T", "L1_M"]
-    connection.find_types.return_value = types
-    assert io_datafind.find_types(
-        "X",
-        trend="m-trend",
-        connection=connection,
-    ) == ["L1_M", "L1_R", "L1_T"]
+    with mock.patch(f"{GWDATAFIND_PATH}.find_types", return_value=types):
+        assert io_datafind.find_types(
+            "X",
+            trend="m-trend",
+        ) == ["L1_M", "L1_R", "L1_T"]
 
 
-def test_on_tape():
+def test_on_tape_false():
+    """Check `on_tape` works with a normal file.
+    """
     assert io_datafind.on_tape(TEST_GWF_FILE) is False
+
+
+def test_on_tape_true():
+    with mock.patch("os.stat") as os_stat:
+        os_stat.return_value.st_blocks = 0
+        assert io_datafind.on_tape(TEST_GWF_FILE) is True
 
 
 @pytest.mark.parametrize('ifo, ftype, trend, priority', [

--- a/gwpy/io/tests/test_ffldatafind.py
+++ b/gwpy/io/tests/test_ffldatafind.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2022)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for :mod:`gwpy.io.ffldatafind`
+"""
+
+__author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
+
+from contextlib import nullcontext
+from unittest import mock
+
+import pytest
+
+from .. import ffldatafind
+
+
+# -- test utilities ---------
+
+@pytest.mark.parametrize("content", [
+    "abcdef",
+    "line 1\nline2",
+])
+def test_read_last_line(tmp_path, content):
+    """Check that the `_read_last_line` utility works
+    """
+    # write content to a file
+    path = tmp_path / "tmp.txt"
+    path.write_text(content)
+    result = content.rsplit("\n", 1)[-1]
+    assert ffldatafind._read_last_line(path) == result
+
+
+def test_read_last_line_oserror(tmp_path):
+    """Check that `_read_last_line` raises `OSError` for empty files.
+    """
+    path = tmp_path / "tmp.txt"
+    path.touch(exist_ok=False)
+    with pytest.raises(OSError):
+        assert ffldatafind._read_last_line(path)
+
+
+# -- test ffl UI ------------
+
+FFLS = {
+    "test.ffl": [
+        "/tmp/X-test-0-1.gwf 0 1 0 0",
+        "/tmp/X-test-1-1.gwf 1 1 0 0",
+        "/tmp/X-test-2-1.gwf 2 1 0 0",
+    ],
+    "test2.ffl": [
+        "/tmp/X-test2-0-1.gwf 0 1 0 0",
+        "/tmp/X-test2-1-1.gwf 1 1 0 0",
+        "/tmp/X-test2-2-1.gwf 2 1 0 0",
+    ],
+    "test3.ffl": [
+        "/tmp/Y-test3-0-1.gwf 0 1 0 0",
+        "/tmp/Y-test3-1-1.gwf 1 1 0 0",
+        "/tmp/Y-test3-2-1.gwf 2 1 0 0",
+    ],
+}
+TEST_URLS = [x.split()[0] for x in FFLS["test.ffl"]]
+
+
+@pytest.fixture(autouse=True)
+def mock_ffl(tmp_path):
+    """Create a temporary FFL file structure and mock it into
+    the test environment.
+    """
+    for path, lines in FFLS.items():
+        ffl = tmp_path / path
+        ffl.write_text("\n".join(lines))
+    with mock.patch.dict(
+        "os.environ",
+        {"FFLPATH": str(tmp_path)},
+        clear=True,
+    ):
+        yield
+
+
+@pytest.mark.parametrize(("site", "match", "result"), [
+    (None, None, ["test", "test2", "test3"]),
+    ("X", None, ["test", "test2"]),
+    (None, "2", ["test2"]),
+    ("Y", "test", ["test3"]),
+])
+def test_find_types(site, match, result):
+    """Check that `ffldatafind.find_types` works.
+    """
+    assert sorted(ffldatafind.find_types(
+        site=site,
+        match=match,
+    )) == sorted(result)
+
+
+@pytest.mark.parametrize(("match", "ctx", "result"), (
+    (None, nullcontext(), TEST_URLS),
+    (r"\-0\-", pytest.warns(UserWarning), TEST_URLS[:1]),
+))
+def test_find_urls(match, ctx, result):
+    """Check that `ffldatafind.find_urls` works.
+    """
+    with ctx:
+        assert sorted(ffldatafind.find_urls(
+            "X",
+            "test",
+            0,
+            3,
+            match=match,
+        )) == result
+
+
+@pytest.mark.parametrize(("on_gaps", "ctx"), (
+    ("ignore", nullcontext()),
+    ("warn", pytest.warns(UserWarning)),
+    ("raise", pytest.raises(RuntimeError)),
+))
+def test_find_urls_on_missing(on_gaps, ctx):
+    """Check that the ``on_missing`` keyword in `ffldatafind.find_latest`
+    works in each case.
+    """
+    with ctx:
+        urls = ffldatafind.find_urls(
+            "X",
+            "test",
+            100,
+            101,
+            on_gaps=on_gaps,
+        )
+    if on_gaps != "raise":
+        assert urls == []
+
+
+def test_find_latest():
+    """Check that `ffldatafind.find_latest` works.
+    """
+    assert ffldatafind.find_latest(
+        "X",
+        "test",
+    ) == sorted(x.split()[0] for x in FFLS["test.ffl"])[-1:]

--- a/gwpy/io/tests/test_ffldatafind.py
+++ b/gwpy/io/tests/test_ffldatafind.py
@@ -26,7 +26,10 @@ from unittest import mock
 
 import pytest
 
-from .. import ffldatafind
+from .. import (
+    datafind as io_datafind,
+    ffldatafind,
+)
 
 
 # -- test utilities ---------
@@ -152,3 +155,27 @@ def test_find_latest():
         "X",
         "test",
     ) == sorted(x.split()[0] for x in FFLS["test.ffl"])[-1:]
+
+
+# -- test gwpy.io.datafind interface
+
+@mock.patch(
+    "gwpy.io.datafind.iter_channel_names",
+    mock.MagicMock(return_value=["Y1:TEST-CHANNEL"]),
+)
+@mock.patch(
+    "gwpy.io.datafind.on_tape",
+    mock.MagicMock(return_value=False),
+)
+@mock.patch(
+    'gwpy.io.datafind.num_channels',
+    mock.MagicMock(return_value=1),
+)
+def test_datafind_find_frametype():
+    """Test that gwpy.io.datafind.find_frametype ends up calling out
+    to ffldatafind under the right circumstances.
+    """
+    assert io_datafind.find_frametype(
+        "Y1:TEST-CHANNEL",
+        allow_tape=True,
+    ) == "test3"

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -38,7 +38,6 @@ This module defines the following classes
 user-facing objects.**
 """
 
-import os
 import sys
 import warnings
 from collections import OrderedDict
@@ -1346,10 +1345,7 @@ class TimeSeriesBaseDict(OrderedDict):
                 nds_kw[key] = val
 
         # try and find from frames
-        if not nds_kw and (
-                os.getenv('LIGO_DATAFIND_SERVER')
-                or os.getenv('VIRGODATA')
-        ):
+        if not nds_kw:
             if verbose:
                 gprint("Attempting to access data from frames...")
             try:

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -639,7 +639,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
     @_gwosc_cvmfs
     @mock.patch.dict(
         "os.environ",
-        {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
+        {"GWDATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
     )
     def test_find(self, gw150914_16384):
         ts = self.TEST_CLASS.find(
@@ -669,7 +669,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
     @_gwosc_cvmfs
     @mock.patch.dict(
         "os.environ",
-        {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
+        {"GWDATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
     )
     def test_find_best_frametype_in_find(self, gw150914_16384):
         ts = self.TEST_CLASS.find(
@@ -691,7 +691,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
     )
     @mock.patch.dict(
         "os.environ",
-        {"LIGO_DATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
+        {"GWDATAFIND_SERVER": GWOSC_DATAFIND_SERVER},
     )
     def test_get_datafind(self, gw150914_16384):
         try:
@@ -713,7 +713,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
     @mock.patch.dict(os.environ)
     def test_get_nds2(self, gw150914_16384):
         # get using NDS2 (if datafind could have been used to start with)
-        os.environ.pop('LIGO_DATAFIND_SERVER', None)
+        os.environ.pop('GWDATAFIND_SERVER', None)
         ts = self.TEST_CLASS.get(
             NDS2_GW150914_CHANNEL,
             *GWOSC_GW150914_SEGMENT,

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ python_requires = >=3.7
 install_requires =
 	astropy >=4.0
 	dqsegdb2
-	gwdatafind
+	gwdatafind >=1.1.0
 	gwosc >=0.5.3
 	h5py >=2.8.0
 	ligo-segments >=1.0.0


### PR DESCRIPTION
This PR updates the GWDataFind interface in `gwpy.io.datafind` to use the supported functional UI, rather than the deprecated `HTTPConnection` class-based interface.

This requires a rewrite of the custom interface for directly reading stuff from FFL files for Virgo, but that is now much cleaner anyway.

This should implicitly enable using SciTokens with GWpy to discover data.