### PR TITLE
Improve handling of invalid inputs when reading data from GWF with LALFrame

### DIFF
--- a/gwpy/testing/utils.py
+++ b/gwpy/testing/utils.py
@@ -34,12 +34,14 @@ from numpy.testing import (assert_array_equal, assert_allclose)
 
 from astropy.time import Time
 
-from ..utils.decorators import deprecated_function
+from gwpy.io.cache import file_segment
+from gwpy.utils.decorators import deprecated_function
 
 # -- useful constants ---------------------------------------------------------
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 TEST_GWF_FILE = os.path.join(TEST_DATA_DIR, 'HLV-HW100916-968654552-1.gwf')
+TEST_GWF_SPAN = file_segment(TEST_GWF_FILE)
 TEST_HDF5_FILE = os.path.join(TEST_DATA_DIR, 'HLV-HW100916-968654552-1.hdf')
 
 

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -149,6 +149,10 @@ def read(source, channels, start=None, end=None, series_class=TimeSeries,
         end = epoch + streamdur
     end = min(epoch + streamdur, lalutils.to_lal_ligotimegps(end))
     duration = float(end - start)
+    if start >= (epoch + streamdur):
+        raise ValueError(
+            "cannot read data starting after stream ends",
+        )
     if duration < 0:
         raise ValueError(
             "cannot read data with negative duration",

--- a/gwpy/timeseries/io/gwf/lalframe.py
+++ b/gwpy/timeseries/io/gwf/lalframe.py
@@ -149,6 +149,10 @@ def read(source, channels, start=None, end=None, series_class=TimeSeries,
         end = epoch + streamdur
     end = min(epoch + streamdur, lalutils.to_lal_ligotimegps(end))
     duration = float(end - start)
+    if duration < 0:
+        raise ValueError(
+            "cannot read data with negative duration",
+        )
 
     # read data
     out = series_class.DictClass()

--- a/gwpy/timeseries/tests/test_timeseries.py
+++ b/gwpy/timeseries/tests/test_timeseries.py
@@ -253,28 +253,29 @@ class TestTimeSeries(_TestTimeSeriesBase):
                                         exclude=['channel'])
 
     @pytest.mark.parametrize('api', GWF_APIS)
-    def test_read_write_gwf_gps_errors(self, tmp_path, api):
+    def test_read_gwf_end_error(self, api):
+        """Test that reading past the end of available data fails.
+        """
         fmt = "gwf" if api is None else "gwf." + api
-        array = self.create(name='TEST')
-        tmp = tmp_path / "test.gwf"
-        array.write(tmp, format=fmt)
-
-        # check that reading past the end of the array fails
-        with pytest.raises((ValueError, RuntimeError)):
+        with pytest.raises(ValueError):
             self.TEST_CLASS.read(
-                tmp,
-                array.name,
+                utils.TEST_GWF_FILE,
+                "L1:LDAS-STRAIN",
                 format=fmt,
-                start=array.span[1],
+                start=utils.TEST_GWF_SPAN[1],
             )
 
-        # check that reading before the start of the array also fails
-        with pytest.raises((ValueError, RuntimeError)):
+    @pytest.mark.parametrize('api', GWF_APIS)
+    def test_read_gwf_negative_duration_error(self, api):
+        """Test that reading a negative duration fails.
+        """
+        fmt = "gwf" if api is None else "gwf." + api
+        with pytest.raises(ValueError):
             self.TEST_CLASS.read(
-                tmp,
-                array.name,
+                utils.TEST_GWF_FILE,
+                "L1:LDAS-STRAIN",
                 format=fmt,
-                end=array.span[0]-1,
+                end=utils.TEST_GWF_SPAN[0]-1,
             )
 
     @pytest.mark.parametrize('api', GWF_APIS)


### PR DESCRIPTION
This PR improves the handling of invalid inputs (start and end GPS times) when attempting to read data from GWF with LALFrame to provide better error messages and avoid [inconsistent behaviour of LALFrame on non-x86_64 systems](https://git.ligo.org/lscsoft/lalsuite/-/issues/745).

The result should be no change in the GWpy UX, other than perhaps a different error class when passing invalid inputs (`ValueError` instead of `RuntimeError`).