### PR TITLE
Suppress frame warnings

### DIFF
--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -115,12 +115,16 @@ class _CacheEntry(namedtuple(
             return cls(*filename_metadata(path) + (path,))
 
         try:
+            import lal
             # Disable lal warnings if this fails
             prev_level = lal.GetDebugLevel()
             lal.ClobberDebugLevel(0)
             entry = _parse_entry_ffl(parts, gpstype=gpstype)
             lal.ClobberDebugLevel(prev_level)
             return entry
+        except ImportError:
+            # Cannot import lal to set debug level
+            return _parse_entry_ffl(parts, gpstype=gpstype)
         except (RuntimeError, TypeError, ValueError) as exc:
             try:
                 return _parse_entry_lal(parts, gpstype=gpstype)

--- a/gwpy/io/cache.py
+++ b/gwpy/io/cache.py
@@ -115,7 +115,12 @@ class _CacheEntry(namedtuple(
             return cls(*filename_metadata(path) + (path,))
 
         try:
-            return _parse_entry_ffl(parts, gpstype=gpstype)
+            # Disable lal warnings if this fails
+            prev_level = lal.GetDebugLevel()
+            lal.ClobberDebugLevel(0)
+            entry = _parse_entry_ffl(parts, gpstype=gpstype)
+            lal.ClobberDebugLevel(prev_level)
+            return entry
         except (RuntimeError, TypeError, ValueError) as exc:
             try:
                 return _parse_entry_lal(parts, gpstype=gpstype)


### PR DESCRIPTION
When reading a cache file, if it is in LAL format there are spurious errors printed, since gwpy tries to call `_parse_entry_ffl` first. This patch stops the spurious warnings by setting the lal debug level to 0 temporarily.