### PR TITLE
Use plot directive to build CLI examples for online docs

### DIFF
--- a/docs/cli/index.rst
+++ b/docs/cli/index.rst
@@ -1,20 +1,18 @@
-.. include: ..
-
 *******************************
 Command line plotting with GWpy
 *******************************
 
-The `gwpy-plot` command-line script provides a terminal-based user interface
+The ``gwpy-plot`` command-line script provides a terminal-based user interface
 to querying data and generating images.
 Functionality for this tool is primarily inspired by LigoDV-web
 (LDVW, https://ldvw.ligo.caltech.edu), a web tool for viewing LIGO data,
 available to members of the joint LIGO-Virgo collaboration.
-LDVW, written in Java, uses the `gwpy-plot` command-line script provided by
+LDVW, written in Java, uses the ``gwpy-plot`` command-line script provided by
 GWpy to generate the plots based on web-form input from the user.
 
 The basic usage for `gwpy-plot` is as follows:
 
-.. code-block:: sh
+.. code-block:: bash
 
     gwpy-plot <ACTION> --chan <channel-name> --start <gps-start-time> [OPTIONS]
 
@@ -58,12 +56,14 @@ The following table summarises the allowed number of inputs for each action
 By default all data are retrieved using :meth:`TimeSeriesDict.get`, which uses |nds2|_ for data access, but the ``--framcache``
 option allows you to pass your own data via a LAL-format cache file.
 
+=================
 Interactive mode
 =================
 
 The ``--interactive`` argument uses :mod:`~matplotlib.pyplot` to display
 the image and allow interactive manipulations, (zoom, pan, etc).
 
+========
 Examples
 ========
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -408,7 +408,7 @@ def build_cli_examples(_):
 
 # -- examples
 
-def _build_example(example, outdir, logger):
+def _render_example(example, outdir, logger):
     # render the example
     rst = ex2rst.ex2rst(example)
 
@@ -420,7 +420,7 @@ def _build_example(example, outdir, logger):
         logger.debug('[examples] wrote {0}'.format(target))
 
 
-def build_examples(_):
+def render_examples(_):
     """Render all examples as RST to be processed by Sphinx.
     """
     logger = logging.getLogger("examples")
@@ -442,8 +442,7 @@ def build_examples(_):
         logger.debug('[examples] copied {0}'.format(index))
         # render python script as RST
         for expy in (srcdir / exdir).glob("*.py"):
-            target = subdir / expy.with_suffix(".rst").name
-            _build_example(expy, subdir, logger)
+            _render_example(expy, subdir, logger)
         logger.info('[examples] converted all in examples/{0}'.format(exdir))
 
 
@@ -483,5 +482,5 @@ def setup_static_content(app):
 def setup(app):
     setup_static_content(app)
     app.connect('builder-inited', write_citing_rst)
-    app.connect('builder-inited', build_examples)
+    app.connect('builder-inited', render_examples)
     app.connect('builder-inited', build_cli_examples)


### PR DESCRIPTION
Thus PR updates the sphinx `conf.py` to render the CLI examples to use the matplotlib `.. plot` directive to actually execute the example and generate the plot, which means that the examples are now executed as part of the main build in the same way as every other plot, rather than as part of the pre-processor function.