### PR TITLE
Fix issues with Nds2Enum on Python 3.11

### DIFF
--- a/gwpy/io/nds2.py
+++ b/gwpy/io/nds2.py
@@ -107,10 +107,10 @@ else:
 class _Nds2Enum(enum.IntFlag):
     """Base class for NDS2 enums
     """
-    def __new__(cls, value, nds2name):
+    def __new__(cls, value, nds2name=None):
         obj = int.__new__(cls, value)
         obj._value_ = value
-        obj.nds2name = nds2name
+        obj.nds2name = nds2name  # will be None for bitwise operations
         return obj
 
     @classmethod

--- a/gwpy/io/tests/test_nds2.py
+++ b/gwpy/io/tests/test_nds2.py
@@ -37,7 +37,7 @@ class _TestNds2Enum(object):
     TEST_CLASS = None
 
     def test_any(self):
-        assert self.TEST_CLASS.any() == 2 ** (len(self.TEST_CLASS) - 1) - 1
+        assert self.TEST_CLASS.any() == 2 * max(self.TEST_CLASS).value - 1
 
     def test_find_errors(self):
         """Test error raising for :meth:`gwpy.io.nds2.Nds2ChannelType.find`
@@ -58,8 +58,11 @@ class TestNds2ChannelType(_TestNds2Enum):
         assert self.TEST_CLASS.MTREND.nds2name == 'm-trend'
 
     def test_nds2names(self):
-        _raw_names = sorted(v[1] for v in io_nds2._NDS2_CHANNEL_TYPE.values())
-        assert sorted(self.TEST_CLASS.nds2names()) == _raw_names
+        expected = sorted(
+            io_nds2._NDS2_CHANNEL_TYPE[x.name][1]
+            for x in self.TEST_CLASS
+        )
+        assert sorted(self.TEST_CLASS.nds2names()) == expected
 
     @pytest.mark.parametrize(('input_', 'expected'), (
         (TEST_CLASS.MTREND.value, TEST_CLASS.MTREND),


### PR DESCRIPTION
This PR fixes compatibility issues between the enums in `gwpy.io.nds2` and updated enum functionality introduced with Python 3.11.

Fixes #1557.