### PR TITLE
Update experimental dependencies job to Python 3.11

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -45,7 +45,7 @@ jobs:
             extras: "test"
             pip-opts: "--upgrade-strategy=only-if-needed"
           - name: "Experimental"
-            python-version: "3.9"
+            python-version: "3.11"
             experimental: true
             extras: "test,dev"
             pip-opts: "--upgrade --upgrade-strategy=eager --pre"


### PR DESCRIPTION
This PR updates the experimental dependencies CI job to use Python 3.11, which is long overdue.

Depends on #1661 