### PR TITLE
Add an upsample_repeat function that uses numpy.repeat to upsample

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1172,19 +1172,20 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert factor * upsamped.dx == gw150914.dx
         assert upsamped.x0 == upsamped.xindex[0]
 
-        # since numpy.arange, which is used when generating an index anew,
-        # lacks precision, we must use approximate assertion
+        # Unlike the values, the xindex is not repeat expanded.
+        # Since numpy.arange, which is used when generating an index anew,
+        # lacks precision, we must use approximate assertion.
         numpy.testing.assert_allclose(
             gw150914.xindex.value,
             upsamped.xindex[::factor].value
         )
 
         for j in range(len(gw150914)):
-            val = gw150914[j].value
+            val = gw150914.value[j]
             for fj in range(factor):
                 # Each index of input valj maps to an index factor * valj
                 upj = factor * j + fj  # index of each repeated sample
-                numpy.testing.assert_equal(val, upsamped[upj])
+                numpy.testing.assert_equal(val, upsamped.value[upj])
 
     def test_upsample_repeat_float_exception(self, gw150914):
         """Assert that upsampling by a non-integer factor raises a ValueError.

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1160,6 +1160,32 @@ class TestTimeSeries(_TestTimeSeriesBase):
             new = data.resample(data.sample_rate)
             assert data is new
 
+    def test_upsample_repeat_factor_3(self, gw150914):
+        """Test that repeat upsampling by a factor of 3 works as intended.
+        """
+        factor = 3
+        upsamped = gw150914.upsample_repeat(factor)
+        upsamped.xindex  # generate the x index
+        assert upsamped.sample_rate == factor * gw150914.sample_rate
+        for valj, val in enumerate(gw150914):
+            for fj in range(factor):
+                assert val == upsamped[factor * valj + fj]
+
+    def test_upsample_repeat_factor_3_xindex(self, gw150914):
+        """Test that repeat upsampling provides the correct xindex.
+        """
+        factor = 3
+        upsamped = gw150914.upsample_repeat(factor)
+        upsamped.xindex  # generate the x index
+        assert len(upsamped) == len(upsamped.xindex)
+
+    def test_upsample_repeat_exception(self, gw150914):
+        """Assert that non-integer factor raises a ValueError.
+        """
+        factor = 3.3
+        with pytest.raises(ValueError):
+            gw150914.upsample_repeat(factor)
+
     def test_rms(self, gw150914):
         rms = gw150914.rms(1.)
         assert rms.sample_rate == 1 * units.Hz

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1169,7 +1169,7 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert upsamped.sample_rate == factor * gw150914.sample_rate
         for valj, val in enumerate(gw150914):
             for fj in range(factor):
-                assert val == upsamped[factor * valj + fj]
+                numpy.testing.assert_equal(val, upsamped[factor * valj + fj])
 
     def test_upsample_repeat_factor_3_xindex(self, gw150914):
         """Test that repeat upsampling provides the correct xindex.

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1169,18 +1169,20 @@ class TestTimeSeries(_TestTimeSeriesBase):
         assert upsamped.sample_rate == factor * gw150914.sample_rate
         for valj, val in enumerate(gw150914):
             for fj in range(factor):
-                numpy.testing.assert_equal(val, upsamped[factor * valj + fj])
+                # Each index of input valj maps to an index factor * valj
+                upj = factor * valj + fj  # index of each repeated sample
+                numpy.testing.assert_equal(val, upsamped[upj])
 
     def test_upsample_repeat_factor_3_xindex(self, gw150914):
-        """Test that repeat upsampling provides the correct xindex.
+        """Test that a repeat upsampled (3X) timeseries has a correct xindex.
         """
         factor = 3
         upsamped = gw150914.upsample_repeat(factor)
         upsamped.xindex  # generate the x index
         assert len(upsamped) == len(upsamped.xindex)
 
-    def test_upsample_repeat_exception(self, gw150914):
-        """Assert that non-integer factor raises a ValueError.
+    def test_upsample_repeat_float_exception(self, gw150914):
+        """Assert that upsampling by a non-integer factor raises a ValueError.
         """
         factor = 3.3
         with pytest.raises(ValueError):

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -973,8 +973,6 @@ class TimeSeries(TimeSeriesBase):
             raise ValueError("Cannot upsample_repeat with non-integer factor.")
         repeat_inds = numpy.repeat(numpy.arange(len(self)), factor)
         new = self[repeat_inds]  # xindex should also be handled here
-        new.__metadata_finalize__(self)
-        new._unit = self.unit
         new.sample_rate = self.sample_rate * factor
         return new
 

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -20,6 +20,7 @@
 """
 
 import math
+import numbers
 import warnings
 
 import numpy
@@ -950,6 +951,32 @@ class TimeSeries(TimeSeriesBase):
             new._unit = self.unit
             new.sample_rate = rate
             return new
+
+    def upsample_repeat(self, factor):
+        """Upsample this TimeSeries by repeating elements by an integer factor.
+
+        This will return a new TimeSeries with a new sample_rate equal to the
+        previous one multiplied by factor.
+
+        Parameters
+        ----------
+        factor: `int`
+                The number of times to repeat each element
+
+        Returns
+        -------
+        TimeSeries
+            a new Series with the resampling applied, and the same
+            metadata
+        """
+        if not isinstance(factor, numbers.Integral):
+            raise ValueError("Cannot upsample_repeat with non-integer factor.")
+        repeat_inds = numpy.repeat(numpy.arange(len(self)), factor)
+        new = self[repeat_inds]  # xindex should also be handled here
+        new.__metadata_finalize__(self)
+        new._unit = self.unit
+        new.sample_rate = self.sample_rate * factor
+        return new
 
     def zpk(self, zeros, poles, gain, analog=True, unit='Hz', **kwargs):
         """Filter this `TimeSeries` by applying a zero-pole-gain filter

--- a/gwpy/timeseries/timeseries.py
+++ b/gwpy/timeseries/timeseries.py
@@ -961,7 +961,7 @@ class TimeSeries(TimeSeriesBase):
         Parameters
         ----------
         factor: `int`
-                The number of times to repeat each element
+            The number of times to repeat each element
 
         Returns
         -------


### PR DESCRIPTION
This should address https://github.com/gwpy/gwpy/issues/1673

In the absence of a reference for the correct name for this method of upsampling, I have named it after the repeat function in numpy.

I also have given it a separate interface instead of modifying TimeSeries.resample.