### PR TITLE
Improve handling/propagation of maya/dateparser errors and refactor gwpy.time tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -91,8 +91,6 @@ jobs:
         miniforge-variant: Mambaforge
         python-version: ${{ matrix.python-version }}
         use-mamba: true
-        # this is needed for caching to work properly:
-        use-only-tar-bz2: true
 
     - name: Conda info
       run: conda info --all

--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -27,7 +27,7 @@ import warnings
 from decimal import Decimal
 from numbers import Number
 
-from dateutil import parser as dateparser
+from dateutil.parser import parse as parse_datestr
 
 from astropy.units import Quantity
 
@@ -272,7 +272,7 @@ def _str_to_datetime(datestr):
         # don't allow lazy passing of time-zones
         warnings.simplefilter("error", RuntimeWarning)
         try:
-            return dateparser.parse(datestr)
+            return parse_datestr(datestr)
         except RuntimeWarning:
             raise ValueError("Cannot parse date string with timezone "
                              "without maya, please install maya")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ dynamic = [
 # test suite
 test = [
   "coverage[toml] >=5.0",
-  "freezegun >=0.3.12",
   "pytest >=3.9.1",
+  "pytest-freezegun",
   "pytest-cov >=2.4.0",
   "pytest-requires",
   "pytest-socket",
@@ -84,6 +84,8 @@ docs = [
 # development environments
 dev = [
   "ciecplib",
+  # for maya to work, see https://github.com/scrapinghub/dateparser/pull/1067
+  "dateparser >=1.1.2",
   "lalsuite ; sys_platform != 'win32'",
   "lscsoft-glue ; sys_platform != 'win32'",
   "maya ; python_version < '3.11'",


### PR DESCRIPTION
This PR improves the handling and propagation of errors from `maya/dateparser` when attempting to convert times.

This also refactors the test suite for `gwpy.time` to improve the tests and make them more readable. As part of this I replace the `freezegun` requirement with `pytest-freezegun`.