### PR TITLE
Add missing detection_snr argument

### DIFF
--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -332,8 +332,13 @@ def inspiral_range_psd(psd, snr=8, mass1=1.4, mass2=1.4, horizon=False,
     )
     dist = (
         inspiral.cosmo.luminosity_distance(z_hor) if horizon else
-        range_func(f[f > 0], psd.value[f > 0], z_hor=z_hor, H=inspiral,
-            detection_snr=snr)
+        range_func(
+            f[f > 0],
+            psd.value[f > 0],
+            z_hor=z_hor,
+            H=inspiral,
+            detection_snr=snr,
+        )
     )
     # calculate the sensitive distance PSD
     (fz, hz) = inspiral.z_scale(z_hor)
@@ -442,7 +447,7 @@ def inspiral_range(psd, snr=8, mass1=1.4, mass2=1.4, fmin=None, fmax=None,
             psd.value[frange],
             z_hor=z_hor,
             H=inspiral,
-            detection_snr=snr
+            detection_snr=snr,
         ),
         unit='Mpc',
     )

--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -332,7 +332,8 @@ def inspiral_range_psd(psd, snr=8, mass1=1.4, mass2=1.4, horizon=False,
     )
     dist = (
         inspiral.cosmo.luminosity_distance(z_hor) if horizon else
-        range_func(f[f > 0], psd.value[f > 0], z_hor=z_hor, H=inspiral)
+        range_func(f[f > 0], psd.value[f > 0], z_hor=z_hor, H=inspiral,
+            detection_snr=snr)
     )
     # calculate the sensitive distance PSD
     (fz, hz) = inspiral.z_scale(z_hor)
@@ -436,7 +437,13 @@ def inspiral_range(psd, snr=8, mass1=1.4, mass2=1.4, fmin=None, fmax=None,
     # return the sensitive distance metric
     return units.Quantity(
         inspiral.cosmo.luminosity_distance(z_hor) if horizon else
-        range_func(f[frange], psd.value[frange], z_hor=z_hor, H=inspiral),
+        range_func(
+            f[frange],
+            psd.value[frange],
+            z_hor=z_hor,
+            H=inspiral,
+            detection_snr=snr
+        ),
         unit='Mpc',
     )
 


### PR DESCRIPTION
This PR addresses #1614 to correctly pass the `detection_snr` argument to `inspiral_range.range()`. 

With this update, the `inspired_range()` function returns sensible values: 
```
>>> from gwosc.datasets import event_gps
>>> from gwpy.timeseries import TimeSeries
>>> from gwpy.astro import sensemon_range, inspiral_range
>>>
>>> gps = event_gps("GW150914")
>>> data = TimeSeries.fetch_open_data('L1', gps-32, gps+32, cache=True)
>>>
>>> psd = data.psd(4,2)
>>>
>>> snrs = [2,8,16]
>>> fmin = 10
>>> fmax = 100
>>>
>>> for s in snrs:
...     print('SNR = %d'%s)
...     r_sensemon = sensemon_range(psd, fmin=fmin, fmax=fmax, snr=s)
...     r_astro = inspiral_range(psd, fmin=fmin, fmax=fmax, snr=s)
...     print('sensemon range: %.2f Mpc'%r_sensemon.value)
...     print('inspiral range: %.2f Mpc'%r_astro.value)
...     print('ratio, sensemon/inspiral: %.2f'%(r_sensemon.value/r_astro.value))
...     print()
...
SNR = 2
sensemon range: 175.12 Mpc
inspiral range: 168.06 Mpc
ratio, sensemon/inspiral: 1.04

SNR = 8
sensemon range: 43.78 Mpc
inspiral range: 42.72 Mpc
ratio, sensemon/inspiral: 1.02

SNR = 16
sensemon range: 21.89 Mpc
inspiral range: 21.42 Mpc
ratio, sensemon/inspiral: 1.02
```

Closes #1614