### PR TITLE
Improve NDSWarning message emitted by TimeSeriesDict.fetch

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1139,8 +1139,12 @@ class TimeSeriesBaseDict(OrderedDict):
                                          scaled=scaled, allow_tape=allow_tape_)
                     except (RuntimeError, ValueError) as exc:
                         error = str(exc)  # need to assign to take out of scope
-                        warnings.warn(error.split('\n', 1)[0],
-                                      io_nds2.NDSWarning)
+                        msg = error.split('\n', 1)[0]
+                        warnings.warn(
+                            f"failed to fetch data for {', '.join(channels)} "
+                            f"in interval [{start}, {end}): {msg}",
+                            io_nds2.NDSWarning,
+                        )
 
                 # if failing occurred because of data on tape, don't try
                 # reading channels individually, the same error will occur

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -35,6 +35,7 @@ from scipy import signal
 from astropy import units
 
 from ...frequencyseries import (FrequencySeries, SpectralVariance)
+from ...io.nds2 import NDSWarning
 from ...segments import (Segment, SegmentList, DataQualityFlag)
 from ...signal import filter_design
 from ...signal.window import planck
@@ -610,6 +611,25 @@ class TestTimeSeries(_TestTimeSeriesBase):
             with pytest.raises(RuntimeError) as exc:
                 self.TEST_CLASS.fetch('L1:TEST', 0, 1, host='nds.gwpy')
             assert 'no data received' in str(exc.value)
+
+    @pytest.mark.requires("nds2")
+    @mock.patch(
+        "gwpy.io.nds2.host_resolution_order",
+        return_value=(["nds.example.com", 31200],),
+    )
+    def test_fetch_warning_message(self, _):
+        """Test that TimeSeries.fetch emits a useful warning on NDS2 issues.
+        """
+        with \
+                pytest.raises(
+                    RuntimeError,
+                    match="Cannot find all relevant data",
+                ), \
+                pytest.warns(
+                    NDSWarning,
+                    match="failed to fetch data for X1:TEST",
+                ):
+            self.TEST_CLASS.fetch("X1:TEST", 0, 1)
 
     @_gwosc_cvmfs
     @mock.patch.dict(


### PR DESCRIPTION
This PR improves the `NDSWarning` message emitted during `TimeSeriesDict.fetch` when errors in the fetch are caught so that a different NDS server can be tried.

The old warning was something like this:

```text
/home/duncan/git/gwpy/gwpy/timeseries/core.py:1142: NDSWarning: no data received from nds.ligo.caltech.edu for [1126260017 ... 1126260617)
  warnings.warn(error.split('\n', 1)[0],
```

The new one includes the channels requested and the GPS interval (which isn't always in the error message emitted by the NDS2 client):

```text
/home/duncan/git/gwpy/gwpy/timeseries/core.py:1143: NDSWarning: failed to fetch data for H1:GDS-CALIB_STRAIN, H1:PEM-CS_ACC_PSL_PERISCOPE_X_DQ in interval [1126260017, 1126260617.0): no data received from nds.ligo.caltech.edu for [1126260017 ... 1126260617)
  warnings.warn(
```