### PR TITLE
Read the unitX from a GWF with frameCPP

### DIFF
--- a/gwpy/timeseries/io/gwf/framecpp.py
+++ b/gwpy/timeseries/io/gwf/framecpp.py
@@ -401,6 +401,7 @@ def read_frvect(vect, epoch, start, end, name=None, series_class=TimeSeries):
     dim = vect.GetDim(0)
     dx = dim.dx
     x0 = dim.startX
+    xunit = dim.GetUnitX() or None
 
     # start and end GPS times of this FrVect
     dimstart = epoch + x0
@@ -428,8 +429,16 @@ def read_frvect(vect, epoch, start, end, name=None, series_class=TimeSeries):
     unit = vect.GetUnitY() or None
 
     # create array
-    series = series_class(arr, t0=dimstart+nxstart*dx, dt=dx, name=name,
-                          channel=name, unit=unit, copy=False)
+    series = series_class(
+        arr,
+        t0=dimstart+nxstart*dx,
+        dt=dx,
+        name=name,
+        channel=name,
+        xunit=xunit,
+        unit=unit,
+        copy=False,
+    )
 
     # add information to channel
     series.channel.sample_rate = series.sample_rate.value


### PR DESCRIPTION
This PR patches the frameCPP GWF timeseries reader to actually use the `unitX` attribute stored in the FrVect structure for a given channel in a GWF.

Depends on #1721.