### PR TITLE
Fix issues with Series.crop precision

### DIFF
--- a/gwpy/frequencyseries/tests/test_hist.py
+++ b/gwpy/frequencyseries/tests/test_hist.py
@@ -106,6 +106,9 @@ class TestSpectralVariance(_TestArray2D):
         assert array.y0 == self.bins[0]
         assert array.dy == self.bins[1] - self.bins[0]
 
+    def test_crop_float_precision(self):
+        pytest.skip("float precision test not supported for SpectralVariance")
+
     def test_is_compatible_yindex(self, array):
         return NotImplemented
 

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -1005,7 +1005,7 @@ class Series(Array):
             idx0 = None
         else:
             if not irregular:
-                idx0 = int((xtype(start) - x0) // self.dx.value)
+                idx0 = floor((xtype(start) - x0) / self.dx.value)
             else:
                 idx0 = numpy.searchsorted(
                     self.xindex.value, xtype(start), side="left"
@@ -1016,7 +1016,7 @@ class Series(Array):
             idx1 = None
         else:
             if not irregular:
-                idx1 = int((xtype(end) - x0) // self.dx.value)
+                idx1 = floor((xtype(end) - x0) / self.dx.value)
                 if idx1 >= self.size:
                     idx1 = None
             else:

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -947,25 +947,26 @@ class Series(Array):
         Parameters
         ----------
         start : `float`, optional
-            lower limit of x-axis to crop to, defaults to
-            current `~Series.x0`
+            Lower limit of x-axis to crop to, defaults to
+            :attr:`~Series.x0`.
 
         end : `float`, optional
-            upper limit of x-axis to crop to, defaults to current series end
+            Upper limit of x-axis to crop to, defaults to series end.
 
-        copy : `bool`, optional, default: `False`
-            copy the input data to fresh memory, otherwise return a view
+        copy : `bool`, optional
+            Copy the input data to fresh memory,
+            otherwise return a view (default).
 
         Returns
         -------
         series : `Series`
-            A new series with a sub-set of the input data
+            A new series with a sub-set of the input data.
 
         Notes
         -----
         If either ``start`` or ``end`` are outside of the original
         `Series` span, warnings will be printed and the limits will
-        be restricted to the :attr:`~Series.xspan`
+        be restricted to the :attr:`~Series.xspan`.
         """
         x0, x1 = self.xspan
         xtype = type(x0)
@@ -978,18 +979,20 @@ class Series(Array):
         if start == x0:
             start = None
         elif start is not None and xtype(start) < x0:
-            warn('%s.crop given start smaller than current start, '
-                 'crop will begin when the Series actually starts.'
-                 % type(self).__name__)
+            warn(
+                f"{type(self).__name__}.crop given start smaller than current "
+                "start, crop will begin when the Series actually starts.",
+            )
             start = None
 
         # pin late ends to time-series end
         if end == x1:
             end = None
         if end is not None and xtype(end) > x1:
-            warn('%s.crop given end larger than current end, '
-                 'crop will end when the Series actually ends.'
-                 % type(self).__name__)
+            warn(
+                f"{type(self).__name__}.crop given end larger than current "
+                "end, crop will begin when the Series actually ends.",
+            )
             end = None
 
         # check if series is irregular
@@ -1003,31 +1006,26 @@ class Series(Array):
         # find start index
         if start is None:
             idx0 = None
+        elif irregular:
+            idx0 = numpy.searchsorted(
+                self.xindex.value,
+                xtype(start),
+                side="left",
+            )
         else:
-            if not irregular:
-                idx0 = floor((xtype(start) - x0) / self.dx.value)
-            else:
-                idx0 = numpy.searchsorted(
-                    self.xindex.value, xtype(start), side="left"
-                )
+            idx0 = floor((xtype(start) - x0) / self.dx.value)
 
         # find end index
         if end is None:
             idx1 = None
+        elif irregular:
+            idx1 = numpy.searchsorted(
+                self.xindex.value,
+                xtype(end),
+                side="left",
+            )
         else:
-            if not irregular:
-                idx1 = floor((xtype(end) - x0) / self.dx.value)
-                if idx1 >= self.size:
-                    idx1 = None
-            else:
-                if xtype(end) >= self.xindex.value[-1]:
-                    idx1 = None
-                else:
-                    idx1 = (
-                        numpy.searchsorted(
-                            self.xindex.value, xtype(end), side="left"
-                        )
-                    )
+            idx1 = floor((xtype(end) - x0) / self.dx.value)
 
         # crop
         if copy:

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -212,6 +212,19 @@ class TestSeries(_TestArray):
         cropped = series.crop(start=25, end=75)
         utils.assert_quantity_equal(series[(x > 25) & (x < 75)], cropped)
 
+    def test_crop_float_precision(self):
+        """Verify the float precision of the crop function.
+
+        This tests regression against https://github.com/gwpy/gwpy/issues/1601.
+        """
+        # construct empty data array with the right shape for this array object
+        shape = (101,) * self.TEST_CLASS._ndim
+        series = self.TEST_CLASS(numpy.empty(shape), dx=0.01)
+
+        # assert that when we crop it, we only crop a single sample
+        cropped = series.crop(end=1.)
+        utils.assert_quantity_equal(series[:-1], cropped)
+
     def test_is_compatible(self, array):
         """Test the `Series.is_compatible` method
         """

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -185,16 +185,25 @@ class TestSeries(_TestArray):
             z, numpy.column_stack((array.xindex.value, array.value)))
 
     def test_crop(self, array):
+        """Test basic functionality of `Series.crop`.
+        """
+        # all defaults
+        utils.assert_quantity_equal(array, array.crop())
+
+        # normal operation
         a2 = array.crop(10, 20)
         utils.assert_quantity_equal(array[10:20], a2)
-        # check that warnings are printed for out-of-bounds
+
+    def test_crop_warnings(self, array):
+        """Test that `Series.crop` emits warnings when it is supposed to.
+        """
         with pytest.warns(UserWarning):
             array.crop(array.xspan[0]-1, array.xspan[1])
         with pytest.warns(UserWarning):
             array.crop(array.xspan[0], array.xspan[1]+1)
 
     def test_crop_irregular(self):
-        """The cropping on an irregularly spaced series.
+        """Test `Series.crop` with an irregular index.
         """
         x = numpy.linspace(0, 100, num=self.data.shape[0])
 


### PR DESCRIPTION
This PR fixes #1601 by tweaking the way that `Series.crop` rounds floats to integers, using `floor` instead of `//`.

I also cleaned up the code and its tests a bunch.