### PR TITLE
Fix plotting TimeSeriesDict on separate Axes

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1441,9 +1441,18 @@ class TimeSeriesBaseDict(OrderedDict):
             all other keyword arguments are passed to the plotter as
             appropriate
         """
+        kwargs.update({
+            "method": method,
+            "label": label,
+        })
+
         # make plot
         from ..plot import Plot
-        plot = Plot(self.values(), method=method, label=label, **kwargs)
+
+        if kwargs.get("separate", False):
+            plot = Plot(*self.values(), **kwargs)
+        else:
+            plot = Plot(self.values(), **kwargs)
 
         # update labels
         artmap = {'plot': 'lines', 'scatter': 'collections'}

--- a/gwpy/timeseries/tests/test_core.py
+++ b/gwpy/timeseries/tests/test_core.py
@@ -420,6 +420,22 @@ class TestTimeSeriesBaseDict(object):
             plot.save(BytesIO(), format='png')
             plot.close()
 
+    def test_plot_separate(self, instance):
+        """Test plotting `TimeSeriesDict` on separate axes.
+
+        See https://github.com/gwpy/gwpy/issues/1609
+        """
+        with rc_context(rc={'text.usetex': False}):
+            plot = instance.plot(separate=True)
+            assert len(plot.axes) == len(instance.keys())
+            for ax, key in zip(plot.axes, instance):
+                utils.assert_array_equal(ax.lines[-1].get_xdata(),
+                                         instance[key].xindex.value)
+                utils.assert_array_equal(ax.lines[-1].get_ydata(),
+                                         instance[key].value)
+            plot.save(BytesIO(), format='png')
+            plot.close()
+
 
 # -- TimeSeriesBaseList -------------------------------------------------------
 


### PR DESCRIPTION
This PR fixes #1609 by adding a special case for `separate=True`.