### PR TITLE
Minor metadata cleanup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,30 @@
+; vim: set ft=dosini :
+
+[flake8]
+select =
+	# pycodestyle errors
+	E,
+	# flake8-executable
+	EXE,
+	# pyflakes
+	F,
+	# pycodestyle warnings
+	W,
+ignore =
+	# missing whitespace around arithmetic operator
+	E226,
+	# line break before binary operator, use W504
+	W503,
+exclude =
+	__pycache__,
+	.eggs/,
+	.git/,
+	build/,
+	docs/,
+	gwpy/_version.py,
+	venv/,
+per-file-ignores =
+	# ignore unused import in __init__
+	__init__.py:F401,
+	# ignore import location in example scripts
+	examples/**.py:E402

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# -- build
+
 [build-system]
 requires = [
     "setuptools>=42",
@@ -6,8 +8,23 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]
-write_to = "gwpy/_version.py"
+# -- coverage.py
+
+[tool.coverage.run]
+source = ["gwpy"]
+omit = [
+	# ignore vendored sphinx extension
+	"gwpy/utils/sphinx/epydoc.py",
+	# don't report coverage for _version.py
+	# (generated automatically by setuptools-scm)
+	"*/_version.py",
+]
+
+[tool.coverage.report]
+# print report with one decimal point
+precision = 1
+
+# -- pytest
 
 [tool.pytest.ini_options]
 addopts = "-r a"
@@ -24,3 +41,8 @@ filterwarnings = [
 	"ignore:distutils Version::matplotlib",
 	"ignore:distutils Version::distutils",  # actually setuptools._distutils
 ]
+
+# -- setuptools-scm
+
+[tool.setuptools_scm]
+write_to = "gwpy/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,17 +97,5 @@ conda =
 	python-ldas-tools-framecpp ; sys_platform != 'win32'
 	python-nds2-client
 
-# -- packaging --------------
-
 [bdist_wheel]
 universal = 1
-
-# -- tools ------------------
-
-[aliases]
-test = pytest
-
-[coverage:run]
-source = gwpy
-omit =
-	gwpy/utils/sphinx/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ console_scripts =
 [options.extras_require]
 # test suite
 test =
-	beautifulsoup4
 	coverage[toml] >=5.0
 	freezegun >=0.3.12
 	pytest >=3.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,24 +111,3 @@ test = pytest
 source = gwpy
 omit =
 	gwpy/utils/sphinx/*
-
-[flake8]
-select =
-	E,
-	EXE,
-	F,
-	W,
-ignore =
-	E226,
-	W503,
-exclude =
-	__pycache__,
-	.eggs/,
-	.git/,
-	build/,
-	docs/,
-	gwpy/_version.py,
-	venv/,
-per-file-ignores =
-	__init__.py:F401,
-	examples/**.py:E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ console_scripts =
 # test suite
 test =
 	beautifulsoup4
+	coverage[toml] >=5.0
 	freezegun >=0.3.12
 	pytest >=3.9.1
 	pytest-cov >=2.4.0


### PR DESCRIPTION
This PR implements a minor metadata cleanup, migrating non-setuptools configurations out of `setup.cfg` into either `pyproject.toml` or their own file.