### PR TITLE
Use python-gssapi for kinit

### DIFF
--- a/gwpy/io/kerberos.py
+++ b/gwpy/io/kerberos.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2023)
 #
 # This file is part of GWpy.
 #
@@ -16,12 +17,12 @@
 # You should have received a copy of the GNU General Public License
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Utility module to initialise a kerberos ticket for NDS2 connections
+"""Utility module to initialise Kerberos ticket-granting tickets.
 
 This module provides a lazy-mans python version of the 'kinit'
-command-line tool, with internal guesswork using keytabs
+command-line tool using the python-gssapi library.
 
-See the documentation of the `kinit` function for example usage
+See the documentation of the `kinit` function for example usage.
 """
 
 import getpass
@@ -29,7 +30,11 @@ import os
 import re
 import subprocess
 import sys
+import warnings
 from collections import OrderedDict
+from unittest import mock
+
+from ..utils.decorators import deprecated_function
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 
@@ -40,6 +45,8 @@ try:
 except NameError:
     _IPYTHON = False
 
+DEFAULT_REALM = "LIGO.ORG"
+
 
 class KerberosError(RuntimeError):
     """Kerberos (krb5) operation failed
@@ -48,49 +55,59 @@ class KerberosError(RuntimeError):
 
 
 def kinit(
-        username=None,
-        password=None,
-        realm=None,
-        exe="kinit",
-        keytab=None,
-        krb5ccname=None,
-        verbose=None,
+    username=None,
+    password=None,
+    realm=None,
+    keytab=None,
+    ccache=None,
+    lifetime=None,
+    krb5ccname=None,
+    verbose=None,
 ):
-    """Initialise a kerberos ticket using the ``kinit`` command-line tool.
-
-    This allows authenticated connections to, amongst others, NDS2 services.
+    """Initialise a Kerberos ticket-granting ticket (TGT).
 
     Parameters
     ----------
     username : `str`, optional
-        name of user, will be prompted for if not given.
-
-    password : `str`, optional
-        cleartext password of user for given realm, will be prompted for
+        Name principal for Kerberos credential, will be prompted for
         if not given.
 
-    realm : `str`, optional
-        name of realm to authenticate against, read from keytab if available,
-        defaults to ``'LIGO.ORG'``.
+    password : `str`, optional
+        Cleartext password of user for given realm, will be prompted for
+        if not given.
 
-    exe : `str`, optional
-        path to kinit executable.
+        .. warning::
+
+            Passing passwords in plain text presents a security risk, please
+            consider using a Kerberos keytab file to store credentials.
+
+    realm : `str`, optional
+        Name of realm to authenticate against, if not given as part of
+        ``username``, defaults to ``'LIGO.ORG'``.
 
     keytab : `str`, optional
-        path to keytab file. If not given this will be read from the
+        Path to keytab file. If not given this will be read from the
         ``KRB5_KTNAME`` environment variable. See notes for more details.
 
-    krb5ccname : `str`, optional
-        path to Kerberos credentials cache.
+    ccache : `str`, optional
+        Path to Kerberos credentials cache.
+
+    lifetime : `int`, optional
+        Desired liftime of the Kerberos credential (may not be respected
+        by the underlying GSSAPI implementation); pass `None` to use
+        the maximum permitted liftime (default).
+
+        This is currently not respected by MIT Kerberos (the most common
+        GSSAPI implementation).
 
     verbose : `bool`, optional
-        print verbose output (if `True`), or not (`False)`; default is `True`
+        Print verbose output (if `True`), or not (`False)`; default is `True`
         if any user-prompting is needed, otherwise `False`.
 
     Notes
     -----
     If a keytab is given, or is read from the ``KRB5_KTNAME`` environment
-    variable, this will be used to guess the username and realm, if it
+    variable, this will be used to guess the principal, if it
     contains only a single credential.
 
     Examples
@@ -107,27 +124,35 @@ def kinit(
     >>> kinit(keytab='~/.kerberos/ligo.org.keytab', verbose=True)
     Kerberos ticket generated for albert.einstein@LIGO.ORG
     """
-    # get keytab
+    try:
+        import gssapi
+    except ImportError as exc:
+        raise type(exc)(
+            "cannot generate kerberos credentials without python-gssapi, ",
+            "or run `kinit` from your terminal manually."
+        )
+
+    # handle deprecated keyword
+    if krb5ccname:
+        warnings.warn(
+            "The `krb5ccname` keyword for gwpy.io.kerberos.kinit was renamed "
+            "to `ccache`, and will stop working in a future release.",
+            DeprecationWarning,
+        )
+        if ccache is None:
+            ccache = krb5ccname
+
+    # get keytab and check we can use it (username in keytab)
     if keytab is None:
         keytab = os.environ.get('KRB5_KTNAME', None)
         if keytab is None or not os.path.isfile(keytab):
             keytab = None
     if keytab:
-        try:
-            principals = parse_keytab(keytab)
-        except KerberosError:
-            pass
+        keyprincipal = _keytab_principal(keytab)
+        if _use_keytab(username, keytab):
+            username = str(keyprincipal)
         else:
-            # is there's only one entry in the keytab, use that
-            if username is None and len(principals) == 1:
-                username = principals[0][0]
-            # or if the given username is in the keytab, find the realm
-            if username in list(zip(*principals))[0]:
-                idx = list(zip(*principals))[0].index(username)
-                realm = principals[idx][1]
-            # otherwise this keytab is useless, so remove it
-            else:
-                keytab = None
+            keytab = False
 
     # refuse to prompt if we can't get an answer
     # note: jupyter streams are not recognised as interactive
@@ -142,42 +167,110 @@ def kinit(
                             "a ticket, or consider using a keytab file")
 
     # get credentials
-    if realm is None:
-        realm = 'LIGO.ORG'
     if username is None:
         verbose = True
         username = input(
-            f"Please provide username for the {realm} kerberos realm: ",
+            "Kerberos principal (user@REALM): ",
         )
-    identity = f"{username}@{realm}"
+    if "@" not in username:
+        username = f"{username}@{DEFAULT_REALM}"
+    principal = gssapi.Name(
+        base=username,
+        name_type=gssapi.NameType.kerberos_principal,
+    )
     if not keytab and password is None:
         verbose = True
-        password = getpass.getpass(prompt=f"Password for {identity}: ")
+        password = getpass.getpass(prompt=f"Password for {principal}: ")
 
-    # format kinit command
-    if keytab:
-        cmd = [exe, '-k', '-t', keytab, identity]
-    else:
-        cmd = [exe, identity]
-    if krb5ccname:
-        krbenv = {'KRB5CCNAME': krb5ccname}
-    else:
-        krbenv = None
-
-    # execute command
-    kget = subprocess.Popen(cmd, env=krbenv, stdout=subprocess.PIPE,
-                            stdin=subprocess.PIPE)
-    if not keytab:
-        kget.communicate(password.encode('utf-8'))
-    kget.wait()
-    retcode = kget.poll()
-    if retcode:
-        raise subprocess.CalledProcessError(kget.returncode, ' '.join(cmd))
+    # generate credential
+    acquire_kw = {  # common options for acquire methods
+        "ccache": ccache,
+        "lifetime": lifetime,
+    }
+    try:
+        if keytab:
+            creds = _acquire_keytab(principal, str(keytab), **acquire_kw)
+        else:
+            creds = _acquire_password(principal, password, **acquire_kw)
+    except gssapi.exceptions.GSSError:
+        raise KerberosError(
+            f"failed to generate Kerberos TGT for {principal}",
+        )
     if verbose:
-        print(f"Kerberos ticket generated for {identity}")
+        print(
+            f"Kerberos ticket acquired for {creds.name} "
+            f"({creds.lifetime} seconds remaining)",
+        )
 
 
-def parse_keytab(keytab):
+def _acquire_keytab(principal, keytab, ccache=None, lifetime=None):
+    """Acquire a Kerberos TGT using a keytab.
+    """
+    import gssapi
+    store = {
+        "client_keytab": str(keytab),
+    }
+    if ccache:
+        store["ccache"] = str(ccache)
+    with mock.patch.dict("os.environ", {"KRB5_KTNAME": keytab}):
+        creds = gssapi.Credentials(
+            name=principal,
+            store=store,
+            usage="initiate",
+            lifetime=lifetime,
+        )
+    creds.inquire()
+    return creds
+
+
+def _acquire_password(principal, password, ccache=None, lifetime=None):
+    """Acquire a Kerberos TGT using principal/password.
+    """
+    import gssapi
+    raw_creds = gssapi.raw.acquire_cred_with_password(
+        name=principal,
+        password=password.encode("utf-8"),
+        usage="initiate",
+    )
+    creds = gssapi.Credentials(raw_creds.creds)
+    creds.inquire()
+    creds.store(
+        store={"ccache": str(ccache)} if ccache else None,
+        usage="initiate",
+        overwrite=True,
+    )
+    return creds
+
+
+def _keytab_principal(keytab):
+    """Return the principal assocated with a Kerberos keytab file.
+    """
+    import gssapi
+    with mock.patch.dict("os.environ", {"KRB5_KTNAME": str(keytab)}):
+        try:
+            creds = gssapi.Credentials(usage="accept")
+        except gssapi.exceptions.MissingCredentialsError as exc:
+            warnings.warn(str(exc))
+            return None
+    return creds.name
+
+
+def _use_keytab(username, principal):
+    """Return `True` if a keytab principal matches the requested username.
+    """
+    if not username:
+        return True
+    username = str(username)
+    return (
+        ("@" in username and username == str(principal))
+        or username == str(principal).split("@", 1)[0]
+    )
+
+
+# -- deprecated
+
+@deprecated_function
+def parse_keytab(keytab):  # pragma: no cover
     """Read the contents of a KRB5 keytab file, returning a list of
     credentials listed within
 

--- a/gwpy/io/tests/test_kerberos.py
+++ b/gwpy/io/tests/test_kerberos.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2014-2020)
+# Copyright (C) Louisiana State University (2014-2017)
+#               Cardiff University (2017-2023)
 #
 # This file is part of GWpy.
 #
@@ -29,6 +30,214 @@ from .. import kerberos as io_kerberos
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
+
+@pytest.fixture(autouse=True)
+def mock_krb5_env():
+    with mock.patch.dict(os.environ):
+        for key in (
+            'KRB5_KTNAME',
+            'KRB5CCNAME',
+        ):
+            os.environ.pop(key, None)
+        yield
+
+
+def kerberos_name(name):
+    import gssapi
+    return gssapi.Name(
+        base=name,
+        name_type=gssapi.NameType.kerberos_principal,
+    )
+
+
+@mock.patch.dict("sys.modules", {"gssapi": None})
+def test_kinit_no_gssapi():
+    """Test that we get an augmented error message if ``gssapi`` is missing.
+    """
+    with pytest.raises(
+        ImportError,
+        match="cannot generate kerberos credentials without python-gssapi",
+    ):
+        io_kerberos.kinit()
+
+
+@pytest.mark.requires("gssapi")
+@mock.patch("sys.stdout.isatty", return_value=True)
+@mock.patch("gwpy.io.kerberos.input", return_value="rainer.weiss")
+@mock.patch("getpass.getpass", return_value="test")
+@mock.patch("gssapi.raw.acquire_cred_with_password")
+@mock.patch("gssapi.Credentials")
+def test_kinit_up(creds, acquire, getpass, input_, _, capsys):
+    """Test `gwpy.io.kerberos.kinit` with username and password given.
+
+    Note: without a real credential to use, we can't do much more than check
+    that the function under test passes the right arguments to the GSSAPI
+    library.
+    """
+    acquire.return_value = mock.MagicMock()
+
+    # basic call should prompt for username and password
+    io_kerberos.kinit()
+    input_.assert_called_with(
+        "Kerberos principal (user@REALM): ",
+    )
+    getpass.assert_called_with(
+        prompt="Password for rainer.weiss@LIGO.ORG: ",
+    )
+
+    # and then use the results in gssapi calls
+    acquire.assert_called_with(
+        name=kerberos_name("rainer.weiss@LIGO.ORG"),
+        password="test".encode("utf-8"),
+        usage="initiate",
+    )
+
+
+@pytest.mark.requires("gssapi")
+@mock.patch('gwpy.io.kerberos.input')
+@mock.patch('getpass.getpass')
+@mock.patch("gssapi.raw.acquire_cred_with_password")
+@mock.patch("gssapi.Credentials")
+def test_kinit_up_kwargs(creds, acquire, getpass, input_):
+    """Test `gwpy.io.kerberos.kinit` with username and password given.
+
+    Note: without a real credential to use, we can't do much more than check
+    that the function under test passes the right arguments to the GSSAPI
+    library.
+    """
+    io_kerberos.kinit(
+        username="albert.einstein@EXAMPLE.COM",
+        password="test",
+    )
+    input_.assert_not_called()
+    getpass.assert_not_called()
+    acquire.assert_called_with(
+        name=kerberos_name("albert.einstein@EXAMPLE.COM"),
+        password="test".encode("utf-8"),
+        usage="initiate",
+    )
+
+
+@pytest.mark.requires("gssapi")
+@mock.patch("gwpy.io.kerberos._acquire_password")
+def test_kinit_keytab_dne(acquire_passwd, tmp_path):
+    """Test `gwpy.io.kerberos.kinit` with a non-existent keytab.
+    """
+    keytab = tmp_path / "keytab"  # does not exist
+
+    # check that missing keytab goes to password auth
+    with pytest.warns(
+        UserWarning,
+        match=rf"{keytab.name} is nonexistent or empty\Z",
+    ):
+        io_kerberos.kinit(
+            username='test',
+            password='passwd',
+            keytab=keytab,
+        )
+    acquire_passwd.assert_called_once_with(
+        kerberos_name("test@LIGO.ORG"),
+        "passwd",
+        ccache=None,
+        lifetime=None,
+    )
+
+
+@pytest.mark.requires("gssapi")
+@mock.patch.dict("os.environ")
+@mock.patch("gssapi.Credentials")
+@mock.patch("gwpy.io.kerberos._keytab_principal")
+def test_kinit_keytab(principal, creds, tmp_path):
+    """Test `gwpy.io.kerberos.kinit` can handle keytabs properly.
+    """
+    principal.return_value = kerberos_name("rainer.weiss@LIGO.ORG")
+
+    keytab = tmp_path / "keytab"
+    keytab.touch()
+    ccache = tmp_path / "ccache"
+
+    # test keytab kwarg
+    io_kerberos.kinit(
+        keytab=keytab,
+        ccache=ccache,
+        lifetime=1000,
+    )
+    creds.assert_called_once_with(
+        name=kerberos_name("rainer.weiss@LIGO.ORG"),
+        store={
+            "client_keytab": str(keytab),
+            "ccache": str(ccache),
+        },
+        usage="initiate",
+        lifetime=1000,
+    )
+
+    # pass keytab via environment
+    creds.reset()
+    os.environ["KRB5_KTNAME"] = str(keytab)
+    io_kerberos.kinit()
+    creds.assert_called_with(
+        name=kerberos_name("rainer.weiss@LIGO.ORG"),
+        store={
+            "client_keytab": str(keytab),
+        },
+        usage="initiate",
+        lifetime=None,
+    )
+
+
+@pytest.mark.requires("gssapi")
+def test_kinit_notty():
+    """Test `gwpy.io.kerberos.kinit` raises an error in a non-interactive
+    session if it needs to prompt for information.
+
+    By default all tests are executed by pytest in a non-interactive session
+    so we don't have to mock anything!
+    """
+    with pytest.raises(io_kerberos.KerberosError):
+        io_kerberos.kinit()
+
+
+@pytest.mark.requires("gssapi")
+@mock.patch("gwpy.io.kerberos._acquire_password")
+def test_kinit_error(_acquire_password):
+    """Test that `gwpy.io.kerberos.kinit` propagates `GSSError`s appropriately.
+    """
+    import gssapi
+    _acquire_password.side_effect = gssapi.exceptions.GSSError(0, 0)
+
+    with pytest.raises(
+        io_kerberos.KerberosError,
+        match=(
+            r"\Afailed to generate Kerberos TGT for test@EXAMPLE.COM\Z"
+        ),
+    ):
+        io_kerberos.kinit(
+            username="test@EXAMPLE.COM",
+            password="test",
+        )
+
+
+# -- deprecated
+
+@pytest.mark.requires("gssapi")
+@mock.patch("gwpy.io.kerberos._acquire_password")
+def test_kinit_krb5ccname(_):
+    """Test that the ``krb5ccname`` keyword emits a deprecation warning.
+    """
+    with pytest.warns(
+        DeprecationWarning,
+        match=(
+            "The `krb5ccname` keyword for gwpy.io.kerberos.kinit was renamed"
+        ),
+    ):
+        io_kerberos.kinit(
+            username="test@EXAMPLE.COM",
+            password="test",
+            krb5ccname="cache",
+        )
+
+
 # mocked klist output
 KLIST = b"""Keytab name: FILE:/test.keytab
 KVNO Principal
@@ -37,32 +246,14 @@ KVNO Principal
    2 ronald.drever@LIGO.ORG
    2 ronald.drever@LIGO.ORG"""
 
-# mock os.environ
-MOCK_ENV = None
-
-
-def setup_module():
-    global MOCK_ENV
-    MOCK_ENV = mock.patch.dict(os.environ, {})
-    MOCK_ENV.start()
-    for key in (
-        'KRB5_KTNAME',
-        'KRB5CCNAME',
-    ):
-        os.environ.pop(key, None)
-
-
-def teardown_module():
-    if MOCK_ENV is not None:
-        MOCK_ENV.stop()
-
 
 @mock.patch('subprocess.check_output', return_value=KLIST)
 def test_parse_keytab(check_output):
     """Test `gwpy.io.kerberos.parse_keytab.
     """
     # assert principals get extracted correctly
-    principals = io_kerberos.parse_keytab('test.keytab')
+    with pytest.deprecated_call():
+        principals = io_kerberos.parse_keytab('test.keytab')
     assert principals == [('albert.einstein', 'LIGO.ORG', 1),
                           ('ronald.drever', 'LIGO.ORG', 2)]
 
@@ -79,138 +270,8 @@ def test_parse_keytab_oserror(mock_check_output, se, match):
     """Test `gwpy.io.kerberos.parse_keytab` fails appropriately.
     """
     mock_check_output.side_effect = se
-    with pytest.raises(io_kerberos.KerberosError, match=match):
+    with pytest.deprecated_call(), pytest.raises(
+        io_kerberos.KerberosError,
+        match=match,
+    ):
         io_kerberos.parse_keytab('test.keytab')
-
-
-@mock.patch('sys.stdout.isatty', return_value=True)
-@mock.patch('gwpy.io.kerberos.input', return_value='rainer.weiss')
-@mock.patch('getpass.getpass', return_value='test')
-@mock.patch('subprocess.Popen')
-def test_kinit_up(popen, getpass, input_, _, capsys):
-    """Test `gwpy.io.kerberos.kinit` with username and password given
-    """
-    proc = popen.return_value
-    proc.poll.return_value = 0
-
-    # basic call should prompt for username and password
-    io_kerberos.kinit()
-    input_.assert_called_with(
-        "Please provide username for the LIGO.ORG kerberos realm: ",
-    )
-    getpass.assert_called_with(
-        prompt="Password for rainer.weiss@LIGO.ORG: ",
-    )
-    popen.assert_called_with(
-        ['kinit', 'rainer.weiss@LIGO.ORG'],
-        stdin=-1,
-        stdout=-1,
-        env=None,
-    )
-    proc.communicate.aossert_called_with(b'test')
-
-
-@mock.patch('gwpy.io.kerberos.input')
-@mock.patch('getpass.getpass')
-@mock.patch('subprocess.Popen')
-def test_kinit_up_kwargs(popen, getpass, input_):
-    """Test `gwpy.io.kerberos.kinit` with username and password given
-    """
-    proc = popen.return_value
-    proc.poll.return_value = 0
-
-    io_kerberos.kinit(
-        username='albert.einstein',
-        password='test',
-        exe='/usr/bin/kinit',
-    )
-    input_.assert_not_called()
-    getpass.assert_not_called()
-    popen.assert_called_with(
-        ['/usr/bin/kinit', 'albert.einstein@LIGO.ORG'],
-        stdin=-1,
-        stdout=-1,
-        env=None,
-    )
-    popen.return_value.communicate.assert_called_with(b'test')
-
-
-@mock.patch('gwpy.io.kerberos.parse_keytab')
-@mock.patch('subprocess.Popen')
-def test_kinit_keytab_dne(popen, parse_keytab):
-    """Test `gwpy.io.kerberos.kinit` with a non-existent keytab
-    """
-    proc = popen.return_value
-    proc.poll.return_value = 0
-
-    # test keytab from environment not found (default) prompts user
-    io_kerberos.kinit(username='test', password='passwd',
-                      exe='/bin/kinit')
-    parse_keytab.assert_not_called()
-    popen.assert_called_with(
-        ['/bin/kinit', 'test@LIGO.ORG'],
-        stdin=-1,
-        stdout=-1,
-        env=None,
-    )
-
-
-@mock.patch.dict(os.environ, {'KRB5_KTNAME': '/test.keytab'})
-@mock.patch('os.path.isfile', return_value=True)
-@mock.patch(
-    'gwpy.io.kerberos.parse_keytab',
-    return_value=[['rainer.weiss', 'LIGO.ORG']],
-)
-@mock.patch('subprocess.Popen')
-def test_kinit_keytab(popen, *unused_mocks):
-    """Test `gwpy.io.kerberos.kinit` can handle keytabs properly
-    """
-    proc = popen.return_value
-    proc.poll.return_value = 0
-
-    # test keytab kwarg
-    io_kerberos.kinit(keytab='test.keytab', exe='/bin/kinit')
-    popen.assert_called_with(
-        ['/bin/kinit', '-k', '-t', 'test.keytab', 'rainer.weiss@LIGO.ORG'],
-        stdin=-1,
-        stdout=-1,
-        env=None,
-    )
-
-    # pass keytab via environment
-    io_kerberos.kinit(exe='/bin/kinit')
-    popen.assert_called_with(
-        ['/bin/kinit', '-k', '-t', '/test.keytab', 'rainer.weiss@LIGO.ORG'],
-        stdin=-1,
-        stdout=-1,
-        env=None,
-    )
-
-
-@mock.patch('subprocess.Popen')
-def test_kinit_krb5ccname(popen):
-    """Test `gwpy.io.kerberos.kinit` passes `KRB5CCNAME` to /bin/kinit
-    """
-    # test using krb5ccname (credentials cache)
-    # this will raise error because we haven't patched the poll() method
-    # to return 0, but will test that we get the right error
-    with pytest.raises(subprocess.CalledProcessError):
-        io_kerberos.kinit(username='test', password='test',
-                          krb5ccname='/test_cc.krb5', exe='/bin/kinit')
-    popen.assert_called_with(
-        ['/bin/kinit', 'test@LIGO.ORG'],
-        stdin=-1,
-        stdout=-1,
-        env={'KRB5CCNAME': '/test_cc.krb5'},
-    )
-
-
-def test_kinit_notty():
-    """Test `gwpy.io.kerberos.kinit` raises an error in a non-interactive
-    session if it needs to prompt for information.
-
-    By default all tests are executed by pytest in a non-interactive session
-    so we don't have to mock anything!
-    """
-    with pytest.raises(io_kerberos.KerberosError):
-        io_kerberos.kinit(exe='/bin/kinit')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ docs = [
 # development environments
 dev = [
   "ciecplib",
+  "gssapi",
   "lalsuite ; sys_platform != 'win32'",
   "lscsoft-glue ; sys_platform != 'win32'",
   "psycopg2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,10 @@ dev = [
   "sqlalchemy",
   "uproot >=4.1.5",
 ]
+# Kerberos authentication
+kerberos = [
+  "gssapi",
+]
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda = [


### PR DESCRIPTION
This PR reimplements `gwpy.io.kerberos.kinit()` using python-gssapi, so that we don't have to use subprocess, which can introduce security holes.