### PR TITLE
Change coherence unit to dimensionless

### DIFF
--- a/gwpy/signal/spectral/_scipy.py
+++ b/gwpy/signal/spectral/_scipy.py
@@ -23,6 +23,7 @@ import numpy
 import warnings
 
 import scipy.signal
+from astropy import units
 
 from ...frequencyseries import FrequencySeries
 from ._utils import scale_timeseries_unit
@@ -243,5 +244,5 @@ def coherence(timeseries, other, segmentlength, downsample=None,
         sdfunc=scipy.signal.coherence,
         **kwargs,
     )
-    out.override_unit("coherence")
+    out.override_unit(units.dimensionless_unscaled)
     return out


### PR DESCRIPTION
Coherence between time series should be a dimensionless number from 0 to 1 (in my understanding), however in GWpy a fictional unit of "coherence" is assigned. This results in `UnitConversionError` in any arithmetic involving coherence and unitless quantities. Such as this example code:

```python
from gwpy.timeseries import TimeSeries
from numpy import random
ts1 = TimeSeries(random.random(1000), sample_rate=100, unit='m')
ts2 = TimeSeries(random.random(1000), sample_rate=100, unit='m')
coh = ts1.coherence(ts2)
# line below will cause UnitConversionError
print(1.0-coh)
```

This pull request instead forces the unit to be `dimensionless_unscaled`, which does not cause this error.