### PR TITLE
Drop `HAS_TEX` for faster startup time

### DIFF
--- a/gwpy/plot/tests/test_tex.py
+++ b/gwpy/plot/tests/test_tex.py
@@ -39,6 +39,7 @@ def test_has_tex_missing_exe():
     """Test that `gwpy.plot.tex.has_tex` returns `False` when
     any one of the necessary executables is missing.
     """
+    plot_tex.has_tex.cache_clear()
     assert not plot_tex.has_tex()
 
 
@@ -47,6 +48,7 @@ def test_has_tex_bad_latex(_):
     """Test that `gwpy.plot.tex.has_tex` returns `False` when
     the LaTeX figure fails to render.
     """
+    plot_tex.has_tex.cache_clear()
     assert not plot_tex.has_tex()
 
 
@@ -57,6 +59,7 @@ def test_has_tex_true(_which_, _test_usetex):
     all of the necessary executables are found, and the LaTeX figure
     doesn't raise an exception.
     """
+    plot_tex.has_tex.cache_clear()
     assert plot_tex.has_tex()
 
 

--- a/gwpy/plot/tex.py
+++ b/gwpy/plot/tex.py
@@ -21,6 +21,7 @@
 """
 
 import re
+from functools import lru_cache
 from shutil import which
 
 __author__ = "Duncan Macleod <duncan.macleod@ligo.org>"
@@ -44,6 +45,7 @@ def _test_usetex():
     pyplot.close(fig)
 
 
+@lru_cache(maxsize=None)
 def has_tex():
     """Returns whether tex is installed on this system
 
@@ -68,8 +70,6 @@ def has_tex():
 
     return True
 
-
-HAS_TEX = has_tex()
 
 # -- tex formatting -----------------------------------------------------------
 

--- a/gwpy/testing/fixtures.py
+++ b/gwpy/testing/fixtures.py
@@ -30,7 +30,7 @@ import numpy
 
 from matplotlib import rc_context
 
-from ..plot.tex import HAS_TEX
+from ..plot.tex import has_tex
 from ..timeseries import TimeSeries
 from ..utils.decorators import deprecated_function
 from .utils import TemporaryFilename
@@ -70,7 +70,7 @@ def _test_usetex():
 
 
 SKIP_TEX = pytest.mark.skipif(
-    not HAS_TEX or not _test_usetex(),
+    not has_tex() or not _test_usetex(),
     reason='TeX is not available',
 )
 


### PR DESCRIPTION
Hello :wave: I have noticed that a significant part of the startup time of `gwpy` comes from the execution of `has_tex` to store the result in `HAS_TEX`, which is never used later on.

In this PR, I deleted `HAX_TEX` and cached the result of `has_tex` in case it would be necessary to call it several times. It reduces the startup time by about 2 seconds which could be huge for some applications.

#### Before

```console
user@host:~ $ time python -c 'from gwpy.timeseries import TimeSeries'
real	0m3,381s
user	0m2,600s
sys	0m2,091s
```

#### After

```console
user@host:~ $ time python -c 'from gwpy.timeseries import TimeSeries'
real	0m1,360s
user	0m1,430s
sys	0m1,419s
```