### PR TITLE
Add Python 3.12 conda CI job

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -42,6 +42,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     runs-on: ${{ matrix.os }}-latest
 
     # this is needed for conda environments to activate automatically


### PR DESCRIPTION
This PR extends #1714 by adding a Conda-based Python 3.12 CI build/test job.