### PR TITLE
Use class fixtures to download GWOSC data that is used many times

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -91,6 +91,7 @@ NDS2_GW150914_CHANNEL = "L1:DCS-CALIB_STRAIN_C02"
 GWOSC_GW150914_FRAMETYPE = "L1_LOSC_16_V1"
 GWOSC_GW150914 = 1126259462
 GWOSC_GW150914_SEGMENT = Segment(GWOSC_GW150914-2, GWOSC_GW150914+2)
+GWOSC_GW150914_SEGMENT_32 = Segment(GWOSC_GW150914-16, GWOSC_GW150914+16)
 GWOSC_GW150914_DQ_BITS = {
     'hdf5': [
         'data present',
@@ -151,6 +152,22 @@ class TestTimeSeries(_TestTimeSeriesBase):
             GWOSC_GW150914_IFO,
             *GWOSC_GW150914_SEGMENT,
             sample_rate=16384,
+        )
+
+    @pytest.fixture(scope="class")
+    @pytest_skip_network_error
+    def gw150914_h1_32(self):
+        return self.TEST_CLASS.fetch_open_data(
+            "H1",
+            *GWOSC_GW150914_SEGMENT_32,
+        )
+
+    @pytest.fixture(scope="class")
+    @pytest_skip_network_error
+    def gw150914_l1_32(self):
+        return self.TEST_CLASS.fetch_open_data(
+            "L1",
+            *GWOSC_GW150914_SEGMENT_32,
         )
 
     # -- test class functionality ---------------
@@ -1659,28 +1676,30 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert comp.name == '%s >= 2.0' % (array.name)
         assert (array == array).name == '{0} == {0}'.format(array.name)
 
-    @pytest_skip_network_error
-    def test_transfer_function(self):
-        tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
-        tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-        tf = tsh.transfer_function(tsl, fftlength=1.0, overlap=0.5)
+    def test_transfer_function(self, gw150914_h1_32, gw150914_l1_32):
+        tf = gw150914_h1_32.transfer_function(
+            gw150914_l1_32,
+            fftlength=1.0,
+            overlap=0.5,
+        )
         assert tf.df == 1 * units.Hz
         assert tf.frequencies[abs(tf).argmax()] == 516 * units.Hz
 
-    @pytest_skip_network_error
-    def test_coherence(self):
-        tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
-        tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-        coh = tsh.coherence(tsl, fftlength=1.0)
+    def test_coherence(self, gw150914_h1_32, gw150914_l1_32):
+        coh = gw150914_h1_32.coherence(
+            gw150914_l1_32,
+            fftlength=1.0,
+        )
         assert coh.df == 1 * units.Hz
         assert coh.frequencies[coh.argmax()] == 60 * units.Hz
 
-    @pytest_skip_network_error
-    def test_coherence_spectrogram(self):
-        tsh = TimeSeries.fetch_open_data('H1', 1126259446, 1126259478)
-        tsl = TimeSeries.fetch_open_data('L1', 1126259446, 1126259478)
-        cohsg = tsh.coherence_spectrogram(tsl, 4, fftlength=1.0)
-        assert cohsg.t0 == tsh.t0
+    def test_coherence_spectrogram(self, gw150914_h1_32, gw150914_l1_32):
+        cohsg = gw150914_h1_32.coherence_spectrogram(
+            gw150914_l1_32,
+            4,
+            fftlength=1.0,
+        )
+        assert cohsg.t0 == gw150914_h1_32.t0
         assert cohsg.dt == 4 * units.second
         assert cohsg.df == 1 * units.Hz
         tmax, fmax = numpy.unravel_index(cohsg.argmax(), cohsg.shape)


### PR DESCRIPTION
This PR abstracts some reused `TimeSeries.fetch_open_data` calls to class-level fixtures for the `TestTimeSeries` tests. This should speed up test execution when `GWPY_CACHE` is not set to something truthy.