### PR TITLE
Update usage of pytest.raises throughout the codebase

### DIFF
--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -89,9 +89,11 @@ def test_sensemon_range(psd):
 
 @mock.patch.dict("sys.modules", {"inspiral_range": None})
 def test_inspiral_range_missing_dep(psd):
-    with pytest.raises(ModuleNotFoundError) as exc:
+    with pytest.raises(
+        ModuleNotFoundError,
+        match="extra package 'inspiral-range'",
+    ):
         astro.inspiral_range(psd)
-    assert "'inspiral-range'" in str(exc.value)
 
 
 @pytest.mark.requires("inspiral_range")
@@ -207,7 +209,8 @@ def test_range_spectrogram(hoft, rangekwargs, outunit):
     astro.range_spectrogram,
 ])
 def test_range_incompatible_input(range_func):
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(
+        TypeError,
+        match="Could not produce a spectrogram from the input",
+    ):
         range_func(2, 0.5)
-    assert str(exc.value).startswith(
-        'Could not produce a spectrogram from the input')

--- a/gwpy/frequencyseries/tests/test_frequencyseries.py
+++ b/gwpy/frequencyseries/tests/test_frequencyseries.py
@@ -278,21 +278,24 @@ class TestFrequencySeries(_TestSeries):
         assert array.epoch is None
 
     @pytest.mark.requires("ligo.lw")
-    def test_read_ligolw_error_multiple_array(self, ligolw):
+    @pytest.mark.parametrize(("args", "match"), [
+        # no name given, 'name' in error message
+        ([], "read: 'channel', 'epoch', 'f0', 'name'$"),
+        # name given, 'name' not in error message
+        (("PSD2",), "read: 'channel', 'epoch', 'f0'$"),
+    ])
+    def test_read_ligolw_error_multiple_array(self, args, match, ligolw):
         # assert errors
-        with pytest.raises(ValueError) as exc:  # multiple <Array> hits
-            FrequencySeries.read(ligolw)
-        assert "'name'" in str(exc.value)
-
-        with pytest.raises(ValueError) as exc:  # multiple <Array> hits
-            FrequencySeries.read(ligolw, "PSD2")
-        assert "'epoch" in str(exc.value) and "'name'" not in str(exc.value)
+        with pytest.raises(
+            ValueError,
+            match=match,
+        ):  # multiple <Array> hits
+            FrequencySeries.read(ligolw, *args)
 
     @pytest.mark.requires("ligo.lw")
     def test_read_ligolw_error_no_array(self, ligolw):
-        with pytest.raises(ValueError) as exc:  # no hits
+        with pytest.raises(ValueError, match="^no <Array> elements found"):
             FrequencySeries.read(ligolw, "blah")
-        assert str(exc.value).startswith("no <Array> elements found")
 
     @pytest.mark.requires("ligo.lw")
     def test_read_ligolw_error_no_match(self, ligolw):

--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -90,9 +90,11 @@ class TestSpectralVariance(_TestArray2D):
                 epoch=array.epoch,
             ),
         )
-        with pytest.raises(NotImplementedError) as exc:
+        with pytest.raises(
+            NotImplementedError,
+            match="^cannot slice SpectralVariance across bins$",
+        ):
             array[0, ::2]
-        assert str(exc.value) == 'cannot slice SpectralVariance across bins'
 
     # -- test methods ---------------------------
 

--- a/gwpy/io/tests/test_cache.py
+++ b/gwpy/io/tests/test_cache.py
@@ -208,13 +208,20 @@ def test_filename_metadata_error():
         io_cache.filename_metadata("A-B-0-4xml.gz")
 
 
-def test_file_segment():
+@pytest.mark.parametrize(("filename", "seg"), [
+    # basic
+    ("A-B-1-2.ext", Segment(1, 3)),
+    # multiple file extensions
+    ("A-B-1-2.ext.gz", Segment(1, 3)),
+    # non-integer
+    ("A-B-1.23-4.ext.gz", Segment(1.23, 5.23)),
+])
+def test_file_segment(filename, seg):
     """Test :func:`gwpy.io.cache.file_segment`
     """
-    # check basic
-    fs = io_cache.file_segment('A-B-1-2.ext')
+    fs = io_cache.file_segment(filename)
     assert isinstance(fs, Segment)
-    assert fs == Segment(1, 3)
+    assert fs == seg
 
     # check mutliple file extensions
     assert io_cache.file_segment('A-B-1-2.ext.gz') == (1, 3)
@@ -222,12 +229,15 @@ def test_file_segment():
     # check floats (and multiple file extensions)
     assert io_cache.file_segment('A-B-1.23-4.ext.gz') == (1.23, 5.23)
 
-    # test errors
-    with pytest.raises(ValueError) as exc:
+
+def test_file_segment_errors():
+    """Test :func:`gwpy.io.cache.file_segment` error handling.
+    """
+    with pytest.raises(
+        ValueError,
+        match="^Failed to parse 'blah' as a LIGO-T050017-compatible filename$"
+    ):
         io_cache.file_segment('blah')
-    assert str(exc.value) == (
-        "Failed to parse 'blah' as a LIGO-T050017-compatible filename"
-    )
 
 
 def test_flatten(cache):

--- a/gwpy/io/tests/test_gwf.py
+++ b/gwpy/io/tests/test_gwf.py
@@ -107,11 +107,14 @@ def test_num_channels():
 @pytest.mark.requires("LDAStools.frameCPP")
 def test_get_channel_type():
     assert io_gwf.get_channel_type('L1:LDAS-STRAIN', TEST_GWF_FILE) == 'proc'
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match=(
+            "^'X1:NOT-IN_FRAME' not found in table-of-contents "
+            f"for {TEST_GWF_FILE}$"
+        ),
+    ):
         io_gwf.get_channel_type('X1:NOT-IN_FRAME', TEST_GWF_FILE)
-    assert str(exc.value) == (
-        f"'X1:NOT-IN_FRAME' not found in table-of-contents for {TEST_GWF_FILE}"
-    )
 
 
 @pytest.mark.requires("LDAStools.frameCPP")

--- a/gwpy/io/tests/test_ligolw.py
+++ b/gwpy/io/tests/test_ligolw.py
@@ -119,9 +119,11 @@ def test_read_table(llwdoc_with_tables):
 
 
 def test_read_table_empty(llwdoc):
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match=r"^No tables found in LIGO_LW document\(s\)$",
+    ):
         io_ligolw.read_table(llwdoc)
-    assert str(exc.value) == "No tables found in LIGO_LW document(s)"
 
 
 @pytest.mark.requires("ligo.lw.lsctables")
@@ -134,11 +136,13 @@ def test_read_table_ilwd(tmp_path):
 
 
 def test_read_table_multiple(llwdoc_with_tables):
-    # check that read_table correctly errors on ambiguity
-    with pytest.raises(ValueError) as exc:
+    """Check that `gwpy.io.ligolw.read_table` correctly errors on ambiguity.
+    """
+    with pytest.raises(
+        ValueError,
+        match="^Multiple tables .* 'process', 'sngl_ringdown'",
+    ):
         io_ligolw.read_table(llwdoc_with_tables)
-    assert str(exc.value).startswith("Multiple tables")
-    assert "'process', 'sngl_ringdown'" in str(exc.value)
 
 
 def test_open_xmldoc(tmp_path, llwdoc_with_tables):

--- a/gwpy/io/tests/test_mp.py
+++ b/gwpy/io/tests/test_mp.py
@@ -81,9 +81,11 @@ def test_read_multi_order_preservation(tmp1, tmp2):
 def test_read_multi_error_empty():
     """Check that an `IndexError` is raised when the input list is empty
     """
-    with pytest.raises(IndexError) as exc:
+    with pytest.raises(
+        IndexError,
+        match="^cannot read int from empty source list$",
+    ):
         io_mp.read_multi(1, int, [])
-    assert str(exc.value) == "cannot read int from empty source list"
 
 
 def test_read_multi_not_a_file():

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -42,11 +42,11 @@ class _TestNds2Enum(object):
     def test_find_errors(self):
         """Test error raising for :meth:`gwpy.io.nds2.Nds2ChannelType.find`
         """
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match=f"'blah' is not a valid {self.TEST_CLASS.__name__}",
+        ):
             self.TEST_CLASS.find('blah')
-        assert str(exc.value) == (
-            f"'blah' is not a valid {self.TEST_CLASS.__name__}"
-        )
 
 
 class TestNds2ChannelType(_TestNds2Enum):
@@ -223,9 +223,8 @@ def test_auth_connect_kinit(connect, kinit):
 def test_auth_connect_error(connect):
     """Test errors from `gwpy.io.nds2.auth_connect`
     """
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(RuntimeError, match="Anything else"):
         io_nds2.auth_connect('host', 'port')
-    assert str(exc.value) == 'Anything else'
     connect.assert_called_once_with("host", "port")
 
 
@@ -291,11 +290,11 @@ def test_find_channels(connection):
 
     # test unique errors (with nds1 protocol)
     conn.find_channels.return_value = [chan, chan]  # any two channels
-    with pytest.raises(ValueError) as exc:
-        assert io_nds2.find_channels(['X1:test'], host='test',
-                                     unique=True) == [chan]
-    assert str(exc.value) == (
-        "unique NDS2 channel match not found for 'X1:test'")
+    with pytest.raises(
+        ValueError,
+        match="^unique NDS2 channel match not found for 'X1:test'$",
+    ):
+        io_nds2.find_channels(['X1:test'], host='test', unique=True)
 
 
 @pytest.mark.requires("nds2")

--- a/gwpy/io/tests/test_utils.py
+++ b/gwpy/io/tests/test_utils.py
@@ -123,9 +123,11 @@ def test_file_path_file():
 def test_file_path_errors(badthing):
     """Check that :func:`gwpy.io.utils.file_path` fails when expected
     """
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match="^Cannot parse file name for ",
+    ):
         io_utils.file_path(badthing)
-    assert str(exc.value).startswith("Cannot parse file name for")
 
 
 @pytest.mark.requires("lal")

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -122,13 +122,12 @@ class TestAxes(AxesTestBase):
         x = 1
         y = 'B'
         c = 'something else'
-        with pytest.raises(ValueError) as exc:
-            ax.scatter(x, y, c=c, sortbycolor=sortbycolor)
         if sortbycolor:  # gwpy error
-            msg = "Axes.scatter argument 'sortbycolor'"
+            match = "^Axes.scatter argument 'sortbycolor'"
         else:  # matplotlib error
-            msg = "'c' argument must be a "
-        assert str(exc.value).startswith(msg)
+            match = "^'c' argument must be a "
+        with pytest.raises(ValueError, match=match):
+            ax.scatter(x, y, c=c, sortbycolor=sortbycolor)
 
     def test_imshow(self, ax):
         # standard imshow call
@@ -202,10 +201,12 @@ class TestAxes(AxesTestBase):
     def test_hist_error(self, ax):
         """Test that `ax.hist` presents the right error message for empty data
         """
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="^cannot generate log-spaced histogram bins",
+        ):
             ax.hist([], logbins=True)
-        assert str(exc.value).startswith('cannot generate log-spaced '
-                                         'histogram bins')
+
         # assert it works if we give the range manually
         ax.hist([], logbins=True, range=(1, 100))
 

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -526,9 +526,11 @@ class TestDataQualityFlag(object):
                                           SegmentList([(0, 10)]))
 
         # flag not in database
-        with pytest.raises(HTTPError) as exc:
+        with pytest.raises(
+            HTTPError,
+            match=r"^HTTP Error 404: Not found \[X1:GWPY-TEST:0\]$",
+        ):
             self.TEST_CLASS.query_dqsegdb('X1:GWPY-TEST:0', 0, 10)
-        assert str(exc.value) == 'HTTP Error 404: Not found [X1:GWPY-TEST:0]'
 
         # bad syntax
         with pytest.raises(ValueError):
@@ -745,10 +747,11 @@ class TestDataQualityDict(object):
                                             **kwargs)
 
             # check on_missing='error' (default) raises ValueError
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(
+                ValueError,
+                match="^'randomname' not found in any input file$",
+            ):
                 _read()
-            assert str(exc.value) == ('\'randomname\' not found in any input '
-                                      'file')
 
             # check on_missing='warn' prints warning
             with pytest.warns(UserWarning):
@@ -760,7 +763,7 @@ class TestDataQualityDict(object):
                 _read(on_missing='ignore')
 
             # check on_missing=<anything else> raises exception
-            with pytest.raises(ValueError) as exc:
+            with pytest.raises(ValueError):
                 _read(on_missing='blah')
 
     @pytest.mark.requires("ligo.lw.lsctables")

--- a/gwpy/signal/tests/test_window.py
+++ b/gwpy/signal/tests/test_window.py
@@ -28,22 +28,39 @@ from .. import window
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
-def test_canonical_name():
-    assert window.canonical_name('Han') == 'hann'
-    with pytest.raises(ValueError) as exc:
+@pytest.mark.parametrize(("in_, out"), [
+    ("Han", "hann"),
+])
+def test_canonical_name(in_, out):
+    assert window.canonical_name(in_) == out
+
+
+def test_canonical_name_error():
+    with pytest.raises(
+        ValueError,
+        match="^no window function in scipy.signal equivalent to 'blah'$",
+    ):
         window.canonical_name('blah')
-    assert str(exc.value) == ('no window function in scipy.signal '
-                              'equivalent to \'blah\'')
 
 
-def test_recommended_overlap():
-    assert window.recommended_overlap('hann') == .5
-    assert window.recommended_overlap('Hamming') == .5
+@pytest.mark.parametrize(("name", "overlap"), [
+    ("hann", 0.5),
+    ("Hamming", 0.5),
+])
+def test_recommended_overlap(name, overlap):
+    assert window.recommended_overlap(name) == overlap
+
+
+def test_recommended_overlap_nfft():
     assert window.recommended_overlap('barthann', nfft=128) == 64
-    with pytest.raises(ValueError) as exc:
+
+
+def test_recommended_overlap_error():
+    with pytest.raises(
+        ValueError,
+        match="^no recommended overlap for 'kaiser' window$",
+    ):
         window.recommended_overlap('kaiser')
-    assert str(exc.value) == ('no recommended overlap for \'kaiser\' '
-                              'window')
 
 
 def test_planck():

--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -50,11 +50,15 @@ class TestSpectrogram(_TestArray2D):
         a = self.create(epoch=10)
         b = self.create(t0=10)
         utils.assert_quantity_sub_equal(a, b)
-        with pytest.raises(ValueError) as exc:
-            self.TEST_CLASS(self.data, epoch=1, t0=1)
-        assert str(exc.value) == 'give only one of epoch or t0'
 
-        # check times
+    def test_new_redundant_args(self):
+        with pytest.raises(
+            ValueError,
+            match="^give only one of epoch or t0$",
+        ):
+            self.TEST_CLASS(self.data, epoch=1, t0=1)
+
+    def test_new_times(self):
         times = numpy.arange(self.data.shape[0])
         a = self.create(times=times)
         utils.assert_quantity_equal(a.times, times * units.second)

--- a/gwpy/table/tests/test_gravityspy.py
+++ b/gwpy/table/tests/test_gravityspy.py
@@ -70,8 +70,12 @@ class TestGravitySpyTable(_TestEventTable):
         of a JSONDecodeError.
         """
         requests_mock = pytest.importorskip("requests_mock")
-        with requests_mock.Mocker() as rmock, \
-             pytest.raises(requests.HTTPError) as exc:
+        mocker = requests_mock.Mocker()
+        raises = pytest.raises(
+            requests.HTTPError,
+            match="please check the request parameters$",
+        )
+        with mocker as rmock, raises:
             rmock.get(
                 "{}{}{}/?{}".format(
                     table_gravityspy.DEFAULT_HOST,
@@ -92,7 +96,6 @@ class TestGravitySpyTable(_TestEventTable):
                 },
             )
             self.TABLE.search(gravityspy_id="abcde")
-        assert str(exc.value).endswith("please check the request parameters")
 
     @pytest_skip_network_error
     def test_download(self, tmp_path):

--- a/gwpy/table/tests/test_io_pycbc.py
+++ b/gwpy/table/tests/test_io_pycbc.py
@@ -229,10 +229,11 @@ def test_read_pycbc_live_multiple_ifos(
     """
     with h5py.File(pycbclivefile, "r+") as h5f:
         h5f.create_group('Z1')
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match="PyCBC live HDF5 file contains dataset groups",
+    ):
         EventTable.read(pycbclivefile, format="hdf5.pycbc_live")
-    assert str(exc.value).startswith(
-        'PyCBC live HDF5 file contains dataset groups')
 
     # but check that we can still read the original
     table = EventTable.read(

--- a/gwpy/table/tests/test_table.py
+++ b/gwpy/table/tests/test_table.py
@@ -171,9 +171,11 @@ class TestTable(object):
         utils.assert_table_equal(vstack((t2, t2)), t3)
 
         # check writing to existing file raises IOError
-        with pytest.raises(IOError) as exc:
+        with pytest.raises(
+            IOError,
+            match=f"^File exists: {tmp}$",
+        ):
             _write()
-        assert str(exc.value) == 'File exists: %s' % tmp
 
         # check overwrite=True, append=False rewrites table
         _write(overwrite=True)
@@ -201,10 +203,11 @@ class TestTable(object):
         # is gone
         insp.write(tmp, format='ligolw', tablename='sngl_inspiral',
                    append=False, overwrite=True)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="^document must contain exactly one sngl_burst table$",
+        ):
             _read()
-        assert str(exc.value) == ('document must contain exactly '
-                                  'one sngl_burst table')
 
     @pytest.mark.requires("ligo.lw.lsctables")
     def test_read_write_ligolw_property_columns(self, tmp_path):
@@ -309,9 +312,11 @@ class TestTable(object):
             a = root.mktree("a", {"branch": "int32"})
             a.extend({"branch": asarray([1, 2, 3, 4, 5])})
             root.mktree("b", {"branch": "int32"})
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="^Multiple trees found",
+        ):
             self.TABLE.read(tmp)
-        assert str(exc.value).startswith('Multiple trees found')
         self.TABLE.read(tmp, treename="a")
 
     @pytest.mark.requires("uproot")
@@ -400,9 +405,11 @@ class TestEventTable(TestTable):
         when no matches are found
         """
         t = self.create(1, ("a",))
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match=" no columns named 'time'",
+        ):
             t._get_time_column()
-        assert " no columns named 'time'" in str(exc.value)
 
     def test_get_time_column_error_multiple_match(self):
         # check that two GPS columns causes issues
@@ -411,9 +418,11 @@ class TestEventTable(TestTable):
             ("a", "b", "c"),
             dtypes=(float, LIGOTimeGPS, LIGOTimeGPS),
         )
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match=" multiple columns named 'time'",
+        ):
             t._get_time_column()
-        assert " multiple columns named 'time'" in str(exc.value)
 
     def test_get_time_column_error_empty(self):
         """Check that `_get_time_column` errors properly on an empty table
@@ -537,9 +546,11 @@ class TestEventTable(TestTable):
         time column (and no data) if and only if start/end are both given.
         """
         t2 = self.create(10, names=['a', 'b'])
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="please give `timecolumn` keyword",
+        ):
             t2.event_rate(1)
-        assert 'please give `timecolumn` keyword' in str(exc.value)
         with pytest.raises(ValueError):
             t2.event_rate(1, start=0)
         with pytest.raises(ValueError):
@@ -561,9 +572,11 @@ class TestEventTable(TestTable):
         # check that method can function without explicit time column
         # (and no data) if and only if start/end are both given
         t2 = self.create(0, names=['a', 'b'])
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="please give `timecolumn` keyword",
+        ):
             t2.binned_event_rates(1, 'a', (10, 100))
-        assert 'please give `timecolumn` keyword' in str(exc.value)
         with pytest.raises(ValueError):
             t2.binned_event_rates(1, 'a', (10, 100), start=0)
         with pytest.raises(ValueError):
@@ -608,9 +621,11 @@ class TestEventTable(TestTable):
 
     def test_cluster_window(self, clustertable):
         # check that a non-positive window throws an appropriate ValueError
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="^Window must be a positive value$",
+        ):
             clustertable.cluster('time', 'amplitude', 0)
-        assert str(exc.value) == 'Window must be a positive value'
 
     def test_cluster_multiple(self, clustertable):
         # check that after clustering a table, clustering the table a
@@ -678,14 +693,14 @@ class TestEventTable(TestTable):
             pass  # write empty file
 
         # assert reading blank file doesn't work with column name error
-        with pytest.raises(InconsistentTableError) as exc:
+        with pytest.raises(
+            InconsistentTableError,
+            match=f"^No column names found in {fmtname} header$",
+        ):
             self.TABLE.read(
                 tmp,
                 format="ascii.{}".format(fmtname.lower()),
             )
-        assert str(exc.value) == (
-            'No column names found in {} header'.format(fmtname)
-        )
 
     @pytest.fixture
     def snaxtable(self):

--- a/gwpy/timeseries/tests/test_io_gwf_lalframe.py
+++ b/gwpy/timeseries/tests/test_io_gwf_lalframe.py
@@ -90,11 +90,11 @@ def test_open_data_source_cache(tmp_path):
 
 
 def test_open_data_source_error():
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match=f"^Don't know how to open data source of type {type(None)}$",
+    ):
         gwpy_lalframe.open_data_source(None)
-    assert str(exc.value) == (
-        "Don't know how to open data source of type {}".format(type(None))
-    )
 
 
 def test_get_stream_duration(stream):
@@ -131,9 +131,11 @@ def test_read(start, end):
 
 
 def test_read_channel_error():
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(
+        RuntimeError,
+        match="^channel 'bad' not found$",
+    ):
         gwpy_lalframe.read(TEST_GWF_FILE, ["bad"])
-    assert str(exc.value) == "channel 'bad' not found"
 
 
 def test_read_deprecated_scaled():

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -284,9 +284,11 @@ class TestStateVector(_TestTimeSeriesBase):
         assert [v.sum() for v in bs.values()] == [50, 41]
 
         # check that invalid bits throws exception
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="^Bit 'blah' not found in StateVector$",
+        ):
             array.get_bit_series(['blah'])
-        assert str(exc.value) == "Bit 'blah' not found in StateVector"
 
     def test_plot(self, array):
         with rc_context(rc={'text.usetex': False}):

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -297,27 +297,36 @@ class TestTimeSeries(_TestTimeSeriesBase):
         ),
     ])
     def test_read_write_gwf_error(self, tmp_path, api, gw150914):
+        fmt = f"gwf.{api}"
         tmp = tmp_path / "test.gwf"
-        gw150914.write(tmp, format="gwf.{}".format(api))
-        with pytest.raises(ValueError) as exc:
-            self.TEST_CLASS.read(tmp, "another channel",
-                                 format="gwf.{}".format(api))
-        assert str(exc.value) == (
-            "no Fr{Adc,Proc,Sim}Data structures with the "
-            "name another channel"
-        )
+        gw150914.write(tmp, format=fmt)
 
-        with pytest.raises(ValueError) as exc:
+        # wrong channel
+        with pytest.raises(
+            ValueError,
+            match=(
+                "^no Fr{Adc,Proc,Sim}Data structures with the "
+                "name another channel$"
+            ),
+        ):
+            self.TEST_CLASS.read(
+                tmp,
+                "another channel",
+                format=fmt,
+            )
+
+        # wrong times
+        with pytest.raises(
+            ValueError,
+            match=f"^Failed to read '{gw150914.name}' from '{tmp}'",
+        ):
             self.TEST_CLASS.read(
                 tmp,
                 gw150914.name,
                 start=gw150914.span[0]-1,
                 end=gw150914.span[0],
-                format="gwf.{}".format(api),
+                format=fmt,
             )
-        assert str(exc.value).startswith(
-            "Failed to read {0!r} from {1!r}".format(gw150914.name, str(tmp))
-        )
 
     @pytest.mark.requires("lalframe")
     def test_read_gwf_scaled_lalframe(self):
@@ -413,9 +422,11 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
         tmp = tmp_path / "test.{}".format(ext)
         # check array with no name fails
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="^Cannot determine HDF5 path",
+        ):
             array.write(tmp, overwrite=True)
-        assert str(exc.value).startswith('Cannot determine HDF5 path')
         array.name = 'TEST'
 
         # write array (with auto-identify)
@@ -608,9 +619,8 @@ class TestTimeSeries(_TestTimeSeriesBase):
         # run fetch and assert error
         with mock.patch('nds2.connection') as mock_connection:
             mock_connection.return_value = nds_connection
-            with pytest.raises(RuntimeError) as exc:
+            with pytest.raises(RuntimeError, match="no data received"):
                 self.TEST_CLASS.fetch('L1:TEST', 0, 1, host='nds.gwpy')
-            assert 'no data received' in str(exc.value)
 
     @pytest.mark.requires("nds2")
     @mock.patch(
@@ -1423,9 +1433,11 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
     def test_q_transform_nan(self):
         data = TimeSeries(numpy.empty(256*10) * numpy.nan, sample_rate=256)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match="^Input signal contains non-numerical values$",
+        ):
             data.q_transform(method="median")
-        assert str(exc.value) == 'Input signal contains non-numerical values'
 
     def test_boolean_statetimeseries(self, array):
         comp = array >= 2 * array.unit

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -229,9 +229,8 @@ class TestArray2D(_TestSeries):
         """
         y = numpy.logspace(0, 2, num=self.data.shape[1])
         other = self.create(yindex=y)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="indexes do not match"):
             array.is_compatible(other)
-        assert "indexes do not match" in str(exc.value)
 
     def test_value_at(self, array):
         assert array.value_at(2, 3) == self.data[2][3] * array.unit

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -222,17 +222,15 @@ class TestSeries(_TestArray):
         """Check that `Series.is_compatible` errors with mismatching ``dx``
         """
         other = self.create(dx=2)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="sample sizes do not match"):
             array.is_compatible(other)
-        assert "sample sizes do not match" in str(exc.value)
 
     def test_is_compatible_error_unit(self, array):
         """Check that `Series.is_compatible` errors with mismatching ``unit``
         """
         other = self.create(unit='m')
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="units do not match"):
             array.is_compatible(other)
-        assert "units do not match" in str(exc.value)
 
     def test_is_compatible_xindex(self):
         """Check that irregular arrays are compatible if their xindexes match
@@ -247,9 +245,8 @@ class TestSeries(_TestArray):
         """
         x = numpy.logspace(0, 2, num=self.data.shape[0])
         other = self.create(xindex=x)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="indexes do not match"):
             array.is_compatible(other)
-        assert "indexes do not match" in str(exc.value)
 
     def test_is_contiguous(self, array):
         a2 = self.create(x0=array.xspan[1])

--- a/gwpy/utils/tests/test_decorators.py
+++ b/gwpy/utils/tests/test_decorators.py
@@ -46,9 +46,11 @@ def test_return_as_error():
     def myfunc(value):
         return str(value)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match="^failed to cast return from myfunc as int: ",
+    ):
         myfunc('test')
-    assert 'failed to cast return from myfunc as int: ' in str(exc.value)
 
 
 def test_deprecated_function():

--- a/gwpy/utils/tests/test_enum.py
+++ b/gwpy/utils/tests/test_enum.py
@@ -68,8 +68,8 @@ class TestNumpyTypeEnum(object):
     def test_find_errors(self):
         """Test :meth:`NumpyTypeEnum.find` method error handling
         """
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError,
+            match=f"^'blah' is not a valid {self.TEST_CLASS.__name__}$",
+        ):
             self.TEST_CLASS.find('blah')
-        assert str(exc.value) == "'blah' is not a valid {}".format(
-            self.TEST_CLASS.__name__,
-        )

--- a/gwpy/utils/tests/test_lal.py
+++ b/gwpy/utils/tests/test_lal.py
@@ -105,9 +105,11 @@ def test_to_lal_unit(in_, out, scale):
 
 
 def test_to_lal_unit_error():
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match="^LAL has no unit corresponding to 'rad'$",
+    ):
         utils_lal.to_lal_unit('rad/s')
-    assert str(exc.value) == "LAL has no unit corresponding to 'rad'"
 
 
 @pytest.mark.parametrize(("in_", "out"), (

--- a/gwpy/utils/tests/test_misc.py
+++ b/gwpy/utils/tests/test_misc.py
@@ -66,10 +66,11 @@ def test_round_to_power():
 def test_round_to_power_error():
     """Test for an errored use case of :func:`gwpy.utils.misc.round_to_power`
     """
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(
+        ValueError,
+        match="^'which' argument must be one of 'lower', 'upper', or None$",
+    ):
         utils_misc.round_to_power(7, which='')
-    assert str(exc.value) == (
-        "'which' argument must be one of 'lower', 'upper', or None")
 
 
 def test_unique():

--- a/gwpy/utils/tests/test_mp.py
+++ b/gwpy/utils/tests/test_mp.py
@@ -54,13 +54,12 @@ def test_multiprocess_with_queues(capsys, nproc, verbose):
 def test_multiprocess_with_queues_errors(nproc):
     """Check that errors from child processes propagate to the parent
     """
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(ValueError, match="^math domain error$"):
         utils_mp.multiprocess_with_queues(
             nproc,
             sqrt,
             [-1, -1, -1, -1],
         )
-    assert str(exc.value) == "math domain error"
 
 
 def test_multiprocess_with_queues_raise():


### PR DESCRIPTION
This PR closes #1541 by updating the use of `pytest.raises` throughout the codebase to use the `match` keyword. This cleans things up a wee bit, and naturally allows more flexibility in matching the error message (since pytest uses a regex, rather than simple string comparisons).