### PR TITLE
Add ValueError when improper starting frequency used with `to_pycbc()`

### DIFF
--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -437,7 +437,7 @@ class FrequencySeries(Series):
             epoch = self.epoch.gps
         if self.f0.to('Hz').value:
             raise ValueError(
-                "Cannot convert FrequencySeries to PyCBC with f0 = {self.f0}. "
+                f"Cannot convert FrequencySeries to PyCBC with f0 = {self.f0}. "
                 "Starting frequency must be equal to 0 Hz."
             )
         return types.FrequencySeries(self.value,

--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -437,8 +437,8 @@ class FrequencySeries(Series):
             epoch = self.epoch.gps
         if self.f0.to('Hz').value:
             raise ValueError(
-                f"Cannot convert FrequencySeries to PyCBC with f0 = {self.f0}. "
-                "Starting frequency must be equal to 0 Hz."
+                f"Cannot convert FrequencySeries to PyCBC with f0 = {self.f0}."
+                " Starting frequency must be equal to 0 Hz."
             )
         return types.FrequencySeries(self.value,
                                      delta_f=self.df.to('Hz').value,

--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -435,6 +435,10 @@ class FrequencySeries(Series):
             epoch = None
         else:
             epoch = self.epoch.gps
+        if self.f0.to('Hz').value > 0.0:
+            raise ValueError("Cannot convert FrequencySeries to PyCBC with "
+                             "f0 = {0}. Starting frequency must be equal "
+                             "to 0 Hz.".format(self.f0))
         return types.FrequencySeries(self.value,
                                      delta_f=self.df.to('Hz').value,
                                      epoch=epoch, copy=copy)

--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -435,10 +435,11 @@ class FrequencySeries(Series):
             epoch = None
         else:
             epoch = self.epoch.gps
-        if self.f0.to('Hz').value > 0.0:
-            raise ValueError("Cannot convert FrequencySeries to PyCBC with "
-                             "f0 = {0}. Starting frequency must be equal "
-                             "to 0 Hz.".format(self.f0))
+        if self.f0.to('Hz').value:
+            raise ValueError(
+                "Cannot convert FrequencySeries to PyCBC with f0 = {self.f0}. "
+                "Starting frequency must be equal to 0 Hz."
+            )
         return types.FrequencySeries(self.value,
                                      delta_f=self.df.to('Hz').value,
                                      epoch=epoch, copy=copy)

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -228,11 +228,16 @@ class TestFrequencySeries(_TestSeries):
         a2 = type(array).from_pycbc(array.to_pycbc(copy=False), copy=False)
         assert shares_memory(array.value, a2.value)
 
-        # test conversion when f0 != 0
+    @pytest.mark.requires("pycbc")
+    def test_to_from_pycbc_nonzero_f0(self, array):
+        """Test `FrequencySeries.to_pycbc` conversion when ``f0 != 0``.
+        """
         array.f0 = 1.
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="^Cannot convert FrequencySeries",
+        ):
             array.to_pycbc()
-        assert str(exc.value).startswith("Cannot convert FrequencySeries")
 
     @pytest.mark.parametrize('format', [
         'txt',

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -228,6 +228,12 @@ class TestFrequencySeries(_TestSeries):
         a2 = type(array).from_pycbc(array.to_pycbc(copy=False), copy=False)
         assert shares_memory(array.value, a2.value)
 
+        # test conversion when f0 != 0
+        array.f0 = 1.
+        with pytest.raises(ValueError) as exc:
+            array.to_pycbc()
+        assert str(exc.value).startswith("Cannot convert FrequencySeries")
+
     @pytest.mark.parametrize('format', [
         'txt',
         'csv',


### PR DESCRIPTION
This PR ensures that a `ValueError` is returned when the user attempts to use `frequencyseries.FrequencySeries.to_pycbc()` in cases when the starting frequency is not `0 Hz`. When a PyCBC frequency series is created with `f0 != 0 Hz`, the PyCBC frequencies are not correct (They are offset by `f0`).

Here is an example of code that now returns a `ValueError` since the starting frequency is `10 Hz`:
```
from gwpy.frequencyseries import FrequencySeries
psd = (FrequencySeries.read('O3-H1-C01_CLEAN_SUB60HZ-1262197260.0_sensitivity_strain_asd.txt')).to_pycbc()
print(psd.sample_frequencies)
```

The above example uses this file: https://dcc.ligo.org/public/0174/G2100674/001/O3-H1-C01_CLEAN_SUB60HZ-1262197260.0_sensitivity_strain_asd.txt 

 