### PR TITLE
Use Path.samefile() to compare paths

### DIFF
--- a/gwpy/timeseries/tests/test_io_gwf_lalframe.py
+++ b/gwpy/timeseries/tests/test_io_gwf_lalframe.py
@@ -61,9 +61,7 @@ def _test_open_data_source(source):
     """
     stream = gwpy_lalframe.open_data_source(source)
     assert stream.epoch == TEST_GWF_SEGMENT[0]
-    assert TEST_GWF_PATH == Path(
-        urlparse(stream.cache.list.url).path
-    ).absolute()
+    assert Path(urlparse(stream.cache.list.url).path).samefile(TEST_GWF_PATH)
 
 
 @pytest.mark.parametrize("source", [


### PR DESCRIPTION
This PR fixes #1519 by updating the relevant test to use [`Path.samefile`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.samefile) which unwraps symlinks properly, rather than a dumb `==`.