### PR TITLE
Use Python 3.12 for experimental dependency test

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -45,7 +45,7 @@ jobs:
             extras: "test"
             pip-opts: "--upgrade-strategy=only-if-needed"
           - name: "Experimental"
-            python-version: "3.11"
+            python-version: "3.12"
             experimental: true
             extras: "test,dev"
             pip-opts: "--upgrade --upgrade-strategy=eager --pre"


### PR DESCRIPTION
This PR upgrades the `experimental` dependency CI job to use Python 3.12.