### PR TITLE
Add H0 and L0 to dynamic_scaled exclusion list

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -84,7 +84,9 @@ def _dynamic_scaled(scaled, channel):
     """Determine default for scaled based on channel name
 
     This is mainly to work around LIGO not correctly recording ADC
-    scaling parameters for most of Advanced LIGO (through 2019).
+    scaling parameters for most of Advanced LIGO (through 2023).
+    Scaling parameters for H0 and L0 data are also not correct
+    starting in mid-2020.
 
     Parameters
     ----------
@@ -108,7 +110,7 @@ def _dynamic_scaled(scaled, channel):
     """
     if scaled is not None:
         return scaled
-    return not str(channel).startswith(("H1", "L1"))
+    return not str(channel).startswith(("H0", "L0", "H1", "L1"))
 
 
 # -- TimeSeriesBase------------------------------------------------------------


### PR DESCRIPTION
This MR addresses #1627 by adding `H0` and `L0` channels to the list of IFOs not scaled by default. These channels have incorrect scaling as of roughly Sept 2020.