### PR TITLE
Fix compatibility with matplotlib 3.8.0

### DIFF
--- a/gwpy/plot/axes.py
+++ b/gwpy/plot/axes.py
@@ -161,7 +161,10 @@ class Axes(_Axes):
         super().__init__(*args, **kwargs)
 
         # handle Series in `ax.plot()`
-        self._get_lines = PlotArgsProcessor(self)
+        if matplotlib_version >= "3.8.0":
+            self._get_lines = PlotArgsProcessor()
+        else:
+            self._get_lines = PlotArgsProcessor(self)
 
         # reset data formatters (for interactive plots) to support
         # GPS time display
@@ -630,6 +633,10 @@ class PlotArgsProcessor(_process_plot_var_args):
         """Find `Series` data in `plot()` args and unwrap
         """
         newargs = []
+        # matplotlib 3.8.0 includes the Axes object up-front
+        if args and isinstance(args[0], Axes):
+            newargs.append(args[0])
+            args = args[1:]
         while args:
             # strip first argument
             this, args = args[:1], args[1:]

--- a/gwpy/plot/plot.py
+++ b/gwpy/plot/plot.py
@@ -521,9 +521,11 @@ class Plot(figure.Figure):
             pass
 
         # add new axes
-        if ax.get_axes_locator():
+        try:
             divider = ax.get_axes_locator()._axes_divider
-        else:
+        except AttributeError:
+            # get_axes_locator() is None _or_ the _axes_divider property
+            # has been removed
             from mpl_toolkits.axes_grid1 import make_axes_locatable
             divider = make_axes_locatable(ax)
         if location not in {'top', 'bottom'}:

--- a/gwpy/plot/tests/test_axes.py
+++ b/gwpy/plot/tests/test_axes.py
@@ -23,7 +23,10 @@ import pytest
 
 import numpy
 
-from matplotlib import rcParams
+from matplotlib import (
+    __version__ as matplotlib_version,
+    rcParams,
+)
 from matplotlib.collections import PolyCollection
 from matplotlib.lines import Line2D
 
@@ -169,7 +172,10 @@ class TestAxes(AxesTestBase):
         array = Array2D(numpy.random.random((10, 10)), dx=.1, dy=.2)
         ax.grid(True, which="both", axis="both")
         mesh = ax.pcolormesh(array)
-        utils.assert_array_equal(mesh.get_array(), array.T.flatten())
+        if matplotlib_version >= "3.8.0":
+            utils.assert_array_equal(mesh.get_array(), array.T)
+        else:  # matplotlib < 3.8.0
+            utils.assert_array_equal(mesh.get_array(), array.T.flatten())
         utils.assert_array_equal(mesh.get_paths()[-1].vertices[2],
                                  (array.xspan[1], array.yspan[1]))
         # check that restore_grid decorator did its job


### PR DESCRIPTION
This PR updates the handling of the `PlotArgsProcessor` class that overrides the builtin `_process_plot_var_args` private object that does all of the low-level argument handling and line generation for `Axes.plot()`.

In matplotlib <3.8.0 the parent `Axes` object is passed to the constructor, while in >=3.8.0 that is passed to the caller.