### PR TITLE
Add aliases for LIGO and Virgo's 'time' units

### DIFF
--- a/gwpy/detector/tests/test_units.py
+++ b/gwpy/detector/tests/test_units.py
@@ -39,6 +39,8 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
     ('degrees_C', units.Unit('Celsius')),
     ('DegC', units.Unit('Celsius')),
     ('degrees_F', units.Unit('Fahrenheit')),
+    ('time', units.second),  # LIGO default time 'unit'
+    ('Time (sec)', units.second),  # Virgo default time 'unit'
 ])
 def test_parse_unit(arg, unit):
     assert parse_unit(arg, parse_strict='silent') == unit

--- a/gwpy/detector/tests/test_units.py
+++ b/gwpy/detector/tests/test_units.py
@@ -41,6 +41,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
     ('degrees_F', units.Unit('Fahrenheit')),
     ('time', units.second),  # LIGO default time 'unit'
     ('Time (sec)', units.second),  # Virgo default time 'unit'
+    ('Seconds', units.second),  # GWOSC default time 'unit'
 ])
 def test_parse_unit(arg, unit):
     assert parse_unit(arg, parse_strict='silent') == unit

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -164,6 +164,13 @@ for unit, aliases in [
     (units.Unit('ct'), ('counts',)),
     (units.Unit('Celsius'), ('Degrees_C', 'DegC')),
     (units.Unit('Fahrenheit'), ('Degrees_F', 'DegF')),
+    # GW observatories like to record 'time' as the unit
+    (units.Unit('second'), (
+        'time',
+        'time [s]',
+        'Time [sec]',
+        'Time (sec)',
+    )),
 ]:
     unit.names.extend(aliases)
     for alias in aliases:

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -170,6 +170,7 @@ for unit, aliases in [
         'time [s]',
         'Time [sec]',
         'Time (sec)',
+        'Seconds',  # GWOSC
     )),
 ]:
     unit.names.extend(aliases)

--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -161,9 +161,9 @@ units.add_enabled_units(units_imperial)
 # 1) alternative names
 registry = units.get_current_unit_registry().registry
 for unit, aliases in [
-        (units.Unit('ct'), ('counts',)),
-        (units.Unit('Celsius'), ('Degrees_C', 'DegC')),
-        (units.Unit('Fahrenheit'), ('Degrees_F', 'DegF')),
+    (units.Unit('ct'), ('counts',)),
+    (units.Unit('Celsius'), ('Degrees_C', 'DegC')),
+    (units.Unit('Fahrenheit'), ('Degrees_F', 'DegF')),
 ]:
     unit.names.extend(aliases)
     for alias in aliases:

--- a/gwpy/plot/gps.py
+++ b/gwpy/plot/gps.py
@@ -164,8 +164,13 @@ class GPSMixin(object):
         """
         if not self.unit:
             return None
-        name = sorted(self.unit.names, key=len)[-1]
-        return name + "s"  # pluralise
+        try:
+            name = self.unit.long_names[0]
+        except IndexError:
+            name = self.unit.name
+        if len(name) > 1:
+            return name + "s"  # pluralise for humans
+        return name
 
     def get_scale(self):
         """The scale (in seconds) of the current GPS unit.

--- a/gwpy/plot/tests/test_gps.py
+++ b/gwpy/plot/tests/test_gps.py
@@ -79,6 +79,7 @@ class TestGPSMixin(object):
     @pytest.mark.parametrize('unit, name', [
         (None, None),
         ('second', 'seconds'),
+        (Unit('sday'), 'sdays'),  # no long_name
     ])
     def test_get_unit_name(self, unit, name):
         mix = self.TYPE(unit=unit)


### PR DESCRIPTION
This PR adds unit aliases for the common 'time'-like unit strings LIGO and Virgo like to use as the `unitX` attribute for `FrVect` structures in GWF (they should just use 's'; 'time' is a dimension, not a unit).