### PR TITLE
Avoid python-framel 8.46.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dev = [
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda = [
-  "python-framel >=8.40.1",
+  "python-framel >=8.40.1,!=8.46.0",
   "python-ldas-tools-framecpp ; sys_platform != 'win32'",
   "python-nds2-client",
 ]


### PR DESCRIPTION
This PR patches the metadata to avoid installing GWpy alongside `python-framel` 8.46.0, see https://git.ligo.org/virgo/virgoapp/Fr/-/issues/8.