### PR TITLE
LALFrame handling of empty arrays.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lib64/
 parts/
 sdist/
 var/
+venv/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -44,6 +45,7 @@ pip-delete-this-directory.txt
 *.swp
 .DS_Store
 .idea
+.vscode
 
 # Examples output
 /examples/*.png

--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -683,12 +683,21 @@ class TimeSeriesBase(Series):
         """Generate a new TimeSeries from a LAL TimeSeries of any type.
         """
         # convert the units
-        from ..utils.lal import from_lal_unit
+        from ..utils.lal import (from_lal_unit, from_lal_type)
         unit = from_lal_unit(lalts.sampleUnits)
+
+        try:
+            dtype = lalts.data.data.dtype
+        except AttributeError:  # no data
+            dtype = from_lal_type(lalts)
+            data = []
+        else:
+            data = lalts.data.data
 
         # create new series
         out = cls(
-            lalts.data.data,
+            data,
+            dtype=dtype,
             name=lalts.name or None,
             unit=unit,
             t0=lalts.epoch,
@@ -697,7 +706,6 @@ class TimeSeriesBase(Series):
             copy=False,
         )
 
-        # return a copy, or the new series
         if copy:
             return out.copy()
         return out

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -153,9 +153,8 @@ def read(source, channels, start=None, end=None, series_class=TimeSeries,
     # read data
     out = series_class.DictClass()
     for name in channels:
-        out[name] = series_class.from_lal(
-            _read_channel(stream, str(name), start=start, duration=duration),
-            copy=False)
+        ts = _read_channel(stream, str(name), start=start, duration=duration)
+        out[name] = series_class.from_lal(ts, copy=False)
         lalframe.FrStreamSeek(stream, epoch)
     return out
 

--- a/gwpy/utils/tests/test_lal.py
+++ b/gwpy/utils/tests/test_lal.py
@@ -52,11 +52,45 @@ def test_find_typed_function():
     try:
         import lalframe
     except ImportError:  # no lalframe
-        pass
-    else:
-        utils_lal.find_typed_function(
-            'REAL4', 'FrStreamRead', 'TimeSeries',
-            module=lalframe) is lalframe.FrStreamReadREAL4TimeSeries
+        return
+    utils_lal.find_typed_function(
+        'REAL4', 'FrStreamRead', 'TimeSeries',
+        module=lalframe) is lalframe.FrStreamReadREAL4TimeSeries
+
+
+@pytest.mark.parametrize(
+    'dtype',
+    [
+        numpy.int16,
+        numpy.int32,
+        numpy.int64,
+        numpy.uint16,
+        numpy.uint32,
+        numpy.uint64,
+        numpy.float32,
+        numpy.float64,
+        numpy.complex64,
+        numpy.complex128,
+    ]
+)
+def test_from_lal_type(dtype):
+    func = utils_lal.find_typed_function(dtype, 'Create', 'TimeSeries')
+    lalts = func(None, None, 0, 1., None, 1)
+    assert utils_lal.from_lal_type(lalts) is dtype
+    assert utils_lal.from_lal_type(type(lalts)) is dtype
+
+
+@pytest.mark.parametrize('name', [
+    'XXX',
+    'XXXCOMPLEX64ZZZ',
+    'INNT2',
+    'INT5',
+    'REAL42',
+])
+def test_from_lal_type_errors(name):
+    lal_type = type(name, (), {})
+    with pytest.raises(ValueError, match='no known numpy'):
+        utils_lal.from_lal_type(lal_type)
 
 
 @pytest.mark.parametrize(("in_", "out", "scale"), (


### PR DESCRIPTION
In case no frames match a time segment, it would be handy if reading by LALframe of a gwf file could return an empty ndarray instead of None for the data.data attribute of the LAL timeseries.

Here is a first attempt to do so.
Currently the writing of an empty LAL series fails when it is added (add_ cython or c function) to the frame in gwpy.timeseries.io.gwf.lalframe.write:
```python
        # add time series to frame
        add_(frame, lalseries)
```
So I've marked the test as xfailed, I would need more pointers to fix it (where is the relevant code ?)
