### PR TITLE
Allow localhost sockets during dist testing

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -118,6 +118,7 @@ jobs:
             --cov gwpy \
             --cov-report=xml \
             --disable-socket \
+            --allow-hosts=127.0.0.1 \
             --junitxml=pytest.xml \
             --pyargs gwpy \
         ;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda = [
+  "lxml !=4.9.1 ; sys_platform == 'win32'",
   "python-framel >=8.40.1,!=8.46.0",
   "python-ldas-tools-framecpp ; sys_platform != 'win32'",
   "python-nds2-client",


### PR DESCRIPTION
~This PR adds the `--allow-unix-socket` to the `dist` CI jobs so that `asyncio` works with 'self-sockets' (required by the latest release of `freezegun`).~

EDIT: for obvious reasons this solution doesn't work on Windows, so now...

This PR adds `--allow-hosts=127.0.0.1` to the `dist` CI jobs so that `asyncio` works with 'self-sockets' (required by the latest release of `freezegun`).