### PR TITLE
Interpret list indices as in NumPy

### DIFF
--- a/gwpy/types/array.py
+++ b/gwpy/types/array.py
@@ -194,8 +194,6 @@ class Array(Quantity):
         return super().__getattribute__(attr)
 
     def __getitem__(self, item):
-        if isinstance(item, list):
-            item = tuple(item)
         new = super().__getitem__(item)
 
         # return scalar as a Quantity

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -125,10 +125,13 @@ def as_slice(slice_):
     if isinstance(slice_, (Integral, numpy.integer, type(None))):
         return slice(0, None, 1)
 
+    if isinstance(slice_, (list,)):
+        slice_ = numpy.array(slice_)
+
     if isinstance(slice_, (slice, numpy.ndarray)):
         return slice_
 
-    if isinstance(slice_, (list, tuple)):
+    if isinstance(slice_, (tuple,)):
         return tuple(map(as_slice, slice_))
 
     raise TypeError("Cannot format {!r} as slice".format(slice_))

--- a/gwpy/types/sliceutils.py
+++ b/gwpy/types/sliceutils.py
@@ -125,13 +125,13 @@ def as_slice(slice_):
     if isinstance(slice_, (Integral, numpy.integer, type(None))):
         return slice(0, None, 1)
 
-    if isinstance(slice_, (list,)):
+    if isinstance(slice_, list):
         slice_ = numpy.array(slice_)
 
     if isinstance(slice_, (slice, numpy.ndarray)):
         return slice_
 
-    if isinstance(slice_, (tuple,)):
+    if isinstance(slice_, tuple):
         return tuple(map(as_slice, slice_))
 
     raise TypeError("Cannot format {!r} as slice".format(slice_))

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -216,6 +216,16 @@ class TestArray2D(_TestSeries):
         utils.assert_array_equal(b.xindex, a.xindex[0:1])
         utils.assert_array_equal(b.yindex, a.yindex)
 
+    def test_two_index_arrays(self):
+        """Test that subsetting with two index arrays works correctly."""
+        # create an array with indices
+        rawa = numpy.arange(12).reshape((4, 3))
+        a = Array2D(rawa)
+        exp = numpy.array([3, 11])
+        ind1, ind2 = numpy.array([1, 3]), numpy.array([0, 2])
+        assert numpy.all(rawa[ind1, ind2] == exp)
+        assert numpy.all(a[ind1, ind2].value == exp)
+
     def test_is_compatible_yindex(self):
         """Check that irregular arrays are compatible if their yindexes match
         """

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -225,8 +225,8 @@ class TestArray2D(_TestSeries):
         a = Array2D(rawa)
         exp = numpy.array([3, 11])
         ind1, ind2 = numpy.array([1, 3]), numpy.array([0, 2])
-        assert testing.assert_array_equal(rawa[ind1, ind2], exp)
-        assert testing.assert_array_equal(a[ind1, ind2].value, exp)
+        testing.assert_array_equal(rawa[ind1, ind2], exp)
+        testing.assert_array_equal(a[ind1, ind2].value, exp)
 
     def test_is_compatible_yindex(self):
         """Check that irregular arrays are compatible if their yindexes match

--- a/gwpy/types/tests/test_array2d.py
+++ b/gwpy/types/tests/test_array2d.py
@@ -24,6 +24,7 @@ import pytest
 import numpy
 
 from astropy import units
+from numpy import testing
 
 from ...segments import Segment
 from ...testing import utils
@@ -217,14 +218,15 @@ class TestArray2D(_TestSeries):
         utils.assert_array_equal(b.yindex, a.yindex)
 
     def test_two_index_arrays(self):
-        """Test that subsetting with two index arrays works correctly."""
+        """Test that subsetting with two index arrays works correctly.
+        """
         # create an array with indices
         rawa = numpy.arange(12).reshape((4, 3))
         a = Array2D(rawa)
         exp = numpy.array([3, 11])
         ind1, ind2 = numpy.array([1, 3]), numpy.array([0, 2])
-        assert numpy.all(rawa[ind1, ind2] == exp)
-        assert numpy.all(a[ind1, ind2].value == exp)
+        assert testing.assert_array_equal(rawa[ind1, ind2], exp)
+        assert testing.assert_array_equal(a[ind1, ind2].value, exp)
 
     def test_is_compatible_yindex(self):
         """Check that irregular arrays are compatible if their yindexes match

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -187,10 +187,7 @@ class TestSeries(_TestArray):
         """
         indices = numpy.array([0, 1, len(array) - 1])
         lindices = [0, 1, len(array) - 1]
-        assert utils.assert_quantity_sub_equal(
-            array[indices].value,
-            array[lindices].value
-        )
+        utils.assert_quantity_sub_equal(array[indices], array[lindices])
 
     def test_single_getitem_not_created(self, array):
         """Test that array[i] does not return an object with a new _xindex."""

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -186,7 +186,7 @@ class TestSeries(_TestArray):
         """Test that __getitem__ works with list and numpy.array"""
         indices = numpy.array([0, 1, len(array) - 1])
         lindices = [0, 1, len(array) - 1]
-        assert numpy.all(array[indices] == array[lindices])
+        assert numpy.all(array[indices].value == array[lindices].value)
 
     def test_single_getitem_not_created(self, array):
         """Test that array[i] does not return an object with a new _xindex."""

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -182,9 +182,14 @@ class TestSeries(_TestArray):
         assert len(newarray) == len(newarray.value)
         assert len(newarray.value) == len(newarray.xindex)
 
+    def test_getitem_list_index(self, array):
+        """Test that __getitem__ works with list and numpy.array"""
+        indices = numpy.array([0, 1, len(array) - 1])
+        lindices = [0, 1, len(array) - 1]
+        assert numpy.all(array[indices] == array[lindices])
+
     def test_single_getitem_not_created(self, array):
         """Test that array[i] does not return an object with a new _xindex."""
-
         # check that there is no xindex when a single value is accessed
         with pytest.raises(AttributeError):
             array[0].xindex

--- a/gwpy/types/tests/test_series.py
+++ b/gwpy/types/tests/test_series.py
@@ -183,10 +183,14 @@ class TestSeries(_TestArray):
         assert len(newarray.value) == len(newarray.xindex)
 
     def test_getitem_list_index(self, array):
-        """Test that __getitem__ works with list and numpy.array"""
+        """Test that __getitem__ works with list and numpy.array.
+        """
         indices = numpy.array([0, 1, len(array) - 1])
         lindices = [0, 1, len(array) - 1]
-        assert numpy.all(array[indices].value == array[lindices].value)
+        assert utils.assert_quantity_sub_equal(
+            array[indices].value,
+            array[lindices].value
+        )
 
     def test_single_getitem_not_created(self, array):
         """Test that array[i] does not return an object with a new _xindex."""


### PR DESCRIPTION
Currently, lists provided as indices are interpreted as tuple, whereas in NumPy they are treated like numpy.array, i.e. advanced index arrays.
