### PR TITLE
Update LatexInlineDimensional unit formatter for Astropy 5.3

### DIFF
--- a/gwpy/plot/units.py
+++ b/gwpy/plot/units.py
@@ -31,10 +31,14 @@ class LatexInlineDimensional(LatexInline):
     name = 'latex_inline_dimensional'
 
     @classmethod
-    def to_string(cls, unit):
-        u = f"[{super().to_string(unit)}]"
+    def to_string(cls, unit, *args, **kwargs):
+        u = f"[{super().to_string(unit, *args, **kwargs)}]"
 
         if unit.physical_type not in {None, 'unknown', 'dimensionless'}:
-            ptype = str(unit.physical_type).split('/', 1)[0].title()
-            return f"{cls._latex_escape(ptype)} {u}"
+            # format physical type of unit for LaTeX
+            ptype = str(
+                unit.physical_type,
+            ).split('/', 1)[0].title().replace("_", r"\_")
+            # return '<Physical type> [<unit>]'
+            return f"{ptype} {u}"
         return u

--- a/gwpy/plot/units.py
+++ b/gwpy/plot/units.py
@@ -48,9 +48,7 @@ class LatexInlineDimensional(LatexInline):
 
         if unit.physical_type not in {None, 'unknown', 'dimensionless'}:
             # format physical type of unit for LaTeX
-            ptype = str(
-                unit.physical_type,
-            ).split('/', 1)[0].title().replace("_", r"\_")
+            ptype = str(unit.physical_type).title().replace("_", r"\_")
             # return '<Physical type> [<unit>]'
             return f"{ptype} {u}"
         return u

--- a/gwpy/plot/units.py
+++ b/gwpy/plot/units.py
@@ -24,9 +24,21 @@ from astropy.units.format import LatexInline
 
 
 class LatexInlineDimensional(LatexInline):
-    """Custom LaTeX formatter that includes physical type (if available)
+    r"""Custom LaTeX formatter that includes physical type (if available)
 
-    Mainly for auto-labelling `Axes` in matplotlib figures
+    Mainly for auto-labelling `Axes` in matplotlib figures.
+
+    Examples
+    --------
+    The built-in astropy ``latex_inline`` formatter gives this:
+
+    >>> Unit('m/s').to_string(format='latex_inline')
+    '$\mathrm{m\,s^{-1}}$'
+
+    This custom 'dimensional' formatter gives:
+
+    >>> Unit('m/s').to_string(format='latex_inline_dimensional')
+    'Speed [$\mathrm{m\,s^{-1}}$]'
     """
     name = 'latex_inline_dimensional'
 


### PR DESCRIPTION
This PR updates the `LatexInlineDimensional` unit formatter to accommodate changes that will be introduced in Astropy 5.3.

The `_latex_escape` private method was removed from the relevant parent class, so this MR replaces that call with a manual version of the same logic, and updates some documentation.