### PR TITLE
Improve documentation of GWF I/O libraries

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,4 +55,4 @@ jobs:
             "rstcheck[sphinx,toml]>=6.0.0" \
         ;
     - name: Lint with rstcheck
-      run: rstcheck . --recursive --report-level error
+      run: rstcheck . --recursive --report-level error --log-level DEBUG

--- a/docs/external/framecpp.rst
+++ b/docs/external/framecpp.rst
@@ -1,0 +1,30 @@
+.. _gwpy-external-framecpp:
+
+########
+FrameCPP
+########
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/python-ldas-tools-framecpp.svg
+   :alt: python-ldas-tools-framecpp conda-forge version
+   :target: https://anaconda.org/conda-forge/python-ldas-tools-framecpp
+.. image:: https://img.shields.io/conda/pn/conda-forge/python-ldas-tools-framecpp.svg
+   :alt: python-ldas-tools-framecpp conda-forge platforms
+   :target: https://anaconda.org/conda-forge/python-ldas-tools-framecpp
+
+FrameCPP is a library for reading and writing data in GWF format defined
+in |GWFSpec|_.
+The main library is written in C++ and documented at
+
+https://computing.docs.ligo.org/ldastools/LDAS_Tools/ldas-tools-framecpp/
+
+GWpy utilises the Python bindings for FrameCPP on Unix platforms
+(Linux and macOS) to provide GWF input/output capabilities.
+
+This optional dependency can be installed using `Conda <https://conda.io>`__
+(or `Mamba <https://mamba.readthedocs.io/en/stable/>`__):
+
+.. code-block:: shell
+    :name: conda-install-python-ldas-tools-framecpp
+    :caption: Install python-ldas-tools-framecpp with conda
+
+    conda install -c conda-forge python-ldas-tools-framecpp

--- a/docs/external/framel.rst
+++ b/docs/external/framel.rst
@@ -1,0 +1,30 @@
+.. _gwpy-external-framel:
+
+######
+FrameL
+######
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/python-framel.svg
+   :alt: python-ldas-tools-framecpp conda-forge version
+   :target: https://anaconda.org/conda-forge/python-framel
+.. image:: https://img.shields.io/conda/pn/conda-forge/python-framel.svg
+   :alt: python-ldas-tools-framecpp conda-forge platforms
+   :target: https://anaconda.org/conda-forge/python-framel
+
+FrameL is a library for reading and writing data in GWF format defined
+in |GWFSpec|_.
+The main library is written in C and documented at
+
+https://lappweb.in2p3.fr/virgo/FrameL/
+
+GWpy can utilises the Python bindings for FrameL to provide GWF
+input/output capabilities.
+
+This optional dependency can be installed using `Conda <https://conda.io>`__
+(or `Mamba <https://mamba.readthedocs.io/en/stable/>`__):
+
+.. code-block:: shell
+    :name: conda-install-python-framel
+    :caption: Install python-framel with conda
+
+    conda install -c conda-forge python-framel

--- a/docs/external/lalsuite.rst
+++ b/docs/external/lalsuite.rst
@@ -1,0 +1,106 @@
+.. _gwpy-external-lalsuite:
+
+########
+LALSuite
+########
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/lalsuite.svg
+   :alt: lalsuite conda-forge version
+   :target: https://anaconda.org/conda-forge/lalsuite
+.. image:: https://img.shields.io/conda/pn/conda-forge/lalsuite.svg
+   :alt: lalsuite conda-forge platforms
+   :target: https://anaconda.org/conda-forge/lalsuite
+
+LALSuite is a large collection of gravitational-wave data analysis libraries,
+mainly written in C but with high-level bindings for Python.
+
+The main LALSuite documentation can be found at
+
+https://lscsoft.docs.ligo.org/lalsuite/
+
+LALSuite is made up of a number of component libraries, some of which are
+utilised by GWpy to provide various extra capabilities.
+
+The full LALsuite can be installed alongside GWpy using
+`Conda <https://conda.io>`__
+(or `Mamba <https://mamba.readthedocs.io/en/stable/>`__)
+or `pip`:
+
+.. md-tab-set::
+    :name: gwpy-install-lalsuite
+
+    .. md-tab-item:: Install LALSuite with conda/mamba
+
+        .. code-block:: shell
+
+            conda install -c conda-forge lalsuite
+
+    .. md-tab-item:: Install LALSuite with pip
+
+        .. code-block:: shell
+
+            python -m pip install lalsuite
+
+.. _gwpy-external-lal:
+
+===
+LAL
+===
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/lal.svg
+   :alt: lal conda-forge version
+   :target: https://anaconda.org/conda-forge/lal
+.. image:: https://img.shields.io/conda/pn/conda-forge/lal.svg
+   :alt: lal conda-forge platforms
+   :target: https://anaconda.org/conda-forge/lal
+
+LAL is the base-level library in LALSuite that provides much of the core
+functionality.
+It's documentation is at
+
+https://lscsoft.docs.ligo.org/lalsuite/lal/
+
+GWpy provides utilities to transform to and from LAL objects
+(like the :lal:`XLALREAL8TimeSeries`) from/to their GWpy equivalent
+(e.g. :class:`gwpy.timeseries.TimeSeries`).
+
+LAL can be installed using `Conda <https://conda.io>`__
+(or `Mamba <https://mamba.readthedocs.io/en/stable/>`__)
+on Unix systems (not Windows):
+
+.. code-block:: shell
+    :name: conda-install-lal
+    :caption: Install python-lal with conda
+
+    conda install -c conda-forge python-lal
+
+.. _gwpy-external-lalframe:
+
+========
+LALFrame
+========
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/lalframe.svg
+   :alt: lalframe conda-forge version
+   :target: https://anaconda.org/conda-forge/lalframe
+.. image:: https://img.shields.io/conda/pn/conda-forge/lalframe.svg
+   :alt: lalframe conda-forge platforms
+   :target: https://anaconda.org/conda-forge/lalframe
+
+LALFrame provides a GWF I/O library compatible with LAL series types.
+It's documentation is at
+
+https://lscsoft.docs.ligo.org/lalsuite/lalframe/
+
+GWpy utilises the Python bindings for LALFrame on Unix platforms
+(Linux and macOS) to provide GWF input/output capabilities.
+
+This optional dependency can be installed using `Conda <https://conda.io>`__
+(or `Mamba <https://mamba.readthedocs.io/en/stable/>`__)
+on Unix systems (not Windows):
+
+.. code-block:: shell
+    :name: conda-install-python-lalframe
+    :caption: Install python-lalframe with conda
+
+    conda install -c conda-forge python-lalframe

--- a/docs/external/nds2.rst
+++ b/docs/external/nds2.rst
@@ -1,0 +1,26 @@
+.. _gwpy-external-nds2:
+
+####
+NDS2
+####
+
+.. image:: https://img.shields.io/conda/vn/conda-forge/python-nds2-client.svg
+   :alt: python-nds2-client conda-forge version
+   :target: https://anaconda.org/conda-forge/python-nds2-client
+.. image:: https://img.shields.io/conda/pn/conda-forge/python-nds2-client.svg
+   :alt: python-nds2-client conda-forge platforms
+   :target: https://anaconda.org/conda-forge/python-nds2-client
+
+Network Data Service (NDS) 2 is a TCP/IP protocol for retrieving data from
+gravitational-wave detector archives.
+The NDS2 Client is a C++ library that provides high-level bindings for Python
+to allow users to securely connect to and retrieve data from NDS2 servers.
+
+The NDS2 client bindings for Python can be installed using `Conda <https://conda.io>`__
+(or `Mamba <https://mamba.readthedocs.io/en/stable/>`__) on any platform:
+
+.. code-block:: shell
+    :name: conda-install-python-nds2-client
+    :caption: Install python-nds2-client with conda
+
+    conda install -c conda-forge python-nds2-client

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -62,12 +62,9 @@ GWpy has the following strict requirements:
 
 All of these will be installed using any of the above install methods.
 
-GWpy also depends on the following other packages for optional features:
+Gwpy also depends on the following other packages for optional features:
 
-- |python-ligo-lw| to read/write :class:`~gwpy.table.EventTable` with
-  LIGO_LW XML format (see :ref:`gwpy-table-io-ligolw`)
-- |LDAStools.frameCPP|_: to read/write data in GWF format
-- |nds2|_: to provide remote data access for `TimeSeries`
-  (see :ref:`gwpy-timeseries-remote`)
-- |uproot|_: to read/write :class:`~gwpy.table.EventTable` with ROOT
-  format (see :ref:`gwpy-table-io-root`)
+.. toctree::
+   :glob:
+
+   external/*

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -95,6 +95,11 @@
 .. |uproot| replace:: `uproot`
 .. _uproot: https://uproot.readthedocs.io/
 
+.. -- Documents ---------------------------------
+
+.. |GWFSpec| replace: LIGO-T970130
+.. _GWFSpec: https://dcc.ligo.org/LIGO-T970130/public
+
 .. -- Other references --------------------------
 
 .. |GravitySpy| replace:: Gravity Spy

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -54,7 +54,7 @@
 .. _framel: http://lappweb.in2p3.fr/virgo/FrameL/
 
 .. |LDAStools.frameCPP| replace:: `LDAStools.frameCPP`
-.. _LDAStools.frameCPP: https://ldas-jobs.ligo.caltech.edu/~emaros/share/doc/ldas-tools/framecpp/html/
+.. _LDAStools.frameCPP: https://computing.docs.ligo.org/ldastools/LDAS_Tools/ldas-tools-framecpp/
 
 .. |lal| replace:: `lal`
 .. _lal: http://software.ligo.org/docs/lalsuite/lal/
@@ -67,9 +67,6 @@
 
 .. |MySQLdb| replace:: `MySQLdb`
 .. _MySQLdb: http://mysql-python.sourceforge.net/
-
-.. |nds2| replace:: `nds2`
-.. _nds2: https://www.lsc-group.phys.uwm.edu/daswg/projects/nds-client/doc/manual/
 
 .. |numpydoc| replace:: `numpydoc`
 .. _numpydoc: https://numpydoc.readthedocs.io/
@@ -97,7 +94,7 @@
 
 .. -- Documents ---------------------------------
 
-.. |GWFSpec| replace: LIGO-T970130
+.. |GWFSpec| replace:: LIGO-T970130
 .. _GWFSpec: https://dcc.ligo.org/LIGO-T970130/public
 
 .. -- Other references --------------------------

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -622,7 +622,8 @@ GstLAL (``LIGO_LW`` XML)
 ========================
 
 GstLAL is a low-latency search for gravitational waves from compact
-binary coalescences, built using |GStreamer|_ elements and tools from the |LALSuite|_ library.
+binary coalescences, built using |GStreamer|_ elements and tools from the
+:ref:`gwpy-external-lalsuite` library.
 This search writes files on the LIGO Data Grid (LIGO.ORG-authenticated users
 only) in ``LIGO_LW`` XML format, containing tables of events.
 
@@ -747,7 +748,7 @@ Writing tables in SNAX HDF5 format is not supported at this time.
 GWF
 ===
 
-**Additional dependencies:** |LDAStools.frameCPP|_
+**Additional dependencies:** :ref:`gwpy-external-framecpp`
 
 The Gravitational-Wave Frame file format supports tabular data via
 ``FrEvent`` structures, which allow storage of arbitrary event information.

--- a/docs/table/io.rst
+++ b/docs/table/io.rst
@@ -776,7 +776,7 @@ All ``FrEvent`` structures contain the following columns, any other
 columns are use-specific:
 
 ===============  ====================================================================================
-Column name      Description (from `LIGO-T970130 <https://dcc.ligo.org/LIGO-T970130/public>`_)
+Column name      Description (from |GWFSpec|_)
 ===============  ====================================================================================
 ``time``         Reference time of event, as defined by the search algorithm
 ``amplitude``    Continuous output amplitude returned by event

--- a/docs/timeseries/datafind.rst
+++ b/docs/timeseries/datafind.rst
@@ -25,8 +25,8 @@ A discovery service called |gwdatafind|_ is provided at each location to
 simplify discovering the file(s) that contain the data of interest for any
 research.
 
-These data are also made available remotely using |nds2|_, which enables
-sending data directly over a network to any location.
+These data are also made available remotely using :ref:`gwpy-external-nds2`,
+which enables sending data directly over a network to any location.
 This is used for both the full proprietary data (which requires an
 authorisation credential to access) and also the |GWOSC_AUX_RELEASE|_
 (which is freely available).
@@ -37,7 +37,7 @@ authorisation credential to access) and also the |GWOSC_AUX_RELEASE|_
 :meth:`TimeSeries.get`
 **********************
 
-**Additional dependencies:** |LDAStools.frameCPP|_ or |nds2|_
+**Additional dependencies:** :ref:`gwpy-external-framecpp` or :ref:`gwpy-external-nds2`
 
 GWpy provides the :meth:`TimeSeries.get` method as a one-stop interface
 to all automatically-discoverable data hosted locally at an IGWN

--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -45,7 +45,7 @@ are archived in :ref:`GWF <gwpy-timeseries-io-gwf>` files stored at the
 relevant observatory.
 These data are available locally to authenticated users of the associated
 computing centres (typically collaboration members), but are also
-distributed using |CVMFS|_ and are available remotely using |nds2|_.
+distributed using |CVMFS|_ and are available remotely using :ref:`gwpy-external-nds2`.
 Access to these data is restricted to active collaboration members.
 
 Additionally |GWOSCl|_ hosts publicly-accessible 'open' data, with *event*
@@ -56,7 +56,7 @@ and *bulk* datasets with the entire observing run data available roughly
 
 GWOSC also hosts the |GWOSC_AUX_RELEASE|_, providing public access to
 environmental sensor data around |GW170814|_.
-These data are freely accessible using |nds2|_.
+These data are freely accessible using :ref:`gwpy-external-nds2`.
 
 ======================
 Data discovery methods
@@ -109,9 +109,22 @@ See :func:`numpy.savetxt` for keyword argument options.
 GWF
 ===
 
-**Additional dependencies:**  |LDAStools.frameCPP|_ or |framel|_ or |lalframe|_
+**Additional dependencies:**  :ref:`gwpy-external-framecpp` or :ref:`gwpy-external-framel` or :ref:`gwpy-external-lalframe`
 
 The raw observatory data are archived in ``.gwf`` files, a custom binary format that efficiently stores the time streams and all necessary metadata, for more details about this particular data format, take a look at the specification document |GWFSpec|_.
+
+GWF library availability
+------------------------
+
+GWpy can use any of the three named GWF input/output libraries, and will try
+to find them in the order they are listed
+(FrameCPP first, then FrameL, then LALFrame).
+If you need to read/write GWF files, any of them will work, but re recommend
+to try and install the libraries in that order; FrameCPP provides a more
+complete Python API than the others.
+
+However, not all libraries may be available on all platforms, the linked pages
+for each library include an up-to-date listing of the supported platforms.
 
 Reading
 -------
@@ -196,24 +209,6 @@ To write data held in any of the :mod:`gwpy.timeseries` classes to a GWF file, s
    >>> data.write('output.gwf')
 
 **If the output file already exists it will be overwritten.**
-
-GWF library availability
-------------------------
-
-(Last we checked...) The three GWF library interfaces are available on
-the following platforms:
-
-.. table:: GWF library availability by platform
-   :align: left
-   :name: gwf-library-platforms
-
-   =====================  ==============================  =====  =====  =======
-   Library                Conda-forge package name        Linux  macOS  Windows
-   =====================  ==============================  =====  =====  =======
-   |LDASTools.frameCPP|_  ``python-ldas-tools-framecpp``  Yes    Yes    No
-   |framel|_              ``python-framel``               Yes    Yes    Yes
-   |lalframe|_            ``python-lalframe``             Yes    Yes    No
-   =====================  ==============================  =====  =====  =======
 
 .. _gwpy-timeseries-io-hdf5:
 

--- a/docs/timeseries/io.rst
+++ b/docs/timeseries/io.rst
@@ -111,7 +111,7 @@ GWF
 
 **Additional dependencies:**  |LDAStools.frameCPP|_ or |framel|_ or |lalframe|_
 
-The raw observatory data are archived in ``.gwf`` files, a custom binary format that efficiently stores the time streams and all necessary metadata, for more details about this particular data format, take a look at the specification document `LIGO-T970130 <https://dcc.ligo.org/LIGO-T970130/public>`_.
+The raw observatory data are archived in ``.gwf`` files, a custom binary format that efficiently stores the time streams and all necessary metadata, for more details about this particular data format, take a look at the specification document |GWFSpec|_.
 
 Reading
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ astro = [
 # sphinx documentation
 docs = [
   "numpydoc >=0.8.0",
-  "sphinx >=4.0.0",
+  "Sphinx >=4.4.0",
   "sphinx-automodapi",
   "sphinx-immaterial >=0.7.3",
   "sphinx-panels >=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,22 +165,31 @@ xfail_strict = true
 
 [tool.rstcheck]
 ignore_directives = [
+  # matplotlib
+  "plot",
+  # sphinx
+  "include",
   # sphinx.ext.autosummary
   "autoclass",
   "autofunction",
   "automethod",
   "automodule",
   "autosummary",
-  # sphinx-automodapi
-  "automodsumm",
-  # sphinxcontrib-programoutput
-  "command-output",
   # sphinx.ext.ifconfig
   "ifconfig",
-  # matplotlib
-  "plot",
+  # sphinx-automodapi
+  "automodsumm",
+  # sphinx-immaterial
+  "md-tab-set",
   # sphinx-panels
   "tabbed",
+  # sphinxcontrib-programoutput
+  "command-output",
+]
+ignore_roles = [
+  # doxylink
+  "lal",
+  "lalframe",
 ]
 # rstcheck doesn't known about our referenced.txt which is implicitly included
 # in all pages via Sphinx's epilog option


### PR DESCRIPTION
This PR closes #1561 by improving the documentation of the optional GWF I/O libraries.

My solution is to provide our own 'external' pages for the various tools where the upstream reference doesn't do a good job of instructed users on how to install the library.

cc @jkanner