### PR TITLE
Fix off-by-one error in timeseries.mask

### DIFF
--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1440,7 +1440,7 @@ class TimeSeries(TimeSeriesBase):
         # the taper window in segments that are too short
         for seg in (span - deadtime):
             k = int((seg[0] - tstart) * sample)
-            N = int(abs(seg) * sample)
+            N = math.ceil(abs(seg) * sample)
             nhalf = min(npad, N)
             window = planck(2*npad, nleft=(int(k != 0) * npad),
                             nright=(int(k + N != self.size) * npad))


### PR DESCRIPTION
This PR resolves an issue with `timeseries.TimeSeries.mask()` where the masked samples may be offset by 1 from the span of samples that are tapered. This results in a single sample that is not masked, as well as a tapering that is applied at the end of the segment. 

In order to reproduce the bug, one needs to set the start and end times of the mask to times that do not correspond exactly with times of samples in the timeseries. The use of `int()` then creates the off-by-one error. 

Example code to reproduce error: 

```
import numpy
from gwpy.timeseries import TimeSeries

data_ones = TimeSeries(numpy.ones(16384), sample_rate=16384)
data_masked = data_ones.mask(deadtime=[(0.35,0.45)], tpad=0.25, const=0)

import matplotlib.pyplot as plt
plt.plot(data_masked)
plt.plot(data_ones)
plt.show()
```