### PR TITLE
Fix array indexing of Series.xindex

### DIFF
--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -612,6 +612,10 @@ class Series(Array):
     def __getitem__(self, item):
         new = super().__getitem__(item)
 
+        have_xindex = getattr(self, '_xindex', None) is not None
+        if have_xindex:
+            new._xindex = self._xindex[item]
+
         # slice axis 0 metadata
         slice_, = sliceutils.format_nd_slice(item, 1)
         if not sliceutils.null_slice(slice_):

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -612,15 +612,10 @@ class Series(Array):
     def __getitem__(self, item):
         new = super().__getitem__(item)
 
-        have_xindex = getattr(self, '_xindex', None) is not None
-        if have_xindex:
-            new._xindex = self._xindex[item]
-
         # slice axis 0 metadata
         slice_, = sliceutils.format_nd_slice(item, 1)
         if not sliceutils.null_slice(slice_):
             sliceutils.slice_axis_attributes(self, 'x', new, 'x', slice_)
-
         return new
 
     def is_contiguous(self, other, tol=1/2.**18):

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -616,6 +616,7 @@ class Series(Array):
         slice_, = sliceutils.format_nd_slice(item, 1)
         if not sliceutils.null_slice(slice_):
             sliceutils.slice_axis_attributes(self, 'x', new, 'x', slice_)
+
         return new
 
     def is_contiguous(self, other, tol=1/2.**18):

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -106,6 +106,7 @@ def null_slice(slice_):
         slice_ = as_slice(slice_)
     except TypeError:
         return False
+    
     if isinstance(slice_, numpy.ndarray) and numpy.all(slice_ == 1):
         return True
     if isinstance(slice_, slice) and slice_ in (

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -106,8 +106,7 @@ def null_slice(slice_):
         slice_ = as_slice(slice_)
     except TypeError:
         return False
-
-    if isinstance(slice_, numpy.ndarray) and numpy.all(slice_):
+    if isinstance(slice_, numpy.ndarray) and numpy.all(slice_ == 1):
         return True
     if isinstance(slice_, slice) and slice_ in (
             slice(None, None, None), slice(0, None, 1)

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -107,7 +107,8 @@ def null_slice(slice_):
     except TypeError:
         return False
 
-    if isinstance(slice_, numpy.ndarray) and numpy.all(slice_ == 1):
+    if isinstance(slice_, numpy.ndarray) and \
+            slice_.dtype == bool and slice_.all():
         return True
     if isinstance(slice_, slice) and slice_ in (
             slice(None, None, None), slice(0, None, 1)

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -107,8 +107,11 @@ def null_slice(slice_):
     except TypeError:
         return False
 
-    if isinstance(slice_, numpy.ndarray) and \
-            slice_.dtype == bool and slice_.all():
+    if (
+        isinstance(slice_, numpy.ndarray)
+        and slice_.dtype == bool
+        and slice_.all()
+    ):
         return True
     if isinstance(slice_, slice) and slice_ in (
             slice(None, None, None), slice(0, None, 1)

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -106,7 +106,7 @@ def null_slice(slice_):
         slice_ = as_slice(slice_)
     except TypeError:
         return False
-    
+
     if isinstance(slice_, numpy.ndarray) and numpy.all(slice_ == 1):
         return True
     if isinstance(slice_, slice) and slice_ in (

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -250,3 +250,7 @@ class TestArray2D(_TestSeries):
     @pytest.mark.skip("not implemented for >1D arrays")
     def test_pad_asymmetric(self):
         return NotImplemented
+
+    @pytest.mark.skip("not applicable for >1D arrays")
+    def test_single_getitem_not_created(self):
+        return NotImplemented

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -167,6 +167,28 @@ class TestSeries(_TestArray):
                 name=array.name, epoch=array.epoch, unit=array.unit),
             )
 
+    def test_getitem_index(self, array):
+        """Test that __getitem__ also applies to an xindex.
+
+        When subsetting a Series with an iterable of integer indices,
+        make sure that the xindex, if it exists, is also subsetted. Tests
+        regression against https://github.com/gwpy/gwpy/issues/1680.
+        """
+        xindex = array.xindex  # create xindex
+        indices = numpy.array([0, 5, 10, 20])
+        newarray = array[indices]
+
+        assert len(newarray) == 4
+        assert len(newarray) == len(newarray.value)
+        assert len(newarray.value) == len(newarray.xindex)
+
+        # check that the first index is correct
+        assert(array[indices[0]] == newarray[0])
+
+        # check that there is no xindex when a single value is accessed
+        with pytest.raises(AttributeError):
+            xindex = array[indices[0]].xindex
+
     def test_empty_slice(self, array):
         """Check that we can slice a `Series` into nothing
 

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -182,12 +182,16 @@ class TestSeries(_TestArray):
         assert len(newarray) == len(newarray.value)
         assert len(newarray.value) == len(newarray.xindex)
 
-        # check that the first index is correct
-        assert(array[indices[0]] == newarray[0])
+    def test_single_getitem_not_created(self, array):
+        """Test that array[i] does not return an object with a new _xindex."""
 
         # check that there is no xindex when a single value is accessed
         with pytest.raises(AttributeError):
-            xindex = array[indices[0]].xindex
+            xindex = array[0].xindex
+
+        # we don't need this, we don't want it accidentally injected
+        with pytest.raises(AttributeError):
+            xindex = array[0]._xindex
 
     def test_empty_slice(self, array):
         """Check that we can slice a `Series` into nothing

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -175,10 +175,10 @@ class TestSeries(_TestArray):
         regression against https://github.com/gwpy/gwpy/issues/1680.
         """
         xindex = array.xindex  # create xindex
-        indices = numpy.array([0, 5, 10, 20])
+        indices = numpy.array([0, 1, len(array)-1])
         newarray = array[indices]
 
-        assert len(newarray) == 4
+        assert len(newarray) == 3
         assert len(newarray) == len(newarray.value)
         assert len(newarray.value) == len(newarray.xindex)
 

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -174,7 +174,7 @@ class TestSeries(_TestArray):
         make sure that the xindex, if it exists, is also subsetted. Tests
         regression against https://github.com/gwpy/gwpy/issues/1680.
         """
-        xindex = array.xindex  # create xindex
+        array.xindex  # create xindex
         indices = numpy.array([0, 1, len(array)-1])
         newarray = array[indices]
 
@@ -187,11 +187,11 @@ class TestSeries(_TestArray):
 
         # check that there is no xindex when a single value is accessed
         with pytest.raises(AttributeError):
-            xindex = array[0].xindex
+            array[0].xindex
 
         # we don't need this, we don't want it accidentally injected
         with pytest.raises(AttributeError):
-            xindex = array[0]._xindex
+            array[0]._xindex
 
     def test_empty_slice(self, array):
         """Check that we can slice a `Series` into nothing


### PR DESCRIPTION
See https://github.com/gwpy/gwpy/issues/1680.

When `__getitem__` is called with an int array, the xindex is not subsetted.

