### PR TITLE
Adding LPSD averaging method

### DIFF
--- a/gwpy/signal/spectral/__init__.py
+++ b/gwpy/signal/spectral/__init__.py
@@ -36,6 +36,7 @@ from ._scipy import (
     rayleigh,
     welch,
 )
+from ._lpsd import lpsd
 from ._ui import (psd, spectrogram, average_spectrogram)
 
 # register deprecated methods

--- a/gwpy/signal/spectral/_lpsd.py
+++ b/gwpy/signal/spectral/_lpsd.py
@@ -1,0 +1,135 @@
+"""
+Wrapper for LPSD method, see https://gitlab.com/uhh-gwd/lpsd
+
+| Martin Hewitson <martin.hewitson@aeiDOTmpg.de> (original LPSD code)
+| Christian Darsow-Fromm <cdarsowf[at]physnet.uni-hamburg.de> (python wrapper for LPSD)
+| Artem Basalaev <artem[dot]basalaev[at]physik.uni-hamburg.de> (this implementation)
+"""
+
+import warnings
+import inspect
+import pandas
+import numpy
+
+from lpsd import lcsd
+from lpsd._lcsd import LCSD
+
+from ...frequencyseries import FrequencySeries
+from . import _registry as fft_registry
+from ._utils import scale_timeseries_unit
+
+
+def lpsd(*args, **kwargs):  # pylint: disable=too-many-branches
+    """Calculate the CSD of a `TimeSeries` using LPSD method.
+
+    Parameters
+    ----------
+    args : `list`
+        timeseries: `TimeSeries`
+            input time series (if only one specified, calculates PSD)
+        other: `TimeSeries`, optional
+            second input time series
+        nfft: `int`
+            number of samples per FFT, user-specified value ignored; calculated by the algorithm instead
+
+    kwargs : dict
+        fftlength : `float`, optional
+            number of seconds in single FFT. User-specified value ignored, algorithm calculates optimal segment lengths.
+        overlap : `float`, optional
+            number of seconds of overlap between FFTs.
+        window : `str`, optional
+            Window function to apply to timeseries prior to FFT. Possible values: 'hann', 'hanning', 'ham', 'hamming', 'bartlett', 'blackman', 'kaiser'. Defaults to 'kaiser'.
+        additional arguments are passed to :class:`lpsd.lcsd`
+
+    Returns
+    -------
+    fs: FrequencySeries
+        resulting CSD
+    """
+
+    try:
+        timeseries, nfft = args
+        other = timeseries
+    except ValueError:
+        timeseries, other, nfft = args
+
+    if len(timeseries.value) != len(other.value):
+        raise ValueError("Time series must have the same length (number of samples)!")
+
+    # No fftlength for LPSD method.
+    if kwargs.get("fftlength") or nfft != len(timeseries.value):
+        raise ValueError(
+            "fftlength/nfft arguments are not supported by LPSD averaging method; "
+            "segment lengths are calculated by the algorithm."
+        )
+
+    # convert overlap given in number of seconds to percentage
+    overlap = kwargs.pop("overlap", 0)
+    if overlap > 0:
+        total_duration = timeseries.duration
+        if overlap > total_duration:
+            raise ValueError(
+                "Specified overlap (in seconds) exceeds total time series duration!"
+            )
+        overlap = overlap / total_duration
+
+    # convert window to numpy function
+    window = kwargs.pop("window_", None)
+    window = "kaiser" if window is None else window
+    # clean up default value from kwargs
+    if "window" in kwargs:
+        kwargs.pop("window")
+    if not isinstance(window, str):
+        warnings.warn(
+            "Specifying window as an array for Daniell averaging method is not supported, defaulting to 'hann' window"
+        )
+        window = "kaiser"
+
+    window_to_func = {
+        "kaiser": numpy.kaiser,
+        "hann": numpy.hanning,
+        "hanning": numpy.hanning,
+        "hamm": numpy.hamming,
+        "hamming": numpy.hamming,
+        "bartlett": numpy.bartlett,
+        "blackman": numpy.blackman,
+    }
+    try:
+        window_function = window_to_func[window]
+    except KeyError as exc:
+        raise KeyError(
+            "Window " + window + "is not supported for LPSD averaging method"
+        ) from exc
+
+    # Convert inputs to pandas.DataFrame
+    df = pandas.DataFrame()
+    df["x1"] = timeseries.value
+    df["x2"] = other.value
+    df.index = timeseries.times.value
+
+    # clean up kwargs: get ones that are allowed for LPSD
+    allowed_kwargs = inspect.getfullargspec(LCSD.__init__).args
+    lpsd_kwargs = kwargs.copy()
+    for k in kwargs:
+        if k not in allowed_kwargs:
+            lpsd_kwargs.pop(k)
+    csd = lcsd(df, overlap=overlap, window_function=window_function, **lpsd_kwargs)
+
+    # generate FrequencySeries and return
+    unit = scale_timeseries_unit(
+        timeseries.unit,
+        kwargs.pop("scaling", "density"),
+    )
+    fs = FrequencySeries(
+        csd["psd"].values,
+        unit=unit,
+        frequencies=csd.index.values,
+        name=timeseries.name,
+        epoch=timeseries.epoch,
+        channel=timeseries.channel,
+    )
+
+    return fs
+
+
+fft_registry.register_method(lpsd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
   "requests",
   "scipy >=1.5.0",
   "tqdm >=4.10.0",
+  "lpsd >=1.0.3,<2.0"
 ]
 
 # dynamic properties set by tools


### PR DESCRIPTION
Introducing logarithmic power spectrum density (LPSD) averaging method for PSD/ASD/CSD and coherence calculation in `TimeSeries`.

The method produces variable-size frequency bins in `FrequencySeries` which results in a smooth curve over large frequency range. See example of performance comparison [here](https://gitlab.com/pyda-group/spicypy/-/blob/main/examples/compare_averaging_methods.ipynb).

Original C code developed for LISA Collaboration by Martin Hewitson [(link)](https://gitlab.com/uhh-gwd/lpsd/-/blob/main/lpsd/ltpda_dft.c), subsequently translated to python by Christian Darsow-Fromm and published on gitlab [(link)](https://gitlab.com/uhh-gwd/lpsd). Both C and python code subsequently generalized by me for CSD. Python code still uses compiled C core when possible, resulting in high computational efficiency. The algorithm is widely used by LISA community.

The code for LPSD method was then introduced into GWpy-based [Spicypy package](https://pyda-group.gitlab.io/spicypy/), and this pull request is mostly back-porting necessary changes into GWpy. The idea being that LPSD averaging method might be of interest for larger community of users of GWpy. 

This is my first pull request, so please forgive me if formatting etc is wrong, and I'd love to read up somewhere on expected format if there's a source. Changes are certainly up to debate, whether it is needed at all, the scope, and particular implementation. For example, I can imagine that you not want to implement also coherence calculation in a single pull request, because limiting it to CSD/PSD/ASD is less new code. I'm happy to split/reduce changes if desired.

Tagging @duncanmmacleod because we discussed this with him once shortly, but we did not go through changes in detail.