### PR TITLE
Add new scan feature for TimeSeries.find

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -759,6 +759,38 @@ class TestTimeSeries(_TestTimeSeriesBase):
         )
         utils.assert_quantity_sub_equal(data, new, exclude=["channel"])
 
+        # -- check that pad translates to on_gaps as expected
+
+        # pad=0 should emit a warning but pad the gap with zeros
+        with pytest.warns(UserWarning):
+            new = self.TEST_CLASS.find(
+                "X1:TEST-DATA",
+                start,
+                end+1,
+                frametype="TEST_DATA",
+                scan=tmp_path,
+                pad=0.,
+            )
+        assert new.span == (start, end + 1)
+        utils.assert_quantity_sub_equal(
+            data.append(
+                numpy.zeros(int(data.sample_rate.to("Hz").value)),
+                inplace=False,
+            ),
+            new,
+            exclude=["channel"],
+        )
+
+        # pad=None (default) should raise an error
+        with pytest.raises(RuntimeError, match="Missing segments"):
+            new = self.TEST_CLASS.find(
+                "X1:TEST-DATA",
+                start-1,
+                end,
+                frametype="TEST_DATA",
+                scan=tmp_path,
+            )
+
     # -- signal processing methods --------------
 
     def test_fft(self, gw150914):


### PR DESCRIPTION
This PR adds a new `scan` keyword argument to `TimeSeries.find` that allows for manually scanning a directory hierarchy instead of calling out to `gwdatafind`, e.g (from LIGO computing centres):

```python
from gwpy.time import to_gps
from gwpy.timeseries import TimeSeries
print(TimeSeries.get(
    "L1:GDS-CALIB_STRAIN",
    to_gps("now") - 100,
    to_gps("now") - 90,
    frametype="L1_llhoft",
    verbose=True,
    scan="/dev/shm/kafka",
))
```

Closes #1638.