### PR TITLE
Fix a bug with DataQualityFlag subtraction & revise a few tests

### DIFF
--- a/docs/segments/index.rst
+++ b/docs/segments/index.rst
@@ -111,7 +111,7 @@ Union (``|``)
 
    >>> a | b
 
-returns the union of both the `~DataQualityFlag.known` and
+returns the intersection of both the `~DataQualityFlag.known` and
 `~DataQualityFlag.active` segment lists, e.g::
 
    >>> print(a | b)

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -902,7 +902,7 @@ class DataQualityFlag(object):
     def __isub__(self, other):
         """Subtract the ``other`` `DataQualityFlag` from this one in-place.
         """
-        self.known &= other.known
+        self.known |= other.known
         self.active -= other.active
         self.active &= self.known
         return self

--- a/gwpy/segments/flag.py
+++ b/gwpy/segments/flag.py
@@ -902,7 +902,7 @@ class DataQualityFlag(object):
     def __isub__(self, other):
         """Subtract the ``other`` `DataQualityFlag` from this one in-place.
         """
-        self.known |= other.known
+        self.known &= other.known
         self.active -= other.active
         self.active &= self.known
         return self

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -349,8 +349,8 @@ class TestDataQualityFlag(object):
 
         diff = a - b
 
-        expected_known = _as_segmentlist((0, 2), (3, 7), (8, 10))
-        expected_active = _as_segmentlist((1, 2), (3, 4))
+        expected_known = _as_segmentlist((3, 7))
+        expected_active = _as_segmentlist((3, 4))
 
         expected_diff = self.TEST_CLASS(
             active=expected_active,

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -602,8 +602,8 @@ class TestDataQualityDict(object):
         a = instance.copy()
         a &= reverse
         keys = list(a.keys())
-        utils.assert_flag_equal(a[keys[0]],
-                                instance[keys[0]] & reverse[keys[1]])
+        for key in keys:
+            utils.assert_flag_equal(a[key], instance[key] & reverse[key])
 
     def test_and(self, instance, reverse):
         a = instance.copy()
@@ -614,8 +614,8 @@ class TestDataQualityDict(object):
         a = instance.copy()
         a |= reverse
         keys = list(a.keys())
-        utils.assert_flag_equal(a[keys[0]],
-                                instance[keys[0]] | reverse[keys[1]])
+        for key in keys:
+            utils.assert_flag_equal(a[key], instance[key] | reverse[key])
 
     def test_or(self, instance, reverse):
         a = instance.copy()
@@ -626,8 +626,8 @@ class TestDataQualityDict(object):
         a = instance.copy()
         a -= reverse
         keys = list(a.keys())
-        utils.assert_flag_equal(a[keys[0]],
-                                instance[keys[0]] - reverse[keys[1]])
+        for key in keys:
+            utils.assert_flag_equal(a[key], instance[key] - reverse[key])
 
     def test_sub(self, instance, reverse):
         a = instance.copy(deep=True)

--- a/gwpy/segments/tests/test_flag.py
+++ b/gwpy/segments/tests/test_flag.py
@@ -329,6 +329,36 @@ class TestDataQualityFlag(object):
         utils.assert_segmentlist_equal(x.active, a.known & ~a.active)
         utils.assert_segmentlist_equal(x.known, a.known)
 
+    def test_difference_simple(self):
+        """Test that subtract works as intended for a simple case.
+
+        Tests regression against https://github.com/gwpy/gwpy/issues/1700
+
+        Returns
+        -------
+
+        """
+        known1 = _as_segmentlist((0, 2), (3, 7))
+        active1 = _as_segmentlist((1, 2), (3, 4), (5, 7))
+
+        known2 = _as_segmentlist((3, 7), (8, 10))
+        active2 = _as_segmentlist((4, 7), (9, 10))
+
+        a = self.TEST_CLASS(active=active1, known=known1)
+        b = self.TEST_CLASS(active=active2, known=known2)
+
+        diff = a - b
+
+        expected_known = _as_segmentlist((0, 2), (3, 7), (8, 10))
+        expected_active = _as_segmentlist((1, 2), (3, 4))
+
+        expected_diff = self.TEST_CLASS(
+            active=expected_active,
+            known=expected_known
+        )
+
+        utils.assert_flag_equal(diff, expected_diff)
+
     def test_coalesce(self):
         flag = self.create()
         flag.coalesce()


### PR DESCRIPTION
This fixes a bug in DataQualityFlag subtraction (https://github.com/gwpy/gwpy/issues/1700) documentation and improves the test for it.

This also changes a few other test assertions in DataQualityDict which I believe were not testing correct elements.

E.g.

```
    def __isub__(self, other):
        for key, value in other.items():
            if key in self:
                self[key] -= value
        return self
```

Subtraction is based on keys. However, the tests were testing on order, which was not the same thing.