### PR TITLE
Update a number of CLI examples to use GWTC-3 data

### DIFF
--- a/docs/cli/examples.ini
+++ b/docs/cli/examples.ini
@@ -82,12 +82,14 @@ description =
 command =
 	spectrum
 	--chan L1:GDS-CALIB_STRAIN
-	--start 1126259446
+	--start 1264316100
 	--duration 32
 title = Simple spectrum
 description =
 	This example shows a simple spectrum (power spectral density) of strain
-	data from the LIGO-Livingston detector around the time of GW150914.
+	data from the LIGO-Livingston detector around the time of GW200129_065458
+	(see |GWTC-3l|_ for full details).
+
 
 [spectrum-times]
 command =
@@ -152,7 +154,7 @@ description =
 command =
 	spectrogram
 	--chan L1:GDS-CALIB_STRAIN
-	--start 1126258950
+	--start 1264315518
 	--duration 1024
 	--norm
 	--cmap Spectral_r

--- a/docs/cli/examples.ini
+++ b/docs/cli/examples.ini
@@ -37,6 +37,7 @@ command =
 	--start 1126259457
 	--title 'LIGO-Hanford strain around GW150914'
 title = Simple timeseries
+description = This example shows the strain timeseries for the LIGO-Hanford detector around GW150914.
 
 [timeseries-filter]
 command =
@@ -55,6 +56,10 @@ command =
 	--geometry 1200x400
 	--title 'LIGO-Hanford strain (filtered) around GW150914'
 title = Filtered timeseries
+description =
+	This example shows the strain timeseries for the LIGO-Hanford detector
+	around GW150914 filtered to emphasise the visibility of the known signal
+	(see :ref:`gwpy-example-signal-gw150914` for more detail).
 
 [timeseries-long]
 command =
@@ -66,6 +71,10 @@ command =
 	--ylabel 'Angle-averaged range (Mpc)'
 	--suptitle 'Distance senstivity to BNS-like inspiral'
 title = Time-series of estimated distance sensitivity
+description =
+	This example plots a timeseries of the estimated distance sensitivity of
+	the LIGO detectors to a typical binary neutron star (BNS)-like signal
+	around the time of GW170817.
 
 ; -- spectrum -----------------------------------
 
@@ -76,6 +85,9 @@ command =
 	--start 1126259446
 	--duration 32
 title = Simple spectrum
+description =
+	This example shows a simple spectrum (power spectral density) of strain
+	data from the LIGO-Livingston detector around the time of GW150914.
 
 [spectrum-times]
 command =
@@ -85,6 +97,10 @@ command =
 	--start 1187008866
 	--duration 32
 title = Spectrum at two times
+description =
+	This example plots the spectrum (power spectral density) of strain data
+	from both LIGO-Hanford and LIGO-Livingston for two different GPS times
+	(around GW150914 and GW170817).
 
 [spectrum-three-ifo]
 ; GW200129_065458
@@ -97,6 +113,10 @@ command =
 	--xmax 4000
 	--title "GW detector sensitivity around GW200129_065458
 title = Spectrum with three interferometers
+description =
+	This example shows the spectrum (power spectral density) of strain
+	data for the three active detectors around GW200129_065458
+	see (|GWTC-3l|_ for full details).
 
 [spectrum-hr]
 command =
@@ -108,6 +128,9 @@ command =
 	--xmin 10
 	--xmax 4000
 title = High-resolution spectrum
+description =
+	This example shows a high-resolution spectrum (power spectral density) of
+	the strain data from LIGO-Livingston around GW150914.
 
 ; -- spectrogram --------------------------------
 
@@ -120,6 +143,9 @@ command =
 	--epoch 1126259462
 	--ymax 4000
 title = Simple spectrogram
+description =
+	This example shows a :ref:`spectrogram <gwpy-spectrogram>` of the strain
+	data from LIGO-Hanford around the time of GW150914.
 
 [spectrogram-norm]
 command =
@@ -132,6 +158,9 @@ command =
 	--imin .25
 	--imax 4
 title = Normalised spectrogram
+description =
+	This example shows a normalised :ref:`spectrogram <gwpy-spectrogram>` of
+	the strain data from LIGO-Hanford around the time of GW150914.
 
 ; -- coherence-----------------------------------
 
@@ -142,6 +171,11 @@ command =
 	--start 1126260017
 	--duration 600
 title = Simple coherence
+description =
+	This example shows the estimated coherence between the strain data for
+	LIGO-Hanford (``H1:GDS-CALIB_STRAIN``) and the motion of an optical
+	periscope used to direct the main laser beam into the Hanford
+	interferometer.
 
 ; -- coherencegram ------------------------------
 
@@ -152,3 +186,9 @@ command =
 	--start 1126260017
 	--duration 600
 title = Simple coherence spectrogram
+description =
+	This example shows the time-variation :ref:`spectrogram <gwpy-spectrogram>`
+	of the estimated coherence between the strain data for
+	LIGO-Hanford (``H1:GDS-CALIB_STRAIN``) and the motion of an optical
+	periscope used to direct the main laser beam into the Hanford
+	interferometer.

--- a/docs/cli/examples.ini
+++ b/docs/cli/examples.ini
@@ -53,8 +53,15 @@ command = spectrum --chan H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN --start 112625
 title = Spectrum at two times
 
 [spectrum-three-ifo]
-; GW1780817
-command = spectrum --chan H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN --chan V1:Hrec_hoft_16384Hz --start 1187008866 --duration 32 --xmin 10 --xmax 4000
+; GW200129_065458
+command =
+	spectrum
+	--chan H1:DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01 L1:DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01 V1:Hrec_hoft_16384Hz
+	--start 1264316100
+	--duration 32
+	--xmin 10
+	--xmax 4000
+	--title "GW detector sensitivity around GW200129_065458
 title = Spectrum with three interferometers
 
 [spectrum-hr]

--- a/docs/cli/examples.ini
+++ b/docs/cli/examples.ini
@@ -31,25 +31,59 @@
 ; -- timeseries ---------------------------------
 
 [timeseries-simple]
-command = timeseries --chan H1:GDS-CALIB_STRAIN --start 1126259457
+command =
+	timeseries
+	--chan H1:GDS-CALIB_STRAIN
+	--start 1126259457
+	--title 'LIGO-Hanford strain around GW150914'
 title = Simple timeseries
 
 [timeseries-filter]
-command = timeseries --chan H1:GDS-CALIB_STRAIN --start 1126259458 --duration 8 --xmin 1126259462.1 --xmax 1126259462.6 --epoch 1126259462 --xscale seconds --lowpass 300 --highpass 50 --notch 60 120 --ylabel 'Strain amplitude' --geometry 1200x400
+command =
+	timeseries
+	--chan H1:GDS-CALIB_STRAIN
+	--start 1126259458
+	--duration 8
+	--xmin 1126259462.1
+	--xmax 1126259462.6
+	--epoch 1126259462
+	--xscale seconds
+	--lowpass 300
+	--highpass 50
+	--notch 60 120
+	--ylabel 'Strain amplitude'
+	--geometry 1200x400
+	--title 'LIGO-Hanford strain (filtered) around GW150914'
 title = Filtered timeseries
 
 [timeseries-long]
-command = timeseries --chan H1:DMT-SNSH_EFFECTIVE_RANGE_MPC.mean --chan L1:DMT-SNSH_EFFECTIVE_RANGE_MPC.mean --start 'August 17 2017' --duration 1day --ylabel 'Angle-averaged range (Mpc)' --suptitle 'Distance senstivity to BNS-like inspiral'
+command =
+	timeseries
+	--chan H1:DMT-SNSH_EFFECTIVE_RANGE_MPC.mean
+	--chan L1:DMT-SNSH_EFFECTIVE_RANGE_MPC.mean
+	--start 'August 17 2017'
+	--duration 1day
+	--ylabel 'Angle-averaged range (Mpc)'
+	--suptitle 'Distance senstivity to BNS-like inspiral'
 title = Time-series of estimated distance sensitivity
 
 ; -- spectrum -----------------------------------
 
 [spectrum-simple]
-command = spectrum --chan L1:GDS-CALIB_STRAIN --start 1126259446 --duration 32
+command =
+	spectrum
+	--chan L1:GDS-CALIB_STRAIN
+	--start 1126259446
+	--duration 32
 title = Simple spectrum
 
 [spectrum-times]
-command = spectrum --chan H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN --start 1126259446 --start 1187008866 --duration 32
+command =
+	spectrum
+	--chan H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN
+	--start 1126259446
+	--start 1187008866
+	--duration 32
 title = Spectrum at two times
 
 [spectrum-three-ifo]
@@ -65,27 +99,56 @@ command =
 title = Spectrum with three interferometers
 
 [spectrum-hr]
-command = spectrum --chan L1:GDS-CALIB_STRAIN --start 1126258950 --duration 1024 --secpfft 64 --xmin 10 --xmax 4000
+command =
+	spectrum
+	--chan L1:GDS-CALIB_STRAIN
+	--start 1126258950
+	--duration 1024
+	--secpfft 64
+	--xmin 10
+	--xmax 4000
 title = High-resolution spectrum
 
 ; -- spectrogram --------------------------------
 
 [spectrogram]
-command = spectrogram --chan H1:GDS-CALIB_STRAIN --start 1126259446 --duration 32 --epoch 1126259462 --ymax 4000
+command =
+	spectrogram
+	--chan H1:GDS-CALIB_STRAIN
+	--start 1126259446
+	--duration 32
+	--epoch 1126259462
+	--ymax 4000
 title = Simple spectrogram
 
 [spectrogram-norm]
-command = spectrogram --chan L1:GDS-CALIB_STRAIN --start 1126258950 --duration 1024 --norm --cmap Spectral_r --imin .25 --imax 4
+command =
+	spectrogram
+	--chan L1:GDS-CALIB_STRAIN
+	--start 1126258950
+	--duration 1024
+	--norm
+	--cmap Spectral_r
+	--imin .25
+	--imax 4
 title = Normalised spectrogram
 
 ; -- coherence-----------------------------------
 
 [coherence]
-command = coherence --chan H1:GDS-CALIB_STRAIN H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ --start 1126260017 --duration 600
+command =
+	coherence
+	--chan H1:GDS-CALIB_STRAIN H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ
+	--start 1126260017
+	--duration 600
 title = Simple coherence
 
 ; -- coherencegram ------------------------------
 
 [coherencegram]
-command = coherencegram --chan H1:GDS-CALIB_STRAIN H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ --start 1126260017 --duration 600
+command =
+	coherencegram
+	--chan H1:GDS-CALIB_STRAIN H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ
+	--start 1126260017
+	--duration 600
 title = Simple coherence spectrogram

--- a/docs/cli/examples.ini
+++ b/docs/cli/examples.ini
@@ -116,13 +116,13 @@ title = Spectrum with three interferometers
 description =
 	This example shows the spectrum (power spectral density) of strain
 	data for the three active detectors around GW200129_065458
-	see (|GWTC-3l|_ for full details).
+	(see |GWTC-3l|_ for full details).
 
 [spectrum-hr]
 command =
 	spectrum
 	--chan L1:GDS-CALIB_STRAIN
-	--start 1126258950
+	--start 1264315518
 	--duration 1024
 	--secpfft 64
 	--xmin 10
@@ -130,7 +130,8 @@ command =
 title = High-resolution spectrum
 description =
 	This example shows a high-resolution spectrum (power spectral density) of
-	the strain data from LIGO-Livingston around GW150914.
+	the strain data from LIGO-Livingston around GW200129_065458
+	(see |GWTC-3l|_ for full details).
 
 ; -- spectrogram --------------------------------
 
@@ -138,9 +139,9 @@ description =
 command =
 	spectrogram
 	--chan H1:GDS-CALIB_STRAIN
-	--start 1126259446
+	--start 1264316116
 	--duration 32
-	--epoch 1126259462
+	--epoch 1264316116.4
 	--ymax 4000
 title = Simple spectrogram
 description =

--- a/docs/cli/examples.ini
+++ b/docs/cli/examples.ini
@@ -33,16 +33,18 @@
 [timeseries-simple]
 command =
 	timeseries
-	--chan H1:GDS-CALIB_STRAIN
+	--gwosc
+	--ifo H1
 	--start 1126259457
-	--title 'LIGO-Hanford strain around GW150914'
+	--suptitle 'LIGO-Hanford strain around GW150914'
 title = Simple timeseries
 description = This example shows the strain timeseries for the LIGO-Hanford detector around GW150914.
 
 [timeseries-filter]
 command =
 	timeseries
-	--chan H1:GDS-CALIB_STRAIN
+	--gwosc
+	--ifo H1
 	--start 1126259458
 	--duration 8
 	--xmin 1126259462.1
@@ -54,7 +56,7 @@ command =
 	--notch 60 120
 	--ylabel 'Strain amplitude'
 	--geometry 1200x400
-	--title 'LIGO-Hanford strain (filtered) around GW150914'
+	--suptitle 'LIGO-Hanford strain (filtered) around GW150914'
 title = Filtered timeseries
 description =
 	This example shows the strain timeseries for the LIGO-Hanford detector
@@ -81,7 +83,8 @@ description =
 [spectrum-simple]
 command =
 	spectrum
-	--chan L1:GDS-CALIB_STRAIN
+	--gwosc
+	--ifo L1
 	--start 1264316100
 	--duration 32
 title = Simple spectrum
@@ -90,11 +93,11 @@ description =
 	data from the LIGO-Livingston detector around the time of GW200129_065458
 	(see |GWTC-3l|_ for full details).
 
-
 [spectrum-times]
 command =
 	spectrum
-	--chan H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN
+	--gwosc
+	--ifo H1 L1
 	--start 1126259446
 	--start 1187008866
 	--duration 32
@@ -108,12 +111,13 @@ description =
 ; GW200129_065458
 command =
 	spectrum
-	--chan H1:DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01 L1:DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01 V1:Hrec_hoft_16384Hz
+	--gwosc
+	--ifo H1 L1 V1
 	--start 1264316100
 	--duration 32
 	--xmin 10
 	--xmax 4000
-	--title "GW detector sensitivity around GW200129_065458"
+	--suptitle "GW detector sensitivity around GW200129_065458"
 title = Spectrum with three interferometers
 description =
 	This example shows the spectrum (power spectral density) of strain
@@ -123,7 +127,8 @@ description =
 [spectrum-hr]
 command =
 	spectrum
-	--chan L1:GDS-CALIB_STRAIN
+	--gwosc
+	--ifo L1
 	--start 1264315518
 	--duration 1024
 	--secpfft 64
@@ -140,7 +145,8 @@ description =
 [spectrogram]
 command =
 	spectrogram
-	--chan H1:GDS-CALIB_STRAIN
+	--gwosc
+	--ifo H1
 	--start 1264316116
 	--duration 32
 	--epoch 1264316116.4
@@ -153,7 +159,8 @@ description =
 [spectrogram-norm]
 command =
 	spectrogram
-	--chan L1:GDS-CALIB_STRAIN
+	--gwosc
+	--ifo L1
 	--start 1264315518
 	--duration 1024
 	--norm

--- a/docs/cli/examples.ini
+++ b/docs/cli/examples.ini
@@ -111,7 +111,7 @@ command =
 	--duration 32
 	--xmin 10
 	--xmax 4000
-	--title "GW detector sensitivity around GW200129_065458
+	--title "GW detector sensitivity around GW200129_065458"
 title = Spectrum with three interferometers
 description =
 	This example shows the spectrum (power spectral density) of strain

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -329,9 +329,9 @@ ${titleunderline}
 
 ${description}
 
-.. code:: sh
+.. code-block:: shell
 
-   $$ ${command}
+   ${command}
 
 .. plot::
    :align: center

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -357,7 +357,11 @@ def _new_or_different(content, target):
 def _render_cli_example(config, section, outdir, logger):
     """Render a :mod:`gwpy.cli` example as RST to be processed by Sphinx.
     """
-    raw = config.get(section, 'command') + " --interactive"
+    # read config values (allow for multi-line definition)
+    raw = config.get(
+        section,
+        'command',
+    ).strip().replace("\n", " ") + " --interactive"
     title = config.get(
         section,
         'title',


### PR DESCRIPTION
This PR updates a number of CLI examples to use an event from GWTC-3, mainly to allow them to use more recent data that is easier to access.