### PR TITLE
Use scipy.integrate.trapezoid in gwpy.astro

### DIFF
--- a/gwpy/astro/range.py
+++ b/gwpy/astro/range.py
@@ -25,7 +25,7 @@ import warnings
 from functools import wraps
 from math import pi
 
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 from scipy.interpolate import interp1d
 
 from astropy import (
@@ -238,7 +238,7 @@ def sensemon_range(psd, snr=8, mass1=1.4, mass2=1.4, fmin=None, fmax=None,
     integrand = sensemon_range_psd(psd[frange], snr=snr, mass1=mass1,
                                    mass2=mass2, horizon=horizon)
     return (units.Quantity(
-        trapz(integrand.value, f.value[frange]),
+        trapezoid(integrand.value, f.value[frange]),
         unit=integrand.unit * units.Hertz,
     ) ** (1/2.)).to('Mpc')
 
@@ -528,7 +528,7 @@ def burst_range(psd, snr=8, energy=1e-2, fmin=100, fmax=500):
     # calculate integrand and integrate
     integrand = burst_range_spectrum(
         psd[frange], snr=snr, energy=energy) ** 3
-    out = trapz(integrand.value, f[frange])
+    out = trapezoid(integrand.value, f[frange])
     # normalize and return
     return (units.Quantity(
         out / (fmax - fmin),

--- a/gwpy/astro/tests/test_range.py
+++ b/gwpy/astro/tests/test_range.py
@@ -24,7 +24,7 @@ from unittest import mock
 import pytest
 
 from astropy import units
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 
 from ... import astro
 from ...testing import utils
@@ -71,7 +71,7 @@ def test_sensemon_range_psd(psd):
     r = astro.sensemon_range_psd(psd[frange])
     assert isinstance(r, FrequencySeries)
     utils.assert_quantity_almost_equal(
-        trapz(r, r.frequencies) ** (1/2.),
+        trapezoid(r, r.frequencies) ** (1/2.),
         TEST_RESULTS['sensemon_range'],
     )
     assert r.f0.value > 0
@@ -103,9 +103,8 @@ def test_inspiral_range_psd(psd):
     frange = (psd.frequencies.value < 4096)
     r = astro.inspiral_range_psd(psd[frange])
     assert isinstance(r, FrequencySeries)
-    print(trapz(r, r.frequencies) ** (1/2.))
     utils.assert_quantity_almost_equal(
-        trapz(r, r.frequencies) ** (1/2.),
+        trapezoid(r, r.frequencies) ** (1/2.),
         TEST_RESULTS['inspiral_range'],
     )
     assert r.f0.value > 0
@@ -129,7 +128,7 @@ def test_burst_range_spectrum(psd):
     r = astro.burst_range_spectrum(psd[frange])
     assert isinstance(r, FrequencySeries)
     utils.assert_quantity_almost_equal(
-        (trapz(r**3, f[frange]) / (400 * units.Hz)) ** (1/3.),
+        (trapezoid(r**3, f[frange]) / (400 * units.Hz)) ** (1/3.),
         TEST_RESULTS['burst_range'],
     )
     assert r.f0.value > 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "numpy >=1.19",
   "python-dateutil",
   "requests",
-  "scipy >=1.5.0",
+  "scipy >=1.6.0",
   "tqdm >=4.10.0",
 ]
 


### PR DESCRIPTION
This PR updates `gwpy.astro` to use the `scipy.integrate.trapezoid` function; this was renamed from trapz in scipy-1.6.0 and removed in scipy-1.16.0.