### PR TITLE
Add support for parsing default GWF api from GWPY_FRAME_LIBRARY environment variable

### DIFF
--- a/docs/env.rst
+++ b/docs/env.rst
@@ -1,9 +1,55 @@
+.. _gwpy-env:
+
 #####################################
 Configuring GWpy from the environment
 #####################################
 
 GWpy can be configured by setting environment variables at run time.
-Each of the variables are boolean switches, meaning they just tell GWpy to
+
+.. _gwpy-env-variables:
+
+=====================
+Environment variables
+=====================
+
+The following variables are understood:
+
+.. list-table:: GWpy environment variables
+    :header-rows: 1
+
+    * - Variable
+      - Type
+      - Default
+      - Purpose
+    * - ``GWPY_CACHE``
+      - :ref:`Bool <gwpy-env-bool>`
+      - `False`
+      - Whether to cache downloaded files from GWOSC to prevent
+        repeated downloads
+    * - ``GWPY_FRAME_LIBRARY``
+      - String
+      - `False`
+      - The library to prefer when reading :ref:`GWF <gwpy-timeseries-io-gwf`
+        data, one of ``"FrameCPP"``, ``"FrameL"``, ``"LALFrame"``
+        (case insensitive)
+    * - ``GWPY_RCPARAMS``
+      - :ref:`Bool <gwpy-env-bool>`
+      - `False`
+      - Whether to update `matplotlib.rcParams` with custom GWpy defaults
+        for rendering images
+    * - ``GWPY_USETEX``
+      - :ref:`Bool <gwpy-env-bool>`
+      - `False`
+      - Whether to use LaTeX when rendering images,
+        only used when ``GWPY_RCPARAMS`` is `True`
+
+.. _gwpy-env-bool:
+
+=================
+Boolean variables
+=================
+
+Many of the variables are boolean switches, meaning they just tell GWpy to
 do something, or not to do something. The following values match as `True`:
 
 - ``'y'``
@@ -20,19 +66,3 @@ And these match as `False`:
 
 The matching is **case-independent**, so, for example, ``'TRUE'`` will
 match as `True`.
-
-The following variables are defined:
-
-+---------------------+---------+---------------------------------------------+
-| Variable            | Default | Purpose                                     |
-+=====================+=========+=============================================+
-| ``GWPY_CACHE``      | `False` | Whether to cache downloaded files from      |
-|                     |         | GWOSC to prevent repeated downloads         |
-+---------------------+---------+---------------------------------------------+
-| ``GWPY_RCPARAMS``   | `True`  | Whether to update `matplotlib.rcParams`     |
-|                     |         | with custom GWpy defaults for rendering     |
-|                     |         | images                                      |
-+---------------------+---------+---------------------------------------------+
-| ``GWPY_USETEX``     | `False` | Whether to use LaTeX when rendering images, |
-|                     |         | only used when ``GWPY_RCPARAMS`` is `True`  |
-+---------------------+---------+---------------------------------------------+

--- a/gwpy/timeseries/io/gwf/__init__.py
+++ b/gwpy/timeseries/io/gwf/__init__.py
@@ -33,6 +33,7 @@ on a system.
 """
 
 import importlib
+import os
 
 import numpy
 
@@ -116,11 +117,28 @@ def import_gwf_library(library, package=__package__):
 
 
 def get_default_gwf_api():
-    """Return the preferred GWF library
+    """Return the preferred GWF library.
+
+    This can be configured via the ``GWPY_FRAME_LIBRARY`` environment
+    variable, which can be set to the name of any of the interface modules
+    defined under `gwpy.timeseres.io.gwf`:
+
+    - ``"framecpp"``
+    - ``"framel"``
+    - ``"lalframe"``
+
+    Otherwise that list is manually searched in the order given above.
 
     Examples
     --------
-    If you have |LDAStools.frameCPP|_ installed:
+    If the environment variable ``GWPY_FRAME_LIBRARY`` is set:
+
+    >>> os.environ["GWPY_FRAME_LIBRARY"] = "FrameL"
+    >>> from gwpy.timeseries.io.gwf import get_default_gwf_api
+    >>> get_default_gwf_api()
+    'framel'
+
+    Or, if you have |LDAStools.frameCPP|_ installed:
 
     >>> from gwpy.timeseries.io.gwf import get_default_gwf_api
     >>> get_default_gwf_api()
@@ -135,9 +153,10 @@ def get_default_gwf_api():
 
     >>> get_default_gwf_api()
     ImportError: no GWF API available, please install a third-party GWF
-    library (framecpp, lalframe) and try again
+    library (framecpp, framel, lalframe) and try again
     """
-    for lib in APIS:
+    default = (os.getenv("GWPY_FRAME_LIBRARY") or APIS[0]).lower()
+    for lib in (default, *APIS):
         try:
             import_gwf_library(lib)
         except ImportError:

--- a/gwpy/timeseries/tests/test_io_gwf.py
+++ b/gwpy/timeseries/tests/test_io_gwf.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2023)
+#
+# This file is part of GWpy.
+#
+# GWpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GWpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GWpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwpy.timeseries.io.gwf`.
+"""
+
+import os
+from unittest import mock
+
+import pytest
+
+from ..io import gwf as ts_io_gwf
+
+
+@mock.patch.dict("os.environ")
+@pytest.mark.requires("framel")  # need at least one library
+def test_get_default_gwf_api():
+    """Test that :func:`get_default_gwf_api` returns a sensible value.
+    """
+    os.environ.pop("GWPY_FRAME_LIBRARY", None)
+    assert ts_io_gwf.get_default_gwf_api() in ts_io_gwf.APIS
+
+
+@mock.patch.dict("os.environ")
+@pytest.mark.parametrize("library", [
+    pytest.param('LALFrame', marks=pytest.mark.requires("lalframe")),
+    pytest.param('FrameCPP', marks=pytest.mark.requires("LDAStools.frameCPP")),
+    pytest.param('FrameL', marks=pytest.mark.requires("framel")),
+])
+def test_get_default_gwf_api_environ(library):
+    os.environ["GWPY_FRAME_LIBRARY"] = library
+    assert ts_io_gwf.get_default_gwf_api() == library.lower()
+
+
+@mock.patch.dict("os.environ")
+@pytest.mark.requires("framel")  # need at least one library
+def test_get_default_gwf_api_environ_bad():
+    """Test that :func:`get_default_gwf_api_environ` returns a valid value
+    even when the environment variable has a bad one.
+    """
+    os.environ["GWPY_FRAME_LIBRARY"] = "blahblahblah"
+    assert ts_io_gwf.get_default_gwf_api() in ts_io_gwf.APIS


### PR DESCRIPTION
This PR adds support for parsing the preferred (default) GWF API from the `GWPY_FRAME_LIBRARY` environment variables, allowing users to override the default search order.

Closes #1720.