### PR TITLE
Fix the Zenodo RST utility module

### DIFF
--- a/gwpy/utils/sphinx/zenodo.py
+++ b/gwpy/utils/sphinx/zenodo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2018-2020)
+# Copyright (C) Cardiff University (2018-2023)
 #
 # This file is part of GWpy.
 #
@@ -17,89 +17,146 @@
 # along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
-import requests
 import sys
 
+import requests
 
-def parse_command_line():
-    parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('id', type=int, help='Zenodo ID for package')
-    parser.add_argument('-u', '--url', default='https://zenodo.org/',
-                        help='%(metavar)s to query')
-    parser.add_argument('-n', '--hits', default=10, type=int,
-                        help='number of versions to display')
-    parser.add_argument('-p', '--tag-prefix', default='v',
-                        help='prefix for git version tags')
-    parser.add_argument('-o', '--output-file', help='output file path')
-
-    if len(sys.argv) == 1:  # print --help message for no arguments
-        parser.print_help()
-        sys.exit(0)
-
-    return parser.parse_args()
+DEFAULT_ZENODO_URL = "https://zenodo.org"
+DEFAULT_HITS = 10
 
 
-def format_citations(zid, url='https://zenodo.org/', hits=10, tag_prefix='v'):
-    """Query and format a citations page from Zenodo entries
+def format_citations(
+    zid,
+    url=DEFAULT_ZENODO_URL,
+    hits=10,
+    tag_prefix="v",
+):
+    """Query and format a citations page from Zenodo entries.
 
     Parameters
     ----------
     zid : `int`, `str`
-        the Zenodo ID of the target record
+        The Zenodo ID (``conceptrecid``) of the parent target record.
 
     url : `str`, optional
-        the base URL of the Zenodo host, defaults to ``https://zenodo.org``
+        The base URL of the Zenodo host, defaults to ``https://zenodo.org``.
 
-    hist : `int`, optional
-        the maximum number of hits to show, default: ``10``
+    hits : `int`, optional
+        The maximum number of results to show, default: ``10``.
 
     tag_prefix : `str`, optional
-        the prefix for git tags. This is removed to generate the section
-        headers in the output RST
+        The prefix for git tags. This is removed to generate the section
+        headers in the output RST.
 
     Returns
     -------
     rst : `str`
-        an RST-formatted string of DOI badges with URLs
+        An RST-formatted string of DOI badges with URLs.
     """
     # query for metadata
-    url = ('{url}/api/records/?'
-           'page=1&'
-           'size={hits}&'
-           'q=conceptrecid:"{id}"&'
-           'sort=-version&'
-           'all_versions=True'.format(id=zid, url=url, hits=hits))
-    resp = requests.get(url)  # make the request
+    apiurl = f"{url.rstrip('/')}/api/records"
+    params = {
+        "q": f"conceptrecid:{zid}",
+        "allversions": True,
+        "sort": "version",
+        "page": 1,
+        "size": int(hits),
+    }
+    resp = requests.get(apiurl, params)  # make the request
     resp.raise_for_status()  # make sure it worked
-    metadata = resp.json()  # parse the response
+    records = resp.json()  # parse the response
 
     lines = []
-    for i, hit in enumerate(metadata['hits']['hits']):
-        version = hit['metadata']['version'][len(tag_prefix):]
-        lines.append('-' * len(version))
-        lines.append(version)
-        lines.append('-' * len(version))
-        lines.append('')
-        lines.append('.. image:: {badge}\n'
-                     '   :target: {doi}'.format(**hit['links']))
-        if i < hits - 1:
-            lines.append('')
+    for i, rec in enumerate(records["hits"]["hits"]):
+        # print RST-format header
+        version = str(rec['metadata']['version'])[len(tag_prefix):]
+        head = "-" * len(version)
+        lines.extend([
+            head,
+            version,
+            head,
+            "",
+        ])
 
-    return '\n'.join(lines)
+        # add DOI badge
+        badge = f"{url}/badge/doi/{rec['doi']}.svg"
+        lines.extend([
+            f".. image:: {badge}",
+            f"    :alt: {rec['title']} Zenodo DOI badge",
+            f"    :target: {rec['doi_url']}",
+        ])
+
+        # add break before next record
+        lines.append("")
+
+    return '\n'.join(lines).strip()
+
+
+# -- command-line usage ---------------
+
+def create_parser():
+    """Create an `argparse.ArgumentParser` for this tool.
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "id",
+        type=int,
+        help="Zenodo concept ID for package",
+    )
+    parser.add_argument(
+        "-u",
+        "--url",
+        default=DEFAULT_ZENODO_URL,
+        help="Base URL of API to query",
+    )
+    parser.add_argument(
+        "-n",
+        "--hits",
+        default=DEFAULT_HITS,
+        type=int,
+        help="Number of versions to display",
+    )
+    parser.add_argument(
+        "-p",
+        "--tag-prefix",
+        default="v",
+        help="Prefix for version tags",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        default="stdout",
+        help="Output file path",
+    )
+    return parser
+
+
+def main(args=None):
+    """Run this tool as a command-line script.
+    """
+    # parse arguments
+    parser = create_parser()
+    opts = parser.parse_args(args=args)
+
+    # generate RST
+    citing = format_citations(
+        opts.id,
+        url=opts.url,
+        hits=opts.hits,
+        tag_prefix=opts.tag_prefix,
+    )
+
+    # print
+    if opts.output_file in {None, "stdout"}:
+        f = sys.stdout
+    else:
+        f = open(opts.output_file, 'w')
+    with f:
+        print(citing, file=f)
 
 
 if __name__ == '__main__':
-    args = parse_command_line()
-
-    if args.output_file:
-        f = open(args.output_file, 'w')
-    else:
-        f = sys.stdout
-
-    citing = format_citations(args.id, url=args.url, hits=args.hits,
-                              tag_prefix=args.tag_prefix)
-
-    with f:
-        print(citing, file=f)
+    sys.exit(main())

--- a/gwpy/utils/tests/test_sphinx_zenodo.py
+++ b/gwpy/utils/tests/test_sphinx_zenodo.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2023)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwpy.utils.sphinx.zenodo`.
+"""
+
+import pytest
+
+import requests
+
+from ...testing.errors import pytest_skip_network_error
+from ..sphinx import zenodo as gwpy_zenodo
+
+GITHUB_RELEASE_API_URL = "https://api.github.com/repos/gwpy/gwpy/releases"
+
+# simplified output of zenodo API query (as of 18/Oct/2023)
+MOCK_ZENODO_API_JSON = {
+    "hits": {
+        "hits": [
+            {
+                "conceptdoi": "10.5281/zenodo.597016",
+                "conceptrecid": "597016",
+                "created": "2023-10-05T10:29:34.092078+00:00",
+                "doi": "10.5281/zenodo.8409995",
+                "doi_url": "https://doi.org/10.5281/zenodo.8409995",
+                "files": None,
+                "id": 8409995,
+                "links": None,
+                "metadata": {
+                    "title": "gwpy/gwpy: GWpy 3.0.7",
+                    "version": "v3.0.7",
+                },
+                "title": "gwpy/gwpy: GWpy 3.0.7",
+            },
+            {
+                "conceptdoi": "10.5281/zenodo.597016",
+                "conceptrecid": "597016",
+                "created": "2023-10-05T09:51:21.482810+00:00",
+                "doi": "10.5281/zenodo.8409892",
+                "doi_url": "https://doi.org/10.5281/zenodo.8409892",
+                "files": None,
+                "links": None,
+                "metadata": {
+                    "title": "gwpy/gwpy: GWpy 3.0.6",
+                    "version": "v3.0.6",
+                },
+                "title": "gwpy/gwpy: GWpy 3.0.6",
+            },
+        ],
+    },
+}
+MOCK_ZENODO_API_RST = """
+-----
+3.0.7
+-----
+
+.. image:: https://zenodo.example.com/badge/doi/10.5281/zenodo.8409995.svg
+    :alt: gwpy/gwpy: GWpy 3.0.7 Zenodo DOI badge
+    :target: https://doi.org/10.5281/zenodo.8409995
+
+-----
+3.0.6
+-----
+
+.. image:: https://zenodo.example.com/badge/doi/10.5281/zenodo.8409892.svg
+    :alt: gwpy/gwpy: GWpy 3.0.6 Zenodo DOI badge
+    :target: https://doi.org/10.5281/zenodo.8409892
+""".strip()
+
+
+@pytest.fixture
+@pytest_skip_network_error
+def latest():
+    """Get the latest release of GWpy from the GitHub API.
+    """
+    resp = requests.get(
+        GITHUB_RELEASE_API_URL,
+        params={"per_page": 1},
+    )
+    resp.raise_for_status()
+    return resp.json()[0]
+
+
+@pytest_skip_network_error
+def test_zenodo_format_citations_latest(latest):
+    """Check that :func:`gwpy.utils.sphinx.zenodo.format_citations` includes
+    the latest actual release in the output.
+    """
+    rst = gwpy_zenodo.format_citations(
+        597016,
+    )
+    latestversion = latest["tag_name"].lstrip("v")
+    latesthead = "-" * len(latestversion)
+    assert f"""
+{latesthead}
+{latestversion}
+{latesthead}""".strip() in rst
+
+
+def test_zenodo_format_citations_mock(requests_mock):
+    """Check that :func:`gwpy.utils.sphinx.zenodo.format_citations` correctly
+    formats the JSON response it gets from Zenodo.
+
+    This uses a mocked API response based on the actual response as of
+    18/Oct/2023.
+    """
+    # mock
+    requests_mock.get(
+        "https://zenodo.example.com/api/records",
+        json=MOCK_ZENODO_API_JSON,
+    )
+
+    # run
+    rst = gwpy_zenodo.format_citations(
+        597016,
+        url="https://zenodo.example.com",
+    )
+
+    # check
+    assert rst.strip() == MOCK_ZENODO_API_RST.strip()
+
+
+def test_zenodo_main(requests_mock, tmp_path):
+    """Check that the command-line entry point for `gwpy.utils.sphinx.zenodo`
+    works correctly (with a mocked API response).
+    """
+    # mock
+    requests_mock.get(
+        "https://zenodo.example.com/api/records",
+        json=MOCK_ZENODO_API_JSON,
+    )
+
+    # run
+    out = tmp_path / "tmp.txt"
+    gwpy_zenodo.main([
+        "597016",
+        "--url", "https://zenodo.example.com",
+        "--output-file", str(out),
+    ])
+
+    # check
+    assert out.read_text().strip() == MOCK_ZENODO_API_RST.strip()


### PR DESCRIPTION
This PR fixes the `gwpy.utils.sphinx.zenodo` API interface module uses to populate the `citing` page on the online docs (e.g. [here](https://gwpy.github.io/docs/latest/citing/)), which was broken by a recent (apparently undocumented) Zenodo API change (see https://github.com/zenodo/zenodo/issues/2483).

I also took the opportunity to refactor the module to improve the layout, and added a test module.