### PR TITLE
Catch ValueError in `fetch_gwosc_data`

### DIFF
--- a/gwpy/timeseries/io/losc.py
+++ b/gwpy/timeseries/io/losc.py
@@ -176,7 +176,12 @@ def fetch_gwosc_data(detector, start, end, cls=TimeSeries, **kwargs):
     out = None
     kwargs['cls'] = cls
     for url in cache:
-        keep = file_segment(url) & span
+        try:
+            keep = file_segment(url) & span
+        except ValueError:
+            # occurs when span and url segments don't overlap
+            # https://git.ligo.org/lscsoft/ligo-segments/-/blob/master/ligo/segments/__init__.py#L403
+            continue
         kwargs["start"], kwargs["end"] = keep
         new = _fetch_gwosc_data_file(url, *args, **kwargs)
         if is_gwf and (not args or args[0] is None):


### PR DESCRIPTION
Addresses #1612. 

This edge case occurs when the last `url` starts at the same timestamp that the `span` ends. 
This leads to [this](https://git.ligo.org/lscsoft/ligo-segments/-/blob/master/ligo/segments/__init__.py#L403) `ligo.segments`
`ValueError` getting raised for calling `__and__` with non overlapping Segments (My expectation would be to return an empty Segment, but I imagine theres good reason for choosing this behavior). 

This addresses the problem by catching the `ValueError` and continuing the iteration past this `url`

