### PR TITLE
Change the way Index.define creates arrays to prevent precision issues

### DIFF
--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -60,9 +60,14 @@ class Index(Quantity):
                 numpy.array(start, subok=True, copy=False).dtype,
                 numpy.array(step, subok=True, copy=False).dtype,
             )
-        start = start.astype(dtype, copy=False)
-        step = step.astype(dtype, copy=False)
-        return cls(start + numpy.arange(num, dtype=dtype) * step, copy=False)
+        start = Quantity(start, dtype=dtype, copy=False)
+        step = Quantity(step, dtype=dtype, copy=False).to(start.unit)
+        stop = start + step * num
+        return cls(
+            numpy.arange(start.value, stop.value, step.value, dtype=dtype),
+            unit=start.unit,
+            copy=False,
+        )
 
     @property
     def regular(self):

--- a/gwpy/types/tests/test_index.py
+++ b/gwpy/types/tests/test_index.py
@@ -27,11 +27,22 @@ from .. import Index
 class TestIndex(object):
     TEST_CLASS = Index
 
+    def test_define_regular(self):
+        """Check for regression against gwpy/gwpy#1506.
+        """
+        a = self.TEST_CLASS.define(
+            units.Quantity(1000000000),
+            units.Quantity(0.01),
+            500,
+        )
+        assert a.is_regular()
+
     def test_is_regular(self):
         a = self.TEST_CLASS([1, 2, 3, 4, 5, 6], 's')
         assert a.is_regular()
         assert a[::-1].is_regular()
 
+    def test_not_is_regular(self):
         b = self.TEST_CLASS([1, 2, 4, 5, 7, 8, 9])
         assert not b.is_regular()
 


### PR DESCRIPTION
This PR closes #1506 by refactoring the way that `Index.define()` creates arrays to prevent precision issues. A regression test has been introduced which demonstrates the precision issues describe in #1506.