### PR TITLE
Pin experimental dependencies build to Python 3.9

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -45,7 +45,7 @@ jobs:
             extras: "test"
             pip-opts: "--upgrade-strategy=only-if-needed"
           - name: "Experimental"
-            python-version: "3.x"
+            python-version: "3.9"
             experimental: true
             extras: "test,dev"
             pip-opts: "--upgrade --upgrade-strategy=eager --pre"


### PR DESCRIPTION
This PR pins the experimental dependencies build to Python 3.9, since the crappy old version of PyYAML we need to support PyCBC (blame `pegasus-wms.common`) doesn't build with the advanced versions of cython and/or setuptools.