### PR TITLE
Don't round TimeSeries.dt when setting via sample_rate

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -245,8 +245,6 @@ class TimeSeriesBase(Series):
             del self.dt
             return
         self.dt = (1 / units.Quantity(val, units.Hertz)).to(self.xunit)
-        if numpy.isclose(self.dt.value, round(self.dt.value)):
-            self.dt = units.Quantity(round(self.dt.value), self.dt.unit)
 
     # -- duration
     @property


### PR DESCRIPTION
This PR fixes #1646 by removing a rounding of `self.dt` when that is set via the `sample_rate` property. I can't remember why that was there in the first place, but it's clearly broken for very high sample rates (for which the `dt` is very small).

Closes #1646.