### PR TITLE
Add HoftOnline as a preferred frametype

### DIFF
--- a/gwpy/io/datafind.py
+++ b/gwpy/io/datafind.py
@@ -65,6 +65,7 @@ GRB_TYPE = re.compile(r'^(?!.*_GRB\d{6}([A-Z])?$)')  # *_GRBYYMMDD{A}
 HIGH_PRIORITY_TYPE = re.compile("({})".format("|".join((
     r'\A[A-Z]\d_HOFT_C\d\d(_T\d{7}_v\d)?\Z',  # X1_HOFT_CXY
     r'\AV1Online\Z',
+    r'\AHoftOnline\Z',
     r'\AV1O[0-9]+([A-Z]+)?Repro[0-9]+[A-Z]+\Z',  # V1OXReproXY
 ))))
 LOW_PRIORITY_TYPE = re.compile("({})".format("|".join((


### PR DESCRIPTION
This PR adds `HoftOnline` as one of the `HIGH_PRIORITY_TYPE` frametypes in `gwpy.io.datafind`. 

The "standard" Virgo strain frametype has changed in O4 from `V1Online` to `HoftOnline`, but it not yet updated in `gwpy`. 

@jacobgolomb noted that this issue prevents `bilby_pipe` from automatically identifying the correct Virgo frametype to use in O4. 