### PR TITLE
Replace datetime.utcnow() with datetime.now(UTC)

### DIFF
--- a/gwpy/time/_tconvert.py
+++ b/gwpy/time/_tconvert.py
@@ -223,7 +223,11 @@ def from_gps(gps):
 # special case strings
 
 def _now():
-    return datetime.datetime.utcnow().replace(microsecond=0)
+    try:
+        now = datetime.datetime.now(datetime.UTC)
+    except AttributeError:  # python < 3.11
+        now = datetime.datetime.utcnow()
+    return now.replace(microsecond=0)
 
 
 def _today():


### PR DESCRIPTION
This PR replaces a call to `datetime.datetime.utcnow()` with the equivalent call to `datetime.datetime.now()`; the former is [deprecated](https://docs.python.org/3/whatsnew/3.12.html#deprecated) as of Python 3.12.