### PR TITLE
Update all usage of 'hanning' window to 'hann'

### DIFF
--- a/examples/frequencyseries/percentiles.py
+++ b/examples/frequencyseries/percentiles.py
@@ -45,7 +45,7 @@ hoft = TimeSeries.fetch_open_data('H1', 1187007040, 1187009088)
 # a number of ASDs, using the :meth:`~gwpy.timeseries.TimeSeries.spectrogram2`
 # method:
 
-sg = hoft.spectrogram2(fftlength=4, overlap=2, window='hanning') ** (1/2.)
+sg = hoft.spectrogram2(fftlength=4, overlap=2, window='hann') ** (1/2.)
 
 # From this we can trivially extract the median, 5th and 95th percentiles:
 

--- a/examples/frequencyseries/percentiles.py
+++ b/examples/frequencyseries/percentiles.py
@@ -45,7 +45,7 @@ hoft = TimeSeries.fetch_open_data('H1', 1187007040, 1187009088)
 # a number of ASDs, using the :meth:`~gwpy.timeseries.TimeSeries.spectrogram2`
 # method:
 
-sg = hoft.spectrogram2(fftlength=4, overlap=2, window='hann') ** (1/2.)
+sg = hoft.spectrogram2(fftlength=4, overlap=2, window='hann') ** (1 / 2.)
 
 # From this we can trivially extract the median, 5th and 95th percentiles:
 

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -181,7 +181,7 @@ def truncate_transfer(transfer, ncorner=None):
     return out
 
 
-def truncate_impulse(impulse, ntaps, window='hanning'):
+def truncate_impulse(impulse, ntaps, window='hann'):
     """Smoothly truncate a time domain impulse response
 
     Parameters
@@ -193,7 +193,7 @@ def truncate_impulse(impulse, ntaps, window='hanning'):
         number of taps in the final filter
 
     window : `str`, `numpy.ndarray`, optional
-        window function to truncate with, default: ``'hanning'``
+        window function to truncate with, default: ``'hann'``
         see :func:`scipy.signal.get_window` for details on acceptable formats
 
     Returns
@@ -211,7 +211,7 @@ def truncate_impulse(impulse, ntaps, window='hanning'):
     return out
 
 
-def fir_from_transfer(transfer, ntaps, window='hanning', ncorner=None):
+def fir_from_transfer(transfer, ntaps, window='hann', ncorner=None):
     """Design a Type II FIR filter given an arbitrary transfer function
 
     Parameters
@@ -223,7 +223,7 @@ def fir_from_transfer(transfer, ntaps, window='hanning', ncorner=None):
         number of taps in the final filter, must be an even number
 
     window : `str`, `numpy.ndarray`, optional
-        window function to truncate with, default: ``'hanning'``
+        window function to truncate with, default: ``'hann'``
         see :func:`scipy.signal.get_window` for details on acceptable formats
 
     ncorner : `int`, optional

--- a/gwpy/signal/tests/test_window.py
+++ b/gwpy/signal/tests/test_window.py
@@ -29,7 +29,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
 def test_canonical_name():
-    assert window.canonical_name('Hanning') == 'hann'
+    assert window.canonical_name('Han') == 'hann'
     with pytest.raises(ValueError) as exc:
         window.canonical_name('blah')
     assert str(exc.value) == ('no window function in scipy.signal '

--- a/gwpy/signal/window.py
+++ b/gwpy/signal/window.py
@@ -54,7 +54,7 @@ def canonical_name(name):
     Examples
     --------
     >>> from gwpy.signal.window import canonical_name
-    >>> canonical_name('hanning')
+    >>> canonical_name('hann')
     'hann'
     >>> canonical_name('ksr')
     'kaiser'

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1709,7 +1709,7 @@ class TimeSeries(TimeSeriesBase):
         return out
 
     def whiten(self, fftlength=None, overlap=0, method=DEFAULT_FFT_METHOD,
-               window='hanning', detrend='constant', asd=None,
+               window='hann', detrend='constant', asd=None,
                fduration=2, highpass=None, **kwargs):
         """Whiten this `TimeSeries` using inverse spectrum truncation
 
@@ -1728,7 +1728,7 @@ class TimeSeries(TimeSeriesBase):
 
         window : `str`, `numpy.ndarray`, optional
             window function to apply to timeseries prior to FFT,
-            default: ``'hanning'``
+            default: ``'hann'``
             see :func:`scipy.signal.get_window` for details on acceptable
             formats
 
@@ -1891,7 +1891,7 @@ class TimeSeries(TimeSeriesBase):
         # return the self-gated timeseries
         return self.mask(deadtime=deadtime, const=0, tpad=tpad)
 
-    def convolve(self, fir, window='hanning'):
+    def convolve(self, fir, window='hann'):
         """Convolve this `TimeSeries` with an FIR filter using the
            overlap-save method
 
@@ -1901,7 +1901,7 @@ class TimeSeries(TimeSeriesBase):
             the time domain filter to convolve with
 
         window : `str`, optional
-            window function to apply to boundaries, default: ``'hanning'``
+            window function to apply to boundaries, default: ``'hann'``
             see :func:`scipy.signal.get_window` for details on acceptable
             formats
 
@@ -1957,7 +1957,7 @@ class TimeSeries(TimeSeriesBase):
         out.__array_finalize__(self)
         return out
 
-    def correlate(self, mfilter, window='hanning', detrend='linear',
+    def correlate(self, mfilter, window='hann', detrend='linear',
                   whiten=False, wduration=2, highpass=None, **asd_kw):
         """Cross-correlate this `TimeSeries` with another signal
 
@@ -1968,7 +1968,7 @@ class TimeSeries(TimeSeriesBase):
 
         window : `str`, optional
             window function to apply to timeseries prior to FFT,
-            default: ``'hanning'``
+            default: ``'hann'``
             see :func:`scipy.signal.get_window` for details on acceptable
             formats
 


### PR DESCRIPTION
This MR fixes #1518 (compatibility with scipy 1.9.0) by updating all references to `'hanning'` as a window name to use `'hann'` instead.