### PR TITLE
Support GWOSC as a data source for gwpy-plot

### DIFF
--- a/gwpy/cli/spectrum.py
+++ b/gwpy/cli/spectrum.py
@@ -117,7 +117,7 @@ class Spectrum(FFTMixin, FrequencyDomainProduct):
             if nlegargs:
                 label = self.args.legend[0][i]
             else:
-                label = series.channel.name
+                label = series.name or series.channel.name
                 if len(self.start_list) > 1:
                     label += f', {series.epoch.gps}'
 

--- a/gwpy/cli/timeseries.py
+++ b/gwpy/cli/timeseries.py
@@ -86,8 +86,10 @@ class TimeSeries(TimeDomainProduct):
             series = self.timeseries[i]
             if nlegargs:
                 label = self.args.legend[0][i]
-            else:
+            elif series.channel:  # GWOSC data doesn't have a 'channel'
                 label = series.channel.name
+            else:
+                label = series.name
             if self.usetex:
                 label = label_to_latex(label)
             ax.plot(series, label=label)


### PR DESCRIPTION
This PR adds a `--gwosc` option for `gwpy-plot` to support getting data from GWOSC.

Depends on #1568.