### PR TITLE
Run apt-get update before apt-get install in CI jobs

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -81,7 +81,13 @@ jobs:
 
     - name: Install system packages for experimental dependencies
       if: matrix.experimental == true
-      run: sudo apt-get -y -q install libkrb5-dev
+      run: |
+        # update repos
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -y -q -q update
+        # install apt requirements
+        sudo DEBIAN_FRONTEND=noninteractive apt-get -y -q install \
+            libkrb5-dev \
+        ;
 
     - name: Install GWpy and dependencies
       run: python -m pip install .[${{ matrix.extras }}] ${{ matrix.pip-opts }}


### PR DESCRIPTION
This PR attempts to fix the current failures in the 'experimental' dependencies CI job that is failing to find debian packages to install.