### PR TITLE
Strict xfail.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ filterwarnings = [
 	"ignore:distutils Version::matplotlib",
 	"ignore:distutils Version::distutils",  # actually setuptools._distutils
 ]
+xfail_strict = true
 
 # -- setuptools-scm
 


### PR DESCRIPTION
Set pytest option so that XPASSED tests are considered as failures.