### PR TITLE
Add support for a minimum gap when appending timeseries

### DIFF
--- a/gwpy/timeseries/core.py
+++ b/gwpy/timeseries/core.py
@@ -1620,7 +1620,7 @@ class TimeSeriesBaseList(list):
         del self[i:]
         return self
 
-    def join(self, pad=None, gap=None):
+    def join(self, pad=None, gap=None, min_gap=None):
         """Concatenate all of the elements of this list into a single object
 
         Parameters
@@ -1654,7 +1654,7 @@ class TimeSeriesBaseList(list):
         self.sort(key=lambda t: t.epoch.gps)
         out = self[0].copy()
         for series in self[1:]:
-            out.append(series, gap=gap, pad=pad)
+            out.append(series, gap=gap, pad=pad, min_gap=min_gap)
         return out
 
     def __getslice__(self, i, j):

--- a/gwpy/types/series.py
+++ b/gwpy/types/series.py
@@ -738,7 +738,8 @@ class Series(Array):
                  % (self.dtype, other.dtype))
         return True
 
-    def append(self, other, inplace=True, pad=None, gap=None, resize=True):
+    def append(self, other, inplace=True, pad=None, gap=None,
+               resize=True, min_gap=None):
         """Connect another series onto the end of the current one.
 
         Parameters
@@ -786,6 +787,8 @@ class Series(Array):
             gap = 'raise' if pad is None else 'pad'
         if pad is None and gap == 'pad':
             pad = 0.
+        if min_gap is None:
+            min_gap = self.dx.value
 
         # check metadata
         self.is_compatible(other)
@@ -797,7 +800,7 @@ class Series(Array):
             if gap == 'pad':
                 ngap = floor(
                     (other.xspan[0] - self.xspan[1]) / self.dx.value + 0.5)
-                if ngap < 1:
+                if ngap < 1 and other.xspan[0] - self.xspan[1] < min_gap:
                     raise ValueError(
                         "Cannot append {0} that starts before this one:\n"
                         "    {0} 1 span: {1}\n    {0} 2 span: {2}".format(


### PR DESCRIPTION
This PR add support for the `min_gap` argument to the `series.append()` and `TimeSeriesList.join()` functions. The reason for this additional argument is how the `append()` function checks if two series are continuous. Updating the `append()` function in this way would make it significantly easier for the LIGO summary pages to display range data from only times during observing mode. 

Currently, `append()` assumes that if the gap between two series is less than `dx` from the series, then the two series overlap. In general, this behavior is desired (and would still be the default behavior). However, if the user has downsampled their data, it is possible that the user does intend to append two series that have a gap smaller than `dx`. The `min_gap` argument supports this behavior by allowing the user to specify a minimum gap that will still be considered discontinuous. 

An example where this appeared is dealing with trend data that was further resampled. The input time series had `dt = 60s`, and then the data was further downsampled so that `dt = 300s`. This meant that if there was a data gap less than 5 minutes long, attempting to append these two time series was not possible. In this case, the user would want to set `min_gap=60`.

This PR still needs to include updates to the code documentation, but I wanted to start the PR to receive feedback.