### PR TITLE
Replace bilinear_zpk with the scipy implementation

### DIFF
--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -287,47 +287,6 @@ def convert_zpk_units(filt, unit):
     return zeros, poles, gain
 
 
-def bilinear_zpk(zeros, poles, gain, fs=1.0):
-    """Convert an analogue ZPK filter to digital using a bilinear transform
-
-    Parameters
-    ----------
-    zeros : array-like
-        list of zeros
-
-    poles : array-like
-        list of poles
-
-    gain : `float`
-        filter gain
-
-    fs : `float`, `~astropy.units.Quantity`
-        sampling rate at which to evaluate bilinear transform, default: 1.
-
-    unit : `str`, `~astropy.units.Unit`
-        unit of inputs, one or 'Hz' or 'rad/s', default: ``'Hz'``
-
-    Returns
-    -------
-    zpk : `tuple`
-        digital version of input zpk
-    """
-    zeros = numpy.array(zeros, dtype=float, copy=False)
-    zeros = zeros[numpy.isfinite(zeros)]
-    poles = numpy.array(poles, dtype=float, copy=False)
-    gain = gain
-
-    # convert to Z-domain via bilinear transform
-    fs = 2 * Quantity(fs, 'Hz').value
-    dpoles = (1 + poles/fs) / (1 - poles/fs)
-    dzeros = (1 + zeros/fs) / (1 - zeros/fs)
-    dzeros = numpy.concatenate((
-        dzeros, -numpy.ones(len(dpoles) - len(dzeros)),
-    ))
-    dgain = gain * numpy.prod(fs - zeros)/numpy.prod(fs - poles)
-    return dzeros, dpoles, dgain
-
-
 def convert_to_digital(filter, sample_rate):
     """Convert an analog filter to digital via bilinear functions.
 
@@ -362,7 +321,7 @@ def convert_to_digital(filter, sample_rate):
         filter = signal.bilinear(b, a, fs=sample_rate)
 
     elif form == 'zpk':
-        filter = bilinear_zpk(*filter, fs=sample_rate)
+        filter = signal.bilinear_zpk(*filter, fs=sample_rate)
 
     else:
         raise ValueError(f"Cannot convert {form}, only 'zpk' or 'ba'")

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -205,6 +205,7 @@ def test_convert_to_digital_complex_type_preserved():
     assert p.dtype == pd.dtype
     assert numpy.iscomplexobj(pd)
 
+
 def test_convert_to_digital_invalid_form():
     with mock.patch('gwpy.signal.filter_design.parse_filter') as tmp_mock:
         tmp_mock.return_value = ("invalid", [1, 2, 3])

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -170,7 +170,7 @@ def test_convert_to_digital_zpk(example_zpk_fs_tuple):
     dform, dfilt = filter_design.convert_to_digital((z, p, k), fs)
 
     assert dform == 'zpk'
-    assert dfilt == filter_design.bilinear_zpk(z, p, k, fs)
+    assert dfilt == signal.bilinear_zpk(z, p, k, fs)
 
 
 def test_convert_to_digital_ba(example_zpk_fs_tuple):
@@ -180,7 +180,7 @@ def test_convert_to_digital_ba(example_zpk_fs_tuple):
     # this should be converted to ZPK form
     dform, dfilt = filter_design.convert_to_digital((b, a), fs)
     assert dform == 'zpk'
-    assert dfilt == filter_design.bilinear_zpk(z, p, k, fs)
+    assert dfilt == signal.bilinear_zpk(z, p, k, fs)
 
 
 def test_convert_to_digital_fir(example_zpk_fs_tuple):
@@ -190,6 +190,14 @@ def test_convert_to_digital_fir(example_zpk_fs_tuple):
     dform, dfilt = filter_design.convert_to_digital(b, fs)
     assert dform == 'ba'
     assert numpy.allclose(dfilt, signal.bilinear(b, [1], fs))
+
+
+def test_convert_to_digital_complex_type_preserved():
+    z, p, k = signal.butter(3, 30, 'low', analog=True, output='zpk')
+    form, filt = filter_design.convert_to_digital((z, p, k), 100)
+    zd, pd, kd = filt
+    assert p.dtype == pd.dtype
+    assert pd.dtype == numpy.complex128
 
 
 def test_convert_to_digital_invalid_form():

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -193,12 +193,17 @@ def test_convert_to_digital_fir(example_zpk_fs_tuple):
 
 
 def test_convert_to_digital_complex_type_preserved():
+    """Test that conversion to digital does not erroneously convert
+    to float types.
+
+    Tests regression against:
+     https://github.com/gwpy/gwpy/issues/1630#issuecomment-1721674653
+    """
     z, p, k = signal.butter(3, 30, 'low', analog=True, output='zpk')
     form, filt = filter_design.convert_to_digital((z, p, k), 100)
     zd, pd, kd = filt
     assert p.dtype == pd.dtype
-    assert pd.dtype == numpy.complex128
-
+    assert numpy.iscomplexobj(pd)
 
 def test_convert_to_digital_invalid_form():
     with mock.patch('gwpy.signal.filter_design.parse_filter') as tmp_mock:


### PR DESCRIPTION
Added an extra test to make sure complex filter dtypes are preserved

Addresses https://github.com/gwpy/gwpy/issues/1630

Using scipy's implementation we also avoid problems with old implementation casting to float as in https://github.com/gwpy/gwpy/issues/1630#issuecomment-1721674653

