### PR TITLE
Fix bug in width-1 slices of Array2D

### DIFF
--- a/gwpy/types/array2d.py
+++ b/gwpy/types/array2d.py
@@ -191,7 +191,10 @@ class Array2D(Series):
         try:
             return self._y0
         except AttributeError:
-            self._y0 = Quantity(0, self.yunit)
+            try:
+                self._y0 = self._yindex[0]
+            except (AttributeError, IndexError):
+                self._y0 = Quantity(0, self.yunit)
             return self._y0
 
     @y0.setter

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -193,6 +193,33 @@ class TestArray2D(_TestSeries):
             exclude=['epoch'],
         )
 
+    @pytest.mark.xfail(
+        reason="https://github.com/gwpy/gwpy/issues/1504",
+        raises=IndexError,
+    )
+    def test_single_column_slice(self):
+        """Check that we can slice an `Array2D` into a single column.
+
+        But still represent the output as an `Array2D` with `Index` arrays.
+
+        This tests regression of https://github.com/gwpy/gwpy/issues/1504.
+        """
+        # create an array with indices
+        a = self.create()
+        a.xindex
+        a.yindex
+
+        # select a slice of width 1 (as opposed to indexing a single column)
+        b = a[0:1]
+
+        # and check that the index arrays were correctly preserved
+        assert isinstance(b, self.TEST_CLASS)
+        for attr in ("x0", "dx", "xunit", "y0", "dy", "yunit"):
+            assert getattr(a, attr) == getattr(b, attr)
+        utils.assert_array_equal(b[0], a[0])
+        utils.assert_array_equal(b.xindex, a.xindex[0:1])
+        utils.assert_array_equal(b.yindex, a.yindex)
+
     def test_is_compatible_yindex(self):
         """Check that irregular arrays are compatible if their yindexes match
         """

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -193,10 +193,6 @@ class TestArray2D(_TestSeries):
             exclude=['epoch'],
         )
 
-    @pytest.mark.xfail(
-        reason="https://github.com/gwpy/gwpy/issues/1504",
-        raises=IndexError,
-    )
     def test_single_column_slice(self):
         """Check that we can slice an `Array2D` into a single column.
 


### PR DESCRIPTION
This PR fixes #1504 which reported an `IndexError` when attempting to create width-1 slices of `Array2D` objects.