### PR TITLE
Fix issues writing StateVector.bits to HDF5

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -50,7 +50,7 @@ GWpy has the following strict requirements:
    |dqsegdb2|_
    |gwdatafind|_       ``>=1.1.0``
    |gwosc-mod|_        ``>=0.5.3``
-   |h5py|_             ``>=2.8.0``
+   |h5py|_             ``>=3.0.0``
    |ligo-segments|_    ``>=1.0.0``
    |ligotimegps|_      ``>=1.2.1``
    |matplotlib|_       ``>=3.1.0``

--- a/gwpy/timeseries/statevector.py
+++ b/gwpy/timeseries/statevector.py
@@ -427,8 +427,8 @@ class Bits(list):
             indent, self.__class__.__name__,
             mask, str(self.channel), str(self.epoch)))
 
-    def __array__(self):
-        return numpy.array([b or '' for b in self])
+    def __array__(self, dtype="U"):
+        return numpy.array([b or '' for b in self], dtype=dtype)
 
 
 # -- StateVector --------------------------------------------------------------

--- a/gwpy/timeseries/tests/test_statevector.py
+++ b/gwpy/timeseries/tests/test_statevector.py
@@ -370,6 +370,22 @@ class TestStateVector(_TestTimeSeriesBase):
         array = self.TEST_CLASS.from_nds2_buffer(nds_buffer)
         assert array.unit is units.dimensionless_unscaled
 
+    @pytest.mark.parametrize('ext', ('hdf5', 'h5'))
+    def test_read_write_hdf5(self, tmp_path, array, ext):
+        array.bits = ["a", "b", "c", "d"]
+        array.name = "test"
+
+        tmp = tmp_path / "test.{}".format(ext)
+
+        # write array (with auto-identify)
+        array.write(tmp, overwrite=True)
+
+        # check reading gives the same data (with/without auto-identify)
+        new = type(array).read(tmp, format='hdf5')
+        utils.assert_quantity_sub_equal(array, new)
+        new = type(array).read(tmp)
+        utils.assert_quantity_sub_equal(array, new)
+
 
 # -- StateVectorDict ----------------------------------------------------------
 

--- a/gwpy/types/io/hdf5.py
+++ b/gwpy/types/io/hdf5.py
@@ -125,8 +125,10 @@ def write_array_metadata(dataset, array):
         try:
             dataset.attrs[attr] = value
         except (TypeError, ValueError, RuntimeError) as exc:
-            exc.args = ("Failed to store {} ({}) for {}: {}".format(
-                attr, type(value).__name__, type(array).__name__, str(exc)))
+            exc.args = (
+                f"Failed to store {attr} ({type(value).__name__}) "
+                f"for {type(array).__name__}: '{exc}'",
+            )
             raise
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "dqsegdb2",
   "gwdatafind >=1.1.0",
   "gwosc >=0.5.3",
-  "h5py >=2.8.0",
+  "h5py >=3.0.0",
   "ligo-segments >=1.0.0",
   "ligotimegps >=1.2.1",
   "matplotlib >=3.3.0",


### PR DESCRIPTION
This PR adds a test for, then fixes issues with, writing `StateVector` to HDF5.

There was an issue converting `Bits` to an array that could be embedded inside an HDF5 attribute.