### PR TITLE
Add git to conda deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev = [
 # conda packages for development
 # NOTE: this isn't a valid extra to install with pip
 conda = [
+  "git",
   "lxml !=4.9.1 ; sys_platform == 'win32'",
   "python-framel >=8.40.1,!=8.46.0",
   "python-ldas-tools-framecpp ; sys_platform != 'win32'",


### PR DESCRIPTION
This MR adds `git` to the `conda` extra in `[project.optional-dependencies]` to ensure that it is installed for dev testing.