### PR TITLE
Fix usage of hann window for scipy 1.13.0

### DIFF
--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -1393,7 +1393,9 @@ class TestTimeSeries(_TestTimeSeriesBase):
 
     def test_convolve(self):
         data = self.TEST_CLASS(
-            signal.hann(1024), sample_rate=512, epoch=-1
+            signal.get_window("hann", 1024),
+            sample_rate=512,
+            epoch=-1,
         )
         filt = numpy.array([1, 0])
 


### PR DESCRIPTION
This PR fixes compatibility with scipy 1.13.0 by using `scipy.signal.get_window` to create a `hann` window in the tests (accessing window functions as attributes of the `scipy.signal` module is deprecated).