### PR TITLE
Update BLRMS tutorial to use public data

### DIFF
--- a/docs/timeseries/opendata.rst
+++ b/docs/timeseries/opendata.rst
@@ -76,12 +76,12 @@ We can then trivially plot these data:
    For more details on all of the available keyword options,
    see the documentation of :meth:`TimeSeries.fetch_open_data`.
 
-************************************************************
-Accessing data from the Auxiliary Channel Three-hour Release
-************************************************************
+**********************************************
+Accessing data from Auxiliary Channel Releases
+**********************************************
 
 |GWOSC|_ has also published a data set containing instrumental sensor data
-in a three-hour window around |GW170814|_.
+in a three-hour window around |GW170814|_ and throughout the entirety of O3.
 These data cannot be loaded using :meth:`TimeSeries.fetch_open_data`,
 but can be loaded using :meth:`TimeSeries.get`
 (or :meth:`TimeSeriesDict.get`), by specifying `host="losc-nds.ligo.org"`.

--- a/examples/timeseries/blrms.py
+++ b/examples/timeseries/blrms.py
@@ -19,7 +19,7 @@
 
 """Comparing seismic trends between LIGO sites
 
-On Feb 13 2015 there was a massive earthquake in the Atlantic Ocean, that
+On Jan 16 2020 there was a series of earthquakes, that
 should have had an impact on LIGO operations, I'd like to find out.
 """
 
@@ -36,24 +36,22 @@ from gwpy.plot import Plot
 # We do this using string-replacement so we can substitute the interferometer
 # prefix easily when we need to:
 channels = [
-    '{ifo}:ISI-BS_ST1_SENSCOR_GND_STS_X_BLRMS_30M_100M.mean,s-trend',
-    '{ifo}:ISI-BS_ST1_SENSCOR_GND_STS_Y_BLRMS_30M_100M.mean,s-trend',
-    '{ifo}:ISI-BS_ST1_SENSCOR_GND_STS_Z_BLRMS_30M_100M.mean,s-trend',
+    '{ifo}:ISI-BS_ST1_SENSCOR_GND_STS_Z_BLRMS_30M_100M',
 ]
 
-# At last we can :meth:`~TimeSeriesDict.get` 12 hours of data for each
+# At last we can :meth:`~TimeSeriesDict.get` 6 hours of data for each
 # interferometer:
 lho = TimeSeriesDict.get([c.format(ifo='H1') for c in channels],
-                         'Feb 13 2015 16:00', 'Feb 14 2015 04:00')
+                         'Jan 16 2020 8:00', 'Jan 16 2020 14:00')
 llo = TimeSeriesDict.get([c.format(ifo='L1') for c in channels],
-                         'Feb 13 2015 16:00', 'Feb 14 2015 04:00')
+                         'Jan 16 2020 8:00', 'Jan 16 2020 14:00')
 
 # Next we can plot the data, with a separate `~gwpy.plot.Axes` for each
 # instrument:
 plot = Plot(lho, llo, figsize=(12, 6), sharex=True, yscale='log')
 ax1, ax2 = plot.axes
 for ifo, ax in zip(('Hanford', 'Livingston'), (ax1, ax2)):
-    ax.legend(['X', 'Y', 'Z'])
+    ax.legend(['ground motion in the Z-direction'])
     ax.text(1.01, 0.5, ifo, ha='left', va='center', transform=ax.transAxes,
             fontsize=18)
 ax1.set_ylabel(r'$1-3$\,Hz motion [nm/s]', y=-0.1)


### PR DESCRIPTION
Now that there is auxiliary channel data available for all of O3, I've started updating tutorials to use this new data instead of proprietary data. This PR makes a minor update to `opendata.rst` to mention this new data release and updates the data source for the BLRMS tutorial.  

This addresses #1450.