### PR TITLE
Gracefully skip requests.exceptions.ConnectionError in testing

### DIFF
--- a/gwpy/testing/errors.py
+++ b/gwpy/testing/errors.py
@@ -26,8 +26,11 @@ from urllib.error import URLError
 
 import pytest
 
+import requests.exceptions
+
 NETWORK_ERROR = (
     ConnectionError,
+    requests.exceptions.ConnectionError,
     socket.timeout,
     SSLError,
     URLError,


### PR DESCRIPTION
This PR adds `requests.exceptions.ConnectionError` to the list of network errors handled by the `gwpy.testing.errors.pytest_skip_network_error` decorator.