### PR TITLE
Remove all use of distutils

### DIFF
--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -23,7 +23,6 @@ import os.path
 import subprocess
 import tempfile
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 from importlib import import_module
 from itertools import zip_longest
 from pathlib import Path
@@ -83,8 +82,9 @@ def skip_missing_dependency(module):  # pragma: no cover
     "be removed in GWpy 3.1.0",
 ))
 def module_older_than(module, minversion):  # pragma: no cover
+    from packaging.version import Version
     mod = import_module(module)
-    return LooseVersion(mod.__version__) < LooseVersion(minversion)
+    return Version(mod.__version__) < Version(minversion)
 
 
 @deprecated_function(message=(

--- a/gwpy/utils/shell.py
+++ b/gwpy/utils/shell.py
@@ -20,7 +20,6 @@
 """
 
 import warnings
-from distutils.spawn import find_executable
 from subprocess import (Popen, PIPE, CalledProcessError)
 
 from .decorators import deprecated_function
@@ -52,7 +51,8 @@ def which(program):
     ValueError
         if not executable program is found
     """
-    exe = find_executable(program)
+    from shutil import which
+    exe = which(program)
     if exe is None:
         raise ValueError("No executable '%s' found in PATH" % program)
     return exe

--- a/gwpy/utils/tests/test_shell.py
+++ b/gwpy/utils/tests/test_shell.py
@@ -20,9 +20,9 @@
 """
 
 import platform
+import shutil
 import subprocess
 import sys
-from distutils.spawn import find_executable
 
 import pytest
 
@@ -72,6 +72,6 @@ def test_shell_call_error_warn():
 
 def test_which():
     with pytest.warns(DeprecationWarning):
-        assert shell.which('python') == find_executable('python')
+        assert shell.which('python') == shutil.which('python')
     with pytest.raises(ValueError), pytest.warns(DeprecationWarning):
         shell.which('gwpy-no-executable')


### PR DESCRIPTION
This PR excises all use of the late `distutils` Python standard library module.