### PR TITLE
Use the GW observatory colour scheme for CLI plots

### DIFF
--- a/gwpy/cli/cliproduct.py
+++ b/gwpy/cli/cliproduct.py
@@ -40,6 +40,7 @@ from ..timeseries import (
     TimeSeriesDict,
 )
 from ..timeseries.timeseries import DEFAULT_FFT_METHOD
+from ..plot.colors import GW_OBSERVATORY_COLORS
 from ..plot.gps import (GPS_SCALES, GPSTransform)
 from ..plot.tex import label_to_latex
 from ..segments import DataQualityFlag
@@ -810,6 +811,33 @@ class CliProduct(object, metaclass=abc.ABCMeta):
         """Override when product needs multiple saves
         """
         self.plot = self.make_plot()
+
+    def _color_by_ifo(self):
+        """Return a list of colours to use for datasets.
+
+        In the specific case where each dataset name has a recognised IFO
+        prefix, and there is only one of each type, the list will contain
+        the relevant colour for that dataset, according to the colour scheme.
+
+        In all other cases a list of `None` is returned.
+        """
+        # get all name prefices
+        names = [name.split(":", 1)[0] for name in (
+            x.name or x.channel.name for x in self.timeseries
+        )]
+
+        # if not all prefixes are unique, don't do anything
+        nnames = len(names)
+        if not len(names) == len(set(names)):
+            return [None] * nnames
+
+        # if not all prefices are in the colour scheme, don't do anything
+        if not all(n in GW_OBSERVATORY_COLORS for n in names):
+            return [None] * nnames
+
+        # each prefix is in the colour scheme, and is unique, so use the
+        # assigned colour
+        return [GW_OBSERVATORY_COLORS[n] for n in names]
 
     # -- the one that does all the work ---------
 

--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -112,6 +112,9 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
             )
             nlegargs = 0  # don't use  themm
 
+        # determine colour
+        colors = self._color_by_ifo()
+
         for i in range(0, self.n_datasets):
             series = self.timeseries[i]
             if nlegargs:
@@ -131,7 +134,8 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
             if self.usetex:
                 label = label_to_latex(label)
 
-            ax.plot(asd, label=label)
+            # plot
+            ax.plot(asd, label=label, color=colors[i])
 
         if args.xscale == 'log' and not args.xmin:
             args.xmin = 1/fftlength

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -82,6 +82,9 @@ class TimeSeries(TimeDomainProduct):
             )
             nlegargs = 0    # don't use  them
 
+        # get colours
+        colors = self._color_by_ifo()
+
         for i in range(0, self.n_datasets):
             series = self.timeseries[i]
             if nlegargs:
@@ -92,7 +95,7 @@ class TimeSeries(TimeDomainProduct):
                 label = series.name
             if self.usetex:
                 label = label_to_latex(label)
-            ax.plot(series, label=label)
+            ax.plot(series, label=label, color=colors[i])
 
         return plot
 


### PR DESCRIPTION
This PR modifies `gwpy.cli` to use the GW observatory colour scheme by default for those plots where all datasets uniquely matches an IFO prefix.