### PR TITLE
Exclude PyCBC from experimental dependencies build

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -79,6 +79,13 @@ jobs:
             -e 's/requires-python = "==/requires-python = ">=/' \
             pyproject.toml
 
+    - name: Prepare experimental dependencies
+      if: matrix.experimental == true
+      run: |
+        # need https://github.com/gwastro/pycbc/pull/4699 to build
+        # with numpy 2
+        sed -i '/\"pycbc/d' pyproject.toml
+
     - name: Install system packages for experimental dependencies
       if: matrix.experimental == true
       run: |


### PR DESCRIPTION
This PR excises PyCBC from the experimental dependencies build until https://github.com/gwastro/pycbc/pull/4699 is released.