### PR TITLE
Add 'time (s)' as alias for 's'

### DIFF
--- a/gwpy/detector/units.py
+++ b/gwpy/detector/units.py
@@ -167,6 +167,7 @@ for unit, aliases in [
     # GW observatories like to record 'time' as the unit
     (units.Unit('second'), (
         'time',
+        'time (s)',
         'time [s]',
         'Time [sec]',
         'Time (sec)',


### PR DESCRIPTION
This PR works around an upstream 'feature' of the GEO and Virgo observatories by adding support for `time (s)` as an unit alias for `s`. This is used as the 'unit' for the time axis for many `Timeseries` channels in GWF data files.