### PR TITLE
Update usage of scipy 'firwin' function

### DIFF
--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -83,7 +83,7 @@ def _design_fir(wp, ws, sample_rate, gpass, gstop, window='hamming', **kwargs):
     # pylint: disable=invalid-name
     wp = numpy.atleast_1d(wp)
     ws = numpy.atleast_1d(ws)
-    tw = abs(wp[0] - ws[0])
+    tw = wp[0] - ws[0]
     nt = num_taps(sample_rate, tw, gpass, gstop)
     if wp[0] > ws[0]:
         kwargs.setdefault('pass_zero', False)
@@ -122,12 +122,16 @@ def num_taps(sample_rate, transitionwidth, gpass, gstop):
     """
     gpass = 10 ** (-gpass / 10.)
     gstop = 10 ** (-gstop / 10.)
-    return int(
+    ntaps = int(
         2/3.
         * log10(1 / (10 * gpass * gstop))
         * sample_rate
-        / transitionwidth
+        / abs(transitionwidth)
     )
+    # highpass filters must have an odd number of taps
+    if transitionwidth > 0 and ntaps % 2 == 0:
+        return ntaps + 1
+    return ntaps
 
 
 def is_zpk(zpktup):

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -89,7 +89,7 @@ def _design_fir(wp, ws, sample_rate, gpass, gstop, window='hamming', **kwargs):
         kwargs.setdefault('pass_zero', False)
     if ws.shape == (1,):
         kwargs.setdefault('width', ws - wp)
-    kwargs.setdefault('nyq', sample_rate/2.)
+    kwargs.setdefault('fs', sample_rate)
     return signal.firwin(nt, wp, window=window, **kwargs)
 
 

--- a/gwpy/signal/filter_design.py
+++ b/gwpy/signal/filter_design.py
@@ -79,22 +79,46 @@ def _design_iir(wp, ws, sample_rate, gpass, gstop,
         raise ValueError("'%s' is not a valid output form." % output)
 
 
-def _design_fir(wp, ws, sample_rate, gpass, gstop, window='hamming', **kwargs):
-    # pylint: disable=invalid-name
+def _design_fir(
+    wp,
+    ws,
+    sample_rate,
+    gpass,
+    gstop,
+    window='hamming',
+    **kwargs,
+):
+    """Design an FIR filter using `scipy.signal.firwin`.
+
+    This is just an internal convenience function to calculate the number of
+    taps based on the pass and stop band frequencies, and to set sensible
+    defaults for a few other keyword arguments.
+
+    See also
+    --------
+    scipy.signal.firwin
+        for details of how the FIR filters are actually generated
+    """
+    # format arguments
     wp = numpy.atleast_1d(wp)
     ws = numpy.atleast_1d(ws)
     tw = wp[0] - ws[0]
+
+    # calculate the number of taps
     nt = num_taps(sample_rate, tw, gpass, gstop)
-    if wp[0] > ws[0]:
-        kwargs.setdefault('pass_zero', False)
-    if ws.shape == (1,):
-        kwargs.setdefault('width', ws - wp)
-    kwargs.setdefault('fs', sample_rate)
+
+    # set default kw based on the filter shape
+    if wp[0] > ws[0]:  # highpass
+        kwargs.setdefault("pass_zero", False)
+    if ws.shape == (1,):  # simple list of taps
+        kwargs.setdefault("width", ws - wp)
+
+    kwargs.setdefault("fs", sample_rate)
     return signal.firwin(nt, wp, window=window, **kwargs)
 
 
 def num_taps(sample_rate, transitionwidth, gpass, gstop):
-    """Returns the number of taps for an FIR filter with the given shape
+    """Returns the number of taps for an FIR filter with the given shape.
 
     Parameters
     ----------
@@ -102,7 +126,7 @@ def num_taps(sample_rate, transitionwidth, gpass, gstop):
         sampling rate of target data
 
     transitionwidth : `float`
-        the width (in the same units as `sample_rate` of the transition
+        the width (in the same units as `sample_rate`) of the transition
         from stop-band to pass-band
 
     gpass : `float`

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -52,7 +52,7 @@ LOWPASS_IIR_100HZ = signal.iirdesign(
     analog=False, ftype='cheby1', output='zpk',
 )
 LOWPASS_FIR_100HZ = signal.firwin(
-    30, 100, window='hamming', width=50., nyq=512.,
+    30, 100, window='hamming', width=50., fs=1024.,
 )
 
 HIGHPASS_IIR_100HZ = signal.iirdesign(
@@ -62,7 +62,7 @@ HIGHPASS_IIR_100HZ = signal.iirdesign(
     analog=False, ftype='cheby1', output='zpk',
 )
 HIGHPASS_FIR_100HZ = signal.firwin(
-    45, 100, window='hamming', pass_zero=False, width=-100/3., nyq=512.,
+    45, 100, window='hamming', pass_zero=False, width=-100/3., fs=1024.,
 )
 
 BANDPASS_IIR_100HZ_200HZ = signal.iirdesign(
@@ -72,7 +72,7 @@ BANDPASS_IIR_100HZ_200HZ = signal.iirdesign(
     analog=False, ftype='cheby1', output='zpk',
 )
 BANDPASS_FIR_100HZ_200HZ = signal.firwin(
-    45, (100, 200.), window='hamming', pass_zero=False, nyq=512.,
+    45, (100, 200.), window='hamming', pass_zero=False, fs=1024.,
 )
 
 

--- a/gwpy/signal/tests/test_filter_design.py
+++ b/gwpy/signal/tests/test_filter_design.py
@@ -36,63 +36,129 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 ONE_HZ = units.Quantity(1, 'Hz')
 
-_nyq = 16384 / 2.
-NOTCH_60HZ = signal.iirdesign(
-    (59 / _nyq, 61 / _nyq),
-    (59.9 / _nyq, 60.1 / _nyq),
-    1, 10,
-    analog=False, ftype='ellip', output='zpk',
-)
+# -- filters --------------------------
 
-_nyq = 1024 / 2.
-LOWPASS_IIR_100HZ = signal.iirdesign(
-    100 / _nyq,
-    150 / _nyq,
-    2, 30,
-    analog=False, ftype='cheby1', output='zpk',
-)
-LOWPASS_FIR_100HZ = signal.firwin(
-    30, 100, window='hamming', width=50., fs=1024.,
-)
-
-HIGHPASS_IIR_100HZ = signal.iirdesign(
-    100 / _nyq,
-    100 * 2/3. / _nyq,
-    2, 30,
-    analog=False, ftype='cheby1', output='zpk',
-)
-HIGHPASS_FIR_100HZ = signal.firwin(
-    45, 100, window='hamming', pass_zero=False, width=-100/3., fs=1024.,
-)
-
-BANDPASS_IIR_100HZ_200HZ = signal.iirdesign(
-    (100 / _nyq, 200 / _nyq),
-    (100 * 2/3. / _nyq, 300 / _nyq),
-    2, 30,
-    analog=False, ftype='cheby1', output='zpk',
-)
-BANDPASS_FIR_100HZ_200HZ = signal.firwin(
-    45, (100, 200.), window='hamming', pass_zero=False, fs=1024.,
-)
+FILTER_FS = 1024.
+FILTER_NYQ = FILTER_FS / 2.
+NOTCH_F = 60.
+LOWPASS_F = 100.
+HIGHPASS_F = 200.
+BANDPASS_F = (LOWPASS_F, HIGHPASS_F)
 
 
-def test_truncate():
+@pytest.fixture(scope="module")
+def notch_60():
+    passband = (NOTCH_F - 1) / FILTER_NYQ, (NOTCH_F + 1) / FILTER_NYQ
+    stopband = (NOTCH_F - .1) / FILTER_NYQ, (NOTCH_F + .1) / FILTER_NYQ
+    return signal.iirdesign(
+        passband,
+        stopband,
+        1,  # max passband loss (dB)
+        10,  # min stopband loss (dB)
+        analog=False,
+        ftype='ellip',
+        output='zpk',
+    )
+
+
+@pytest.fixture(scope="module")
+def lowpass_100_iir():
+    return signal.iirdesign(
+        LOWPASS_F / FILTER_NYQ,
+        LOWPASS_F * 1.5 / FILTER_NYQ,
+        2,
+        30,
+        analog=False,
+        ftype='cheby1',
+        output='zpk',
+    )
+
+
+@pytest.fixture(scope="module")
+def lowpass_100_fir():
+    return signal.firwin(
+        30,
+        LOWPASS_F,
+        window='hamming',
+        width=50.,
+        fs=FILTER_FS,
+    )
+
+
+@pytest.fixture(scope="module")
+def highpass_100_iir():
+    return signal.iirdesign(
+        HIGHPASS_F / FILTER_NYQ,
+        HIGHPASS_F * 2/3. / FILTER_NYQ,
+        2,
+        30,
+        analog=False,
+        ftype='cheby1',
+        output='zpk',
+    )
+
+
+@pytest.fixture(scope="module")
+def highpass_100_fir():
+    return signal.firwin(
+        23,
+        HIGHPASS_F,
+        window="hamming",
+        pass_zero=False,
+        width=-HIGHPASS_F/3.,
+        fs=FILTER_FS,
+    )
+
+
+@pytest.fixture(scope="module")
+def bandpass_100_200_iir():
+    return signal.iirdesign(
+        (LOWPASS_F / FILTER_NYQ, HIGHPASS_F / FILTER_NYQ),
+        (LOWPASS_F * 2/3. / FILTER_NYQ, HIGHPASS_F * 3/2. / FILTER_NYQ),
+        2,
+        30,
+        analog=False,
+        ftype='cheby1',
+        output='zpk',
+    )
+
+
+@pytest.fixture(scope="module")
+def bandpass_100_200_fir():
+    return signal.firwin(
+        45,
+        BANDPASS_F,
+        window='hamming',
+        pass_zero=False,
+        fs=FILTER_FS,
+    )
+
+
+# -- tests ----------------------------
+
+def test_truncate_transfer():
+    """Test :func:`gwpy.signal.filter_design.truncate_transfer`.
+    """
     series = numpy.ones(64)
+    trunc = filter_design.truncate_transfer(series)
+    assert trunc[0] == 0
+    assert trunc[-1] == 0
+    utils.assert_allclose(series[5:59], trunc[5:59])
 
-    # test truncate_transfer
-    trunc1 = filter_design.truncate_transfer(series)
-    assert trunc1[0] == 0
-    assert trunc1[-1] == 0
-    utils.assert_allclose(trunc1[5:59], trunc1[5:59])
 
-    # test truncate_impulse
-    trunc2 = filter_design.truncate_impulse(series, ntaps=10)
-    assert trunc2[0] != 0
-    assert trunc2[-1] != 0
-    utils.assert_allclose(trunc2[5:59], numpy.zeros(54))
+def test_truncate_impulse():
+    """Test :func:`gwpy.signal.filter_design.truncate_impulse`.
+    """
+    series = numpy.ones(64)
+    trunc = filter_design.truncate_impulse(series, ntaps=10)
+    assert trunc[0] != 0
+    assert trunc[-1] != 0
+    utils.assert_allclose(trunc[5:59], numpy.zeros(54))
 
 
 def test_fir_from_transfer():
+    """Test :func:`gwpy.signal.filter_design.fir_from_transfer`.
+    """
     frequencies = numpy.arange(0, 64)
     fseries = numpy.cos(2*numpy.pi*frequencies)
 
@@ -105,56 +171,99 @@ def test_fir_from_transfer():
     assert fir.size == 10
 
 
-def test_notch_design():
+def test_notch_iir(notch_60):
+    """Test :func:`gwpy.signal.filter_design.notch` with an IIR filter.
+    """
     # test simple notch
-    zpk = filter_design.notch(60, 16384)
-    utils.assert_zpk_equal(zpk, NOTCH_60HZ)
+    zpk = filter_design.notch(NOTCH_F, FILTER_FS)
+    utils.assert_zpk_equal(zpk, notch_60)
 
+
+def test_notch_iir_quantities(notch_60):
+    """Test :func:`gwpy.signal.filter_design.notch` with an IIR filter.
+    """
     # test Quantities
-    zpk2 = filter_design.notch(60 * ONE_HZ, 16384 * ONE_HZ)
-    utils.assert_zpk_equal(zpk, zpk2)
+    zpk = filter_design.notch(NOTCH_F * ONE_HZ, FILTER_FS * ONE_HZ)
+    utils.assert_zpk_equal(zpk, notch_60)
 
-    # test FIR notch doesn't work
+
+def test_notch_fir_notimplemented():
+    """Test :func:`gwpy.signal.filter_design.notch` with an FIR filter.
+    """
     with pytest.raises(NotImplementedError):
         filter_design.notch(60, 16384, type='fir')
 
 
-def test_lowpass():
-    iir = filter_design.lowpass(100, 1024)
-    utils.assert_zpk_equal(iir, LOWPASS_IIR_100HZ)
-    fir = filter_design.lowpass(100, 1024, type='fir')
-    utils.assert_allclose(fir, LOWPASS_FIR_100HZ)
+def test_lowpass_iir(lowpass_100_iir):
+    """Test :func:`gwpy.signal.filter_design.lowpass` with an IIR filter.
+    """
+    iir = filter_design.lowpass(LOWPASS_F, FILTER_FS)
+    utils.assert_zpk_equal(iir, lowpass_100_iir)
 
 
-def test_highpass():
-    iir = filter_design.highpass(100, 1024)
-    utils.assert_zpk_equal(iir, HIGHPASS_IIR_100HZ)
-    fir = filter_design.highpass(100, 1024, type='fir')
-    utils.assert_allclose(fir, HIGHPASS_FIR_100HZ)
+def test_lowpass_fir(lowpass_100_fir):
+    """Test :func:`gwpy.signal.filter_design.lowpass` with an FIR filter.
+    """
+    fir = filter_design.lowpass(LOWPASS_F, FILTER_FS, type='fir')
+    utils.assert_allclose(fir, lowpass_100_fir)
 
 
-def test_bandpass():
-    iir = filter_design.bandpass(100, 200, 1024)
-    utils.assert_zpk_equal(iir, BANDPASS_IIR_100HZ_200HZ)
-    fir = filter_design.bandpass(100, 200, 1024, type='fir')
-    utils.assert_allclose(fir, BANDPASS_FIR_100HZ_200HZ)
+def test_highpass_iir(highpass_100_iir):
+    """Test :func:`gwpy.signal.filter_design.highpass` with an IIR filter.
+    """
+    iir = filter_design.highpass(HIGHPASS_F, FILTER_FS)
+    utils.assert_zpk_equal(iir, highpass_100_iir)
+
+
+def test_highpass_fir(highpass_100_fir):
+    """Test :func:`gwpy.signal.filter_design.highpass` with an FIR filter.
+    """
+    fir = filter_design.highpass(HIGHPASS_F, FILTER_FS, type='fir')
+    utils.assert_allclose(fir, highpass_100_fir)
+
+
+def test_bandpass_iir(bandpass_100_200_iir):
+    """Test :func:`gwpy.signal.filter_design.bandwith with an IIR filter`.
+    """
+    iir = filter_design.bandpass(LOWPASS_F, HIGHPASS_F, FILTER_FS)
+    utils.assert_zpk_equal(iir, bandpass_100_200_iir)
+
+
+def test_bandpass_fir(bandpass_100_200_fir):
+    """Test :func:`gwpy.signal.filter_design.bandpass` with an FIR filter.
+    """
+    fir = filter_design.bandpass(LOWPASS_F, HIGHPASS_F, FILTER_FS, type='fir')
+    utils.assert_allclose(fir, bandpass_100_200_fir)
 
 
 def test_concatenate_zpks():
-    zpk1 = ([1, 2, 3], [4, 5, 6], 1.)
-    zpk2 = ([1, 2, 3, 4], [5, 6, 7, 8], 100)
+    """Test :func:`gwpy.signal.filter_design.notch`.
+    """
+    z1, p1, k1 = [1, 2, 3], [4, 5, 6], 1.
+    z2, p2, k2 = [1, 2, 3, 4], [5, 6, 7, 8], 100
     utils.assert_zpk_equal(
-        filter_design.concatenate_zpks(zpk1, zpk2),
-        ([1, 2, 3, 1, 2, 3, 4], [4, 5, 6, 5, 6, 7, 8], 100))
+        filter_design.concatenate_zpks((z1, p1, k1), (z2, p2, k2)),
+        (z1 + z2, p1 + p2, k1 * k2),
+    )
 
 
-def test_parse_filter():
-    fir = numpy.arange(10)
-    assert filter_design.parse_filter(fir) == ('ba', (fir, [1.]))
-    zpk = ([1, 2, 3], [4, 5, 6], 1.)
-    parsed = filter_design.parse_filter(zpk)
-    assert parsed[0] == 'zpk'
-    utils.assert_zpk_equal(parsed[1], zpk)
+def test_parse_filter_fir():
+    """Test :func:`gwpy.signal.filter_design.parse_filter` with an FIR filter.
+    """
+    taps = numpy.arange(10)
+    assert filter_design.parse_filter(taps) == (
+        "ba",
+        (taps, [1.]),
+    )
+
+
+def test_parse_filter_iir():
+    """Test :func:`gwpy.signal.filter_design.parse_filter` with an FIR filter.
+    """
+    zpk = [1, 2, 3], [4, 5, 6], 1.
+    typ, filt = filter_design.parse_filter(zpk)
+    assert typ == "zpk"
+    utils.assert_zpk_equal(filt, zpk)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR updates the the usage of the `scipy.signal.firwin` function to remove deprecated arguments.