### PR TITLE
Deprecate gwpy.utils.null_context

### DIFF
--- a/gwpy/signal/spectral/_pycbc.py
+++ b/gwpy/signal/spectral/_pycbc.py
@@ -21,8 +21,9 @@
 This module is deprecated and will be removed in a future release.
 """
 
+from contextlib import nullcontext
+
 from ...frequencyseries import FrequencySeries
-from ...utils.misc import null_context
 from ._utils import scale_timeseries_unit
 from . import _registry as fft_registry
 
@@ -65,7 +66,7 @@ def welch(timeseries, segmentlength, noverlap=None, scheme=None, **kwargs):
 
     # get scheme
     if scheme is None:
-        scheme = null_context()
+        scheme = nullcontext()
 
     # generate pycbc FrequencySeries
     with scheme:

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -21,6 +21,7 @@
 
 import os.path
 import warnings
+from contextlib import nullcontext
 from itertools import (chain, product)
 from unittest import mock
 
@@ -46,7 +47,6 @@ from ...testing.errors import (
 )
 from ...types import Index
 from ...time import LIGOTimeGPS
-from ...utils.misc import null_context
 from .. import (TimeSeries, TimeSeriesDict, TimeSeriesList, StateTimeSeries)
 from ..io.gwf import get_default_gwf_api
 from .test_core import (TestTimeSeriesBase as _TestTimeSeriesBase,
@@ -608,7 +608,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             utils.assert_quantity_sub_equal(ts, ts2, exclude=['channel'])
 
             # check padding works (with warning for nds2-server connections)
-            ctx = pytest.warns(UserWarning) if protocol > 1 else null_context()
+            ctx = pytest.warns(UserWarning) if protocol > 1 else nullcontext()
             with ctx:
                 ts2 = self.TEST_CLASS.fetch('L1:TEST', *ts.span.protract(10),
                                             pad=-100., host='anything')
@@ -876,7 +876,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         if method.startswith(("lal", "pycbc")):
             ctx = pytest.deprecated_call
         else:
-            ctx = null_context
+            ctx = nullcontext
 
         # generate spectrogram
         with ctx():

--- a/gwpy/utils/misc.py
+++ b/gwpy/utils/misc.py
@@ -21,8 +21,9 @@
 
 import sys
 import math
+import warnings
 from collections import OrderedDict
-from contextlib import contextmanager
+from contextlib import nullcontext
 
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -38,11 +39,16 @@ def gprint(*values, **kwargs):  # pylint: disable=missing-docstring
 gprint.__doc__ = print.__doc__
 
 
-@contextmanager
 def null_context():
     """Null context manager
     """
-    yield
+    warnings.warn(
+        "gwpy.utils.null_context is deprecated and will be removed in "
+        "GWpy 3.1.0, please update your code to use "
+        "contextlib.nullcontext from the Python standard library (>=3.7)",
+        DeprecationWarning,
+    )
+    return nullcontext()
 
 
 def if_not_none(func, value):

--- a/gwpy/utils/tests/test_misc.py
+++ b/gwpy/utils/tests/test_misc.py
@@ -42,7 +42,8 @@ def test_gprint(capsys):
 def test_null_context():
     """Test for :func:`gwpy.utils.misc.null_context`
     """
-    ctx = utils_misc.null_context()
+    with pytest.warns(DeprecationWarning):
+        ctx = utils_misc.null_context()
     with ctx:
         print('this should work')
 


### PR DESCRIPTION
This PR deprecates the `gwpy.utils.null_context` function, replacing all internals and all usage in GWpy with `contextlib.nullcontext`.

Closes #1498.