### PR TITLE
Add wrapper around scipy.signal.get_window to handle pre-computed window arrays

### DIFF
--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -30,7 +30,7 @@ from scipy import signal
 
 from astropy.units import (Unit, Quantity)
 
-from .window import planck
+from .window import (get_window, planck)
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 __all__ = ['lowpass', 'highpass', 'bandpass', 'notch', 'concatenate_zpks']
@@ -204,7 +204,7 @@ def truncate_impulse(impulse, ntaps, window='hann'):
     out = impulse.copy()
     trunc_start = int(ntaps / 2)
     trunc_stop = out.size - trunc_start
-    window = signal.get_window(window, ntaps)
+    window = get_window(window, ntaps)
     out[0:trunc_start] *= window[trunc_start:ntaps]
     out[trunc_stop:out.size] *= window[0:trunc_start]
     out[trunc_start:trunc_stop] = 0

--- a/gwpy/signal/tests/test_window.py
+++ b/gwpy/signal/tests/test_window.py
@@ -22,10 +22,37 @@
 import numpy
 import pytest
 
+from scipy.signal import get_window as scipy_get_window
+
 from ...testing import utils
 from .. import window
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+
+@pytest.mark.parametrize(("win", "Nx", "out"), [
+    ("hann", 10, scipy_get_window("hann", 10)),
+    (24, 10, scipy_get_window(("kaiser", 24), 10)),
+    (("kaiser", 24), 10, scipy_get_window(("kaiser", 24), 10)),
+    (range(10), 10, numpy.arange(10)),
+])
+def test_get_window(win, Nx, out):
+    numpy.testing.assert_array_equal(
+        window.get_window(win, Nx),
+        out,
+    )
+
+
+@pytest.mark.parametrize(("win", "Nx", "exc"), [
+    (range(11), 10, "window array wrong size"),
+    ([[0, 1], [1, 2]], 4, "multi-dimensional windows are not supported"),
+])
+def test_get_window_error(win, Nx, exc):
+    with pytest.raises(
+        AssertionError,
+        match=exc,
+    ):
+        window.get_window(win, Nx)
 
 
 @pytest.mark.parametrize(("in_, out"), [


### PR DESCRIPTION
This PR adds a new `gwpy.signal.window.get_window()` function which wraps `scipy.signal.get_window` but also accepts pre-computed window arrays, with some validation.

This helps to simplify some repeated logic for handling different windows and allows pre-computed windows to be used in all SP functions.

Closes #1546.