### PR TITLE
Move 2pi scaling of zpk filters for better encapsulation and more explicit use

### DIFF
--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -274,12 +274,12 @@ def convert_zpk_units(filt, unit):
     gain : input, unadjusted gain
     """
     zeros, poles, gain = filt
-    zeros = numpy.array(zeros).astype(numpy.cfloat)
-    poles = numpy.array(poles).astype(numpy.cfloat)
 
     if unit == 'Hz':
-        zeros *= -2. * numpy.pi
-        poles *= -2. * numpy.pi
+        for zi in range(len(zeros)):
+            zeros[zi] *= -2. * numpy.pi
+        for pi in range(len(poles)):
+            poles[pi] *= -2. * numpy.pi
     elif unit != 'rad/s':
         raise ValueError("zpk can only be given with unit='Hz' "
                          "or 'rad/s'")

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -28,7 +28,7 @@ from numpy import fft as npfft
 
 from scipy import signal
 
-from astropy.units import (Unit, Quantity)
+from astropy.units import (Quantity)
 
 from .window import (get_window, planck)
 

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -28,7 +28,7 @@ from numpy import fft as npfft
 
 from scipy import signal
 
-from astropy.units import (Quantity)
+from astropy.units import Quantity
 
 from .window import (get_window, planck)
 
@@ -265,7 +265,7 @@ def convert_zpk_units(filt, unit):
         zeros, poles, gain
 
     unit : `str`
-        `'Hz'` or `'rad/s'`
+        ``'Hz'`` or ``'rad/s'``
 
     Returns
     -------

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -278,8 +278,8 @@ def convert_zpk_units(filt, unit):
     if unit == 'Hz':
         for zi in range(len(zeros)):
             zeros[zi] *= -2. * numpy.pi
-        for pi in range(len(poles)):
-            poles[pi] *= -2. * numpy.pi
+        for pj in range(len(poles)):
+            poles[pj] *= -2. * numpy.pi
     elif unit != 'rad/s':
         raise ValueError("zpk can only be given with unit='Hz' "
                          "or 'rad/s'")

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -280,9 +280,9 @@ def convert_zpk_units(filt, unit):
             zeros[zi] *= -2. * numpy.pi
         for pj in range(len(poles)):
             poles[pj] *= -2. * numpy.pi
-    elif unit != 'rad/s':
+    elif unit not in ['rad/s', 'rad/sample']:
         raise ValueError("zpk can only be given with unit='Hz' "
-                         "or 'rad/s'")
+                         f"'rad/s', or 'rad/sample', not {unit}")
 
     return zeros, poles, gain
 

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -257,7 +257,22 @@ def fir_from_transfer(transfer, ntaps, window='hann', ncorner=None):
 
 
 def convert_zpk_units(filt, unit):
-    """Convert zeros and poles created for a freq response in Hz to rad/s."""
+    """Convert zeros and poles created for a freq response in Hz to rad/s.
+
+    Parameters
+    ----------
+    filt : `tuple`
+        zeros, poles, gain
+
+    unit : `str`
+        `'Hz'` or `'rad/s'`
+
+    Returns
+    -------
+    zeros : `numpy.array` of `numpy.cfloat`
+    poles : `numpy.array` of `numpy.cfloat`
+    gain : input, unadjusted gain
+    """
     zeros, poles, gain = filt
     zeros = numpy.array(zeros).astype(numpy.cfloat)
     poles = numpy.array(poles).astype(numpy.cfloat)

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -221,7 +221,6 @@ def test_convert_to_digital_fir_still_zpk(example_zpk_fs_tuple):
     dform, dfilt = filter_design.convert_to_digital(
         (z, p, k),
         fs,
-        unit='rad/s'
     )
     assert dform == 'zpk'
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1488,7 +1488,8 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert numpy.isclose(absd[nf_ind], numpy.max(absd))
 
     def test_bandpass_happy_path(self, gw150914):
-        """Check that passband val are approx equal, stopband are not."""
+        """Check that passband val are approx equal, stopband are not.
+        """
 
         asd = gw150914.asd()
         bp_asd = gw150914.bandpass(100, 1000).asd()

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1511,7 +1511,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             bp_asd[eqind0:eqindn].value,
             asd[eqind0:eqindn].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
 
         # dont be within 40% for all value before
@@ -1519,7 +1519,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             bp_asd[:eqind0].value,
             asd[:eqind0].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
 
         # or after
@@ -1527,7 +1527,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             bp_asd[eqindn:].value,
             asd[eqindn:].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
 
     def test_notch(self, gw150914):

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1104,6 +1104,18 @@ class TestTimeSeries(_TestTimeSeriesBase):
         # FIXME: this test needs to be more robust
         assert l2.sample_rate == 1024 * units.Hz
 
+    def test_resample_simple_upsample(self, gw150914):
+        """Test consistency when upsampling by 2x`
+        """
+        upsamp = gw150914.resample(gw150914.sample_rate.value * 2)
+        assert numpy.allclose(gw150914.value, upsamp.value[::2])
+
+    def test_resample_simple_downsample(self, gw150914):
+        """Test consistency when downsampling by 2x`
+        """
+        downsamp = gw150914.resample(gw150914.sample_rate.value // 2)
+        assert numpy.allclose(gw150914.value[::2], downsamp.value)
+
     def test_resample_noop(self):
         data = self.TEST_CLASS([1, 2, 3, 4, 5])
         with pytest.warns(UserWarning):
@@ -1467,7 +1479,6 @@ class TestTimeSeries(_TestTimeSeriesBase):
             rtol=0.4,
             atol=0
         )
-
 
     def test_notch(self, gw150914):
         # test notch runs end-to-end

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1438,7 +1438,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         )
 
     def test_notch_happy_path(self, gw150914):
-        """For notch filtering, check that passband vals are approx equal, stopband are not."""
+        """Check passband vals are approx equal, stopband are not."""
 
         nf = 10
         notched = gw150914.notch(nf, filtfilt=True)
@@ -1453,29 +1453,38 @@ class TestTimeSeries(_TestTimeSeriesBase):
         r_inds = numpy.where(notched_asd.frequencies.value > nf + eps)[0]
         # index at 10 rad/s
         nf_ind = numpy.argmin(numpy.abs(notched_asd.frequencies.value - nf))
-        # indices inside interval around 10 rad/s and 
+        # indices inside interval around 10 rad/s
         nf_inds = numpy.arange(nf_ind - n_eps, nf_ind + n_eps)
-
-        print("??")
-        print(nf_ind, nf_inds)
-        print(l_inds[-1], r_inds[0], nf_ind)
-        print((notched_asd[nf_inds].value - asd[nf_inds].value) / asd[nf_inds].value)
-
 
         assert l_inds[-1] <= nf_ind
         assert r_inds[0] >= nf_ind
 
         # be within 40% for all values outside nbrhood
-        assert numpy.allclose(notched_asd[l_inds].value, asd[l_inds].value, rtol=0.4, atol=0)
-        assert numpy.allclose(notched_asd[r_inds].value, asd[r_inds].value, rtol=0.4, atol=0)
+        assert numpy.allclose(
+            notched_asd[l_inds].value,
+            asd[l_inds].value,
+            rtol=0.4,
+            atol=0
+        )
+        assert numpy.allclose(
+            notched_asd[r_inds].value,
+            asd[r_inds].value,
+            rtol=0.4,
+            atol=0
+        )
 
         # dont be within 40% for all values inside nbrhood
-        assert not numpy.allclose(notched_asd[nf_inds].value, asd[nf_inds].value, rtol=0.4, atol=0)
+        assert not numpy.allclose(
+            notched_asd[nf_inds].value,
+            asd[nf_inds].value,
+            rtol=0.4,
+            atol=0
+        )
 
-        # biggest difference between filtered and unfiltered should be at closest f to nf=10
+        # biggest difference between filtered and unfiltered
+        # should be at closest f to nf=10
         abs_prop_diff = numpy.abs(notched_asd.value - asd.value)
         assert numpy.argmax(abs_prop_diff) in (nf_ind - 1, nf_ind, nf_ind + 1)
-
 
     def test_bandpass_happy_path(self, gw150914):
         """Check that passband val are approx equal, stopband are not."""

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1437,6 +1437,46 @@ class TestTimeSeries(_TestTimeSeriesBase):
             atol=0
         )
 
+    def test_notch_happy_path(self, gw150914):
+        """For notch filtering, check that passband vals are approx equal, stopband are not."""
+
+        nf = 10
+        notched = gw150914.notch(nf, filtfilt=True)
+        notched_asd = notched.asd()
+        asd = gw150914.asd()
+
+        n_eps = 3
+        eps = n_eps * notched_asd.df.value
+
+        # indices outside interval around 10 rad/s
+        l_inds = numpy.where(notched_asd.frequencies.value < nf - eps)[0]
+        r_inds = numpy.where(notched_asd.frequencies.value > nf + eps)[0]
+        # index at 10 rad/s
+        nf_ind = numpy.argmin(numpy.abs(notched_asd.frequencies.value - nf))
+        # indices inside interval around 10 rad/s and 
+        nf_inds = numpy.arange(nf_ind - n_eps, nf_ind + n_eps)
+
+        print("??")
+        print(nf_ind, nf_inds)
+        print(l_inds[-1], r_inds[0], nf_ind)
+        print((notched_asd[nf_inds].value - asd[nf_inds].value) / asd[nf_inds].value)
+
+
+        assert l_inds[-1] <= nf_ind
+        assert r_inds[0] >= nf_ind
+
+        # be within 40% for all values outside nbrhood
+        assert numpy.allclose(notched_asd[l_inds].value, asd[l_inds].value, rtol=0.4, atol=0)
+        assert numpy.allclose(notched_asd[r_inds].value, asd[r_inds].value, rtol=0.4, atol=0)
+
+        # dont be within 40% for all values inside nbrhood
+        assert not numpy.allclose(notched_asd[nf_inds].value, asd[nf_inds].value, rtol=0.4, atol=0)
+
+        # biggest difference between filtered and unfiltered should be at closest f to nf=10
+        abs_prop_diff = numpy.abs(notched_asd.value - asd.value)
+        assert numpy.argmax(abs_prop_diff) in (nf_ind - 1, nf_ind, nf_ind + 1)
+
+
     def test_bandpass_happy_path(self, gw150914):
         """Check that passband val are approx equal, stopband are not."""
 

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1383,8 +1383,8 @@ class TestTimeSeries(_TestTimeSeriesBase):
             gw150914.zpk(*zpk), gw150914.filter(*zpk, analog=True))
 
     def test_highpass_happy_path(self, gw150914):
-        """Check that passband val are approx equal, stopband are not."""
-
+        """Check that passband val are approx equal, stopband are not.
+        """
         asd = gw150914.asd()
         hp_asd = gw150914.highpass(100).asd()
 
@@ -1399,19 +1399,20 @@ class TestTimeSeries(_TestTimeSeriesBase):
             hp_asd[eqind0:].value,
             asd[eqind0:].value,
             rtol=0.4,
-            atol=0)
+            atol=0,
+        )
 
         # dont be within 40% for all value before
         assert not numpy.allclose(
             hp_asd[:eqind0].value,
             asd[:eqind0].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
 
     def test_lowpass_happy_path(self, gw150914):
-        """Check that passband val are approx equal, stopband are not."""
-
+        """Check that passband val are approx equal, stopband are not.
+        """
         asd = gw150914.asd()
         lp_asd = gw150914.lowpass(500).asd()
 
@@ -1426,7 +1427,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             lp_asd[eqind0:].value,
             asd[eqind0:].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
 
         # dont be within 40% for all value after
@@ -1434,12 +1435,12 @@ class TestTimeSeries(_TestTimeSeriesBase):
             lp_asd[:eqind0].value,
             asd[:eqind0].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
 
     def test_notch_happy_path(self, gw150914):
-        """Check passband vals are approx equal, stopband are not."""
-
+        """Check passband vals are approx equal, stopband are not.
+        """
         nf = 10
         notched = gw150914.notch(nf, filtfilt=True)
         notched_asd = notched.asd()
@@ -1464,13 +1465,13 @@ class TestTimeSeries(_TestTimeSeriesBase):
             notched_asd[l_inds].value,
             asd[l_inds].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
         assert numpy.allclose(
             notched_asd[r_inds].value,
             asd[r_inds].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
 
         # dont be within 40% for all values inside nbrhood
@@ -1478,7 +1479,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
             notched_asd[nf_inds].value,
             asd[nf_inds].value,
             rtol=0.4,
-            atol=0
+            atol=0,
         )
 
         # biggest difference between filtered and unfiltered

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1483,8 +1483,8 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
         # biggest difference between filtered and unfiltered
         # should be at closest f to nf=10
-        abs_prop_diff = numpy.abs(notched_asd.value - asd.value)
-        assert numpy.argmax(abs_prop_diff) in (nf_ind - 1, nf_ind, nf_ind + 1)
+        absd = numpy.abs(notched_asd.value - asd.value)
+        assert numpy.isclose(absd[nf_ind], numpy.max(absd))
 
     def test_bandpass_happy_path(self, gw150914):
         """Check that passband val are approx equal, stopband are not."""

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -1090,7 +1090,7 @@ class TimeSeries(TimeSeriesBase):
         # parse filter
         form, filt = filter_design.parse_filter(filt)
 
-        unit = kwargs.pop('unit', False)
+        unit = kwargs.pop('unit', None)
         if not unit:
             if kwargs.get('analog', False):
                 unit = 'Hz'

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -971,7 +971,7 @@ class TimeSeries(TimeSeriesBase):
 
         unit: `str`
             The frequency response units this filter was designed for
-             either Hz or rad/s. Default: 'Hz'.
+            either Hz or rad/s. Default: 'Hz'.
 
         Returns
         -------

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -990,14 +990,13 @@ class TimeSeries(TimeSeriesBase):
 
         >>> data2 = data.zpk([100]*5, [1]*5, 1e-10)
         """
-
         return self.filter(
             zeros,
             poles,
             gain,
             analog=analog,
             unit=unit,
-            **kwargs
+            **kwargs,
         )
 
     def filter(self, *filt, **kwargs):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -798,8 +798,8 @@ class TimeSeries(TimeSeriesBase):
         filt = filter_design.highpass(frequency, self.sample_rate,
                                       fstop=fstop, gpass=gpass, gstop=gstop,
                                       analog=False, type=type, **kwargs)
-        # apply filter
-        return self.filter(*filt, filtfilt=filtfilt)
+        # filter_design.highpass returns rad/sample already
+        return self.filter(*filt, unit='rad/sample', filtfilt=filtfilt)
 
     def lowpass(self, frequency, gpass=2, gstop=30, fstop=None, type='iir',
                 filtfilt=True, **kwargs):
@@ -842,8 +842,8 @@ class TimeSeries(TimeSeriesBase):
         filt = filter_design.lowpass(frequency, self.sample_rate,
                                      fstop=fstop, gpass=gpass, gstop=gstop,
                                      analog=False, type=type, **kwargs)
-        # apply filter
-        return self.filter(*filt, filtfilt=filtfilt)
+        # apply filter, it is already rad/sample
+        return self.filter(*filt, unit='rad/sample', filtfilt=filtfilt)
 
     def bandpass(self, flow, fhigh, gpass=2, gstop=30, fstop=None, type='iir',
                  filtfilt=True, **kwargs):
@@ -890,7 +890,7 @@ class TimeSeries(TimeSeriesBase):
                                       fstop=fstop, gpass=gpass, gstop=gstop,
                                       analog=False, type=type, **kwargs)
         # apply filter
-        return self.filter(*filt, filtfilt=filtfilt)
+        return self.filter(*filt, unit='rad/sample', filtfilt=filtfilt)
 
     def resample(self, rate, window='hamming', ftype='fir', n=None):
         """Resample this Series to a new rate

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -991,8 +991,14 @@ class TimeSeries(TimeSeriesBase):
         >>> data2 = data.zpk([100]*5, [1]*5, 1e-10)
         """
 
-        f = self.filter(zeros, poles, gain, analog=analog, unit=unit, **kwargs)
-        return f
+        return self.filter(
+            zeros,
+            poles,
+            gain,
+            analog=analog,
+            unit=unit,
+            **kwargs
+        )
 
     def filter(self, *filt, **kwargs):
         """Filter this `TimeSeries` with an IIR or FIR filter

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -994,7 +994,7 @@ class TimeSeries(TimeSeriesBase):
         f = self.filter(zeros, poles, gain, analog=analog, unit=unit, **kwargs)
         return f
 
-    def filter(self, *filt, unit='Hz', **kwargs):
+    def filter(self, *filt, **kwargs):
         """Filter this `TimeSeries` with an IIR or FIR filter
 
         Parameters
@@ -1022,7 +1022,7 @@ class TimeSeries(TimeSeriesBase):
 
         unit: `str`
             If zpk, the frequency response units this filter was designed for,
-             either Hz or rad/s. Default: 'Hz'.
+             either Hz or rad/s. Default: 'Hz' if analog. Rad/s if digital.
 
         **kwargs
             other keyword arguments are passed to the filter method
@@ -1089,6 +1089,13 @@ class TimeSeries(TimeSeriesBase):
 
         # parse filter
         form, filt = filter_design.parse_filter(filt)
+
+        unit = kwargs.pop('unit', False)
+        if not unit:
+            if kwargs.get('analog', False):
+                unit = 'Hz'
+            else:
+                unit = 'rad/s'
 
         # convert units if the system was designed in Hz
         if form == "zpk":


### PR DESCRIPTION
2pi scaling happens by default inside bilinear_zpk for Hz -> rad/s. Extract that functionality so that i) bilinear transform is not also responsible for scaling (single responsibility principle) ii) it is used more explicitly where it is needed iii) the functions are more easily tested.

This MR will be followed by another MR that includes a comprehensive set of tests for filter design functionality, including zpk_transform, as well as bugfixes.