### PR TITLE
Update all references to nds.gwosc.org

### DIFF
--- a/docs/timeseries/datafind.rst
+++ b/docs/timeseries/datafind.rst
@@ -94,7 +94,7 @@ channel by specifying the special GWOSC NDS2 server url using the
    >>> gps = event_gps("GW170814")
    >>> start = int(gps) - 100
    >>> end = int(gps) + 100
-   >>> data = TimeSeries.get("H1:IMC-PWR_IN_OUT_DQ", start, end, host="losc-nds.ligo.org")
+   >>> data = TimeSeries.get("H1:IMC-PWR_IN_OUT_DQ", start, end, host="nds.gwosc.org")
    >>> plot = data.plot(ylabel="Power [W]")
    >>> plot.show()
 

--- a/docs/timeseries/opendata.rst
+++ b/docs/timeseries/opendata.rst
@@ -84,5 +84,5 @@ Accessing data from Auxiliary Channel Releases
 in a three-hour window around |GW170814|_ and throughout the entirety of O3.
 These data cannot be loaded using :meth:`TimeSeries.fetch_open_data`,
 but can be loaded using :meth:`TimeSeries.get`
-(or :meth:`TimeSeriesDict.get`), by specifying `host="losc-nds.ligo.org"`.
+(or :meth:`TimeSeriesDict.get`), by specifying `host="nds.gwosc.org"`.
 For more details, see :ref:`gwpy-timeseries-get`.

--- a/docs/timeseries/statevector.rst
+++ b/docs/timeseries/statevector.rst
@@ -63,7 +63,7 @@ Alternatively, applying a standard mathematical comparison to a regular
    ...     "H1:IMC-PWR_IN_OUT_DQ",
    ...     1186741850,
    ...     1186741870,
-   ...     host="losc-nds.ligo.org",
+   ...     host="nds.gwosc.org",
    ... )
    >>> threshold = 29.2 > laserpower.unit
    >>> above_29_2 = laserpower > threshold

--- a/examples/timeseries/blrms.py
+++ b/examples/timeseries/blrms.py
@@ -43,10 +43,10 @@ channels = [
 # interferometer:
 lho = TimeSeriesDict.get([c.format(ifo='H1') for c in channels],
                          'Jan 16 2020 8:00', 'Jan 16 2020 14:00',
-                         host='losc-nds.ligo.org')
+                         host='nds.gwosc.org')
 llo = TimeSeriesDict.get([c.format(ifo='L1') for c in channels],
                          'Jan 16 2020 8:00', 'Jan 16 2020 14:00',
-                         host='losc-nds.ligo.org')
+                         host='nds.gwosc.org')
 
 # Next we can plot the data, with a separate `~gwpy.plot.Axes` for each
 # instrument:


### PR DESCRIPTION
This PR updates any references to `losc-nds.ligo.org` to `nds.gwosc.org`.