### PR TITLE
Update versions for GitHub Actions actions

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -167,7 +167,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-conda-${{ matrix.os }}-${{ matrix.python-version }}
         path: pytest.xml

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - name: Get source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -56,7 +56,7 @@ jobs:
         fetch-depth: 0
 
     - name: Cache conda packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         # increment to reset cache
         CACHE_NUMBER: 0
@@ -67,7 +67,7 @@ jobs:
 
     - name: Cache apt (Linux)
       if: matrix.os == 'Ubuntu'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         # increment to reset cache
         CACHE_NUMBER: 0

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-experimental-${{ matrix.os }}-${{ matrix.python-version }}
         path: pytest.xml

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
     - name: Get source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -59,7 +59,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -97,7 +97,7 @@ jobs:
       run: python -m coverage report --show-missing
 
     - name: Publish coverage to Codecov
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
         flags: ${{ runner.os }},python${{ matrix.python-version }}

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -92,7 +92,7 @@ jobs:
 
     steps:
     - name: Download ${{ matrix.artifact }}
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ matrix.artifact }}
 

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -52,12 +52,12 @@ jobs:
     - name: Create distributions
       run: python -m build . --sdist --wheel --outdir .
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: tarball
         path: gwpy-*.tar.*
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: wheel
         path: gwpy*.whl
@@ -133,7 +133,7 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-${{ matrix.artifact }}-${{ matrix.os }}-${{ matrix.python-version }}
         path: pytest.xml

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -42,7 +42,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 
@@ -97,7 +97,7 @@ jobs:
         name: ${{ matrix.artifact }}
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Get source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     name: Flake8
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -43,7 +43,7 @@ jobs:
     name: rstcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
This PR updates the versions of actions uses in the GHA workflows to the latest stable versions, mainly for housekeeping.

This shouldn't resolve any actual issues, but will silence some warnings emitted by some jobs.