### PR TITLE
Enhance LaTeX detection

### DIFF
--- a/gwpy/plot/tests/test_tex.py
+++ b/gwpy/plot/tests/test_tex.py
@@ -34,20 +34,30 @@ def _which(arg):
     return arg
 
 
-@mock.patch("gwpy.plot.tex.which", return_value="path")
-def test_has_tex_true(_):
-    """Test that `gwpy.plot.tex.has_tex` returns `True` when
-    all of the necessary executables are found
-    """
-    assert plot_tex.has_tex()
-
-
 @mock.patch("gwpy.plot.tex.which", _which)
-def test_has_tex_false():
+def test_has_tex_missing_exe():
     """Test that `gwpy.plot.tex.has_tex` returns `False` when
     any one of the necessary executables is missing.
     """
     assert not plot_tex.has_tex()
+
+
+@mock.patch("gwpy.plot.tex._test_usetex", side_effect=RuntimeError)
+def test_has_tex_bad_latex(_):
+    """Test that `gwpy.plot.tex.has_tex` returns `False` when
+    the LaTeX figure fails to render.
+    """
+    assert not plot_tex.has_tex()
+
+
+@mock.patch("gwpy.plot.tex.which", return_value="path")
+@mock.patch("gwpy.plot.tex._test_usetex")
+def test_has_tex_true(_which_, _test_usetex):
+    """Test that `gwpy.plot.tex.has_tex` returns `True` when
+    all of the necessary executables are found, and the LaTeX figure
+    doesn't raise an exception.
+    """
+    assert plot_tex.has_tex()
 
 
 @pytest.mark.parametrize('in_, out', [

--- a/gwpy/plot/tex.py
+++ b/gwpy/plot/tex.py
@@ -32,20 +32,40 @@ MACROS = [
 ]
 
 
+def _test_usetex():
+    """Draw (but don't show) a test image using matplotlib and LaTeX.
+    """
+    from matplotlib import (pyplot, rc_context)
+    with rc_context({"text.usetex": True}):
+        fig = pyplot.figure()
+        ax = fig.gca()
+        ax.set_xlabel(r"\LaTeX")
+        fig.canvas.draw()
+    pyplot.close(fig)
+
+
 def has_tex():
     """Returns whether tex is installed on this system
 
-    Checks for ``latex``, ``pdflatex``, and ``dvipng`` on the path.
+    Checks for ``latex``, ``pdflatex``, and ``dvipng`` on the path, and
+    then attemps to draw an image using LaTeX syntax.
 
     Returns
     -------
     hastex : `bool`
-        `True` if all required executables are found on the path, otherwise
-        `False`
+        `True` if the test image is drawn correctly, otherwise `False`
     """
+    # run basic sanity checks
     for exe in ('latex', 'pdflatex', 'dvipng'):
         if which(exe) is None:
             return False
+
+    # attempt to render an image with latex
+    try:
+        _test_usetex()
+    except Exception:  # failed for any reason
+        return False
+
     return True
 
 


### PR DESCRIPTION
This PR enhances the `gwpy.plot.tex.has_tex` function that attempts to detect whether LaTeX can be used as a text renderer by attempting to draw (but not render) an image that actually uses latex.

This should amount to an end-to-end test such that if `has_tex` returns `True`, then the user has significant assurance that the LaTeX installation is complete enough for MPL.