### PR TITLE
replace deprecated interp2d with RectBivariateSpline

### DIFF
--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -568,7 +568,6 @@ class QGram(object):
         #     since they don't support log scaling
         interp = RectBivariateSpline(xout, frequencies, out.value)
 
-
         if not logf:
             if fres == "<default>":
                 fres = .5

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -536,7 +536,7 @@ class QGram(object):
         It is also highly recommended to use the `outseg` keyword argument
         when only a small window around a given GPS time is of interest.
         """
-        from scipy.interpolate import (interp2d, InterpolatedUnivariateSpline)
+        from scipy.interpolate import (RectBivariateSpline, InterpolatedUnivariateSpline)
         from ..spectrogram import Spectrogram
         if outseg is None:
             outseg = self.energies[0].span
@@ -565,7 +565,9 @@ class QGram(object):
         # interpolate the spectrogram to increase its frequency resolution
         # --- this is done because Duncan doesn't like interpolated images
         #     since they don't support log scaling
-        interp = interp2d(xout, frequencies, out.value.T, kind='cubic')
+        interp = RectBivariateSpline(xout, frequencies, out.value)
+
+
         if not logf:
             if fres == "<default>":
                 fres = .5
@@ -581,7 +583,7 @@ class QGram(object):
                 num=int(fres),
             )
         new = type(out)(
-            interp(xout, outfreq).T.astype(
+            interp(xout, outfreq).astype(
                 dtype, casting="same_kind", copy=False),
             t0=outseg[0], dt=tres, frequencies=outfreq,
         )

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -536,8 +536,10 @@ class QGram(object):
         It is also highly recommended to use the `outseg` keyword argument
         when only a small window around a given GPS time is of interest.
         """
-        from scipy.interpolate import (RectBivariateSpline,
-                                       InterpolatedUnivariateSpline)
+        from scipy.interpolate import (
+            InterpolatedUnivariateSpline,
+            RectBivariateSpline,
+        )
         from ..spectrogram import Spectrogram
         if outseg is None:
             outseg = self.energies[0].span

--- a/gwpy/signal/qtransform.py
+++ b/gwpy/signal/qtransform.py
@@ -536,7 +536,8 @@ class QGram(object):
         It is also highly recommended to use the `outseg` keyword argument
         when only a small window around a given GPS time is of interest.
         """
-        from scipy.interpolate import (RectBivariateSpline, InterpolatedUnivariateSpline)
+        from scipy.interpolate import (RectBivariateSpline,
+                                       InterpolatedUnivariateSpline)
         from ..spectrogram import Spectrogram
         if outseg is None:
             outseg = self.energies[0].span

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1384,6 +1384,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert qspecgram.shape == (1000, 2403)
         assert qspecgram.q == 5.65685424949238
         nptest.assert_almost_equal(qspecgram.value.max(), 155.93567, decimal=5)
+        nptest.assert_almost_equal(numpy.mean(qspecgram.value), 1.936469, decimal=5)
 
         # test whitening args
         asd = gw150914.asd(2, 1, method='scipy-welch')

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1384,7 +1384,9 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert qspecgram.shape == (1000, 2403)
         assert qspecgram.q == 5.65685424949238
         nptest.assert_almost_equal(qspecgram.value.max(), 155.93567, decimal=5)
-        nptest.assert_almost_equal(numpy.mean(qspecgram.value), 1.936469, decimal=5)
+        nptest.assert_almost_equal(
+            numpy.mean(qspecgram.value), 1.936469, decimal=5
+        )
 
         # test whitening args
         asd = gw150914.asd(2, 1, method='scipy-welch')

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1385,7 +1385,9 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert qspecgram.q == 5.65685424949238
         nptest.assert_almost_equal(qspecgram.value.max(), 155.93567, decimal=5)
         nptest.assert_almost_equal(
-            numpy.mean(qspecgram.value), 1.936469, decimal=5
+            qspecgram.value.mean(),
+            1.936469,
+            decimal=5,
         )
 
         # test whitening args


### PR DESCRIPTION
Closes #1580 

(near) drop-in replacement found at see https://gist.github.com/ev-br/8544371b40f414b7eaf3fe6217209bff

https://gwpy.github.io/docs/latest/examples/timeseries/qscan/ produces same result

unit tests seem to pass, though gwpy/timeseries/tests/test_timeseries.py maybe contains a more robust test (though it downloads data) than gwpy/signal/tests/test_qtransform.py. Not sure the latter ones passing will prove the result is the same in general.

Added another assertion to test in test_timeseries, to check not just max val but mean of vals (perhaps more sensitive to subtle changes)

