### PR TITLE
Keep FrequencySeries name when taking ifft, addressing issue #1666

### DIFF
--- a/gwpy/frequencyseries/frequencyseries.py
+++ b/gwpy/frequencyseries/frequencyseries.py
@@ -229,7 +229,7 @@ class FrequencySeries(Series):
         # so we account for it here
         dift = npfft.irfft(self.value * nout) / 2
         new = TimeSeries(dift, epoch=self.epoch, channel=self.channel,
-                         unit=self.unit, dx=1/self.dx/nout)
+                         name=self.name, unit=self.unit, dx=1/self.dx/nout)
         return new
 
     def zpk(self, zeros, poles, gain, analog=True):


### PR DESCRIPTION
When going from TimeSeries to FrequencySeries, the name of the Series are kept the same. This is not the case when going the opposite way. This was causing some issues when writing series as HDF5.