### PR TITLE
Fix a bug with frequency domain filtering

### DIFF
--- a/gwpy/frequencyseries/_fdcommon.py
+++ b/gwpy/frequencyseries/_fdcommon.py
@@ -54,16 +54,17 @@ def fdfilter(data, *filt, **kwargs):
     form, filt = parse_filter(filt)
     freqs = data.frequencies.value.copy()
 
-    if not analog:
+    if analog:
+        lti = signal.lti(*filt).to_zpk()
+        z, p, k = lti.zeros, lti.poles, lti.gain
+        w, fr = signal.freqs_zpk(z, p, k, worN=freqs)
+    else:
         lti = signal.dlti(*filt).to_zpk()
         z, p, k = lti.zeros, lti.poles, lti.gain
         # dlti.freqresp does not take into account fs
         # better to use the more straightforward functions
         w, fr = signal.freqz_zpk(z, p, k, worN=freqs, fs=fs)
-    else:
-        lti = signal.lti(*filt).to_zpk()
-        z, p, k = lti.zeros, lti.poles, lti.gain
-        w, fr = signal.freqs_zpk(z, p, k, worN=freqs)
+
     fresp = numpy.nan_to_num(abs(fr))
 
     # apply to array

--- a/gwpy/frequencyseries/_fdcommon.py
+++ b/gwpy/frequencyseries/_fdcommon.py
@@ -25,7 +25,7 @@ import numpy
 
 from scipy import signal
 
-from ..signal.filter_design import parse_filter, convert_to_digital
+from ..signal.filter_design import parse_filter
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
 

--- a/gwpy/frequencyseries/_fdcommon.py
+++ b/gwpy/frequencyseries/_fdcommon.py
@@ -57,12 +57,12 @@ def fdfilter(data, *filt, **kwargs):
     if analog:
         lti = signal.lti(*filt).to_zpk()
         z, p, k = lti.zeros, lti.poles, lti.gain
+        # dlti.freqresp does not take into account fs
+        # better to use the more straightforward functions
         w, fr = signal.freqs_zpk(z, p, k, worN=freqs)
     else:
         lti = signal.dlti(*filt).to_zpk()
         z, p, k = lti.zeros, lti.poles, lti.gain
-        # dlti.freqresp does not take into account fs
-        # better to use the more straightforward functions
         w, fr = signal.freqz_zpk(z, p, k, worN=freqs, fs=fs)
 
     fresp = numpy.nan_to_num(abs(fr))

--- a/gwpy/spectrogram/tests/test_spectrogram.py
+++ b/gwpy/spectrogram/tests/test_spectrogram.py
@@ -174,11 +174,11 @@ class TestSpectrogram(_TestArray2D):
             lti.freqresp(w=array.frequencies.value)[1]))
 
         # test simple filter
-        a2 = array.filter(*zpk)
+        a2 = array.filter(*zpk, analog=True)
         utils.assert_array_equal(array * fresp, a2)
 
         # test inplace filtering
-        array.filter(lti, inplace=True)
+        array.filter(lti, inplace=True, analog=True)
         utils.assert_array_equal(array, a2)
 
         # test errors


### PR DESCRIPTION
Fix a bug where frequency domain filtering was not returning an expected result because analog scipy methods were being used despite default analog=False args. 

Now, analog and digital filters use corresponding scipy functions (freqs_zpk and freqz_zpk) that take into account fs.

Also, two tests were added, and some test assertions, to check results of frequency domain filtering for some simple examples.

In a few places, tests have changed.