### PR TITLE
Pin cython to <3.0.0a0 for dev builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,9 @@ dev =
 	; https://github.com/gwpy/gwpy/issues/1496
 	astropy <5.1a0 ; sys_platform != 'win32'
 	ciecplib
+	; pycbc needs pegasus-wms.common, which needs
+	; pyyaml <5.5, which doesn't build with cython 3.x
+	cython <3.0.0a0 ; sys_platform != 'win32'
 	lalsuite ; sys_platform != 'win32'
 	lscsoft-glue ; sys_platform != 'win32'
 	maya


### PR DESCRIPTION
This PR pins the `dev` extra to depend on `cython <3.0.0a0` so that `PyYAML` 5.4 can build cleanly on Python 3.10, which is required for `pegasus-wms.common`.

This should be resolved (so this commit can be reverted) whenever pegasus-wms.common 5.0.2 is available from PyPI, see https://github.com/pegasus-isi/pegasus/commit/590c6881f01014417e635030195e072e158f59a8.