### PR TITLE
Replace skip_missing_dependency test decorator with pytest.mark.requires

### DIFF
--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -41,8 +41,6 @@ TEST_RESULTS = {
     'burst_range': 13.592140825568954 * units.Mpc,
 }
 
-SKIP_INSPIRAL_RANGE = utils.skip_missing_dependency("inspiral_range")
-
 
 @pytest.fixture(scope='module')
 def hoft():
@@ -96,7 +94,7 @@ def test_inspiral_range_missing_dep(psd):
     assert "'inspiral-range'" in str(exc.value)
 
 
-@SKIP_INSPIRAL_RANGE
+@pytest.mark.requires("inspiral_range")
 def test_inspiral_range_psd(psd):
     """Test for :func:`gwpy.astro.inspiral_range_psd`
     """
@@ -111,7 +109,7 @@ def test_inspiral_range_psd(psd):
     assert r.f0.value > 0
 
 
-@SKIP_INSPIRAL_RANGE
+@pytest.mark.requires("inspiral_range")
 def test_inspiral_range(psd):
     """Test for :func:`gwpy.astro.inspiral_range`
     """
@@ -147,7 +145,7 @@ def test_burst_range(psd):
 @pytest.mark.parametrize('rangekwargs', [
     pytest.param(
         {'mass1': 1.4, 'mass2': 1.4},
-        marks=[SKIP_INSPIRAL_RANGE],
+        marks=[pytest.mark.requires("inspiral_range")],
         id="inspiral_range",
     ),
     pytest.param(
@@ -176,7 +174,7 @@ def test_range_timeseries(hoft, rangekwargs):
     pytest.param(
         {'mass1': 1.4, 'mass2': 1.4},
         units.Mpc ** 2 / units.Hz,
-        marks=[SKIP_INSPIRAL_RANGE],
+        marks=[pytest.mark.requires("inspiral_range")],
         id="inspiral_range",
     ),
     pytest.param(

--- a/gwpy/cli/tests/base.py
+++ b/gwpy/cli/tests/base.py
@@ -178,7 +178,7 @@ class _TestCliProduct(object):
         else:
             assert out == ''
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_get_data(self, prod):
         conn, data = mock_nds2_connection()
         with mock.patch('nds2.connection') as mocker:
@@ -250,7 +250,7 @@ class _TestCliProduct(object):
                                  params.get('ymax', ymax))
         assert ax.get_ylabel() == params.get('ylabel', plotprod.get_ylabel())
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_run(self, tmp_path, prod):
         conn, _ = mock_nds2_connection()
         tmp = tmp_path / "plot.png"

--- a/gwpy/cli/tests/test_gwpy_plot.py
+++ b/gwpy/cli/tests/test_gwpy_plot.py
@@ -23,9 +23,6 @@ from unittest import mock
 
 import pytest
 
-from ...testing.utils import (
-    skip_missing_dependency,
-)
 from .. import (
     PRODUCTS,
     gwpy_plot,
@@ -41,7 +38,7 @@ def test_gwpy_plot_help(mode):
     assert exc.value.code == 0
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 def test_gwpy_plot_timeseries(tmp_path):
     tmp = tmp_path / "plot.png"
     with mock.patch(

--- a/gwpy/cli/tests/test_qtransform.py
+++ b/gwpy/cli/tests/test_qtransform.py
@@ -23,8 +23,9 @@ import os
 import re
 from unittest import mock
 
+import pytest
+
 from ... import cli
-from ...testing.utils import skip_missing_dependency
 from .base import (update_namespace, mock_nds2_connection)
 from .test_spectrogram import TestCliSpectrogram as _TestCliSpectrogram
 
@@ -68,7 +69,7 @@ class TestCliQtransform(_TestCliSpectrogram):
     def test_get_suptitle(self, prod):
         assert prod.get_suptitle() == f'Q-transform: {prod.chan_list[0]}'
 
-    @skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_run(self, prod):
         conn, _ = mock_nds2_connection()
         outf = 'X1-TEST_CHANNEL-5.0-0.5.png'

--- a/gwpy/detector/tests/test_channel.py
+++ b/gwpy/detector/tests/test_channel.py
@@ -312,7 +312,7 @@ class TestChannel(object):
             assert getattr(c, key) == pdict[key]
         assert c.ndsname == name
 
-    @utils.skip_missing_dependency("ciecplib")
+    @pytest.mark.requires("ciecplib")
     @pytest.mark.parametrize('name', ('X1:TEST-CHANNEL', 'Y1:TEST_CHANNEL'))
     def test_query(self, name):
         requests_mock = pytest.importorskip("requests_mock")
@@ -355,7 +355,7 @@ class TestChannel(object):
                 assert str(exc.value) == f'No channels found matching {name!r}'
 
     @pytest.mark.parametrize('name', ('X1:TEST-CHANNEL', 'Y1:TEST_CHANNEL'))
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_query_nds2(self, name):
         # mock NDS2 query
         ndsb = mocks.nds2_buffer('X1:TEST-CHANNEL', [], 0, 64, 'm')
@@ -380,7 +380,7 @@ class TestChannel(object):
                 with pytest.raises(ValueError):
                     c = self.TEST_CLASS.query_nds2(name, host='test')
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_from_nds2(self):
         nds2c = mocks.nds2_channel('X1:TEST-CHANNEL', 64, 'm')
         c = self.TEST_CLASS.from_nds2(nds2c)
@@ -428,7 +428,7 @@ class TestChannelList(object):
         cl = instance.sieve(name='GWPY-CHANNEL', sample_range=[2, 16])
         assert cl == instance[1:]
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_query_nds2(self):
         # mock NDS2 query
         buffers = []
@@ -448,7 +448,7 @@ class TestChannelList(object):
             assert len(
                 self.TEST_CLASS.query_nds2([self.NAMES[-1]], host='test')) == 0
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_query_nds2_availability(self):
         # mock NDS2 connection
         ndsb = mocks.nds2_buffer(self.NAMES[0], [], 0, 64, 'm')

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -180,7 +180,7 @@ class TestFrequencySeries(_TestSeries):
         assert newf.f0 == fseries.f0
         utils.assert_allclose(newf.value, numpy.ones(2*int(nyquist/df) + 1))
 
-    @utils.skip_missing_dependency('lal')
+    @pytest.mark.requires("lal")
     def test_to_from_lal(self, array):
         import lal
 
@@ -204,8 +204,7 @@ class TestFrequencySeries(_TestSeries):
         a2 = self.TEST_CLASS.from_lal(lalts)
         assert a2.unit is units.dimensionless_unscaled
 
-    @utils.skip_missing_dependency('lal')
-    @utils.skip_missing_dependency('pycbc')
+    @pytest.mark.requires("lal", "pycbc")
     def test_to_from_pycbc(self, array):
         from pycbc.types import FrequencySeries as PyCBCFrequencySeries
 
@@ -245,8 +244,7 @@ class TestFrequencySeries(_TestSeries):
         tmp.write_text(LIGO_LW_ARRAY)
         return tmp
 
-    @utils.skip_missing_dependency('lal')
-    @utils.skip_missing_dependency('ligo.lw')
+    @pytest.mark.requires("lal", "ligo.lw")
     def test_read_ligolw(self, ligolw):
         array = FrequencySeries.read(ligolw, 'PSD1')
         utils.assert_quantity_equal(
@@ -260,8 +258,7 @@ class TestFrequencySeries(_TestSeries):
         assert numpy.isclose(array.epoch.gps, 1000000000)  # precision gah!
         assert array.unit == units.Hz ** -1
 
-    @utils.skip_missing_dependency('lal')
-    @utils.skip_missing_dependency('ligo.lw')
+    @pytest.mark.requires("lal", "ligo.lw")
     def test_read_ligolw_params(self, ligolw):
         array = FrequencySeries.read(
             ligolw,
@@ -270,7 +267,7 @@ class TestFrequencySeries(_TestSeries):
         assert list(array.value) == [10, 20, 30, 40, 50]
         assert array.epoch is None
 
-    @utils.skip_missing_dependency('ligo.lw')
+    @pytest.mark.requires("ligo.lw")
     def test_read_ligolw_error_multiple_array(self, ligolw):
         # assert errors
         with pytest.raises(ValueError) as exc:  # multiple <Array> hits
@@ -281,13 +278,13 @@ class TestFrequencySeries(_TestSeries):
             FrequencySeries.read(ligolw, "PSD2")
         assert "'epoch" in str(exc.value) and "'name'" not in str(exc.value)
 
-    @utils.skip_missing_dependency('ligo.lw')
+    @pytest.mark.requires("ligo.lw")
     def test_read_ligolw_error_no_array(self, ligolw):
         with pytest.raises(ValueError) as exc:  # no hits
             FrequencySeries.read(ligolw, "blah")
         assert str(exc.value).startswith("no <Array> elements found")
 
-    @utils.skip_missing_dependency('ligo.lw')
+    @pytest.mark.requires("ligo.lw")
     def test_read_ligolw_error_no_match(self, ligolw):
         with pytest.raises(ValueError):  # wrong epoch
             FrequencySeries.read(ligolw, epoch=0)
@@ -299,7 +296,7 @@ class TestFrequencySeries(_TestSeries):
                 f0=0,
             )
 
-    @utils.skip_missing_dependency('ligo.lw')
+    @pytest.mark.requires("ligo.lw")
     def test_read_ligolw_error_no_param(self, ligolw):
         with pytest.raises(ValueError):  # no <Param>
             FrequencySeries.read(
@@ -308,7 +305,7 @@ class TestFrequencySeries(_TestSeries):
                 blah="blah",
             )
 
-    @utils.skip_missing_dependency('ligo.lw')
+    @pytest.mark.requires("ligo.lw")
     def test_read_ligolw_error_dim(self, ligolw):
         with pytest.raises(ValueError):  # wrong dimensionality
             FrequencySeries.read(ligolw, epoch=1000000001)

--- a/gwpy/io/tests/test_cache.py
+++ b/gwpy/io/tests/test_cache.py
@@ -28,7 +28,6 @@ import numpy
 import pytest
 
 from ...segments import (Segment, SegmentList)
-from ...testing.utils import skip_missing_dependency
 from .. import cache as io_cache
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -94,7 +93,7 @@ def test_read_write_cache(cache, tmp_path, format, entry1):
     ) == cache[1::-1]
 
 
-@skip_missing_dependency('lal.utils')
+@pytest.mark.requires("lal.utils")
 def test_write_cache_cacheentry(cache, tmp_path):
     from lal.utils import CacheEntry
     tmp = tmp_path / "test.lcf"
@@ -121,14 +120,14 @@ def test_is_cache(input_, result):
     assert io_cache.is_cache(input_) is result
 
 
-@skip_missing_dependency('lal.utils')
+@pytest.mark.requires("lal.utils")
 def test_is_cache_lal():
     cache = [io_cache.CacheEntry.from_T050017('/tmp/A-B-12345-6.txt')]
     assert io_cache.is_cache(cache)
     assert not io_cache.is_cache(cache + [None])
 
 
-@skip_missing_dependency('glue.lal')
+@pytest.mark.requires("glue.lal")
 def test_is_cache_glue():
     assert io_cache.is_cache(io_cache.Cache())
 
@@ -140,7 +139,7 @@ def test_is_cache_glue():
         assert io_cache.is_cache(f) is False
 
 
-@skip_missing_dependency('lal.utils')
+@pytest.mark.requires("lal.utils")
 def test_is_cache_file(tmp_path):
     """Check that `gwpy.io.cache.is_cache` returns `True` when it should
     """
@@ -155,7 +154,7 @@ def test_is_cache_file(tmp_path):
         assert io_cache.is_cache(tmpf)  # open file object
 
 
-@skip_missing_dependency('lal.utils')
+@pytest.mark.requires("lal.utils")
 def test_is_cache_file_empty(tmp_path):
     """Check that `gwpy.io.cache.is_cache` returns False when it should
     """

--- a/gwpy/io/tests/test_datafind.py
+++ b/gwpy/io/tests/test_datafind.py
@@ -32,7 +32,6 @@ from ...testing.errors import (
 )
 from ...testing.utils import (
     TEST_GWF_FILE,
-    skip_missing_dependency,
 )
 from .. import datafind as io_datafind
 
@@ -94,7 +93,7 @@ def _gwosc_gwdatafind(func):
         reason="GWOSC CVMFS repository not available",
     )
     @pytest.mark.cvmfs  # mark test as requiring cvmfs
-    @skip_missing_dependency('LDAStools.frameCPP')  # skip if no frameCPP
+    @pytest.mark.requires("LDAStools.frameCPP")  # skip if no frameCPP
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
 
@@ -225,7 +224,7 @@ def test_find_best_frametype_with_gaps_multiple():
     }
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 @pytest_skip_network_error
 @pytest.mark.skipif(
     "GWDATAFIND_SERVER" not in os.environ,

--- a/gwpy/io/tests/test_gwf.py
+++ b/gwpy/io/tests/test_gwf.py
@@ -24,7 +24,6 @@ import pytest
 from ...testing.utils import (
     TEST_GWF_FILE,
     assert_segmentlist_equal,
-    skip_missing_dependency,
 )
 from .. import gwf as io_gwf
 from ..cache import file_segment
@@ -43,20 +42,20 @@ def test_identify_gwf():
     assert not io_gwf.identify_gwf('read', None, None)
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_open_gwf_r(tmp_path):
     from LDAStools import frameCPP
     assert isinstance(io_gwf.open_gwf(TEST_GWF_FILE), frameCPP.IFrameFStream)
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_open_gwf_w(tmp_path):
     from LDAStools import frameCPP
     tmp = tmp_path / "test.gwf"
     assert isinstance(io_gwf.open_gwf(tmp, mode='w'), frameCPP.OFrameFStream)
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_open_gwf_w_file_url(tmp_path):
     from LDAStools import frameCPP
     # check that we can use a file:// URL as well
@@ -67,13 +66,13 @@ def test_open_gwf_w_file_url(tmp_path):
     )
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_open_gwf_a_error():
     with pytest.raises(ValueError):
         io_gwf.open_gwf('test', mode='a')
 
 
-@skip_missing_dependency("LDAStools.frameCPP")
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_create_frvect(noisy_sinusoid):
     vect = io_gwf.create_frvect(noisy_sinusoid)
     assert vect.nData == noisy_sinusoid.size
@@ -86,7 +85,7 @@ def test_create_frvect(noisy_sinusoid):
     assert xdim.startX == noisy_sinusoid.x0.value
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_iter_channel_names():
     # maybe need something better?
     from types import GeneratorType
@@ -95,17 +94,17 @@ def test_iter_channel_names():
     assert list(names) == TEST_CHANNELS
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_get_channel_names():
     assert io_gwf.get_channel_names(TEST_GWF_FILE) == TEST_CHANNELS
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_num_channels():
     assert io_gwf.num_channels(TEST_GWF_FILE) == 3
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_get_channel_type():
     assert io_gwf.get_channel_type('L1:LDAS-STRAIN', TEST_GWF_FILE) == 'proc'
     with pytest.raises(ValueError) as exc:
@@ -115,13 +114,13 @@ def test_get_channel_type():
     )
 
 
-@skip_missing_dependency('LDAStools.frameCPP')
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_channel_in_frame():
     assert io_gwf.channel_in_frame('L1:LDAS-STRAIN', TEST_GWF_FILE) is True
     assert io_gwf.channel_in_frame('X1:NOT-IN_FRAME', TEST_GWF_FILE) is False
 
 
-@skip_missing_dependency("LDAStools.frameCPP")
+@pytest.mark.requires("LDAStools.frameCPP")
 def test_data_segments():
     assert_segmentlist_equal(
         io_gwf.data_segments([TEST_GWF_FILE], "L1:LDAS-STRAIN"),

--- a/gwpy/io/tests/test_ligolw.py
+++ b/gwpy/io/tests/test_ligolw.py
@@ -26,7 +26,6 @@ import pytest
 
 import numpy
 
-from ...testing.utils import skip_missing_dependency
 from .. import ligolw as io_ligolw
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -163,7 +162,7 @@ def test_list_tables_file(llwdoc_with_tables):
         assert io_ligolw.list_tables(f) == names
 
 
-@skip_missing_dependency("ligo.lw.lsctables")
+@pytest.mark.requires("ligo.lw.lsctables")
 @pytest.mark.parametrize('value, name, result', [
     (None, 'peak_time', None),
     (1.0, 'peak_time', numpy.int32(1)),
@@ -254,7 +253,7 @@ def test_write_tables(tmp_path):
     assert len(stab2) == len(stab)
 
 
-@skip_missing_dependency("ligo.lw.lsctables")
+@pytest.mark.requires("ligo.lw.lsctables")
 def test_is_ligolw_false():
     assert not io_ligolw.is_ligolw("read", None, None, 1)
 

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -27,7 +27,6 @@ import pytest
 from ...detector import Channel
 from ...segments import (Segment, SegmentList)
 from ...testing import mocks
-from ...testing.utils import skip_missing_dependency
 from ...utils.tests.test_enum import TestNumpyTypeEnum as _TestNumpyTypeEnum
 from .. import nds2 as io_nds2
 
@@ -170,7 +169,7 @@ def test_host_resolution_order_warning():
     assert len(record) == 1  # make sure only one warning was emitted
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 @pytest.mark.parametrize('host, port, callport', [
     ('nds.test.gwpy', None, None),
     ('nds.test.gwpy', 31200, 31200),
@@ -187,7 +186,7 @@ def test_connect(connector, host, port, callport):
         connector.assert_called_once_with(host, callport)
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 @mock.patch('gwpy.io.nds2.connect')
 def test_auth_connect(connect):
     """Test `gwpy.io.nds2.auth_connect`
@@ -196,7 +195,7 @@ def test_auth_connect(connect):
     connect.assert_called_once_with('host', 'port')
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 @mock.patch('gwpy.io.nds2.kinit')
 @mock.patch(
     'gwpy.io.nds2.connect',
@@ -216,7 +215,7 @@ def test_auth_connect_kinit(connect, kinit):
     connect.assert_called_with('host', 'port')
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 @mock.patch('gwpy.io.nds2.connect', side_effect=RuntimeError('Anything else'))
 def test_auth_connect_error(connect):
     """Test errors from `gwpy.io.nds2.auth_connect`
@@ -244,7 +243,7 @@ def test_open_connection(auth_connect):
     auth_connect.assert_called_once_with('test', None)
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 @mock.patch('nds2.connection')
 def test_find_channels(connection):
     """Test `gwpy.io.nds2.find_channels`
@@ -296,7 +295,7 @@ def test_find_channels(connection):
         "unique NDS2 channel match not found for 'X1:test'")
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 @mock.patch('gwpy.io.nds2.find_channels', return_value=['X1:test'])
 @mock.patch('gwpy.io.nds2.auth_connect')
 def test_get_availability(auth_connect, _):
@@ -338,7 +337,7 @@ def test_minute_trend_times(start, end, out):
     assert io_nds2.minute_trend_times(start, end) == out
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 def test_get_nds2_name():
     """Test `gwpy.io.nds2._get_nds2_name`
     """
@@ -353,7 +352,7 @@ def test_get_nds2_name():
         assert io_nds2._get_nds2_name(channel) == name
 
 
-@skip_missing_dependency('nds2')
+@pytest.mark.requires("nds2")
 def test_get_nds2_names():
     """Test `gwpy.io.nds2._get_nds2_names`
     """

--- a/gwpy/io/tests/test_utils.py
+++ b/gwpy/io/tests/test_utils.py
@@ -25,7 +25,6 @@ from pathlib import Path
 
 import pytest
 
-from ...testing.utils import skip_missing_dependency
 from .. import (
     cache as io_cache,
     utils as io_utils,
@@ -71,7 +70,7 @@ def test_file_list_file(cache):  # noqa: F811
         assert io_utils.file_list(f) == [f.name]
 
 
-@skip_missing_dependency("lal")
+@pytest.mark.requires("lal")
 def test_file_list_cache(cache):  # noqa: F811
     from lal.utils import CacheEntry
     # test CacheEntry -> [CacheEntry.path]
@@ -129,7 +128,7 @@ def test_file_path_errors(badthing):
     assert str(exc.value).startswith("Cannot parse file name for")
 
 
-@skip_missing_dependency("lal")
+@pytest.mark.requires("lal")
 def test_file_path_cacheentry():
     from lal.utils import CacheEntry
     path = "/path/to/A-B-0-1.txt"

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -386,7 +386,7 @@ class TestDataQualityFlag(object):
         with pytest.raises(TypeError):
             flag.pad(*PADDING, kwarg='test')
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     def test_from_veto_def(self):
         from ligo.lw.lsctables import VetoDef
 
@@ -465,7 +465,7 @@ class TestDataQualityFlag(object):
         f2 = self.TEST_CLASS.read(tmp)
         utils.assert_flag_equal(f2, flag)
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     def test_read_write_ligolw(self, flag):
         utils.test_read_write(
             flag,
@@ -476,7 +476,7 @@ class TestDataQualityFlag(object):
             read_kw={},
         )
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     def test_write_ligolw_attrs(self, tmp_path, flag):
         from gwpy.io.ligolw import read_table
         tmp = tmp_path / "tmp.xml"
@@ -665,7 +665,7 @@ class TestDataQualityDict(object):
 
     # -- test I/O -------------------------------
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     def test_from_veto_definer_file(self, veto_definer):
         # read veto definer
         vdf = self.TEST_CLASS.from_veto_definer_file(veto_definer)
@@ -716,7 +716,7 @@ class TestDataQualityDict(object):
             _read_write(autoidentify=True)
         _read_write(autoidentify=True, write_kw={'overwrite': True})
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     def test_read_write_ligolw(self, instance):
         def _assert(a, b):
             return utils.assert_dict_equal(a, b, utils.assert_flag_equal)
@@ -762,7 +762,7 @@ class TestDataQualityDict(object):
             with pytest.raises(ValueError) as exc:
                 _read(on_missing='blah')
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     def test_to_ligolw_tables(self, instance):
         tables = instance.to_ligolw_tables()
         assert len(tables[0]) == len(instance)  # segdef

--- a/gwpy/signal/tests/test_spectral_median_mean.py
+++ b/gwpy/signal/tests/test_spectral_median_mean.py
@@ -23,12 +23,10 @@ from unittest import mock
 
 import pytest
 
-from ...testing.utils import skip_missing_dependency
 from ..spectral import _median_mean as fft_median_mean
 
 
-@skip_missing_dependency("pycbc.psd")
-@skip_missing_dependency("lal")
+@pytest.mark.requires("lal", "pycbc.psd")
 @mock.patch(
     "gwpy.signal.spectral._pycbc.welch",
     side_effect=(None, ImportError, ImportError),

--- a/gwpy/signal/tests/test_spectral_ui.py
+++ b/gwpy/signal/tests/test_spectral_ui.py
@@ -30,7 +30,6 @@ from astropy import units
 from ...testing.utils import (
     assert_array_equal,
     assert_quantity_sub_equal,
-    skip_missing_dependency,
 )
 from ...timeseries import TimeSeries
 from ..spectral import _ui as fft_ui
@@ -73,7 +72,7 @@ def test_normalize_fft_params_window_array():
     assert_array_equal(ftp.pop("window"), win)
 
 
-@skip_missing_dependency("lal")
+@pytest.mark.requires("lal")
 @pytest.mark.parametrize("win", [
     "hann",
     signal.get_window(("kaiser", 14), 1024),

--- a/gwpy/table/tests/test_io_ligolw.py
+++ b/gwpy/table/tests/test_io_ligolw.py
@@ -25,7 +25,6 @@ import numpy
 from numpy.testing import assert_array_equal
 
 from .. import EventTable
-from ...testing.utils import skip_missing_dependency
 
 
 # -- fixtures -----------------------------------------------------------------
@@ -44,14 +43,14 @@ def llwtable():
 
 # -- test to_astropy_table() via EventTable conversions -----------------------
 
-@skip_missing_dependency('ligo.lw.lsctables')
+@pytest.mark.requires("ligo.lw.lsctables")
 def test_to_astropy_table(llwtable):
     tab = EventTable(llwtable)
     assert set(tab.colnames) == {"peak_frequency", "snr"}
     assert_array_equal(tab["snr"], llwtable.getColumnByName("snr"))
 
 
-@skip_missing_dependency('ligo.lw.lsctables')
+@pytest.mark.requires("ligo.lw.lsctables")
 def test_to_astropy_table_rename(llwtable):
     tab = EventTable(llwtable, rename={"peak_frequency": "frequency"})
     assert set(tab.colnames) == {"frequency", "snr"}
@@ -61,7 +60,7 @@ def test_to_astropy_table_rename(llwtable):
     )
 
 
-@skip_missing_dependency('ligo.lw.lsctables')
+@pytest.mark.requires("ligo.lw.lsctables")
 def test_to_astropy_table_empty():
     from ligo.lw.lsctables import (New, SnglBurstTable)
     llwtable = New(
@@ -74,7 +73,7 @@ def test_to_astropy_table_empty():
     assert tab['ifo'].dtype.type is numpy.unicode_
 
 
-@skip_missing_dependency('ligo.lw.lsctables')
+@pytest.mark.requires("ligo.lw.lsctables")
 def test_read_process_table():
     """Regression test against gwpy/gwpy#1367
     """

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -128,7 +128,7 @@ class TestTable(object):
 
     # -- test I/O -------------------------------
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     @pytest.mark.parametrize('ext', ['xml', 'xml.gz'])
     def test_read_write_ligolw(self, tmp_path, ext):
         table = self.create(
@@ -207,7 +207,7 @@ class TestTable(object):
         assert str(exc.value) == ('document must contain exactly '
                                   'one sngl_burst table')
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     def test_read_write_ligolw_property_columns(self, tmp_path):
         table = self.create(100, ['peak', 'snr', 'central_freq'],
                             ['f8', 'f4', 'f4'])
@@ -234,7 +234,7 @@ class TestTable(object):
         )
         utils.assert_table_equal(t2, table, almost_equal=True)
 
-    @utils.skip_missing_dependency('ligo.lw.lsctables')
+    @pytest.mark.requires("ligo.lw.lsctables")
     def test_read_ligolw_get_as_exclude(self, tmp_path):
         table = self.TABLE(
             rows=[
@@ -262,7 +262,7 @@ class TestTable(object):
         t2.sort("instrument")
         utils.assert_table_equal(t2, table)
 
-    @utils.skip_missing_dependency('uproot')
+    @pytest.mark.requires("uproot")
     def test_read_write_root(self, table, tmp_path):
         tmp = tmp_path / "table.root"
 
@@ -290,7 +290,7 @@ class TestTable(object):
             ),
         )
 
-    @utils.skip_missing_dependency('uproot')
+    @pytest.mark.requires("uproot")
     def test_write_root_overwrite(self, table, tmp_path):
         tmp = tmp_path / "table.root"
         table.write(tmp)
@@ -302,7 +302,7 @@ class TestTable(object):
         # assert works with overwrite=True
         table.write(tmp, overwrite=True)
 
-    @utils.skip_missing_dependency('uproot')
+    @pytest.mark.requires("uproot")
     def test_read_root_multiple_trees(self, tmp_path):
         uproot = pytest.importorskip("uproot")
         tmp = tmp_path / "table.root"
@@ -315,7 +315,7 @@ class TestTable(object):
         assert str(exc.value).startswith('Multiple trees found')
         self.TABLE.read(tmp, treename="a")
 
-    @utils.skip_missing_dependency('uproot')
+    @pytest.mark.requires("uproot")
     def test_read_write_root_append(self, table, tmp_path):
         tmp = tmp_path / "table.root"
         # write one tree
@@ -326,7 +326,7 @@ class TestTable(object):
         self.TABLE.read(tmp, treename="a")
         self.TABLE.read(tmp, treename="b")
 
-    @utils.skip_missing_dependency('uproot')
+    @pytest.mark.requires("uproot")
     def test_read_write_root_append_overwrite(self, table, tmp_path):
         tmp = tmp_path / "table.root"
         # write one tree
@@ -341,7 +341,7 @@ class TestTable(object):
         utils.assert_table_equal(table, self.TABLE.read(tmp, treename="b"))
         utils.assert_table_equal(t2, self.TABLE.read(tmp, treename="a"))
 
-    @utils.skip_missing_dependency('LDAStools.frameCPP')
+    @pytest.mark.requires("LDAStools.frameCPP")
     def test_read_write_gwf(self, tmp_path):
         table = self.create(100, ['time', 'blah', 'frequency'])
         columns = table.dtype.names
@@ -520,7 +520,7 @@ class TestEventTable(TestTable):
         assert isinstance(rate, TimeSeries)
         assert rate.sample_rate == 1 * units.Hz
 
-    @utils.skip_missing_dependency('lal')
+    @pytest.mark.requires("lal")
     def test_event_rates_gpsobject(self, table):
         """Test that `EventTable.event_rate` can handle object dtypes
         """

--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -46,7 +46,11 @@ TEST_HDF5_FILE = os.path.join(TEST_DATA_DIR, 'HLV-HW100916-968654552-1.hdf')
 
 # -- dependencies -------------------------------------------------------------
 
-def has(module):
+@deprecated_function(message=(
+    "gwpy.testing.utils.has is deprecated and will "
+    "be removed in GWpy 3.1.0",
+))
+def has(module):  # pragma: no cover
     """Test whether a module is available
 
     Returns `True` if `import module` succeeded, otherwise `False`
@@ -59,20 +63,38 @@ def has(module):
         return True
 
 
-def skip_missing_dependency(module):
+@deprecated_function(message=(
+    "gwpy.testing.utils.skip_missing_dependency is deprecated and will "
+    "be removed in GWpy 3.1.0, please update your code to use "
+    "pytest.mark.requires from the pytest-requires package",
+))
+def skip_missing_dependency(module):  # pragma: no cover
     """Returns a mark generator to skip a test if the dependency is missing
+
+    .. deprecated:: 3.0.0
+       Use `pytest.mark.requires` from pytest-requires instead.
     """
     return pytest.mark.skipif(not has(module),
                               reason='No module named %s' % module)
 
 
-def module_older_than(module, minversion):
+@deprecated_function(message=(
+    "gwpy.testing.utils.module_older_than is deprecated and will "
+    "be removed in GWpy 3.1.0",
+))
+def module_older_than(module, minversion):  # pragma: no cover
     mod = import_module(module)
     return LooseVersion(mod.__version__) < LooseVersion(minversion)
 
 
-def skip_minimum_version(module, minversion):
+@deprecated_function(message=(
+    "gwpy.testing.utils.skip_minimum_version is deprecated and will "
+    "be removed in GWpy 3.1.0",
+))
+def skip_minimum_version(module, minversion):  # pragma: no cover
     """Returns a mark generator to skip a test if the dependency is too old
+
+    .. deprecated:: 3.0.0
     """
     return pytest.mark.skipif(
         module_older_than(module, minversion),

--- a/gwpy/time/tests/test_time.py
+++ b/gwpy/time/tests/test_time.py
@@ -33,7 +33,6 @@ from astropy.time import Time
 from astropy.units import (UnitConversionError, Quantity)
 
 from ... import time
-from ...testing.utils import skip_missing_dependency
 from .. import LIGOTimeGPS
 
 try:
@@ -88,7 +87,7 @@ def _test_with_errors(func, in_, out):
     (Quantity(1167264018, 's'), 1167264018),
     (Decimal('1126259462.391000000'), GW150914),
     pytest.param(GlueGPS(GW150914.gpsSeconds, GW150914.gpsNanoSeconds),
-                 GW150914, marks=skip_missing_dependency('glue')),
+                 GW150914, marks=pytest.mark.requires("glue")),
     (numpy.int32(NOW), NOW),  # fails with lal-6.18.0
     ('now', NOW),
     ('today', TODAY),
@@ -97,7 +96,7 @@ def _test_with_errors(func, in_, out):
     (Quantity(1, 'm'), UnitConversionError),
     ('random string', (ValueError, TypeError)),
     pytest.param('Oct 30 2016 12:34 CST', 1161887657,
-                 marks=skip_missing_dependency('maya')),
+                 marks=pytest.mark.requires("maya")),
 ])
 def test_to_gps(in_, out):
     """Test :func:`gwpy.time.to_gps`
@@ -111,7 +110,7 @@ def test_to_gps(in_, out):
     (1126259462.391, datetime(2015, 9, 14, 9, 50, 45, 391000)),
     ('1.13e9', datetime(2015, 10, 27, 16, 53, 3)),
     pytest.param(GlueGPS(GW150914.gpsSeconds, GW150914.gpsNanoSeconds),
-                 GW150914_DT, marks=skip_missing_dependency('glue')),
+                 GW150914_DT, marks=pytest.mark.requires("glue")),
     ('test', ValueError),
     (1167264017, ValueError),  # gwpy/gwpy#1021
 ])
@@ -126,7 +125,7 @@ def test_from_gps(in_, out):
     (GW150914, GW150914_DT),
     (GW150914_DT, GW150914),
     pytest.param(GlueGPS(float(GW150914)), GW150914_DT,
-                 marks=skip_missing_dependency('glue')),
+                 marks=pytest.mark.requires("glue")),
     ('now', NOW),
     ('today', TODAY),
     ('tomorrow', TOMORROW),

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -133,7 +133,7 @@ class TestTimeSeriesBase(_TestSeries):
             plot.save(BytesIO(), format='png')
             plot.close()
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_from_nds2_buffer(self):
         # build fake buffer
         nds_buffer = mocks.nds2_buffer(
@@ -171,7 +171,7 @@ class TestTimeSeriesBase(_TestSeries):
         assert b.dt == 1/128. * units.s
         assert shares_memory(nds_buffer.data, b.value)
 
-    @utils.skip_missing_dependency("lal")
+    @pytest.mark.requires("lal")
     def test_to_from_lal(self, array):
         # check that to + from returns the same array
         lalts = array.to_lal()
@@ -179,7 +179,7 @@ class TestTimeSeriesBase(_TestSeries):
         utils.assert_quantity_sub_equal(array, a2, exclude=['name', 'channel'])
         assert a2.name == ''
 
-    @utils.skip_missing_dependency("lal")
+    @pytest.mark.requires("lal")
     @pytest.mark.parametrize("copy", (False, True))
     def test_to_from_lal_no_copy(self, array, copy):
         """Check that copy=False shares data
@@ -188,7 +188,7 @@ class TestTimeSeriesBase(_TestSeries):
         a2 = type(array).from_lal(lalts, copy=copy)
         assert shares_memory(a2.value, lalts.data.data) is not copy
 
-    @utils.skip_missing_dependency("lal")
+    @pytest.mark.requires("lal")
     def test_to_from_lal_unrecognised_units(self, array):
         """Test that unrecognised units get warned, but the operation continues
         """
@@ -200,7 +200,7 @@ class TestTimeSeriesBase(_TestSeries):
         a2 = self.TEST_CLASS.from_lal(lalts)
         assert a2.unit == units.dimensionless_unscaled
 
-    @utils.skip_missing_dependency("lal")
+    @pytest.mark.requires("lal")
     def test_to_from_lal_pow10_units(self, array):
         """Test that normal scaled units scale the data properly
         """
@@ -210,7 +210,7 @@ class TestTimeSeriesBase(_TestSeries):
         utils.assert_array_equal(lalts.data.data, array.value)
         assert lalts.sampleUnits == lal.MeterUnit * 1000.
 
-    @utils.skip_missing_dependency("lal")
+    @pytest.mark.requires("lal")
     def test_to_from_lal_scaled_units(self, array):
         """Test that weird scaled units scale the data properly
         """
@@ -220,8 +220,7 @@ class TestTimeSeriesBase(_TestSeries):
         utils.assert_array_equal(lalts.data.data, array.value * 123.)
         assert lalts.sampleUnits == lal.MeterUnit
 
-    @utils.skip_missing_dependency('lal')
-    @utils.skip_missing_dependency('pycbc')
+    @pytest.mark.requires("lal", "pycbc")
     def test_to_from_pycbc(self, array):
         from pycbc.types import TimeSeries as PyCBCTimeSeries
 
@@ -381,7 +380,7 @@ class TestTimeSeriesBaseDict(object):
     def test_get(self):
         return NotImplemented
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_from_nds2_buffers(self):
         buffers = [
             mocks.nds2_buffer('X1:TEST', numpy.arange(100), 1000000000,

--- a/gwpy/timeseries/tests/test_io_gwf_lalframe.py
+++ b/gwpy/timeseries/tests/test_io_gwf_lalframe.py
@@ -30,7 +30,6 @@ from ...io.cache import write_cache
 from ...testing.utils import (
     assert_dict_equal,
     assert_quantity_sub_equal,
-    skip_missing_dependency,
     TEST_GWF_FILE,
 )
 from ...timeseries import TimeSeries
@@ -76,7 +75,7 @@ def test_open_data_source(source):
     return _test_open_data_source(source)
 
 
-@skip_missing_dependency("glue.lal")
+@pytest.mark.requires("glue.lal")
 def test_open_data_source_glue():
     from glue.lal import Cache
     Cache.entry_class = lal_utils.CacheEntry

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -108,7 +108,7 @@ class TestStateTimeSeries(_TestTimeSeriesBase):
         assert a2.dtype is numpy.dtype(bool)
         utils.assert_array_equal(array.value, a2.value)
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_from_nds2_buffer(self):
         # build fake buffer
         nds_buffer = mocks.nds2_buffer(
@@ -331,7 +331,9 @@ class TestStateVector(_TestTimeSeriesBase):
     @pytest.mark.parametrize('format', [
         'hdf5',
         pytest.param(  # only frameCPP actually reads units properly
-            'gwf', marks=utils.skip_missing_dependency('LDAStools.frameCPP')),
+            "gwf",
+            marks=pytest.mark.requires("LDAStools.frameCPP"),
+        ),
     ])
     @pytest_skip_network_error
     def test_fetch_open_data(self, format):
@@ -352,7 +354,7 @@ class TestStateVector(_TestTimeSeriesBase):
         utils.assert_quantity_sub_equal(sv, ref, exclude=['channel', 'bits'])
         assert sorted(map(str, sv.bits)) == sorted(map(str, ref.bits))
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_from_nds2_buffer(self):
         # build fake buffer
         nds_buffer = mocks.nds2_buffer(

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -53,29 +53,21 @@ from .test_core import (TestTimeSeriesBase as _TestTimeSeriesBase,
                         TestTimeSeriesBaseDict as _TestTimeSeriesBaseDict,
                         TestTimeSeriesBaseList as _TestTimeSeriesBaseList)
 
-SKIP_CVMFS_GWOSC = pytest.mark.skipif(
-    not os.path.isdir('/cvmfs/gwosc.osgstorage.org/'),
-    reason="GWOSC CVMFS repository not available",
-)
-SKIP_FRAMECPP = utils.skip_missing_dependency('LDAStools.frameCPP')
-SKIP_FRAMEL = utils.skip_missing_dependency('framel')
-SKIP_LAL = utils.skip_missing_dependency('lal')
-SKIP_LALFRAME = utils.skip_missing_dependency('lalframe')
-SKIP_PYCBC_PSD = utils.skip_missing_dependency('pycbc.psd')
-
 try:
     get_default_gwf_api()
 except ImportError:
     HAVE_GWF_API = False
 else:
     HAVE_GWF_API = True
-SKIP_GWF_API = pytest.mark.skipif(not HAVE_GWF_API, reason="no GWF API")
 
 GWF_APIS = [
-    pytest.param(None, marks=SKIP_GWF_API),
-    pytest.param('lalframe', marks=SKIP_LALFRAME),
-    pytest.param('framecpp', marks=SKIP_FRAMECPP),
-    pytest.param('framel', marks=SKIP_FRAMEL),
+    pytest.param(
+        None,
+        marks=pytest.mark.skipif(not HAVE_GWF_API, reason="no GWF API"),
+    ),
+    pytest.param('lalframe', marks=pytest.mark.requires("lalframe")),
+    pytest.param('framecpp', marks=pytest.mark.requires("LDAStools.frameCPP")),
+    pytest.param('framel', marks=pytest.mark.requires("framel")),
 ]
 
 
@@ -125,9 +117,12 @@ def _gwosc_cvmfs(func):
     """
     for dec in (
         pytest.mark.cvmfs,
+        pytest.mark.requires("LDAStools.frameCPP"),
+        pytest.mark.skipif(
+            not os.path.isdir('/cvmfs/gwosc.osgstorage.org/'),
+            reason="GWOSC CVMFS repository not available",
+        ),
         pytest_skip_cvmfs_read_error,
-        SKIP_CVMFS_GWOSC,
-        SKIP_FRAMECPP,
     ):
         func = dec(func)
     return func
@@ -320,7 +315,10 @@ class TestTimeSeries(_TestTimeSeriesBase):
         )
 
     @pytest.mark.parametrize('api', [
-        pytest.param('framecpp', marks=SKIP_FRAMECPP),
+        pytest.param(
+            'framecpp',
+            marks=pytest.mark.requires("LDAStools.frameCPP"),
+        ),
     ])
     def test_read_write_gwf_error(self, tmp_path, api, gw150914):
         tmp = tmp_path / "test.gwf"
@@ -345,7 +343,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             "Failed to read {0!r} from {1!r}".format(gw150914.name, str(tmp))
         )
 
-    @SKIP_LALFRAME
+    @pytest.mark.requires("lalframe")
     def test_read_gwf_scaled_lalframe(self):
         with warnings.catch_warnings():
             warnings.simplefilter("error")
@@ -364,7 +362,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             )
         utils.assert_quantity_sub_equal(data, data2)
 
-    @SKIP_FRAMECPP  # we need framecpp to extract frdata types
+    @pytest.mark.requires("LDAStools.frameCPP")
     @pytest.mark.parametrize("ctype", ("adc", "proc", "sim", None))
     @pytest.mark.parametrize("api", GWF_APIS)
     def test_write_gwf_type(self, gw150914, tmp_path, api, ctype):
@@ -521,7 +519,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
                 gap="raise",
             )
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_from_nds2_buffer_dynamic_scaled(self):
         # build fake buffer for LIGO channel
         nds_buffer = mocks.nds2_buffer(
@@ -553,7 +551,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
     @pytest.mark.parametrize('format', [
         'hdf5',
-        pytest.param('gwf', marks=SKIP_FRAMECPP),
+        pytest.param('gwf', marks=pytest.mark.requires("LDAStools.frameCPP")),
     ])
     @pytest_skip_network_error
     def test_fetch_open_data(self, gw150914, format):
@@ -587,7 +585,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
                 1,
             )
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     @pytest.mark.parametrize('protocol', (1, 2))
     def test_fetch(self, protocol):
         ts = self.create(name='L1:TEST', t0=1000000000, unit='m')
@@ -618,7 +616,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             assert ts2[-11] == ts[-1]
             assert ts2[-1] == -100. * ts.unit
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     def test_fetch_empty_iterate_error(self):
         # test that the correct error is raised if nds2.connection.iterate
         # yields no buffers (and no errors)
@@ -710,7 +708,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             exclude=['name', 'channel', 'unit'],
         )
 
-    @utils.skip_missing_dependency('nds2')
+    @pytest.mark.requires("nds2")
     @utils.skip_kerberos_credential
     @mock.patch.dict(os.environ)
     def test_get_nds2(self, gw150914_16384):
@@ -761,7 +759,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             gw150914.psd(.5, .25, method="median", window="hann"),
         )
 
-    @SKIP_LAL
+    @pytest.mark.requires("lal")
     def test_psd_lal_median_mean(self, gw150914):
         # check that warnings and errors get raised in the right place
         # for a median-mean PSD with the wrong data size or parameters
@@ -859,12 +857,15 @@ class TestTimeSeries(_TestTimeSeriesBase):
         'scipy-welch',
         'scipy-bartlett',
         'scipy-median',
-        pytest.param('lal-welch', marks=SKIP_LAL),
-        pytest.param('lal-bartlett', marks=SKIP_LAL),
-        pytest.param('lal-median', marks=SKIP_LAL),
-        pytest.param('pycbc-welch', marks=SKIP_PYCBC_PSD),
-        pytest.param('pycbc-bartlett', marks=SKIP_PYCBC_PSD),
-        pytest.param('pycbc-median', marks=SKIP_PYCBC_PSD),
+        pytest.param("lal-welch", marks=pytest.mark.requires("lal")),
+        pytest.param("lal-bartlett", marks=pytest.mark.requires("lal")),
+        pytest.param("lal-median", marks=pytest.mark.requires("lal")),
+        pytest.param("pycbc-welch", marks=pytest.mark.requires("pycbc.psd")),
+        pytest.param(
+            "pycbc-bartlett",
+            marks=pytest.mark.requires("pycbc.psd"),
+        ),
+        pytest.param("pycbc-median", marks=pytest.mark.requires("pycbc.psd")),
     ])
     @pytest.mark.parametrize(
         'window', (None, 'hann', ('kaiser', 24), 'array'),
@@ -931,8 +932,8 @@ class TestTimeSeries(_TestTimeSeriesBase):
         utils.assert_quantity_sub_equal(sg, sg2, almost_equal=True)
 
     @pytest.mark.parametrize('library', [
-        pytest.param('lal', marks=SKIP_LAL),
-        pytest.param('pycbc', marks=SKIP_PYCBC_PSD),
+        pytest.param('lal', marks=pytest.mark.requires("lal")),
+        pytest.param('pycbc', marks=pytest.mark.requires("pycbc.psd")),
     ])
     def test_spectrogram_median_mean(self, gw150914, library):
         method = '{0}-median-mean'.format(library)
@@ -1473,7 +1474,7 @@ class TestTimeSeriesDict(_TestTimeSeriesBaseDict):
     TEST_CLASS = TimeSeriesDict
     ENTRY_CLASS = TimeSeries
 
-    @SKIP_FRAMEL
+    @pytest.mark.requires("framel")
     def test_read_write_gwf(self, instance, tmp_path):
         tmp = tmp_path / "test.gwf"
         instance.write(tmp)

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ test =
 	freezegun >=0.3.12
 	pytest >=3.9.1
 	pytest-cov >=2.4.0
+	pytest-requires
 	pytest-socket
 	pytest-xdist
 	requests-mock


### PR DESCRIPTION
This PR closes #1495 by replacing all usage of `gwpy.testing.utils.skip_missing_dependency` with `pytest.mark.requires` from pytest-requires, and deprecates the former (but doesn't remove it).