### PR TITLE
Update rstcheck to 6.x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install \
-            "rstcheck>=6.0.0" \
+            "rstcheck[sphinx,toml]>=6.0.0" \
         ;
     - name: Lint with rstcheck
       run: rstcheck . --recursive --report-level error

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,4 +55,4 @@ jobs:
             "rstcheck>=6.0.0" \
         ;
     - name: Lint with rstcheck
-      run: rstcheck . --recursive --report-level severe
+      run: rstcheck . --recursive --report-level error

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install \
-            "rstcheck" \
+            "rstcheck>=6.0.0" \
         ;
     - name: Lint with rstcheck
-      run: rstcheck . --recursive --report severe
+      run: rstcheck . --recursive --report-level severe

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -41,6 +41,7 @@ Step-by-step
    for major/minor releases, or
 
    .. code-block:: bash
+
       git push -u origin release/X.Y.x
 
    for bug-fix releases

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -127,7 +127,7 @@ The full list of available columns can be queried as follows:
                    chirp_mass_lower float64                         chirp_mass_lower
    ...
 
-.. adminition:: GWOSC catalogues
+.. admonition:: GWOSC catalogues
 
    For more details on the GWOSC catalogues, see https://www.gw-openscience.org/catalog/.
 

--- a/docs/timeseries/datafind.rst
+++ b/docs/timeseries/datafind.rst
@@ -229,7 +229,7 @@ method call, or you can use a suffix in the channel name:
 
 e.g.
 
-.. code-block::
+.. code-block:: python
 
    >>> TimeSeries.get("L1:IMC-PWR_IN_OUT_DQ.mean,s-trend", 1186741850, 1186741870)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,31 @@ filterwarnings = [
 	"ignore:distutils Version::distutils",  # actually setuptools._distutils
 ]
 
+# -- rstcheck
+
+[tool.rstcheck]
+ignore_directives = [
+	# sphinx.ext.autosummary
+	"autoclass",
+	"autofunction",
+	"automethod",
+	"automodule",
+	"autosummary",
+	# sphinx-automodapi
+	"automodsumm",
+	# sphinxcontrib-programoutput
+	"command-output",
+	# sphinx.ext.ifconfig
+	"ifconfig",
+	# matplotlib
+	"plot",
+	# sphinx-panels
+	"tabbed",
+]
+# rstcheck doesn't known about our referenced.txt which is implicitly included
+# in all pages via Sphinx's epilog option
+ignore_messages = "(Unknown target name:.*|Undefined substitution referenced: .*)"
+
 # -- setuptools-scm
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This PR updates `rstcheck` in the Lint CI workflow to use `>=6.0.0`, which has renamed command-line options.