### PR TITLE
Address floating point errors for index creation

### DIFF
--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -64,8 +64,8 @@ class Index(Quantity):
         step = Quantity(step, dtype=dtype, copy=False).to(start.unit)
         stop = start + step * num
         return cls(
-                numpy.arange(start.value, stop.value,
-                    step.value, dtype=dtype)[:num],
+            numpy.arange(start.value, stop.value,
+                         step.value, dtype=dtype)[:num],
             unit=start.unit,
             copy=False,
         )

--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -64,8 +64,12 @@ class Index(Quantity):
         step = Quantity(step, dtype=dtype, copy=False).to(start.unit)
         stop = start + step * num
         return cls(
-            numpy.arange(start.value, stop.value,
-                         step.value, dtype=dtype)[:num],
+            numpy.arange(
+                start.value,
+                stop.value,
+                step.value,
+                dtype=dtype,
+            )[:num],
             unit=start.unit,
             copy=False,
         )

--- a/gwpy/types/index.py
+++ b/gwpy/types/index.py
@@ -64,7 +64,8 @@ class Index(Quantity):
         step = Quantity(step, dtype=dtype, copy=False).to(start.unit)
         stop = start + step * num
         return cls(
-            numpy.arange(start.value, stop.value, step.value, dtype=dtype),
+                numpy.arange(start.value, stop.value,
+                    step.value, dtype=dtype)[:num],
             unit=start.unit,
             copy=False,
         )

--- a/gwpy/types/tests/test_index.py
+++ b/gwpy/types/tests/test_index.py
@@ -28,6 +28,17 @@ class TestIndex(object):
     TEST_CLASS = Index
 
     def test_define_regular(self):
+        """Check for regression against gwpy/gwpy#1596.
+        """
+        ind_len = 1000
+        a = self.TEST_CLASS.define(
+                1262936373.4853957,
+                0.051,
+                ind_len
+        )
+        assert len(a) == ind_len
+
+    def test_define_index_length(self):
         """Check for regression against gwpy/gwpy#1506.
         """
         a = self.TEST_CLASS.define(

--- a/gwpy/types/tests/test_index.py
+++ b/gwpy/types/tests/test_index.py
@@ -32,9 +32,9 @@ class TestIndex(object):
         """
         ind_len = 1000
         a = self.TEST_CLASS.define(
-                1262936373.4853957,
-                0.051,
-                ind_len
+            1262936373.4853957,
+            0.051,
+            ind_len
         )
         assert len(a) == ind_len
 


### PR DESCRIPTION
This PR addresses #1596 and introduces a new test to confirm that this issue does not pop up again with the `Index` class. 