### PR TITLE
Don't install python-nds2-client on windows for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ dev = [
 conda = [
   "python-framel >=8.40.1",
   "python-ldas-tools-framecpp ; sys_platform != 'win32'",
-  "python-nds2-client",
+  "python-nds2-client ; sys_platform != 'win32'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This PR patches the Python metadata to not install `python-nds2-client` for testing on Windows; there's something is wrong with it, and I can't figure out what it is, see https://github.com/conda-forge/nds2-client-swig-feedstock/pull/37.