### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -38,7 +38,6 @@ jobs:
           - Ubuntu
           - Windows
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
           - name: "Minimum"
-            python-version: "3.7"
+            python-version: "3.8"
             experimental: false
             extras: "test"
             pip-opts: "--upgrade-strategy=only-if-needed"

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -80,7 +80,6 @@ jobs:
           - Ubuntu
           - Windows
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -83,6 +83,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     runs-on: ${{ matrix.os }}-latest
 
     defaults:

--- a/gwpy/detector/channel.py
+++ b/gwpy/detector/channel.py
@@ -34,11 +34,6 @@ from .units import parse_unit
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-try:  # python >= 3.7
-    Pattern = re.Pattern
-except AttributeError:  # python < 3.7
-    Pattern = re._pattern_type
-
 QUOTE_REGEX = re.compile(r'^[\s\"\']+|[\s\"\']+$')
 
 
@@ -729,7 +724,7 @@ class ChannelList(list):
             a new `ChannelList` containing the matching channels
         """
         # format name regex
-        if isinstance(name, Pattern):
+        if isinstance(name, re.Pattern):
             flags = name.flags
             name = name.pattern
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "ligo-segments >=1.0.0",
   "ligotimegps >=1.2.1",
   "matplotlib >=3.3.0",
-  "numpy >=1.17",
+  "numpy >=1.19",
   "python-dateutil",
   "requests",
   "scipy >=1.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "numpy >=1.19",
   "python-dateutil",
   "requests",
-  "scipy >=1.2.0",
+  "scipy >=1.5.0",
   "tqdm >=4.10.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -34,7 +33,7 @@ classifiers = [
 ]
 
 # requirements
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
   "astropy >=4.3.0",
   "dqsegdb2",


### PR DESCRIPTION
This PR removes support for Python 3.7, which is [end-of-life at the end of June](https://devguide.python.org/versions/#supported-versions).