### PR TITLE
Replace maya with dateparser in gwpy.time

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,6 +236,7 @@ doxylink = {
 # Intersphinx
 intersphinx_mapping = {
     'astropy': ('https://docs.astropy.org/en/stable/', None),
+    'dateparser': ('https://dateparser.readthedocs.io/en/stable/', None),
     'dateutil': ('https://dateutil.readthedocs.io/en/stable/', None),
     'dqsegdb2': ('https://dqsegdb2.readthedocs.io/en/stable/', None),
     # 'glue': ('https://docs.ligo.org/lscsoft/glue/', None),

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -47,6 +47,7 @@ GWpy has the following strict requirements:
    Name                Constraints
    ==================  ===========================
    |astropy|_          ``>=4.0``
+   |dateparser|_       ``>=1.1.4``
    |dqsegdb2|_
    |gwdatafind|_       ``>=1.1.0``
    |gwosc-mod|_        ``>=0.5.3``

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -6,6 +6,9 @@
 .. |CVMFS| replace:: CVMFS
 .. _CVMFS: https://cvmfs.readthedocs.io/
 
+.. |dateparser| replace:: `dateparser`
+.. _dateparser: https://dateparser.readthedocs.io
+
 .. |dateutil| replace:: `dateutil`
 .. _dateutil: https://dateutil.readthedocs.io
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
   "astropy >=4.3.0",
+  "dateparser >=1.1.4",
   "dqsegdb2",
   "gwdatafind >=1.1.0",
   "gwosc >=0.5.3",
@@ -83,11 +84,8 @@ docs = [
 # development environments
 dev = [
   "ciecplib",
-  # for maya to work, see https://github.com/scrapinghub/dateparser/pull/1067
-  "dateparser >=1.1.2",
   "lalsuite ; sys_platform != 'win32'",
   "lscsoft-glue ; sys_platform != 'win32'",
-  "maya ; python_version < '3.11'",
   "psycopg2",
   "pycbc >=1.13.4 ; sys_platform != 'win32'",
   "pymysql",


### PR DESCRIPTION
This  PR replaces all use of the `maya` module with `dateparser`.

`maya` is not actively maintained any more, while `dateparser` is, and is what `maya` calls out to anyway.