### PR TITLE
Revert "docs: use GWOSC where we can in CLI examples" in 3.0.x release branch

### DIFF
--- a/docs/cli/examples.ini
+++ b/docs/cli/examples.ini
@@ -33,18 +33,16 @@
 [timeseries-simple]
 command =
 	timeseries
-	--gwosc
-	--ifo H1
+	--chan H1:GDS-CALIB_STRAIN
 	--start 1126259457
-	--suptitle 'LIGO-Hanford strain around GW150914'
+	--title 'LIGO-Hanford strain around GW150914'
 title = Simple timeseries
 description = This example shows the strain timeseries for the LIGO-Hanford detector around GW150914.
 
 [timeseries-filter]
 command =
 	timeseries
-	--gwosc
-	--ifo H1
+	--chan H1:GDS-CALIB_STRAIN
 	--start 1126259458
 	--duration 8
 	--xmin 1126259462.1
@@ -56,7 +54,7 @@ command =
 	--notch 60 120
 	--ylabel 'Strain amplitude'
 	--geometry 1200x400
-	--suptitle 'LIGO-Hanford strain (filtered) around GW150914'
+	--title 'LIGO-Hanford strain (filtered) around GW150914'
 title = Filtered timeseries
 description =
 	This example shows the strain timeseries for the LIGO-Hanford detector
@@ -83,8 +81,7 @@ description =
 [spectrum-simple]
 command =
 	spectrum
-	--gwosc
-	--ifo L1
+	--chan L1:GDS-CALIB_STRAIN
 	--start 1264316100
 	--duration 32
 title = Simple spectrum
@@ -93,11 +90,11 @@ description =
 	data from the LIGO-Livingston detector around the time of GW200129_065458
 	(see |GWTC-3l|_ for full details).
 
+
 [spectrum-times]
 command =
 	spectrum
-	--gwosc
-	--ifo H1 L1
+	--chan H1:GDS-CALIB_STRAIN L1:GDS-CALIB_STRAIN
 	--start 1126259446
 	--start 1187008866
 	--duration 32
@@ -111,13 +108,12 @@ description =
 ; GW200129_065458
 command =
 	spectrum
-	--gwosc
-	--ifo H1 L1 V1
+	--chan H1:DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01 L1:DCS-CALIB_STRAIN_CLEAN_SUB60HZ_C01 V1:Hrec_hoft_16384Hz
 	--start 1264316100
 	--duration 32
 	--xmin 10
 	--xmax 4000
-	--suptitle "GW detector sensitivity around GW200129_065458"
+	--title "GW detector sensitivity around GW200129_065458"
 title = Spectrum with three interferometers
 description =
 	This example shows the spectrum (power spectral density) of strain
@@ -127,8 +123,7 @@ description =
 [spectrum-hr]
 command =
 	spectrum
-	--gwosc
-	--ifo L1
+	--chan L1:GDS-CALIB_STRAIN
 	--start 1264315518
 	--duration 1024
 	--secpfft 64
@@ -145,8 +140,7 @@ description =
 [spectrogram]
 command =
 	spectrogram
-	--gwosc
-	--ifo H1
+	--chan H1:GDS-CALIB_STRAIN
 	--start 1264316116
 	--duration 32
 	--epoch 1264316116.4
@@ -159,8 +153,7 @@ description =
 [spectrogram-norm]
 command =
 	spectrogram
-	--gwosc
-	--ifo L1
+	--chan L1:GDS-CALIB_STRAIN
 	--start 1264315518
 	--duration 1024
 	--norm


### PR DESCRIPTION
This PR removes 2c9862e1199bb9cdd683596debb36eb79de42536 (cherry picked from ef3833224c5521b68b9e18d757e770770aaa9505) from the `release/3.0.x` branch. This is dependent on #1569 which is scheduled for inclusion first in [3.1.0](https://github.com/gwpy/gwpy/milestone/60).