### PR TITLE
Fix type comparison lint

### DIFF
--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -839,8 +839,7 @@ class Series(Array):
             N = min(self.shape[0], other.shape[0])
 
         # if units are the same, can shortcut
-        # NOTE: why not use isinstance here?
-        if type(other) == type(self) and other.unit == self.unit:
+        if isinstance(other, Series) and other.unit == self.unit:
             self.value[-N:] = other.value[-N:]
         # otherwise if its just a numpy array
         elif type(other) is type(self.value) or (  # noqa: E721

--- a/gwpy/utils/tests/test_misc.py
+++ b/gwpy/utils/tests/test_misc.py
@@ -60,7 +60,7 @@ def test_round_to_power():
     base = 10.
     rounded = utils_misc.round_to_power(9, base=base)
     assert base == rounded
-    assert type(base) == type(rounded)
+    assert type(base) == type(rounded)  # noqa: E721
 
 
 def test_round_to_power_error():


### PR DESCRIPTION
This PR fixes some lint complaints regarding exact type comparisons. It seems flake8 6.1.0 is more discerning than 6.0.0, which is probably for the best.